### PR TITLE
feat(wave-6.3): add-ecm-tohit-modifier — +1 to-hit for ECM-degraded guidance

### DIFF
--- a/openspec/changes/add-ecm-tohit-modifier/tasks.md
+++ b/openspec/changes/add-ecm-tohit-modifier/tasks.md
@@ -2,25 +2,25 @@
 
 ## 1. Modifier table + types
 
-- [ ] 1.1 Define `ECM_TO_HIT_MODIFIERS` constant in `src/types/combat/ToHitModifier.ts` (or new `EcmModifiers.ts` if cleaner) with the 4 guidance-type → modifier-value entries
-- [ ] 1.2 Extend `IToHitModifier` discriminated-union with an `ecm` kind carrying `{ value: number; reason: 'c3-broken' | 'artemis-degraded' | 'tc-degraded' | 'narc-degraded' }` so the modifier surfaces in the post-resolve UI breakdown
+- [x] 1.1 Define `ECM_TO_HIT_MODIFIERS` constant in `src/types/combat/ToHitModifier.ts` (or new `EcmModifiers.ts` if cleaner) with the 4 guidance-type → modifier-value entries
+- [x] 1.2 Extend `IToHitModifier` discriminated-union with an `ecm` kind carrying `{ value: number; reason: 'c3-broken' | 'artemis-degraded' | 'tc-degraded' | 'narc-degraded' }` so the modifier surfaces in the post-resolve UI breakdown
 
 ## 2. To-hit calculator integration
 
-- [ ] 2.1 `src/engine/combatResolution/toHitCalculator.ts`: inject the active `EcmCoverageMap` (resolved at scenario start) into the modifier-accumulator
-- [ ] 2.2 For each weapon attack the calculator evaluates: detect the weapon's guidance type (C3 / Artemis / TC / NARC) and apply the modifier when the shooter, target, or both are inside an ECM bubble per the per-guidance rule
-- [ ] 2.3 The modifier stacks additively with existing modifiers (range, movement, terrain, heat) — total to-hit is the sum
+- [x] 2.1 `src/engine/combatResolution/toHitCalculator.ts`: inject the active `EcmCoverageMap` (resolved at scenario start) into the modifier-accumulator
+- [/] 2.2 Partial — `calculateEcmModifier` evaluates each guidance type per the per-guidance rule. Per-weapon guidance detection (mapping weapon definitions → `WeaponGuidanceType`) is DEFERRED to the EcmCoverageMap follow-on; callers currently pass guidance explicitly via `IEcmContext`.
+- [x] 2.3 The modifier stacks additively with existing modifiers (range, movement, terrain, heat) — total to-hit is the sum
 
 ## 3. Test coverage
 
-- [ ] 3.1 Unit tests for each of the 4 guidance types across the 4 ECM-position combinations (shooter-only / target-only / both / neither) = 16 test cases
-- [ ] 3.2 Regression test: a fixed-seed combat scenario with mixed C3 + ECM produces the same total to-hit numbers as MegaMek's reference calculation (capture the MegaMek baseline as a golden-file)
-- [ ] 3.3 Balance-sanity test: aggregate BV change across the unit catalog under the new modifier is < 1% (ECM is positional, not per-unit, so no balance-driven re-rating expected)
+- [x] 3.1 Unit tests for each of the 4 guidance types across the 4 ECM-position combinations (shooter-only / target-only / both / neither) = 16 test cases
+- [/] 3.2 DEFERRED to EcmCoverageMap follow-on — MegaMek golden-file regression test requires the full per-weapon guidance detection + ECM coverage map pipeline, which lands in the follow-up change. The 30-test `ecmModifier.test.ts` covers the modifier formula side; the scenario-level integration test lives in the follow-up.
+- [x] 3.3 N/A — ECM is a positional to-hit modifier, NOT a per-unit BV input. The unit catalog's BV values do not change under this modifier; no balance-sanity test is needed because there is no per-unit BV input affected.
 
 ## 4. Spec delta + archive
 
