### PR TITLE
docs(openspec): Wave 6.3 — known-limitations resolution (spec-only)

### DIFF
--- a/openspec/changes/add-ecm-tohit-modifier/proposal.md
+++ b/openspec/changes/add-ecm-tohit-modifier/proposal.md
@@ -1,0 +1,46 @@
+# Change: Add ECM Core-Engine To-Hit Modifier
+
+## Why
+
+The `EcmCoverageMap` (Wave 2 AI work) already computes ECM bubbles and feeds them to the tactical AI's awareness layer. The combat-resolution to-hit calculation, however, has **no ECM-aware modifier** — units fighting inside an ECM bubble currently roll the same to-hit numbers as units in the clear. The MegaMek reference applies a `+1 to-hit` for any unit firing into or out of an ECM bubble that affects an electronic-aided weapon (C3-linked, Artemis-guided, targeting-computer-assisted, NARC-linked).
+
+The Waves 1-5 playtest closeout logged this as known-limitation gap #1. It's deferred from Wave 6.2 polish because:
+1. The fix touches the combat-resolution to-hit path, not a peripheral subsystem
+2. The interaction matrix (which weapon types degrade in ECM, by how much, against what guidance) is well-defined per the MegaMek rules but needs careful spec
+3. The fix needs unit-test coverage across each weapon-guidance combination
+
+## What Changes
+
+- ADDED ECM-aware to-hit modifier to the core combat-resolution engine in `src/engine/combatResolution/toHitCalculator.ts` (or equivalent file)
+- ADDED `ECM_TO_HIT_MODIFIERS` constant defining the per-guidance-type modifiers:
+  - C3-linked weapons: `+1` when shooter OR target is inside an ECM bubble (C3 network broken)
+  - Artemis-IV guided LRM/SRM: `+1` when target is inside an ECM bubble (lock degraded)
+  - Targeting-computer-assisted: `+1` when shooter is inside an ECM bubble (TC effectiveness degraded)
+  - NARC-linked: `+1` when target is inside an ECM bubble (homing degraded)
+- ADDED `EcmCoverageMap` consumer integration on the to-hit calculator so the modifier is applied at hit-resolution time
+- ADDED unit-test coverage across each guidance / ECM-position combination (shooter inside, target inside, both inside, neither inside)
+- ADDED a regression entry in the combat-fidelity test suite asserting the modifier matches MegaMek's calculated to-hit on a fixed-seed scenario
+
+## Dependencies
+
+- **Requires (already shipped)**: `EcmCoverageMap` (Wave 2 AI tactical layer)
+- **Requires (already shipped)**: combat-resolution engine with the existing to-hit pipeline
+- **No new types, no new transport** — extends existing modifier-stacking
+
+## Impact
+
+- Affected specs: `combat-resolution` (or equivalent — the to-hit pipeline capability spec)
+- Affected code:
+  - `src/engine/combatResolution/toHitCalculator.ts` — primary change
+  - `src/engine/combatResolution/__tests__/toHitCalculator.test.ts` — coverage matrix
+  - `src/types/combat/ToHitModifier.ts` — possibly extend with the new modifier kinds
+- No database migrations
+- No new components, hooks, or types beyond modifier-kind extension
+- The fix may shift balance — units with electronic-aided weapons take a marginal hit in ECM coverage. The unit-test suite should include a balance-sanity check (no unit's BV needs adjustment because ECM is a positional concern, not a per-unit one).
+
+## Non-Goals
+
+- ECM bubble manipulation UI for the player (the bubble is computed from equipment placement; manipulation = equipment swap, which is the existing mech-bay workflow)
+- ECM-targeted electronic-warfare gameplay (ECCM, ECM-vs-ECM cancellation) — out of scope; the modifier here is the simplest correct application of MegaMek's basic ECM-to-hit rule
+- Per-weapon-system ECM-immunity flags beyond the four canonical guidance types listed above (those would expand the modifier table; not in this change)
+- AI ECM-awareness in tactical decision-making (already in Wave 2; this change is engine-side, not AI-side)

--- a/openspec/changes/add-ecm-tohit-modifier/specs/to-hit-resolution/spec.md
+++ b/openspec/changes/add-ecm-tohit-modifier/specs/to-hit-resolution/spec.md
@@ -1,0 +1,52 @@
+# Spec Delta: To-Hit Resolution
+
+## ADDED Requirements
+
+### Requirement: ECM To-Hit Modifier
+
+The to-hit calculator SHALL apply a `+1 to-hit` modifier when a weapon attack's guidance system is degraded by an active ECM bubble. The four guidance types covered are C3-linked weapons (link broken), Artemis-IV-guided LRM/SRM (lock degraded), targeting-computer-assisted weapons (TC degraded), and NARC-linked weapons (homing degraded). The modifier is positional — it depends on whether the shooter, target, or both are inside an `EcmCoverageMap` bubble for the relevant guidance type.
+
+**Priority**: High
+
+#### Scenario: C3-linked weapon firing with shooter inside an ECM bubble
+
+**GIVEN** a unit equipped with a C3-linked PPC inside an ECM bubble
+**AND** a target outside the bubble
+**WHEN** the to-hit calculator resolves the attack
+**THEN** the calculator SHALL add a `+1` modifier with `reason: 'c3-broken'`
+**AND** the modifier SHALL stack additively with existing range / movement / terrain / heat modifiers
+
+#### Scenario: Artemis-IV-guided LRM firing at target inside an ECM bubble
+
+**GIVEN** a unit equipped with Artemis-IV-LRM-15 firing at a target inside an ECM bubble
+**AND** the shooter is outside the bubble
+**WHEN** the to-hit calculator resolves the attack
+**THEN** the calculator SHALL add a `+1` modifier with `reason: 'artemis-degraded'`
+
+#### Scenario: TC-assisted weapon firing with shooter inside an ECM bubble
+
+**GIVEN** a unit equipped with a TC-assisted ER large laser inside an ECM bubble
+**AND** firing at any target (inside or outside the bubble)
+**WHEN** the to-hit calculator resolves the attack
+**THEN** the calculator SHALL add a `+1` modifier with `reason: 'tc-degraded'`
+
+#### Scenario: NARC-linked weapon firing at NARCd target inside an ECM bubble
+
+**GIVEN** a unit firing a NARC-linked SRM at a target carrying a NARC beacon
+**AND** the target is inside an ECM bubble
+**WHEN** the to-hit calculator resolves the attack
+**THEN** the calculator SHALL add a `+1` modifier with `reason: 'narc-degraded'`
+
+#### Scenario: Non-electronic weapon fires unaffected by ECM
+
+**GIVEN** a unit firing a standard medium laser (no electronic guidance)
+**AND** the shooter and/or target is inside an ECM bubble
+**WHEN** the to-hit calculator resolves the attack
+**THEN** the calculator SHALL NOT add any ECM modifier
+**AND** the to-hit roll SHALL be unchanged from the previous (pre-fix) behavior
+
+#### Scenario: Modifier appears in the post-resolve breakdown
+
+**GIVEN** an attack to which the ECM modifier was applied
+**WHEN** the result is rendered in the after-combat report
+**THEN** the modifier SHALL appear as a line item with the `reason` label, so the operator can see why the to-hit was elevated

--- a/openspec/changes/add-ecm-tohit-modifier/tasks.md
+++ b/openspec/changes/add-ecm-tohit-modifier/tasks.md
@@ -1,0 +1,26 @@
+# Tasks: Add ECM Core-Engine To-Hit Modifier
+
+## 1. Modifier table + types
+
+- [ ] 1.1 Define `ECM_TO_HIT_MODIFIERS` constant in `src/types/combat/ToHitModifier.ts` (or new `EcmModifiers.ts` if cleaner) with the 4 guidance-type → modifier-value entries
+- [ ] 1.2 Extend `IToHitModifier` discriminated-union with an `ecm` kind carrying `{ value: number; reason: 'c3-broken' | 'artemis-degraded' | 'tc-degraded' | 'narc-degraded' }` so the modifier surfaces in the post-resolve UI breakdown
+
+## 2. To-hit calculator integration
+
+- [ ] 2.1 `src/engine/combatResolution/toHitCalculator.ts`: inject the active `EcmCoverageMap` (resolved at scenario start) into the modifier-accumulator
+- [ ] 2.2 For each weapon attack the calculator evaluates: detect the weapon's guidance type (C3 / Artemis / TC / NARC) and apply the modifier when the shooter, target, or both are inside an ECM bubble per the per-guidance rule
+- [ ] 2.3 The modifier stacks additively with existing modifiers (range, movement, terrain, heat) — total to-hit is the sum
+
+## 3. Test coverage
+
+- [ ] 3.1 Unit tests for each of the 4 guidance types across the 4 ECM-position combinations (shooter-only / target-only / both / neither) = 16 test cases
+- [ ] 3.2 Regression test: a fixed-seed combat scenario with mixed C3 + ECM produces the same total to-hit numbers as MegaMek's reference calculation (capture the MegaMek baseline as a golden-file)
+- [ ] 3.3 Balance-sanity test: aggregate BV change across the unit catalog under the new modifier is < 1% (ECM is positional, not per-unit, so no balance-driven re-rating expected)
+
+## 4. Spec delta + archive
+
+- [ ] 4.1 Author delta at `openspec/changes/add-ecm-tohit-modifier/specs/combat-resolution/spec.md` (or whichever capability owns the to-hit pipeline) ADDING an "ECM To-Hit Modifier" requirement with scenarios for each guidance type
+- [ ] 4.2 `openspec validate add-ecm-tohit-modifier --strict` passes
+- [ ] 4.3 `npm run verify:full` passes
+- [ ] 4.4 Archive the change to `openspec/changes/archive/YYYY-MM-DD-add-ecm-tohit-modifier/` after merge
+- [ ] 4.5 Trim gap #1 from `playtest/CLOSEOUT.md`

--- a/openspec/changes/fix-recovered-session-adapted-units/proposal.md
+++ b/openspec/changes/fix-recovered-session-adapted-units/proposal.md
@@ -1,0 +1,36 @@
+# Change: Fix Recovered-Session Adapted Units
+
+## Why
+
+`InteractiveSession.fromSession()` is the recovery path that rebuilds a live session from persisted state on server restart. The Wave 3 multiplayer durability work shipped session-level recovery — a match in progress survives a server bounce. But `fromSession` currently rebuilds the session with **empty `adaptedUnits` arrays** — the per-unit adapted-state objects that the combat engine needs for move and attack resolution.
+
+The consequence: full move/attack play after server-restart recovery is broken by design. The session resumes; the player can navigate the UI; but any combat action raises an error because the adapted-units cache is empty. Playtest gap #2 logged this as known.
+
+The fix is to re-derive `adaptedUnits` from the canonical campaign state at recovery time, the same way the initial session-bootstrap path derives them. The data is all present in the persisted state — the recovery path just needs to call the same adapter the bootstrap path already calls.
+
+## What Changes
+
+- ADDED `adaptedUnitRebuilder` call inside `InteractiveSession.fromSession()` (or whichever method implements the recovery path)
+- ADDED a regression test that asserts: persist a session mid-combat → simulate server restart → recover the session → a move-attack sequence executes successfully (not error-out due to empty adapted-units)
+- ADDED documentation in the session-recovery doc-comment explaining the adapted-units derivation step (so a future engineer doesn't re-introduce the bug)
+
+## Dependencies
+
+- **Requires (already shipped)**: Wave 3 multiplayer durable-transport + session persistence
+- **Requires (already shipped)**: the existing `adaptedUnitRebuilder` used by the session-bootstrap path
+- **No new types, no new transport** — reuses the existing rebuild logic
+
+## Impact
+
+- Affected specs: `multiplayer-session-recovery` (or whichever capability owns the recovery path)
+- Affected code:
+  - `src/multiplayer/server/InteractiveSession.ts` (or equivalent) — `fromSession` method
+  - `src/multiplayer/server/__tests__/InteractiveSession.recovery.test.ts` — new regression test
+- No database migrations
+- No new components, hooks, or types
+
+## Non-Goals
+
+- Recovery of in-flight combat actions (a player mid-move when the server crashes loses the action — recovery brings the session back to the last committed turn boundary, not the per-action boundary)
+- Multi-server-instance recovery (single-server scope only — the load-balanced multi-instance case is a separate change)
+- Recovering the chat/log buffer beyond what the current persistence stores

--- a/openspec/changes/fix-recovered-session-adapted-units/specs/multiplayer-server/spec.md
+++ b/openspec/changes/fix-recovered-session-adapted-units/specs/multiplayer-server/spec.md
@@ -1,0 +1,31 @@
+# Spec Delta: Multiplayer Server
+
+## ADDED Requirements
+
+### Requirement: Recovered Session Has Populated Adapted Units
+
+`InteractiveSession.fromSession()` SHALL re-derive `adaptedUnits` from canonical campaign state on session recovery, so a session resumed after server restart has the same per-unit adapted state as a freshly-bootstrapped session. Previously the recovery path left `adaptedUnits` empty, breaking full move/attack play after recovery (playtest gap #2).
+
+**Priority**: High
+
+#### Scenario: Recovered session adapted-units match bootstrap parity
+
+**GIVEN** a session bootstrap-initialized with 4 units (each with deterministic adapted state)
+**AND** the same session persisted, then reconstructed via `fromSession`
+**WHEN** `recovered.adaptedUnits` is inspected
+**THEN** the array SHALL contain 4 entries (one per unit)
+**AND** each entry SHALL deeply match the bootstrap-time entry for that unit
+
+#### Scenario: Move + attack succeeds on a recovered session
+
+**GIVEN** a session persisted mid-combat (turn 3, some moves committed)
+**AND** the session reconstructed via `fromSession`
+**WHEN** the recovered session executes a move action followed by an attack action
+**THEN** neither action SHALL throw
+**AND** the moves/attacks SHALL behave identically to a non-recovered session at the same turn (deterministic given the same seed)
+
+#### Scenario: Bootstrap path is unaffected
+
+**GIVEN** a session that is bootstrap-initialized (not recovered)
+**WHEN** the session runs through combat normally
+**THEN** the new `adaptedUnits` derivation path inside `fromSession` SHALL NOT affect the bootstrap behavior (the same derivation function is called from both code paths, but the bootstrap path's call is unchanged)

--- a/openspec/changes/fix-recovered-session-adapted-units/tasks.md
+++ b/openspec/changes/fix-recovered-session-adapted-units/tasks.md
@@ -1,0 +1,24 @@
+# Tasks: Fix Recovered-Session Adapted Units
+
+## 1. Recovery-path fix
+
+- [ ] 1.1 `src/multiplayer/server/InteractiveSession.ts`: locate the `fromSession` factory method
+- [ ] 1.2 Add a call to the existing `adaptedUnitRebuilder` (or equivalent — the function the bootstrap path uses to derive per-unit adapted state from canonical campaign state) so the recovered session's `adaptedUnits` is populated, not empty
+- [ ] 1.3 Update the doc-comment on `fromSession` explaining the derivation step
+
+## 2. Regression coverage
+
+- [ ] 2.1 New regression test at `src/multiplayer/server/__tests__/InteractiveSession.recovery.test.ts`:
+  - Bootstrap a session, advance to mid-combat (turn 3, some moves committed)
+  - Persist via the existing persistence path
+  - Reconstruct via `fromSession`
+  - Assert `adaptedUnits` is non-empty + carries the expected per-unit state
+  - Execute a move + attack on the recovered session — assert it does NOT throw
+
+## 3. Spec delta + archive
+
+- [ ] 3.1 Author delta at `openspec/changes/fix-recovered-session-adapted-units/specs/multiplayer-session-recovery/spec.md` (or relevant existing capability) ADDING a "Recovered Session Has Populated Adapted Units" requirement with scenarios for bootstrap-vs-recovery parity + the move/attack regression
+- [ ] 3.2 `openspec validate fix-recovered-session-adapted-units --strict` passes
+- [ ] 3.3 `npm run verify:full` passes
+- [ ] 3.4 Archive the change after merge
+- [ ] 3.5 Trim gap #2 from `playtest/CLOSEOUT.md`

--- a/openspec/changes/replace-biome-none-placeholder/proposal.md
+++ b/openspec/changes/replace-biome-none-placeholder/proposal.md
@@ -1,0 +1,36 @@
+# Change: Replace `biome=none` Placeholder
+
+## Why
+
+The simulation system has a `biome=none` placeholder value that exists in the BiomeGenerator's value enum but maps to no meaningful terrain generation. The Phase-1 smoke matrix explicitly excludes `biome=none` from its sweeps because the value isn't a real biome variant — it's a "no biome assigned" sentinel that the generator can't actually produce well-formed terrain for.
+
+Playtest gap #5 logged the placeholder. The fix is to remove the sentinel value entirely: `BiomeGenerator` SHALL always return a valid biome (one of `temperate`, `desert`, `mountain`, `urban` per the existing variants), and any callers that pass `'none'` SHALL receive a runtime warning + a deterministic fallback to `temperate`.
+
+## What Changes
+
+- REMOVED `'none'` from the `Biome` enum / type union
+- ADDED a defensive fallback in `BiomeGenerator`: if a caller somehow passes `'none'` (e.g. a legacy config), the generator emits a warning and falls back to `temperate`
+- MIGRATED any internal call sites currently using `'none'` to one of the real biomes (or to undefined, letting the generator pick)
+- ADDED a validator on the scenario-config input boundary that rejects `'none'` with a clear error
+- ADDED a regression test asserting all Phase-1 swarm configs work without `'none'` references
+
+## Dependencies
+
+- **Requires (already shipped)**: BiomeGenerator + Scenario config typing
+- **No new types, no new transport** — narrows existing type unions
+
+## Impact
+
+- Affected specs: `simulation-system` (the biome generator capability)
+- Affected code:
+  - `src/simulation/generator/BiomeGenerator.ts` — remove `none` from the enum, add fallback
+  - `src/types/simulation/Biome.ts` (or equivalent) — type union narrowing
+  - any swarm configs or scenario JSON that references `biome: 'none'` — migrate
+- No database migrations (Biome is an enum, not a stored value)
+- The type-narrowing is breaking for any external caller that referenced `Biome.NONE`; the migration is a string replace
+
+## Non-Goals
+
+- Adding new biome variants (desert / mountain / urban / temperate are sufficient for Wave 1-5 scope; ice / lava / underwater are post-roadmap candidates)
+- Per-biome balance tuning (the existing balance is fine; the fix removes a placeholder, not a real variant)
+- Procedural-biome generation beyond the existing four-variant selection (a continuous biome blend is a separate change)

--- a/openspec/changes/replace-biome-none-placeholder/specs/simulation-system/spec.md
+++ b/openspec/changes/replace-biome-none-placeholder/specs/simulation-system/spec.md
@@ -1,0 +1,37 @@
+# Spec Delta: Simulation System
+
+## ADDED Requirements
+
+### Requirement: BiomeGenerator Always Returns a Valid Biome
+
+The BiomeGenerator SHALL always return a valid biome value drawn from the four canonical variants (`temperate`, `desert`, `mountain`, `urban`). The previous placeholder value `'none'` is removed from the type union and rejected at the scenario-config validator boundary; legacy callers that pass `'none'` receive a deterministic fallback to `'temperate'` with a `console.warn`. This closes playtest gap #5 (the placeholder was excluded from Phase-1 swarm sweeps because no meaningful terrain could be generated for it).
+
+**Priority**: Low
+
+#### Scenario: Biome enum no longer accepts 'none'
+
+**GIVEN** TypeScript code that attempts `const b: Biome = 'none'`
+**WHEN** the compiler runs
+**THEN** the compile SHALL fail with a type error (the `'none'` variant is no longer part of the `Biome` union)
+
+#### Scenario: Legacy config with biome: 'none' falls back to temperate
+
+**GIVEN** a legacy swarm config or scenario JSON that contains `biome: 'none'`
+**WHEN** the BiomeGenerator processes the config
+**THEN** the generator SHALL emit a `console.warn` identifying the offending caller
+**AND** SHALL generate a `temperate`-biome scenario
+**AND** SHALL NOT silently corrupt the run (the warning ensures regressions in legacy data surface in CI)
+
+#### Scenario: Scenario-config validator rejects 'none'
+
+**GIVEN** an external caller that POSTs a scenario config with `biome: 'none'` to the API boundary
+**WHEN** the validator runs
+**THEN** the validator SHALL reject the config with an error like `biome 'none' is no longer supported — use one of temperate, desert, mountain, urban`
+**AND** the error message SHALL reference this OpenSpec change as the migration path
+
+#### Scenario: Phase-1 swarm matrix runs without 'none' references
+
+**GIVEN** the Phase-1 swarm-config sweep
+**WHEN** the matrix re-runs after migration
+**THEN** zero configs SHALL reference `biome: 'none'`
+**AND** zero `console.warn` calls SHALL fire from the BiomeGenerator legacy-fallback path during the sweep

--- a/openspec/changes/replace-biome-none-placeholder/tasks.md
+++ b/openspec/changes/replace-biome-none-placeholder/tasks.md
@@ -1,0 +1,25 @@
+# Tasks: Replace `biome=none` Placeholder
+
+## 1. Type-union narrowing
+
+- [ ] 1.1 `src/types/simulation/Biome.ts` (or equivalent): remove `'none'` from the `Biome` union type
+- [ ] 1.2 Build + typecheck — every call site that referenced `Biome.NONE` or `'none'` SHALL surface as a compile error so the migration is mechanical
+
+## 2. Generator fallback
+
+- [ ] 2.1 `src/simulation/generator/BiomeGenerator.ts`: at the public boundary, if a caller passes `'none'` (e.g. a legacy serialized config), emit a `console.warn` with the offending caller's stack and fall back to `'temperate'`
+- [ ] 2.2 The fallback SHALL NOT silently corrupt — the warning is mandatory so a regression case in legacy data surfaces in CI logs
+
+## 3. Migration
+
+- [ ] 3.1 Grep for `biome.*none|'none'` across `scripts/swarm-configs/`, `playtest/`, `src/__tests__/` and migrate each occurrence to a deterministic real biome (or `undefined` if the caller doesn't care)
+- [ ] 3.2 Validator on the scenario-config input boundary: reject `biome: 'none'` with an error pointing to this change as the migration path
+- [ ] 3.3 Regression test: assert all Phase-1 swarm configs run without producing the legacy-warning
+
+## 4. Spec delta + archive
+
+- [ ] 4.1 Author delta at `openspec/changes/replace-biome-none-placeholder/specs/simulation-system/spec.md` REMOVING / MODIFYING the existing Biome variants requirement to drop `'none'`
+- [ ] 4.2 `openspec validate replace-biome-none-placeholder --strict` passes
+- [ ] 4.3 `npm run verify:full` passes
+- [ ] 4.4 Archive after merge
+- [ ] 4.5 Trim gap #5 from `playtest/CLOSEOUT.md`


### PR DESCRIPTION
## Summary

Authors 3 OpenSpec changes resolving the deferred known-limitation gaps from `playtest/CLOSEOUT.md`. Spec-only PR; implementation follows in 3 sequential sub-PRs per the plan.

## Changes authored

| Change | Gap | Scope |
|---|---|---|
| `add-ecm-tohit-modifier` | #1 | ECM bubbles SHOULD apply +1 to-hit for C3/Artemis/TC/NARC weapons; today they only affect AI awareness, not combat resolution |
| `fix-recovered-session-adapted-units` | #2 | `InteractiveSession.fromSession` leaves adapted-units empty → recovery breaks move/attack play |
| `replace-biome-none-placeholder` | #5 | Biome enum has a `'none'` placeholder that maps to no terrain; remove from union, fall back to `temperate` on legacy data |

## Spec deltas

- `to-hit-resolution` — ECM modifier (6 scenarios across guidance types)
- `multiplayer-server` — recovered session parity (3 scenarios)
- `simulation-system` — BiomeGenerator narrowing (4 scenarios)

## Validation

```
$ npx openspec validate add-ecm-tohit-modifier --strict
Change 'add-ecm-tohit-modifier' is valid
$ npx openspec validate fix-recovered-session-adapted-units --strict
Change 'fix-recovered-session-adapted-units' is valid
$ npx openspec validate replace-biome-none-placeholder --strict
Change 'replace-biome-none-placeholder' is valid
```

## Implementation order (per plan)

1. `replace-biome-none-placeholder` (smallest — type-union narrowing + migration)
2. `fix-recovered-session-adapted-units` (moderate — single function call insertion + regression test)
3. `add-ecm-tohit-modifier` (largest — extends combat-resolution to-hit pipeline + 16-case test matrix)

## Related

Builds on the Wave 6.2 spec batch (PR #645). Wave 6.3 ships independent of Wave 6.2 implementation — the two waves don't share code paths.