### PR TITLE
feat(wave-6.3): fix-recovered-session-adapted-units — re-derive on recovery

### DIFF
--- a/openspec/changes/fix-recovered-session-adapted-units/tasks.md
+++ b/openspec/changes/fix-recovered-session-adapted-units/tasks.md
@@ -2,13 +2,13 @@
 
 ## 1. Recovery-path fix
 
-- [ ] 1.1 `src/multiplayer/server/InteractiveSession.ts`: locate the `fromSession` factory method
-- [ ] 1.2 Add a call to the existing `adaptedUnitRebuilder` (or equivalent — the function the bootstrap path uses to derive per-unit adapted state from canonical campaign state) so the recovered session's `adaptedUnits` is populated, not empty
-- [ ] 1.3 Update the doc-comment on `fromSession` explaining the derivation step
+- [x] 1.1 `src/multiplayer/server/InteractiveSession.ts`: locate the `fromSession` factory method
+- [x] 1.2 Add a call to the existing `adaptedUnitRebuilder` (or equivalent — the function the bootstrap path uses to derive per-unit adapted state from canonical campaign state) so the recovered session's `adaptedUnits` is populated, not empty
+- [x] 1.3 Update the doc-comment on `fromSession` explaining the derivation step
 
 ## 2. Regression coverage
 
-- [ ] 2.1 New regression test at `src/multiplayer/server/__tests__/InteractiveSession.recovery.test.ts`:
+- [x] 2.1 New regression test at `src/multiplayer/server/__tests__/InteractiveSession.recovery.test.ts`:
   - Bootstrap a session, advance to mid-combat (turn 3, some moves committed)
   - Persist via the existing persistence path
   - Reconstruct via `fromSession`
@@ -17,8 +17,8 @@
 
 ## 3. Spec delta + archive
 
-- [ ] 3.1 Author delta at `openspec/changes/fix-recovered-session-adapted-units/specs/multiplayer-session-recovery/spec.md` (or relevant existing capability) ADDING a "Recovered Session Has Populated Adapted Units" requirement with scenarios for bootstrap-vs-recovery parity + the move/attack regression
-- [ ] 3.2 `openspec validate fix-recovered-session-adapted-units --strict` passes
-- [ ] 3.3 `npm run verify:full` passes
+- [x] 3.1 Author delta at `openspec/changes/fix-recovered-session-adapted-units/specs/multiplayer-session-recovery/spec.md` (or relevant existing capability) ADDING a "Recovered Session Has Populated Adapted Units" requirement with scenarios for bootstrap-vs-recovery parity + the move/attack regression
+- [x] 3.2 `openspec validate fix-recovered-session-adapted-units --strict` passes
+- [x] 3.3 `npm run verify:full` passes
 - [ ] 3.4 Archive the change after merge
 - [ ] 3.5 Trim gap #2 from `playtest/CLOSEOUT.md`

--- a/src/engine/InteractiveSession.ts
+++ b/src/engine/InteractiveSession.ts
@@ -50,6 +50,7 @@ import { declarePlayerWithdrawal } from '@/utils/gameplay/morale';
 import type { IInteractiveSessionLinkage } from './InteractiveSession.types';
 import type { IAdaptedUnit, IAvailableActions } from './types';
 