-- [ ] 4.1 Author delta at `openspec/changes/add-ecm-tohit-modifier/specs/combat-resolution/spec.md` (or whichever capability owns the to-hit pipeline) ADDING an "ECM To-Hit Modifier" requirement with scenarios for each guidance type
-- [ ] 4.2 `openspec validate add-ecm-tohit-modifier --strict` passes
-- [ ] 4.3 `npm run verify:full` passes
+- [x] 4.1 Author delta at `openspec/changes/add-ecm-tohit-modifier/specs/combat-resolution/spec.md` (or whichever capability owns the to-hit pipeline) ADDING an "ECM To-Hit Modifier" requirement with scenarios for each guidance type
+- [x] 4.2 `openspec validate add-ecm-tohit-modifier --strict` passes
+- [x] 4.3 `npm run verify:full` passes
 - [ ] 4.4 Archive the change to `openspec/changes/archive/YYYY-MM-DD-add-ecm-tohit-modifier/` after merge
 - [ ] 4.5 Trim gap #1 from `playtest/CLOSEOUT.md`

--- a/src/utils/gameplay/toHit/__tests__/ecmModifier.test.ts
+++ b/src/utils/gameplay/toHit/__tests__/ecmModifier.test.ts
@@ -1,0 +1,328 @@
+/**
+ * ECM to-hit modifier tests — `add-ecm-tohit-modifier` (closes playtest gap #1).
+ *
+ * Covers:
+ *   - 16 combinations of 4 guidance types × 4 ECM coverage combos
+ *   - The "non-electronic weapon" no-op
+ *   - The modifier shape (value, reason, source)
+ *   - Wire-through via `calculateToHit(..., ecmContext)`
+ *
+ * Per the spec scenarios at
+ * `openspec/changes/add-ecm-tohit-modifier/specs/to-hit-resolution/spec.md`.
+ */
+
+import type {
+  IAttackerState,
+  ITargetState,
+} from '@/types/gameplay/CombatInterfaces';
+
+import { MovementType, RangeBracket } from '@/types/gameplay';
+
+import { calculateToHit } from '../calculate';
+import {
+  ECM_MODIFIER_VALUE,
+  ECM_TO_HIT_MODIFIERS,
+  calculateEcmModifier,
+  type IEcmCoverageState,
+  type WeaponGuidanceType,
+} from '../ecmModifier';
+
+// =============================================================================
+// Coverage fixtures
+// =============================================================================
+
+const NONE: IEcmCoverageState = {
+  attackerInBubble: false,
+  targetInBubble: false,
+};
+const SHOOTER_ONLY: IEcmCoverageState = {
+  attackerInBubble: true,
+  targetInBubble: false,
+};
+const TARGET_ONLY: IEcmCoverageState = {
+  attackerInBubble: false,
+  targetInBubble: true,
+};
+const BOTH: IEcmCoverageState = {
+  attackerInBubble: true,
+  targetInBubble: true,
+};
+
+const COVERAGE_CASES: ReadonlyArray<{
+  readonly label: string;
+  readonly state: IEcmCoverageState;
+}> = [
+  { label: 'neither in bubble', state: NONE },
+  { label: 'shooter only', state: SHOOTER_ONLY },
+  { label: 'target only', state: TARGET_ONLY },
+  { label: 'both', state: BOTH },
+];
+
+/**
+ * Expected firing matrix per the spec rules:
+ *   - C3 + TC key on the SHOOTER (attackerInBubble)
+ *   - Artemis + NARC key on the TARGET  (targetInBubble)
+ *
+ * Each cell is true iff the modifier SHALL fire for that combo.
+ */
+const EXPECTED_FIRES: Record<
+  Exclude<WeaponGuidanceType, 'none'>,
+  Record<string, boolean>
+> = {
+  c3: {
+    'neither in bubble': false,
+    'shooter only': true,
+    'target only': false,
+    both: true,
+  },
+  tc: {
+    'neither in bubble': false,
+    'shooter only': true,
+    'target only': false,
+    both: true,
+  },
+  artemis: {
+    'neither in bubble': false,
+    'shooter only': false,
+    'target only': true,
+    both: true,
+  },
+  narc: {
+    'neither in bubble': false,
+    'shooter only': false,
+    'target only': true,
+    both: true,
+  },
+};
+
+// =============================================================================
+// calculateEcmModifier — direct tests
+// =============================================================================
+
+describe('calculateEcmModifier — 4 guidance × 4 coverage combos (16 cases)', () => {
+  for (const guidance of ['c3', 'artemis', 'tc', 'narc'] as const) {
+    describe(`guidance: ${guidance}`, () => {
+      for (const { label, state } of COVERAGE_CASES) {
+        const expectedFires = EXPECTED_FIRES[guidance][label];
+        const expectFireText = expectedFires
+          ? 'fires +1 modifier'
+          : 'returns null';
+
+        it(`${label} → ${expectFireText}`, () => {
+          const mod = calculateEcmModifier(guidance, state);
+
+          if (!expectedFires) {
+            expect(mod).toBeNull();
+            return;
+          }
+
+          expect(mod).not.toBeNull();
+          expect(mod!.value).toBe(ECM_MODIFIER_VALUE);
+          expect(mod!.value).toBe(1);
+          expect(mod!.source).toBe('equipment');
+
+          // The reason label is the one the post-resolve UI reads to label
+          // the badge — distinguishable per guidance type.
+          const expectedReason = ECM_TO_HIT_MODIFIERS[guidance].reason;
+          expect(mod!.name).toContain(expectedReason);
+        });
+      }
+    });
+  }
+});
+
+describe("calculateEcmModifier — 'none' guidance is unaffected", () => {
+  // Per the spec scenario "Non-electronic weapon fires unaffected by ECM":
+  // a weapon with no guidance returns null for every coverage combo so the
+  // to-hit accumulator stays unchanged.
+  for (const { label, state } of COVERAGE_CASES) {
+    it(`'none' guidance with ${label} returns null`, () => {
+      expect(calculateEcmModifier('none', state)).toBeNull();
+    });
+  }
+});
+
+// =============================================================================
+// calculateEcmModifier — reason / source / shape
+// =============================================================================
+
+describe('calculateEcmModifier — modifier shape', () => {
+  it("the C3-fires path carries 'c3-broken' reason and equipment source", () => {
+    const mod = calculateEcmModifier('c3', SHOOTER_ONLY);
+    expect(mod).not.toBeNull();
+    expect(mod!.source).toBe('equipment');
+    expect(mod!.name).toContain('c3-broken');
+    expect(mod!.description).toContain('C3 link');
+  });
+
+  it("the Artemis-fires path carries 'artemis-degraded' reason", () => {
+    const mod = calculateEcmModifier('artemis', TARGET_ONLY);
+    expect(mod).not.toBeNull();
+    expect(mod!.name).toContain('artemis-degraded');
+    expect(mod!.description).toContain('Artemis');
+  });
+
+  it("the TC-fires path carries 'tc-degraded' reason", () => {
+    const mod = calculateEcmModifier('tc', SHOOTER_ONLY);
+    expect(mod).not.toBeNull();
+    expect(mod!.name).toContain('tc-degraded');
+    expect(mod!.description).toContain('Targeting computer');
+  });
+
+  it("the NARC-fires path carries 'narc-degraded' reason", () => {
+    const mod = calculateEcmModifier('narc', TARGET_ONLY);
+    expect(mod).not.toBeNull();
+    expect(mod!.name).toContain('narc-degraded');
+    expect(mod!.description).toContain('NARC');
+  });
+});
+
+// =============================================================================
+// calculateToHit — wire-through test
+// =============================================================================
+//
+// The ECM modifier stacks additively with existing modifiers. Verify by
+// comparing the same scenario with and without an ecmContext: the ECM
+// case is exactly `+1` higher than the non-ECM case.
+
+function makeAttacker(): IAttackerState {
+  return {
+    gunnery: 4,
+    movementType: MovementType.Stationary,
+    heat: 0,
+    damageModifiers: [],
+  };
+}
+
+function makeTarget(): ITargetState {
+  return {
+    movementType: MovementType.Stationary,
+    hexesMoved: 0,
+    prone: false,
+    immobile: false,
+    partialCover: false,
+  };
+}
+
+describe('calculateToHit — ECM context wire-through', () => {
+  it('without ecmContext the result is identical to the legacy signature', () => {
+    const baseline = calculateToHit(
+      makeAttacker(),
+      makeTarget(),
+      RangeBracket.Short,
+      3,
+    );
+    const withUndefined = calculateToHit(
+      makeAttacker(),
+      makeTarget(),
+      RangeBracket.Short,
+      3,
+      0,
+      undefined,
+    );
+    expect(withUndefined.finalToHit).toBe(baseline.finalToHit);
+    expect(withUndefined.modifiers).toHaveLength(baseline.modifiers.length);
+  });
+
+  it("ecmContext with guidance: 'none' adds no modifier (legacy compat)", () => {
+    const baseline = calculateToHit(
+      makeAttacker(),
+      makeTarget(),
+      RangeBracket.Short,
+      3,
+    );
+    const withNoneEcm = calculateToHit(
+      makeAttacker(),
+      makeTarget(),
+      RangeBracket.Short,
+      3,
+      0,
+      { guidance: 'none', coverage: BOTH },
+    );
+    expect(withNoneEcm.finalToHit).toBe(baseline.finalToHit);
+  });
+
+  it('C3 + shooter in bubble adds exactly +1 to the total', () => {
+    const baseline = calculateToHit(
+      makeAttacker(),
+      makeTarget(),
+      RangeBracket.Short,
+      3,
+    );
+    const withEcm = calculateToHit(
+      makeAttacker(),
+      makeTarget(),
+      RangeBracket.Short,
+      3,
+      0,
+      { guidance: 'c3', coverage: SHOOTER_ONLY },
+    );
+    expect(withEcm.finalToHit - baseline.finalToHit).toBe(1);
+
+    // The ECM modifier appears in the breakdown so the post-resolve UI
+    // can render the "why" line.
+    expect(withEcm.modifiers.some((m) => m.name.includes('c3-broken'))).toBe(
+      true,
+    );
+  });
+
+  it('Artemis + target in bubble adds exactly +1 to the total', () => {
+    const baseline = calculateToHit(
+      makeAttacker(),
+      makeTarget(),
+      RangeBracket.Short,
+      3,
+    );
+    const withEcm = calculateToHit(
+      makeAttacker(),
+      makeTarget(),
+      RangeBracket.Short,
+      3,
+      0,
+      { guidance: 'artemis', coverage: TARGET_ONLY },
+    );
+    expect(withEcm.finalToHit - baseline.finalToHit).toBe(1);
+    expect(
+      withEcm.modifiers.some((m) => m.name.includes('artemis-degraded')),
+    ).toBe(true);
+  });
+
+  it('C3 + target-only (no shooter) does NOT fire the modifier', () => {
+    const baseline = calculateToHit(
+      makeAttacker(),
+      makeTarget(),
+      RangeBracket.Short,
+      3,
+    );
+    const withEcm = calculateToHit(
+      makeAttacker(),
+      makeTarget(),
+      RangeBracket.Short,
+      3,
+      0,
+      { guidance: 'c3', coverage: TARGET_ONLY },
+    );
+    expect(withEcm.finalToHit).toBe(baseline.finalToHit);
+  });
+
+  it('ECM stacks additively with the heat modifier', () => {
+    // Set heat high enough to trigger the +1 heat modifier (heat >= 8).
+    const hotAttacker: IAttackerState = { ...makeAttacker(), heat: 9 };
+    const baseline = calculateToHit(
+      hotAttacker,
+      makeTarget(),
+      RangeBracket.Short,
+      3,
+    );
+    const withEcm = calculateToHit(
+      hotAttacker,
+      makeTarget(),
+      RangeBracket.Short,
+      3,
+      0,
+      { guidance: 'tc', coverage: SHOOTER_ONLY },
+    );
+    // Heat already contributed to baseline; ECM adds exactly +1 on top.
+    expect(withEcm.finalToHit - baseline.finalToHit).toBe(1);
+  });
+});

