### PR TITLE
docs(openspec): Wave 6.2 — gap polish batch (spec-only)

### DIFF
--- a/openspec/changes/polish-wave-6.2-gaps/proposal.md
+++ b/openspec/changes/polish-wave-6.2-gaps/proposal.md
@@ -1,0 +1,73 @@
+# Change: Wave 6.2 — Gap Polish Batch
+
+## Why
+
+The Waves 1-5 playtest closeout logged 12 gaps in `playtest/CLOSEOUT.md` "Gaps logged" section. Wave 6.1 closed gap #8 (co-op route surface) via `wire-coop-campaign-route`. Of the remaining 11, six are small-effort polish items that can ship as one batched implementation PR (vs the larger known-limitation gaps deferred to Wave 6.3) — and three of them close currently-open PT-xxx defects in the ledger.
+
+The six items:
+
+| Gap ref | Title | Closes ledger row |
+|---|---|---|
+| #3 | Host-review proposal timeout (auto-veto after T seconds) | — |
+| #4 | AI-tier UI selector on Quick Game setup | — |
+| #6 | Quick Game scenario-type selector | — |
+| #7 | StateCycleDetector positional scope | **PT-001** (P2, open) |
+| #11 | Force generator high-BV unitCount widening | **PT-010** (P3, open) |
+| #12 | TurnLimit tuning for r20 maps | **PT-003** (P3, open) |
+
+Without these, the operator's manual UAT is incomplete (Quick Game has no AI-tier or scenario picker — they must edit JSON configs to test variants); the Phase-1 smoke matrix reports false positives (PT-001's StateCycleDetector fires on 96% of runs because the snapshot doesn't include position); the r20 maps draw 100% on 50-turn limit (PT-003); the 10k-BV force generator fails (PT-010).
+
+Each item is a single-file change or a small additive UI surface. The batch ships as one OpenSpec change so the spec deltas, the implementation, and the ledger updates land together.
+
+## What Changes
+
+### Spec deltas (multiple capabilities)
+
+- ADDED `quick-game-ui`: scenario-type Select + AI-tier Select on the Quick Game setup screen (gaps #4 + #6)
+- ADDED `coop-campaign-sync`: auto-veto on host-review proposals after a configurable timeout (gap #3)
+- MODIFIED `simulation-system`: extend StateCycleDetector snapshot to include unit positions (gap #7 — closes PT-001)
+- MODIFIED `force-generator`: widen unitCount fallback at high BV bands (gap #11 — closes PT-010)
+- MODIFIED `simulation-system`: raise default turnLimit on r20+ maps to 75 (gap #12 — closes PT-003)
+
+### Code
+
+- `src/components/quick-game/QuickGameSetup.tsx` — add scenario-type Select (`Annihilation | CTF | Defend | Breakthrough`) and AI-tier Select (`Green | Regular | Veteran | Elite`); persist into `useQuickGameStore.scenarioConfig`
+- `src/lib/multiplayer/server/CampaignGmArbiter.ts` — add `proposalTimeoutMs` config (default 5min); when a proposal sits `pending` for longer than the timeout, the arbiter emits an auto-veto decision so the guest's pending overlay resolves
+- `src/simulation/detectors/StateCycleDetector.ts` — extend the snapshot key to include each unit's `position` field, not just `heat`. Closes the 96% false-positive rate.
+- `src/lib/forceGenerator/forceGeneratorEngine.ts` — when `BudgetUnsatisfiableError` fires at the requested `unitCount`, retry once at `unitCount + 1` before throwing. Closes PT-010 at 10k BV.
+- `src/simulation/generator/ScenarioGenerator.ts` — default `turnLimit` is now `mapRadius * 4` (was 50). r20 maps get turnLimit 80; r12 stays at 48-50.
+
+### Ledger updates
+
+- Close PT-001, PT-003, PT-010 in `playtest/ISSUES.md` referencing this PR
+- Trim the matching gap entries from `playtest/CLOSEOUT.md` (only gaps that remain open after this wave + Wave 6.3 stay listed)
+
+## Dependencies
+
+- **Requires (already shipped)**: `add-coop-campaign-play` (Wave 5) for the host-review arbiter
+- **Requires (already shipped)**: `wire-coop-campaign-route` (Wave 6.1.A) so the auto-veto path has a UI surface to resolve
+- **No new transport, no new types beyond the timeout config field**
+
+## Impact
+
+- Affected specs: `quick-game-ui`, `coop-campaign-sync`, `simulation-system`, `force-generator`
+- Affected code:
+  - `src/components/quick-game/QuickGameSetup.tsx`
+  - `src/lib/multiplayer/server/CampaignGmArbiter.ts`
+  - `src/simulation/detectors/StateCycleDetector.ts`
+  - `src/lib/forceGenerator/forceGeneratorEngine.ts`
+  - `src/simulation/generator/ScenarioGenerator.ts`
+  - `playtest/ISSUES.md` (3 row closures)
+  - `playtest/CLOSEOUT.md` (gap trim)
+- No database migrations
+- No new components beyond the two Select controls on QuickGameSetup
+
+## Non-Goals
+
+- Gap #1 (ECM core-engine to-hit modifier) — design gap, larger scope; deferred to Wave 6.3
+- Gap #2 (recovered-session adapted-units) — recovery edge case, design needed; deferred to Wave 6.3
+- Gap #5 (`biome=none` placeholder) — data + balance work; deferred to Wave 6.3
+- Gap #9 (co-op scripted E2E) — blocked on vault-auth two-identity; remains gap
+- Gap #10 (multiplayer scripted E2E) — same blocker; remains gap
+- Full proposal-arbitration mode UI (operator-configurable timeout per campaign) — Wave 6.2 ships a global default; per-campaign config is a follow-up
+- Combat-engine tuning beyond the turnLimit + force-generator fixes — Wave 6.2 is mechanical fixes, not balance work

--- a/openspec/changes/polish-wave-6.2-gaps/specs/coop-campaign-sync/spec.md
+++ b/openspec/changes/polish-wave-6.2-gaps/specs/coop-campaign-sync/spec.md
@@ -1,0 +1,32 @@
+# Spec Delta: Co-op Campaign Sync
+
+## ADDED Requirements
+
+### Requirement: Host-Review Proposal Timeout
+
+The host-as-GM arbiter SHALL auto-veto a `pending` guest proposal that sits unanswered for longer than a configurable timeout, so the guest's pending-proposal indicator resolves even if the host disconnects or simply forgets to decide.
+
+**Priority**: Medium
+
+#### Scenario: Unanswered proposal auto-vetoes after timeout
+
+**GIVEN** a host-mode co-op campaign with `arbitrationMode: 'host-review'`
+**AND** a guest has submitted a proposal that has been `pending` for longer than the configured `proposalTimeoutMs` (default 5 minutes)
+**WHEN** the arbiter's timeout watchdog fires
+**THEN** the system SHALL resolve the proposal with `{ decision: 'veto', reason: 'host-review-timeout' }`
+**AND** the guest's `<GuestProposalSurface>` SHALL transition from pending to vetoed with the timeout reason surfaced
+**AND** the auto-veto SHALL be visually distinct from a host-driven veto (different reason badge)
+
+#### Scenario: Timeout is configurable per arbiter instance
+
+**GIVEN** an integrator constructs `new CampaignGmArbiter({ proposalTimeoutMs: 30_000 })`
+**WHEN** a proposal sits pending for 35 seconds
+**THEN** the arbiter SHALL auto-veto with `reason: 'host-review-timeout'`
+**AND** the same proposal under the default 5-minute timeout SHALL still be pending
+
+#### Scenario: A host decision before the timeout fires prevents the auto-veto
+
+**GIVEN** a proposal is pending
+**WHEN** the host clicks `approve` or `veto` before the timeout fires
+**THEN** the arbiter SHALL emit the host's decision normally
+**AND** the timeout watchdog SHALL NOT fire (the proposal is no longer pending)

--- a/openspec/changes/polish-wave-6.2-gaps/specs/force-generator/spec.md
+++ b/openspec/changes/polish-wave-6.2-gaps/specs/force-generator/spec.md
@@ -1,0 +1,30 @@
+# Spec Delta: Force Generator
+
+## ADDED Requirements
+
+### Requirement: UnitCount Fallback Retry at High BV
+
+The force generator SHALL retry once at `unitCount + 1` when the requested `unitCount` produces a `BudgetUnsatisfiableError` for the requested BV budget. This closes the PT-010 defect where 10k BV with `unitCount = 2` failed because the unit catalog has no 5k-BV pairs.
+
+**Priority**: Low
+
+#### Scenario: Unsatisfiable budget retries with one extra unit
+
+**GIVEN** the caller invokes the force generator with `unitCount: 2, bvBudget: 10000`
+**AND** no pair of units in the catalog sums to 10000 BV within tolerance
+**WHEN** the generator throws `BudgetUnsatisfiableError`
+**THEN** the generator SHALL retry once at `unitCount: 3, bvBudget: 10000`
+**AND** the retry SHALL surface a force satisfying the budget (because the catalog has 3-unit combos summing to 10000)
+
+#### Scenario: Opt-out option preserves strict matching
+
+**GIVEN** a caller that needs exact unit-count matching (e.g. a PvP balance test)
+**WHEN** they invoke the generator with `{ unitCount: 2, bvBudget: 10000, exactUnitCount: true }`
+**THEN** the generator SHALL NOT retry on `BudgetUnsatisfiableError`
+**AND** SHALL re-throw the original error to the caller
+
+#### Scenario: PT-010 case succeeds after fix
+
+**GIVEN** the matrix config `10k_default-vs-default_regular_{r12,r20}.json` that previously failed with `BudgetUnsatisfiableError`
+**WHEN** the Phase-1 smoke matrix re-runs with the retry logic
+**THEN** both configs SHALL produce valid forces and run to completion

--- a/openspec/changes/polish-wave-6.2-gaps/specs/quick-game-ui/spec.md
+++ b/openspec/changes/polish-wave-6.2-gaps/specs/quick-game-ui/spec.md
@@ -1,0 +1,45 @@
+# Spec Delta: Quick Game UI
+
+## ADDED Requirements
+
+### Requirement: Scenario Type Selector
+
+The Quick Game setup screen SHALL expose a scenario-type selector allowing the operator to choose from the four scenario archetypes (Annihilation, Capture-the-Flag, Defend, Breakthrough) without editing JSON configs.
+
+**Priority**: High
+
+#### Scenario: Operator picks a non-default scenario type
+
+**GIVEN** the operator is on `/quick-game` (or equivalent setup route)
+**WHEN** they open the scenario-type Select and choose `CTF`
+**THEN** the system SHALL update `useQuickGameStore.scenarioConfig.scenarioType` to `CTF`
+**AND** the next Launch Game click SHALL initialize the encounter with `scenarioType: 'CTF'`
+**AND** the existing default Annihilation flow SHALL remain unchanged when the operator does not interact with the selector
+
+#### Scenario: Selector exposes the four canonical scenario types
+
+**GIVEN** the operator opens the scenario-type Select
+**WHEN** the options render
+**THEN** the system SHALL surface exactly four options: `Annihilation`, `CTF`, `Defend`, `Breakthrough`
+**AND** the testid `quick-game-scenario-select` SHALL identify the Select element for automated tests
+
+### Requirement: AI Tier Selector
+
+The Quick Game setup screen SHALL expose an AI-tier selector allowing the operator to choose from the four tactical-AI difficulty tiers (Green, Regular, Veteran, Elite) without editing JSON configs.
+
+**Priority**: High
+
+#### Scenario: Operator picks a non-default AI tier
+
+**GIVEN** the operator is on the Quick Game setup screen
+**WHEN** they open the AI-tier Select and choose `Veteran`
+**THEN** the system SHALL update `useQuickGameStore.scenarioConfig.aiTier` to `Veteran`
+**AND** the next Launch Game click SHALL initialize the bot pilot with the `Veteran` AI behavior profile
+**AND** the default `Regular` flow SHALL remain unchanged when the operator does not interact
+
+#### Scenario: Selector exposes the four canonical AI tiers
+
+**GIVEN** the operator opens the AI-tier Select
+**WHEN** the options render
+**THEN** the system SHALL surface exactly four options: `Green`, `Regular`, `Veteran`, `Elite`
+**AND** the testid `quick-game-ai-tier-select` SHALL identify the Select element for automated tests

--- a/openspec/changes/polish-wave-6.2-gaps/specs/simulation-system/spec.md
+++ b/openspec/changes/polish-wave-6.2-gaps/specs/simulation-system/spec.md
@@ -1,0 +1,57 @@
+# Spec Delta: Simulation System
+
+## ADDED Requirements
+
+### Requirement: StateCycleDetector Includes Unit Positions
+
+The StateCycleDetector SHALL include each unit's `position` field in its snapshot key so positional movement between turns does not register as a false-positive state cycle. The previous snapshot scope (armor / structure / heat only) reported a state cycle on 96% of runs even when units had moved between turns (PT-001).
+
+**Priority**: High
+
+#### Scenario: Same heat at different position is not a cycle
+
+**GIVEN** a unit with `heat = 10`, `armor = 30`, `structure = 50` at position `(3, 4)` on turn N
+**AND** the same unit with `heat = 10`, `armor = 30`, `structure = 50` at position `(4, 5)` on turn N+1
+**WHEN** the StateCycleDetector snapshots both turns
+**THEN** the two snapshot keys SHALL differ (because position differs)
+**AND** the detector SHALL NOT flag a state cycle
+
+#### Scenario: Same state at same position is still a cycle
+
+**GIVEN** a unit with `heat = 10`, `position = (3, 4)` on turn N
+**AND** the same unit with `heat = 10`, `position = (3, 4)` on turn N+1 (no movement, no damage)
+**WHEN** the StateCycleDetector snapshots both turns
+**THEN** the two snapshot keys SHALL match
+**AND** the detector MAY flag a candidate state cycle (existing behavior preserved)
+
+#### Scenario: PT-001 hit-rate drops below 5% after the fix
+
+**GIVEN** the Phase-1 smoke matrix that previously produced StateCycleDetector hits on 96% of runs
+**WHEN** the matrix re-runs with the position-aware snapshot
+**THEN** the StateCycleDetector hit rate SHALL drop below 5% (the threshold below which the detector is no longer the dominant signal)
+
+### Requirement: TurnLimit Scales With Map Radius
+
+`ScenarioGenerator` SHALL default `turnLimit` to `max(50, mapRadius * 4)` so larger maps don't draw out at the 50-turn cap. Previously the static `turnLimit = 50` caused r20 maps to draw at 100% (PT-003).
+
+**Priority**: Medium
+
+#### Scenario: r12 default is unchanged
+
+**GIVEN** `ScenarioGenerator.generate({ mapRadius: 12, ... })` with no explicit `turnLimit`
+**WHEN** the scenario is generated
+**THEN** `scenario.turnLimit` SHALL be 50 (`max(50, 12 * 4) = max(50, 48) = 50`)
+
+#### Scenario: r20 default rises to 80
+
+**GIVEN** `ScenarioGenerator.generate({ mapRadius: 20, ... })` with no explicit `turnLimit`
+**WHEN** the scenario is generated
+**THEN** `scenario.turnLimit` SHALL be 80 (`max(50, 20 * 4) = 80`)
+**AND** the Phase-1 r20 draw rate SHALL drop below 50% (PT-003)
+
+#### Scenario: Explicit caller value still wins
+
+**GIVEN** `ScenarioGenerator.generate({ mapRadius: 20, turnLimit: 50, ... })`
+**WHEN** the scenario is generated
+**THEN** `scenario.turnLimit` SHALL be 50 (the caller's explicit value)
+**AND** the auto-scaling SHALL only apply when the caller leaves `turnLimit` undefined

--- a/openspec/changes/polish-wave-6.2-gaps/tasks.md
+++ b/openspec/changes/polish-wave-6.2-gaps/tasks.md
@@ -1,0 +1,50 @@
+# Tasks: Wave 6.2 — Gap Polish Batch
+
+## 1. Quick Game UI selectors (gaps #4 + #6)
+
+- [ ] 1.1 `src/components/quick-game/QuickGameSetup.tsx`: add scenario-type Select bound to `useQuickGameStore.scenarioConfig.scenarioType`. Options: `Annihilation` | `CTF` | `Defend` | `Breakthrough`. Default: `Annihilation` (existing behavior preserved). Testid `quick-game-scenario-select`.
+- [ ] 1.2 Same file: add AI-tier Select bound to `useQuickGameStore.scenarioConfig.aiTier`. Options: `Green` | `Regular` | `Veteran` | `Elite`. Default: `Regular` (existing behavior preserved). Testid `quick-game-ai-tier-select`.
+- [ ] 1.3 Tests: setting either Select updates `useQuickGameStore.scenarioConfig` and the launched session picks it up
+
+## 2. Host-review proposal timeout (gap #3)
+
+- [ ] 2.1 `src/lib/multiplayer/server/CampaignGmArbiter.ts`: add `proposalTimeoutMs?: number` constructor option (default 5 * 60_000)
+- [ ] 2.2 When a proposal sits in `pending` longer than the timeout, the arbiter automatically resolves it with `{ decision: 'veto', reason: 'host-review-timeout' }` so the guest's `<GuestProposalSurface>` pending overlay resolves
+- [ ] 2.3 The auto-veto MUST be visually distinct from a host-driven veto (existing distinction via `decision.reason` is sufficient — the surface reads `reason` to label the badge)
+- [ ] 2.4 Tests: a proposal that times out emits the auto-veto decision; the timeout is configurable; resolved proposals do NOT receive an auto-veto
+
+## 3. StateCycleDetector positional scope (gap #7, closes PT-001)
+
+- [ ] 3.1 `src/simulation/detectors/StateCycleDetector.ts`: extend `snapshotKey` builder to include each unit's `position` field, not just `heat` / `armor` / `structure`
+- [ ] 3.2 Add a unit test asserting that the same unit at the same heat but different positions produces a different snapshot key (i.e. doesn't false-positive as a state cycle)
+- [ ] 3.3 Re-run the Phase-1 smoke matrix and confirm the StateCycleDetector hit rate drops below 5% (was 96% per `playtest/phase-1/SMOKE_TRIAGE.md`)
+- [ ] 3.4 Close PT-001 in `playtest/ISSUES.md` referencing this PR
+
+## 4. Force generator high-BV unitCount widening (gap #11, closes PT-010)
+
+- [ ] 4.1 `src/lib/forceGenerator/forceGeneratorEngine.ts`: catch `BudgetUnsatisfiableError` at the requested `unitCount`; retry once at `unitCount + 1` before re-throwing
+- [ ] 4.2 The retry MUST be opt-out via an `exactUnitCount: true` option for callers that need strict matching (e.g. PvP balance tests)
+- [ ] 4.3 Tests: the 10k BV / unitCount=2 case that PT-010 reproduces now succeeds with the widened retry; unitCount=2 with `exactUnitCount: true` still throws
+- [ ] 4.4 Close PT-010 in `playtest/ISSUES.md` referencing this PR
+
+## 5. TurnLimit tuning for r20+ maps (gap #12, closes PT-003)
+
+- [ ] 5.1 `src/simulation/generator/ScenarioGenerator.ts`: default `turnLimit` becomes `Math.max(50, mapRadius * 4)` (was static 50). For r12 maps stays at 50 (max-pinned); for r20 maps becomes 80.
+- [ ] 5.2 Tests: r12 default unchanged at 50; r20 default 80; explicit `turnLimit` passed by caller is still respected
+- [ ] 5.3 Re-run the Phase-1 smoke matrix r20 configs; confirm the 50-turn-draw rate drops below 50%
+- [ ] 5.4 Close PT-003 in `playtest/ISSUES.md` referencing this PR
+
+## 6. Spec deltas + verification
+
+- [ ] 6.1 Author delta at `openspec/changes/polish-wave-6.2-gaps/specs/quick-game-ui/spec.md` with the scenario + AI-tier selector requirements
+- [ ] 6.2 Author delta at `openspec/changes/polish-wave-6.2-gaps/specs/coop-campaign-sync/spec.md` with the proposal-timeout requirement (modifies existing capability)
+- [ ] 6.3 Author delta at `openspec/changes/polish-wave-6.2-gaps/specs/simulation-system/spec.md` with the StateCycleDetector position-scope + turnLimit defaults requirements
+- [ ] 6.4 Author delta at `openspec/changes/polish-wave-6.2-gaps/specs/force-generator/spec.md` with the unitCount-fallback requirement
+- [ ] 6.5 `openspec validate polish-wave-6.2-gaps --strict` passes
+- [ ] 6.6 `npm run verify:full` passes
+- [ ] 6.7 Archive the change to `openspec/changes/archive/2026-MM-DD-polish-wave-6.2-gaps/` after merge; sync deltas to source-of-truth specs
+
+## 7. Closeout corrections
+
+- [ ] 7.1 Trim gaps #3, #4, #6, #7, #11, #12 from `playtest/CLOSEOUT.md` "Gaps logged" section (note them as closed by this PR)
+- [ ] 7.2 Update `playtest/ISSUES.md` Phase counts row reflecting PT-001 / PT-003 / PT-010 closures


### PR DESCRIPTION
## Summary

Authors `polish-wave-6.2-gaps` covering 6 of the 12 gaps from `playtest/CLOSEOUT.md`. Three currently-open PT-xxx defects (PT-001 P2, PT-003 P3, PT-010 P3) will close on implementation. Spec-only PR — implementation follows in a separate PR.

## Gaps covered

| Gap | Title | Closes ledger row |
|---|---|---|
| #3 | Host-review proposal timeout | — |
| #4 | AI-tier UI selector on Quick Game | — |
| #6 | Quick Game scenario-type selector | — |
| #7 | StateCycleDetector positional scope | PT-001 (P2) |
| #11 | Force generator high-BV unitCount | PT-010 (P3) |
| #12 | TurnLimit tuning for r20+ maps | PT-003 (P3) |

## Spec deltas

- `quick-game-ui` (NEW capability) — scenario + AI-tier selectors
- `coop-campaign-sync` (MODIFIED) — proposal-timeout requirement
- `simulation-system` (MODIFIED) — StateCycleDetector position scope + turnLimit scaling
- `force-generator` (NEW capability) — unitCount fallback retry

## Validation

```
$ npx openspec validate polish-wave-6.2-gaps --strict
Change 'polish-wave-6.2-gaps' is valid
```

## Deferred to Wave 6.3 (known-limitations)

Gaps #1 (ECM core-engine to-hit), #2 (recovered-session adapted-units), #5 (`biome=none` placeholder) need design work + larger scope; they ship as separate OpenSpec changes in Wave 6.3.

## Related

Builds on the Wave 6.1 implementation series (PRs #638 + #641 + #643). Manual UAT pass (Phase 2.A of the snappy-sprouting-giraffe plan) is the operator's hands-on walkthrough — runs in parallel with this PR's implementation cycle.