+import { adaptUnit } from './adapters/CompendiumAdapter';
 import { createMinimalGrid } from './GameEngine.helpers';
 import {
   applyInteractiveSessionAttack,
@@ -195,6 +196,51 @@ export class InteractiveSession {
       createMinimalGrid(session.config.mapRadius),
       [],
       [],
+      session.units,
+    );
+    // Replace the fresh Setup-phase session with the replayed one so
+    // `currentState` (status / turn / phase / board) matches history.
+    instance.session = session;
+    return instance;
+  }
+
+  /**
+   * Per `fix-recovered-session-adapted-units` (closes playtest gap #2):
+   * async recovery factory that RE-DERIVES the per-unit adapted state
+   * from each game unit's `unitRef` against the canonical unit catalog,
+   * matching the bootstrap path's `weaponsByUnit` / `movementByUnit` /
+   * gunnery / piloting / tonnage maps.
+   *
+   * The plain `fromSession` adoption skipped this step, so a session
+   * recovered after a server restart had EMPTY adapted-units maps —
+   * which broke move/attack play (the engine's `getAvailableActions`
+   * returned empty lists, and any action throw'd because the per-unit
+   * weapon / movement capability lookup hit `undefined`).
+   *
+   * Callers that need the recovered session to accept new intents
+   * (move, attack) MUST use `fromSessionAsync`. The sync `fromSession`
+   * remains for callers that only need the data-shape adoption
+   * (terminal-outcome derivation, replay streaming) — those paths
+   * don't need adapted-units maps.
+   *
+   * Throws nothing — units whose `unitRef` is not in the catalog are
+   * skipped with a console.warn (the recovered host still has the
+   * other units' adapted state, which is better than a hard failure).
+   */
+  static async fromSessionAsync(
+    session: IGameSession,
+  ): Promise<InteractiveSession> {
+    const adapted = await deriveAdaptedUnitsFromSession(session);
+    const playerAdapted = adapted.filter((u) => u.side === GameSide.Player);
+    const opponentAdapted = adapted.filter((u) => u.side === GameSide.Opponent);
+
+    const instance = new InteractiveSession(
+      session.config.mapRadius,
+      session.config.turnLimit,
+      new SeededRandom(0xc0ffee),
+      createMinimalGrid(session.config.mapRadius),
+      playerAdapted,
+      opponentAdapted,
       session.units,
     );
     // Replace the fresh Setup-phase session with the replayed one so
@@ -501,4 +547,41 @@ export class InteractiveSession {
     };
     return deriveCombatOutcome(this.session, merged);
   }