--- a/src/utils/gameplay/toHit/calculate.ts
+++ b/src/utils/gameplay/toHit/calculate.ts
@@ -27,6 +27,11 @@ import {
   calculateCalledShotModifier,
 } from './damageModifiers';
 import {
+  type IEcmCoverageState,
+  type WeaponGuidanceType,
+  calculateEcmModifier,
+} from './ecmModifier';
+import {
   calculateHeatModifier,
   calculatePartialCoverModifier,
   calculateHullDownModifier,
@@ -43,17 +48,44 @@ import {
 } from './rangeModifiers';
 import { calculateChinTurretPivotModifier } from './vehicleModifiers';
 
+/**
+ * Per `add-ecm-tohit-modifier` (closes playtest gap #1): optional ECM
+ * context that, when present, adds a `+1 to-hit` modifier when the
+ * weapon's electronic guidance is degraded by an active ECM bubble. The
+ * field is OPTIONAL so existing callers (no ECM in the scenario, or
+ * weapon has no electronic guidance) are unaffected.
+ */
+export interface IEcmContext {
+  /** The weapon's guidance type (`'none'` returns no modifier). */
+  readonly guidance: WeaponGuidanceType;
+  /** Resolved per-attack ECM coverage flags. */
+  readonly coverage: IEcmCoverageState;
+}
+
 export function calculateToHit(
   attacker: IAttackerState,
   target: ITargetState,
   rangeBracket: RangeBracket,
   range: number,
   minRange: number = 0,
+  ecmContext?: IEcmContext,
 ): IToHitCalculation {
   const modifiers: IToHitModifierDetail[] = [];
 
   modifiers.push(createBaseModifier(attacker.gunnery));
   modifiers.push(getRangeModifierForBracket(rangeBracket));
+
+  // Per `add-ecm-tohit-modifier`: ECM modifier is appended to the
+  // accumulator and stacks additively with every other modifier. The
+  // helper returns null when the guidance is 'none' or the per-guidance
+  // rule does not fire, so no-ECM scenarios are unchanged.
+  if (ecmContext !== undefined) {
+    const ecmMod = calculateEcmModifier(
+      ecmContext.guidance,
+      ecmContext.coverage,
+    );
+    if (ecmMod !== null) modifiers.push(ecmMod);
+  }
 
   const minRangeMod = calculateMinimumRangeModifier(range, minRange);
   if (minRangeMod) modifiers.push(minRangeMod);

--- a/src/utils/gameplay/toHit/ecmModifier.ts
+++ b/src/utils/gameplay/toHit/ecmModifier.ts
@@ -1,0 +1,142 @@
+/**
+ * ECM (Electronic Counter-Measures) to-hit modifier.
+ *
+ * Per `add-ecm-tohit-modifier` (closes playtest gap #1): a weapon attack
+ * whose guidance system is degraded by an active ECM bubble incurs a
+ * `+1 to-hit` penalty. The modifier is positional — each guidance type
+ * has its own rule for whether the shooter, target, or both must be
+ * inside the bubble.
+ *
+ * The four guidance types covered:
+ *
+ *   - `'c3'`      — C3 link broken when the SHOOTER is in an ECM bubble.
+ *                   The target's coverage is irrelevant: the link breaks
+ *                   at the source.
+ *   - `'artemis'` — Artemis-IV lock degraded when the TARGET is in an
+ *                   ECM bubble. The lock is on the target, so the bubble
+ *                   at the target is what matters.
+ *   - `'tc'`      — Targeting computer degraded when the SHOOTER is in
+ *                   an ECM bubble. TC processing happens on the shooter.
+ *   - `'narc'`    — NARC homing degraded when the TARGET (carrying the
+ *                   NARC beacon) is in an ECM bubble.
+ *   - `'none'`    — A weapon with no electronic guidance is unaffected.
+ *
+ * The modifier is added to the modifier accumulator and stacks
+ * additively with range / movement / terrain / heat / other modifiers
+ * (per the spec scenario "Modifier stacks additively").
+ *
+ * The full `EcmCoverageMap` (per-hex scenario-time resolution of where
+ * ECM bubbles cover the map) is OUT of scope for this change — callers
+ * provide the resolved per-attack flags as `IEcmCoverageState`. A
+ * follow-up change wires the map-level resolution.
+ *
+ * @spec openspec/changes/add-ecm-tohit-modifier/specs/to-hit-resolution/spec.md
+ */
+
+import type { IToHitModifierDetail } from '@/types/gameplay';
+
+/**
+ * The four guidance types affected by ECM, plus `'none'` for weapons
+ * with no electronic guidance system. The to-hit pipeline reads this
+ * tag off the weapon definition (or off the attacker state if the
+ * caller resolved it eagerly).
+ */
+export type WeaponGuidanceType = 'c3' | 'artemis' | 'tc' | 'narc' | 'none';
+
+/**
+ * Resolved per-attack ECM coverage state. The caller (combat resolver
+ * or scenario engine) computes these flags by intersecting each ECM
+ * bubble's hex coverage with the shooter's and target's positions.
+ *
+ * The full scenario-time EcmCoverageMap lives in a follow-up — this
+ * shape is stable and the map producer will populate it.
+ */
+export interface IEcmCoverageState {
+  /** Whether the shooter's hex is inside any active ECM bubble. */
+  readonly attackerInBubble: boolean;
+  /** Whether the target's hex is inside any active ECM bubble. */
+  readonly targetInBubble: boolean;
+}
+
+/**
+ * The four `reason` codes the modifier carries. The post-resolve UI
+ * reads `reason` to label the badge so the operator can see why the
+ * to-hit was elevated.
+ */
+export type EcmModifierReason =
+  | 'c3-broken'
+  | 'artemis-degraded'
+  | 'tc-degraded'
+  | 'narc-degraded';
+
+/** The `+1` value the spec mandates. Exported for test parity. */
+export const ECM_MODIFIER_VALUE = 1;
+
+/**
+ * Per-guidance ECM modifier rule. Each entry encodes which of the two
+ * ECM flags must be set for the modifier to fire, and the `reason` the
+ * resulting modifier carries.
+ *
+ * Exported so tests can iterate the table directly rather than coding
+ * the rule in two places.
+ */
+export const ECM_TO_HIT_MODIFIERS: Readonly<
+  Record<
+    Exclude<WeaponGuidanceType, 'none'>,
+    {
+      readonly fires: (ecm: IEcmCoverageState) => boolean;
+      readonly reason: EcmModifierReason;
+      readonly description: string;
+    }
+  >
+> = {
+  c3: {
+    fires: (ecm) => ecm.attackerInBubble,
+    reason: 'c3-broken',
+    description: 'C3 link broken by ECM bubble at shooter',
+  },
+  artemis: {
+    fires: (ecm) => ecm.targetInBubble,
+    reason: 'artemis-degraded',
+    description: 'Artemis-IV lock degraded by ECM bubble at target',
+  },
+  tc: {
+    fires: (ecm) => ecm.attackerInBubble,
+    reason: 'tc-degraded',
+    description: 'Targeting computer degraded by ECM bubble at shooter',
+  },
+  narc: {
+    fires: (ecm) => ecm.targetInBubble,
+    reason: 'narc-degraded',
+    description: 'NARC homing degraded by ECM bubble at target',
+  },
+};
+
+/**
+ * Compute the ECM to-hit modifier for a single weapon attack.
+ *
+ *   - Returns `null` when the guidance is `'none'` or when the per-guidance
+ *     ECM rule does NOT fire (no modifier added — the caller leaves the
+ *     accumulator unchanged).
+ *   - Returns an `IToHitModifierDetail` with `value: +1`, `source: 'equipment'`,
+ *     and a `reason`-tagged name when the rule fires.
+ *
+ * The returned modifier slots into the existing aggregator unchanged —
+ * it stacks additively with range / movement / terrain / heat / etc.
+ */
+export function calculateEcmModifier(
+  guidance: WeaponGuidanceType,
+  ecm: IEcmCoverageState,
+): IToHitModifierDetail | null {
+  if (guidance === 'none') return null;
+
+  const rule = ECM_TO_HIT_MODIFIERS[guidance];
+  if (!rule.fires(ecm)) return null;
+
+  return {
+    name: `ECM (${rule.reason})`,
+    value: ECM_MODIFIER_VALUE,
+    source: 'equipment',
+    description: rule.description,
+  };
+}

--- a/src/utils/gameplay/toHit/index.ts
+++ b/src/utils/gameplay/toHit/index.ts
@@ -39,9 +39,23 @@ export {
   calculateIndirectFireModifier,
   calculateCalledShotModifier,
 } from './damageModifiers';
-export { calculateToHit, calculateToHitFromContext } from './calculate';
+export {
+  calculateToHit,
+  calculateToHitFromContext,
+  type IEcmContext,
+} from './calculate';
 export { calculateToHitWithC3 } from './c3';
 export type { IC3ToHitInput } from './c3';
+
+// Per `add-ecm-tohit-modifier` (closes playtest gap #1).
+export {
+  calculateEcmModifier,
+  ECM_TO_HIT_MODIFIERS,
+  ECM_MODIFIER_VALUE,
+  type EcmModifierReason,
+  type IEcmCoverageState,
+  type WeaponGuidanceType,
+} from './ecmModifier';
 
 export {
   buildToHitForecast,


### PR DESCRIPTION
Implements `openspec/changes/add-ecm-tohit-modifier` modifier formula + to-hit wire-through. Closes playtest gap #1 (first half — the map-level EcmCoverageMap is deferred to a follow-up).

## What's in this PR

| Surface | Detail |
|---------|--------|
| `ecmModifier.ts` (new) | `WeaponGuidanceType` union, `IEcmCoverageState`, `ECM_TO_HIT_MODIFIERS` table, `calculateEcmModifier(guidance, coverage)` |
| `calculate.ts` | `calculateToHit(…, ecmContext?: IEcmContext)` — optional 6th param, additive stacking, no-op when omitted |
| `toHit/index.ts` | Re-exports |
| `ecmModifier.test.ts` (new) | 30 tests: 16-case firing matrix + 4 'none' no-ops + 4 modifier shape + 6 wire-through |

## Per-guidance firing rules

| Guidance | Fires when | Reason code |
|----------|------------|-------------|
| C3       | shooter in bubble | `c3-broken` |
| TC       | shooter in bubble | `tc-degraded` |
| Artemis  | target in bubble  | `artemis-degraded` |
| NARC     | target in bubble  | `narc-degraded` |
| none     | never             | — |

Modifier value: `+1`. Stacks additively (verified by the heat-stacking test).

## Tests

- 30 new ECM-specific tests
- 64 total toHit tests green, full toHit suite stable
- `npx tsc --noEmit` clean, `oxlint` clean, `oxfmt --check` clean

## Spec coverage

All 6 spec scenarios pass via the test suite:
- C3-linked, shooter in bubble → +1 c3-broken ✓
- Artemis at target in bubble → +1 artemis-degraded ✓
- TC, shooter in bubble → +1 tc-degraded ✓
- NARC at target in bubble → +1 narc-degraded ✓
- Non-electronic unchanged ✓
- Modifier appears in post-resolve breakdown ✓

## Deferred (named in tasks.md)

- Per-weapon guidance detection (mapping weapon defs → `WeaponGuidanceType`)
- MegaMek golden-file integration regression
- BV balance test is **N/A** — ECM is positional, not per-unit, so no per-unit BV input changes

## Plan position

Second of three Wave-6.3 sub-PRs. After #648 (biome-none) and this, next is \`fix-recovered-session-adapted-units\`.