+}
+
+/**
+ * Per `fix-recovered-session-adapted-units` (closes playtest gap #2):
+ * re-derive adapted units from each game unit's `unitRef` against the
+ * canonical unit catalog. The bootstrap path's
+ * `preBattleSessionBuilder.adaptParticipants` runs the same `adaptUnit`
+ * call per participant; this helper is the recovery-path mirror. Both
+ * paths converge on the same `IAdaptedUnit` shape so a recovered
+ * session is byte-equivalent to a freshly-bootstrapped one with the
+ * same units (bootstrap parity, per spec scenario "Recovered session
+ * adapted-units match bootstrap parity").
+ *
+ * Exported for the recovery test only — production code should use
+ * `InteractiveSession.fromSessionAsync`.
+ */
+export async function deriveAdaptedUnitsFromSession(
+  session: IGameSession,
+): Promise<IAdaptedUnit[]> {
+  const adapted: IAdaptedUnit[] = [];
+  for (const gameUnit of session.units) {
+    const adaptedUnit = await adaptUnit(gameUnit.unitRef, {
+      side: gameUnit.side,
+    });
+    if (adaptedUnit === null) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[InteractiveSession.fromSessionAsync] unit '${gameUnit.id}' ` +
+          `(unitRef '${gameUnit.unitRef}') not found in the canonical ` +
+          `catalog — skipping. The recovered host will not have adapted ` +
+          `state for this unit and any action targeting it will fail.`,
+      );
+      continue;
+    }
+    adapted.push(adaptedUnit);
+  }
+  return adapted;
 }

--- a/src/engine/__tests__/InteractiveSession.recovery.test.ts
+++ b/src/engine/__tests__/InteractiveSession.recovery.test.ts
@@ -1,0 +1,369 @@
+/**
+ * InteractiveSession recovery-path tests — `fix-recovered-session-adapted-units`
+ * (closes playtest gap #2).
+ *
+ * Asserts the recovery path's `fromSessionAsync` rebuilds the per-unit
+ * adapted-state maps the engine needs to drive move + attack actions.
+ * Pre-fix, `fromSession` left adapted-units empty and any move/attack
+ * on a recovered session threw because the per-unit weapon / movement
+ * capability lookup hit `undefined`.
+ *
+ * The bootstrap path's `weaponsByUnit` / `movementByUnit` / pilot-skill
+ * maps are the parity reference — the recovery path must populate the
+ * same shape so a session recovered after a server restart is
+ * indistinguishable from a freshly-bootstrapped one with the same
+ * units (spec scenario "Recovered session adapted-units match
+ * bootstrap parity").
+ */
+
+import type { IWeapon } from '@/simulation/ai/types';
+
+import type { IAdaptedUnit } from '../types';
+
+// Mock the CompendiumAdapter so the test is deterministic and doesn't
+// depend on the on-disk catalog. The recovery path consumes `adaptUnit`
+// the same way the bootstrap path does, so mocking here proves the
+// recovery integration end-to-end (the adapter's own behavior is
+// covered by CompendiumAdapter.test.ts).
+jest.mock('../adapters/CompendiumAdapter', () => {
+  const mockAdaptUnit = jest.fn();
+  return {
+    adaptUnit: mockAdaptUnit,
+    __mockAdaptUnit: mockAdaptUnit,
+  };
+});
+
+import {
+  GameSide,
+  LockState,
+  type IGameSession,
+  type IGameUnit,
+} from '@/types/gameplay/GameSessionInterfaces';
+import { Facing, MovementType } from '@/types/gameplay/HexGridInterfaces';
+import { createGameSession, startGame } from '@/utils/gameplay/gameSession';
+
+import { InteractiveSession } from '../InteractiveSession';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const adapterModule = require('../adapters/CompendiumAdapter') as {
+  __mockAdaptUnit: jest.Mock;
+};
+const mockAdaptUnit = adapterModule.__mockAdaptUnit;
+
+function makeWeapon(id: string): IWeapon {
+  return {
+    id,
+    name: 'Medium Laser',
+    shortRange: 3,
+    mediumRange: 6,
+    longRange: 9,
+    damage: 5,
+    heat: 3,
+    minRange: 0,
+    ammoPerTon: -1,
+    destroyed: false,
+  };
+}
+
+function makeAdaptedUnit(id: string, side: GameSide): IAdaptedUnit {
+  return {
+    id,
+    side,
+    position: side === GameSide.Player ? { q: 0, r: -2 } : { q: 0, r: 2 },
+    facing: side === GameSide.Player ? Facing.North : Facing.South,
+    heat: 0,
+    movementThisTurn: MovementType.Stationary,
+    hexesMovedThisTurn: 0,
+    armor: {
+      head: 9,
+      center_torso: 31,
+      left_torso: 22,
+      right_torso: 22,
+      left_arm: 17,
+      right_arm: 17,
+      left_leg: 21,
+      right_leg: 21,
+    },
+    structure: {
+      head: 3,
+      center_torso: 21,
+      left_torso: 14,
+      right_torso: 14,
+      left_arm: 11,
+      right_arm: 11,
+      left_leg: 14,
+      right_leg: 14,
+    },
+    startingInternalStructure: {
+      head: 3,
+      center_torso: 21,
+      left_torso: 14,
+      right_torso: 14,
+      left_arm: 11,
+      right_arm: 11,
+      left_leg: 14,
+      right_leg: 14,
+    },
+    destroyedLocations: [],
+    destroyedEquipment: [],
+    ammo: {},
+    pilotWounds: 0,
+    pilotConscious: true,
+    destroyed: false,
+    lockState: LockState.Pending,
+    weapons: [makeWeapon(`${id}-medium-laser`)],
+    walkMP: 4,
+    runMP: 6,
+    jumpMP: 0,
+  };
+}
+
+// Per `preBattleSessionBuilder.buildGameUnits`: the bootstrap path
+// sets IGameUnit.id to the adapted unit's id (the catalog ID).
+// `unitRef` carries the same catalog ID. The recovery path's lookups
+// (movementByUnit) key by adapted-unit-id, which equals game-unit-id
+// in the bootstrap path. Mirror the convention in the fixture.
+function makeFourUnits(): readonly IGameUnit[] {
+  return [
+    {
+      id: 'atlas-as7-d',
+      name: 'Atlas',
+      side: GameSide.Player,
+      unitRef: 'atlas-as7-d',
+      pilotRef: 'pilot-p1',
+      gunnery: 4,
+      piloting: 5,
+    },
+    {
+      id: 'marauder-mad-3r',
+      name: 'Marauder',
+      side: GameSide.Player,
+      unitRef: 'marauder-mad-3r',
+      pilotRef: 'pilot-p2',
+      gunnery: 4,
+      piloting: 5,
+    },
+    {
+      id: 'warhammer-whm-6r',
+      name: 'Warhammer',
+      side: GameSide.Opponent,
+      unitRef: 'warhammer-whm-6r',
+      pilotRef: 'pilot-o1',
+      gunnery: 4,
+      piloting: 5,
+    },
+    {
+      id: 'rifleman-rfl-3n',
+      name: 'Rifleman',
+      side: GameSide.Opponent,
+      unitRef: 'rifleman-rfl-3n',
+      pilotRef: 'pilot-o2',
+      gunnery: 4,
+      piloting: 5,
+    },
+  ];
+}
+
+function makeSessionWith(units: readonly IGameUnit[]): IGameSession {
+  const session = createGameSession(
+    {
+      mapRadius: 7,
+      turnLimit: 30,
+      victoryConditions: ['elimination'],
+      optionalRules: [],
+    },
+    units,
+  );
+  return startGame(session, GameSide.Player);
+}
+
+describe('InteractiveSession.fromSessionAsync — gap #2 recovery parity', () => {
+  beforeEach(() => {
+    mockAdaptUnit.mockReset();
+  });
+
+  it('rebuilds per-unit adapted state for every game unit (bootstrap parity)', async () => {
+    // Stub adaptUnit to return a fresh adapted unit per call so the
+    // recovery path's derive loop has a deterministic catalog.
+    mockAdaptUnit.mockImplementation(
+      async (
+        _unitRef: string,
+        options: { side: GameSide } = { side: GameSide.Player },
+      ) => {
+        return makeAdaptedUnit(_unitRef, options.side);
+      },
+    );
+
+    const units = makeFourUnits();
+    const session = makeSessionWith(units);
+
+    const recovered = await InteractiveSession.fromSessionAsync(session);
+
+    // The recovery path called adaptUnit once per game unit.
+    expect(mockAdaptUnit).toHaveBeenCalledTimes(4);
+
+    // Each unit's adapted state is now reachable from the engine.
+    // getMovementCapability and getAvailableActions returning non-null
+    // is the proof that weaponsByUnit / movementByUnit were populated.
+    for (const u of units) {
+      const cap = recovered.getMovementCapability(u.id);
+      // The bootstrap path's buildInteractiveSessionUnitMaps keys the
+      // movementByUnit map by IGameUnit.id (not the adapted unit's id),
+      // so the lookup uses the game-unit id. A populated map returns
+      // walk/run/jump MP > 0; an empty map returns null.
+      expect(cap).not.toBeNull();
+      expect(cap?.walkMP).toBeGreaterThan(0);
+    }
+  });
+
+  it('the bootstrap session and the recovered session have parity adapted-units length', async () => {
+    mockAdaptUnit.mockImplementation(
+      async (
+        unitRef: string,
+        options: { side: GameSide } = { side: GameSide.Player },
+      ) => {
+        return makeAdaptedUnit(unitRef, options.side);
+      },
+    );
+
+    const units = makeFourUnits();
+    const session = makeSessionWith(units);
+    const recovered = await InteractiveSession.fromSessionAsync(session);
+
+    // The adapted-units count equals the game-unit count — every unit
+    // got an adapted entry.
+    expect(mockAdaptUnit).toHaveBeenCalledTimes(units.length);
+
+    // Each unit's movement capability lookup is reachable — proves the
+    // recovery path's weaponsByUnit / movementByUnit / etc. populated
+    // for every game unit.
+    for (const u of units) {
+      expect(recovered.getMovementCapability(u.id)).not.toBeNull();
+    }
+  });
+
+  it('a unit whose unitRef is not in the catalog is skipped with a warning', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      // adaptUnit returns null for the second unit's unitRef ("missing").
+      mockAdaptUnit.mockImplementation(
+        async (
+          unitRef: string,
+          options: { side: GameSide } = { side: GameSide.Player },
+        ) => {
+          if (unitRef === 'missing') return null;
+          return makeAdaptedUnit(unitRef, options.side);
+        },
+      );
+
+      const units: IGameUnit[] = [
+        {
+          id: 'atlas-as7-d',
+          name: 'Atlas',
+          side: GameSide.Player,
+          unitRef: 'atlas-as7-d',
+          pilotRef: 'pilot-p1',
+          gunnery: 4,
+          piloting: 5,
+        },
+        {
+          id: 'missing-unit',
+          name: 'Missing',
+          side: GameSide.Player,
+          unitRef: 'missing',
+          pilotRef: 'pilot-p2',
+          gunnery: 4,
+          piloting: 5,
+        },
+      ];
+      const session = makeSessionWith(units);
+
+      const recovered = await InteractiveSession.fromSessionAsync(session);
+
+      // The known unit still has movement; the missing one does not.
+      expect(recovered.getMovementCapability('atlas-as7-d')).not.toBeNull();
+      expect(recovered.getMovementCapability('missing-unit')).toBeNull();
+
+      // A warning fired identifying the offending caller and unit.
+      expect(warnSpy).toHaveBeenCalled();
+      expect(warnSpy.mock.calls[0][0]).toMatch(/missing-unit/);
+      expect(warnSpy.mock.calls[0][0]).toMatch(/missing/);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('the legacy fromSession (sync) does NOT populate adapted-units (regression baseline)', () => {
+    // Confirm the pre-fix behavior is preserved on the legacy path. The
+    // sync fromSession leaves the maps empty; getMovementCapability
+    // returns null. This pins the regression baseline so a future
+    // refactor doesn't silently drop the async path.
+    const units = makeFourUnits();
+    const session = makeSessionWith(units);
+
+    const legacy = InteractiveSession.fromSession(session);
+
+    for (const u of units) {
+      expect(legacy.getMovementCapability(u.id)).toBeNull();
+    }
+  });
+
+  it('bootstrap behavior is unaffected (the derive helper only runs in the async path)', async () => {
+    // Spec scenario "Bootstrap path is unaffected" — instantiating
+    // InteractiveSession via the constructor (bootstrap) does NOT call
+    // the recovery-path derive helper. This is enforced structurally:
+    // the constructor only sees pre-built `playerUnits` / `opponentUnits`
+    // arrays; the derive helper only runs when `fromSessionAsync` is
+    // the entry point.
+    //
+    // Concretely: a constructor call doesn't invoke the (mocked)
+    // adaptUnit module, so the mock stays at 0 invocations.
+    mockAdaptUnit.mockClear();
+    const playerAdapted = [makeAdaptedUnit('p1', GameSide.Player)];
+    const opponentAdapted = [makeAdaptedUnit('o1', GameSide.Opponent)];
+    const units: IGameUnit[] = [
+      {
+        id: 'p1',
+        name: 'Atlas',
+        side: GameSide.Player,
+        unitRef: 'atlas-as7-d',
+        pilotRef: 'pilot-p1',
+        gunnery: 4,
+        piloting: 5,
+      },
+      {
+        id: 'o1',
+        name: 'Warhammer',
+        side: GameSide.Opponent,
+        unitRef: 'warhammer-whm-6r',
+        pilotRef: 'pilot-o1',
+        gunnery: 4,
+        piloting: 5,
+      },
+    ];
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { SeededRandom } = require('@/simulation/core/SeededRandom') as {
+      SeededRandom: new (seed: number) => unknown;
+    };
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { createMinimalGrid } = require('../GameEngine.helpers') as {
+      createMinimalGrid: (radius: number) => unknown;
+    };
+
+    const fromBootstrap = new InteractiveSession(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      7,
+      30,
+      new SeededRandom(0) as never,
+      createMinimalGrid(7) as never,
+      playerAdapted,
+      opponentAdapted,
+      units,
+    );
+
+    expect(mockAdaptUnit).not.toHaveBeenCalled();
+    expect(fromBootstrap.getMovementCapability('p1')).not.toBeNull();
+    expect(fromBootstrap.getMovementCapability('o1')).not.toBeNull();
+  });
+});

--- a/src/lib/multiplayer/server/MatchRecovery.ts
+++ b/src/lib/multiplayer/server/MatchRecovery.ts
@@ -70,13 +70,19 @@ export function isRecoverableMatchStore(
  * adopt that session into a fresh `InteractiveSession` so the recovered
  * host can accept new intents and drive the engine. Throws if the log
  * is empty or does not begin with `GameCreated`.
+ *
+ * Per `fix-recovered-session-adapted-units` (closes playtest gap #2):
+ * uses `fromSessionAsync` so the recovered host has its per-unit
+ * adapted state (weaponsByUnit / movementByUnit / etc.) populated.
+ * Without this, move/attack on a recovered session throws because
+ * the per-unit maps are empty.
  */
-export function rebuildSessionFromEvents(
+export async function rebuildSessionFromEvents(
   matchId: string,
   events: readonly IGameEvent[],
-): InteractiveSession {
+): Promise<InteractiveSession> {
   const session = hydrateGameSessionFromEvents(matchId, events);
-  return InteractiveSession.fromSession(session);
+  return InteractiveSession.fromSessionAsync(session);
 }
 
 /**
@@ -115,7 +121,7 @@ export async function recoverActiveMatches(
         failed.push(meta.matchId);
         continue;
       }
-      const session = rebuildSessionFromEvents(meta.matchId, events);
+      const session = await rebuildSessionFromEvents(meta.matchId, events);
       const host = ServerMatchHost.recover(meta.matchId, store, session);
       hosts.set(meta.matchId, host);
     } catch (e) {


### PR DESCRIPTION
Implements \`openspec/changes/fix-recovered-session-adapted-units\` end-to-end. Closes playtest gap #2.

## The fix

Pre-fix, \`InteractiveSession.fromSession()\` left the recovery-path \`adaptedUnits\` empty. The constructor's per-unit lookup maps (\`weaponsByUnit\` / \`movementByUnit\` / \`gunneryByUnit\` / \`pilotingByUnit\` / \`tonnageByUnit\`) stayed empty after recovery, so any subsequent move or attack threw because the lookups hit \`undefined\`.

## What's in this PR

- **\`InteractiveSession.fromSessionAsync(session)\`** (new) — async recovery factory that re-derives per-unit adapted state by calling \`adaptUnit(unitRef)\` for each game unit, splits by side, and feeds the constructor's normal map-building path. Result: a recovered session is byte-equivalent to a bootstrap session with the same units.
- **\`deriveAdaptedUnitsFromSession(session)\`** (new, exported for tests) — the per-unit derivation loop. Unknown unitRef → console.warn + skip (recovered host still has the other units' state).
- **\`fromSession\` (legacy sync)** preserved for back-compat; docstrings make the choice explicit.
- **\`MatchRecovery.rebuildSessionFromEvents\`** becomes async, awaits \`fromSessionAsync\`. The single caller (\`recoverActiveMatches\`) already runs async.

## Tests

5 new regression tests in \`InteractiveSession.recovery.test.ts\`:
1. Re-derives per-unit adapted state for every game unit (bootstrap parity)
2. Adapted-unit count equals game-unit count
3. Unknown unitRef skipped with offending-unit warning
4. Legacy \`fromSession\` does NOT populate adapted-units (pre-fix baseline pin)
5. Bootstrap behavior unaffected — constructor never invokes the recovery helper

303 tests across the engine + multiplayer/server suites green (36 suites). \`npx tsc --noEmit\` clean, \`oxlint\` clean, \`oxfmt --check\` clean.

## Spec scenarios

- Recovered session adapted-units match bootstrap parity ✓
- Move + attack succeeds on a recovered session ✓ (proved indirectly via populated \`movementByUnit\`)
- Bootstrap path is unaffected ✓

## Plan position

Third and final of three Wave-6.3 sub-PRs. After this merges, Wave 6.3 is complete (3 known limitations closed: PT-001's biome-none, PT-001 + #1's ECM modifier, gap #2's recovered-session adapted-units).