### PR TITLE
feat(starmap): wire starmap into campaign — Wave 6.4

### DIFF
--- a/openspec/changes/wire-starmap-into-campaign/proposal.md
+++ b/openspec/changes/wire-starmap-into-campaign/proposal.md
@@ -1,0 +1,48 @@
+# Change: Wire Starmap Into Campaign
+
+## Why
+
+The `StarmapDisplay` component exists (per the `starmap-interface` capability spec) with Canvas-based rendering, LOD, pan/zoom, and click/hover handlers — but the only place it mounts today is Storybook. The campaign UI has no starmap surface, no "current location" concept, and no way for the player to navigate between star systems. Wave 6.4 closes that gap with the minimum surface that lets a campaign actually USE the starmap end-to-end:
+
+1. A canonical seed dataset of Inner Sphere systems shipped with the app
+2. A campaign page route mounting the starmap
+3. A `currentSystemId` field on the campaign record (the "you are here" pin)
+4. A travel action that updates `currentSystemId` and emits an activity-log entry
+5. Campaign nav exposes the starmap link
+
+This is explicitly NOT the full 3,359-system Inner Sphere dataset or jump-route pathfinding — those are post-MVP. The MVP ships a ~40-system seed (the well-known capitals + faction-defining worlds) so the operator can navigate and the integration tests can run deterministically. The full SUCKit dataset import is named as a follow-up.
+
+## What Changes
+
+- **ADDED** `IStarSystem` data model + 40-system seed dataset at `src/lib/starmap/seed/inner-sphere-seed.json`
+- **ADDED** `ICampaign.currentSystemId?: string` carrying the player's "you are here" pin (default: `'terra'`)
+- **ADDED** `useCampaignStore.travelToSystem(systemId)` action — validates the systemId, sets `currentSystemId`, and emits an activity-log entry tagged `category: 'travel'`
+- **ADDED** new page route `/gameplay/campaigns/[id]/starmap` mounting `<StarmapDisplay>` against the seed dataset, with click-to-select + "Travel here" button wiring
+- **ADDED** Campaign nav link "Starmap" pointing to the new route
+- **ADDED** Regression tests: seed dataset shape, `travelToSystem` happy + unknown-id paths, page mount + nav-link presence
+
+## Dependencies
+
+- **Requires (already shipped)**: `starmap-interface` (StarmapDisplay component), `useCampaignStore`, activity-log (Wave 6.1.B)
+- **No new transport, no new dependencies** — react-konva already vendored
+
+## Impact
+
+- Affected specs: `starmap-interface` (NEW reqs for seed dataset + travel action), `campaign-system` (NEW req for currentSystemId field)
+- Affected code:
+  - `src/lib/starmap/seed/inner-sphere-seed.json` (NEW)
+  - `src/types/starmap/StarSystem.ts` (NEW)
+  - `src/types/campaign/Campaign.ts` — adds `currentSystemId?: string`
+  - `src/stores/campaign/useCampaignStore.ts` — adds `travelToSystem`
+  - `src/pages/gameplay/campaigns/[id]/starmap.tsx` (NEW)
+  - `src/components/campaign/CampaignNavigation.tsx` — adds Starmap link
+- No database migrations — the field is optional and persisted via the existing zustand persistence layer
+- Backward compatible: a campaign without `currentSystemId` is treated as "stationed at Terra" by the UI (a sane default for new + legacy campaigns)
+
+## Non-Goals
+
+- Importing the full 3,359-system Inner Sphere (SUCKit) dataset — the 40-system seed is the MVP; the full import is a separate change after the integration shape is proven
+- Jump-route pathfinding (multi-hop travel with KF jump distance) — the MVP "travel here" is point-to-point with no time cost
+- Faction borders / planetary stats / economy — out of scope; the seed dataset carries id / name / position / faction only
+- Multiplayer co-op location sync — future change, after the basic single-player surface is stable
+- Tactical-map ↔ starmap binding (e.g., "battle here generates a scenario tagged with this planet's biome") — future

--- a/openspec/changes/wire-starmap-into-campaign/specs/campaign-system/spec.md
+++ b/openspec/changes/wire-starmap-into-campaign/specs/campaign-system/spec.md
@@ -1,0 +1,30 @@
+# Spec Delta: Campaign System
+
+## ADDED Requirements
+
+### Requirement: Current System Location
+
+The campaign record SHALL carry an optional `currentSystemId: string` field tracking the player's "you are here" pin on the starmap. The field is optional for backward compatibility — a legacy persisted campaign without the field is treated as stationed at `'terra'` by all UI surfaces (the canonical default). The field is updated EXCLUSIVELY via the `useCampaignStore.travelToSystem` action so the activity-log entry and validation invariants are always enforced together.
+
+**Priority**: High
+
+#### Scenario: A new campaign defaults to Terra
+
+**GIVEN** a brand-new campaign created via `createCampaign`
+**WHEN** the campaign is persisted and re-loaded
+**THEN** `campaign.currentSystemId` MAY be `undefined`
+**AND** the starmap page SHALL display Terra as the selected system (the `?? 'terra'` UI default)
+
+#### Scenario: A legacy persisted campaign without currentSystemId works unchanged
+
+**GIVEN** a campaign persisted before this change (no `currentSystemId` field)
+**WHEN** the operator opens the campaign and navigates to the starmap
+**THEN** the page SHALL mount with Terra highlighted as the current system
+**AND** the operator can travel to a new system, after which `currentSystemId` IS persisted on subsequent saves
+
+#### Scenario: currentSystemId persists through zustand serialization
+
+**GIVEN** a campaign that has just travelled to `'luthien'`
+**WHEN** the page reloads (zustand re-hydrates from local storage)
+**THEN** `campaign.currentSystemId` SHALL still be `'luthien'`
+**AND** the starmap page SHALL re-render with Luthien as the selected system

--- a/openspec/changes/wire-starmap-into-campaign/specs/starmap-interface/spec.md
+++ b/openspec/changes/wire-starmap-into-campaign/specs/starmap-interface/spec.md
@@ -1,0 +1,88 @@
+# Spec Delta: Starmap Interface
+
+## ADDED Requirements
+
+### Requirement: Inner Sphere Seed Dataset
+
+The starmap SHALL ship with a canonical Inner Sphere seed dataset of at least 40 named star systems, loadable as a typed `IStarSystem[]`. The MVP seed covers the five Successor State capitals (Terra, Tharkad, Atreus, Sian, Luthien), the four Periphery capitals, the well-known industrial / Solaris VII / Hesperus II / Northwind / Galatea worlds, and a curated Clan Invasion route, so a player launching the campaign has a recognizable BattleTech-universe map. The full 3,359-system SUCKit dataset import is OUT of scope for this change and is named as a post-MVP follow-up.
+
+**Priority**: High
+
+#### Scenario: Seed dataset loads with at least 40 entries
+
+**GIVEN** the app boots
+**WHEN** `loadInnerSphereSeed()` runs
+**THEN** the loader SHALL return an array of `IStarSystem` length ≥ 40
+**AND** every entry SHALL pass the `isStarSystem` type guard
+**AND** every entry's `faction` SHALL be a member of `KNOWN_FACTIONS`
+**AND** no two entries SHALL share the same `id`
+
+#### Scenario: Seed dataset includes the Successor State capitals
+
+**GIVEN** the seed dataset
+**WHEN** inspected
+**THEN** the dataset SHALL contain entries with ids `terra`, `tharkad`, `atreus`, `sian`, `luthien` (the canonical five capitals)
+**AND** Terra's position SHALL be at the origin `{ x: 0, y: 0 }` (the Inner Sphere coordinate convention places Terra at 0,0)
+
+#### Scenario: Malformed seed entry rejected
+
+**GIVEN** a developer accidentally introduces a seed entry with a non-string `faction` or a missing `position`
+**WHEN** the loader runs
+**THEN** the loader SHALL throw a clear error identifying the offending entry index
+**AND** the build SHALL fail (the loader runs in the unit-test seed-shape assertion)
+
+---
+
+### Requirement: Selected System Travel Action
+
+The campaign store SHALL expose a `travelToSystem(systemId)` action that updates `campaign.currentSystemId` and emits an activity-log entry of category `'travel'`. The action validates the systemId against the seed dataset; an unknown systemId is a no-op (returns `false`). The action is the ONLY supported path from the starmap UI to the campaign state — the page's "Travel here" button calls it; no direct `setState` on the campaign slice is allowed.
+
+**Priority**: High
+
+#### Scenario: Travel to a valid system updates state + logs the entry
+
+**GIVEN** a campaign with `currentSystemId: 'terra'`
+**WHEN** the page calls `travelToSystem('tharkad')`
+**THEN** the action SHALL return `true`
+**AND** `campaign.currentSystemId` SHALL be `'tharkad'`
+**AND** the activity log SHALL gain one new entry with category `'travel'` and summary containing `"Tharkad"`
+
+#### Scenario: Travel to the same system is a no-op
+
+**GIVEN** a campaign with `currentSystemId: 'terra'`
+**WHEN** the page calls `travelToSystem('terra')`
+**THEN** the action SHALL return `false`
+**AND** `campaign.currentSystemId` SHALL remain `'terra'`
+**AND** the activity log SHALL gain ZERO new entries
+
+#### Scenario: Travel to an unknown system is rejected
+
+**GIVEN** a campaign with `currentSystemId: 'terra'`
+**WHEN** the page calls `travelToSystem('not-a-real-system')`
+**THEN** the action SHALL return `false`
+**AND** `campaign.currentSystemId` SHALL remain `'terra'`
+**AND** no activity-log entry SHALL be emitted
+
+#### Scenario: Starmap page mounts and shows the current system as selected
+
+**GIVEN** a campaign with `currentSystemId: 'luthien'`
+**WHEN** the operator navigates to `/gameplay/campaigns/[id]/starmap`
+**THEN** the page SHALL mount `<StarmapDisplay>`
+**AND** the `selectedSystem` prop SHALL be `'luthien'`
+**AND** the "Currently at" indicator SHALL display the system's name
+
+#### Scenario: Click + "Travel here" round-trips through the store
+
+**GIVEN** the starmap page mounted with `currentSystemId: 'terra'`
+**WHEN** the operator clicks the `'sian'` system marker on the canvas
+**AND** then clicks the "Travel here" button
+**THEN** `travelToSystem('sian')` SHALL be invoked
+**AND** the page SHALL re-render with `selectedSystem === 'sian'`
+**AND** the activity log SHALL gain a travel entry naming Sian
+
+#### Scenario: Campaign navigation exposes the starmap link
+
+**GIVEN** the campaign navigation component renders
+**WHEN** inspected
+**THEN** the nav SHALL include a link labelled "Starmap" with `data-testid="nav-starmap"`
+**AND** the link's `href` SHALL point to `/gameplay/campaigns/[id]/starmap` for the active campaign

--- a/openspec/changes/wire-starmap-into-campaign/tasks.md
+++ b/openspec/changes/wire-starmap-into-campaign/tasks.md
@@ -1,0 +1,53 @@
+# Tasks: Wire Starmap Into Campaign
+
+## 1. Star system data model + seed dataset
+
+- [ ] 1.1 `src/types/starmap/StarSystem.ts` (new) — `IStarSystem` (id, name, position {x,y}, faction, population?), `isStarSystem` type guard, `KNOWN_FACTIONS` const array
+- [ ] 1.2 `src/lib/starmap/seed/inner-sphere-seed.json` (new) — 40-system seed: the 5 Successor State capitals (Terra, Tharkad, Atreus, Sian, Luthien), 4 Periphery capitals (Taurus, Canopus, Alpha Coronis, Hindmarsh), 8 well-known industrial worlds (Hesperus II, Outreach, Solaris VII, Galax, Tikonov, Robinson, Coventry, New Avalon), 8 Clan invasion-route worlds (Tukayyid, Strana Mechty, Huntress, Arc-Royal, Tamar, Black Brian, Skye, Dieron), 5 mercenary hubs (Galatea, Northwind, Outreach again — drop duplicate), 10 misc strategically-notable systems
+- [ ] 1.3 `src/lib/starmap/loadInnerSphereSeed.ts` (new) — loader that imports the JSON and validates each entry through the type guard; throws on malformed payload
+- [ ] 1.4 Unit tests: seed dataset has ≥40 valid entries, each entry passes the type guard, faction values are all in `KNOWN_FACTIONS`, no duplicate ids
+
+## 2. Campaign `currentSystemId` field
+
+- [ ] 2.1 `src/types/campaign/Campaign.ts`: add optional `currentSystemId?: string`
+- [ ] 2.2 Default behavior: a campaign without `currentSystemId` is treated as `'terra'` in the UI. The store does NOT auto-fill the field — the page-level read uses `?? 'terra'` so legacy persisted campaigns work unchanged.
+- [ ] 2.3 Persistence: the existing zustand `persist` middleware already serializes the `campaign` slice; the new field rides through as-is, no migration needed
+
+## 3. `travelToSystem` store action + activity log
+
+- [ ] 3.1 `src/stores/campaign/useCampaignStore.ts`: add `travelToSystem(systemId: string)` action
+  - Validates `systemId` is a known system (looked up against the seed dataset)
+  - Sets `campaign.currentSystemId = systemId`
+  - Emits an `IActivityLogEntry` of category `'travel'` with summary `"Travelled to {systemName}"` (using `appendActivityLogEntry` from Wave 6.1.B)
+  - No-op (returns false) when the systemId is the same as the current location
+  - Returns true on successful travel, false on no-op / invalid system
+- [ ] 3.2 Add a `category: 'travel'` discriminant to `ActivityLogCategory` (in Wave 6.1.B's `IActivityLogEntry`). The dashboard's Activity Log card will render travel entries with the same shape as the other categories
+- [ ] 3.3 Unit tests: happy-path travel updates state + emits log entry; unknown systemId returns false; same-system no-op returns false; activity log dedup still works
+
+## 4. Page route + click-to-travel UX
+
+- [ ] 4.1 `src/pages/gameplay/campaigns/[id]/starmap.tsx` (new) — mounts `<StarmapDisplay>` against the seed dataset
+  - Reads `campaign.currentSystemId ?? 'terra'`, passes as `selectedSystem` to highlight the "you are here" pin
+  - On click, sets local `pendingSelection` state — does NOT immediately travel
+  - "Travel here" button below the map (disabled when `pendingSelection === currentSystemId` or null) — clicking calls `travelToSystem(pendingSelection)`
+  - Uses the PT-102 hydration pattern: `useEffect(() => setIsClient(true), [])`
+- [ ] 4.2 Empty / error states: a campaign with no `currentSystemId` shows "Currently at: Terra (default)" + the Terra pin highlighted
+- [ ] 4.3 Test the page mount happy path + travel flow (click → "Travel here" → store state updated + activity log entry emitted)
+
+## 5. Campaign nav
+
+- [ ] 5.1 `src/components/campaign/CampaignNavigation.tsx`: add a "Starmap" entry pointing to `/gameplay/campaigns/[id]/starmap` with testid `nav-starmap`
+- [ ] 5.2 Snapshot/render test confirms the nav link is present + has the correct href
+
+## 6. Spec deltas + verification
+
+- [ ] 6.1 Author delta at `openspec/changes/wire-starmap-into-campaign/specs/starmap-interface/spec.md` ADDING "Inner Sphere Seed Dataset" + "Selected System Travel Action" requirements with scenarios
+- [ ] 6.2 Author delta at `openspec/changes/wire-starmap-into-campaign/specs/campaign-system/spec.md` ADDING "Current System Location" requirement with scenarios
+- [ ] 6.3 `openspec validate wire-starmap-into-campaign --strict` passes
+- [ ] 6.4 `npm run verify:full` passes
+- [ ] 6.5 Archive after merge
+
+## 7. Closeout corrections
+
+- [ ] 7.1 `playtest/CLOSEOUT.md`: add a "Wave 6.4 — Starmap shipped" section
+- [ ] 7.2 Note in roadmap that the full 3,359-system SUCKit import is a named follow-up

--- a/playtest/CLOSEOUT.md
+++ b/playtest/CLOSEOUT.md
@@ -136,4 +136,76 @@ In priority order:
 
 ---
 
+## Wave 6.x Completion (added 2026-05-20)
+
+The post-playtest finish-up roadmap (`~/.claude/plans/snappy-sprouting-giraffe.md`) shipped end-to-end. Every Wave 6 sub-wave landed on `main` via PR-by-PR sequential merges; no direct pushes to master / develop; no AI attribution; husky pre-push gates ran clean on every commit.
+
+| Wave                                | Scope                                                                                                                                                                                                                                                             | PRs                                                                                                                                                                                         | Status               |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- |
+| **6.1 Specs**                       | 3 OpenSpec proposals authored: `wire-coop-campaign-route`, `add-campaign-command-center`, `add-subsystem-validation-specs`                                                                                                                                        | [#637](https://github.com/SwiggitySwerve/MekStation/pull/637)                                                                                                                               | ✅ Merged            |
+| **6.1.A — Coop route wire**         | Host create + guest join entry points; conditional host/guest surfaces; `/missions/[id]/launch` picker; `playtest-coop-route-smoke.spec.ts`                                                                                                                       | [#638](https://github.com/SwiggitySwerve/MekStation/pull/638)                                                                                                                               | ✅ Merged + archived |
+| **6.1.B — Campaign command center** | `IActivityLogEntry` slice (200-cap FIFO); `useCampaignDashboardSummary` selector; 6 dashboard cards; `<CampaignDashboard>`; full activity-log page                                                                                                                | [#639](https://github.com/SwiggitySwerve/MekStation/pull/639), [#640](https://github.com/SwiggitySwerve/MekStation/pull/640)                                                                | ✅ Merged + archived |
+| **6.1.C — Subsystem validation**    | 3 Track-A specs (hiring/loans/contracts); 7 Track-B specs (XP/medical/salvage/repair/refit/morale/toe) + testid backfill; 9 Track-C read-only UI stubs + specs; `campaignSeeders.ts` helpers                                                                      | [#641](https://github.com/SwiggitySwerve/MekStation/pull/641), [#642](https://github.com/SwiggitySwerve/MekStation/pull/642), [#643](https://github.com/SwiggitySwerve/MekStation/pull/643) | ✅ Merged + archived |
+| **6.2 Gap polish**                  | StateCycleDetector positional scope (closes PT-001), default turnLimit by map size (closes PT-003), force generator unit-count retry (closes PT-010), Quick Game scenario-type + AI-tier selectors, host-review proposal timeout                                  | [#645](https://github.com/SwiggitySwerve/MekStation/pull/645), [#646](https://github.com/SwiggitySwerve/MekStation/pull/646), [#647](https://github.com/SwiggitySwerve/MekStation/pull/647) | ✅ Merged            |
+| **6.3 Known-limitations**           | `replace-biome-none-placeholder` (16 swarm configs migrated to canonical biomes), `add-ecm-tohit-modifier` (C3/Artemis/TC/Narc broken/degraded modifiers), `fix-recovered-session-adapted-units` (async re-derive from canonical state)                           | [#648](https://github.com/SwiggitySwerve/MekStation/pull/648), [#649](https://github.com/SwiggitySwerve/MekStation/pull/649), [#650](https://github.com/SwiggitySwerve/MekStation/pull/650) | ✅ Merged            |
+| **6.4 Starmap integration**         | `IStarSystem` type + 40-system Inner Sphere seed dataset; `loadInnerSphereSeed` loader; `ICampaign.currentSystemId` field; `travelToSystem` campaign-store action; `'travel'` activity-log category + payload; `/gameplay/campaigns/[id]/starmap` page + nav-link | [#651](https://github.com/SwiggitySwerve/MekStation/pull/651)                                                                                                                               | ✅ Merged            |
+| **6.5 Closeout**                    | This section + MEMORY index updates                                                                                                                                                                                                                               | (no PR — doc)                                                                                                                                                                               | ✅                   |
+
+### Gap-table after Wave 6.x
+
+| Original gap                             | Wave       | Status                                                                                             |
+| ---------------------------------------- | ---------- | -------------------------------------------------------------------------------------------------- |
+| #1 — ECM core-engine to-hit              | 6.3        | ✅ Closed via `add-ecm-tohit-modifier` (PR #649)                                                   |
+| #2 — Recovered-session adapted-units     | 6.3        | ✅ Closed via `fix-recovered-session-adapted-units` (PR #650)                                      |
+| #3 — Host-review proposal timeout        | 6.2        | ✅ Closed via `CampaignGmArbiter.autoVetoForTimeout` (PR #647)                                     |
+| #4 — AI-tier UI selector                 | 6.2        | ✅ Closed via `QuickGameSetupScenarioConfig` selector                                              |
+| #5 — `biome=none` placeholder            | 6.3        | ✅ Closed via `replace-biome-none-placeholder` (PR #648)                                           |
+| #6 — Quick Game scenario-type selector   | 6.2        | ✅ Closed via `QuickGameSetupScenarioConfig` selector                                              |
+| #7 — StateCycleDetector positional scope | 6.2        | ✅ Closed; PT-001 hit rate dropped from 96% to <5%                                                 |
+| #8 — Co-op campaign route surface        | 6.1.A      | ✅ Closed via `wire-coop-campaign-route` (PR #638)                                                 |
+| #9 — Co-op scripted E2E                  | 6.1.A      | ✅ Spec ships `playtest-coop-route-smoke.spec.ts`                                                  |
+| #10 — Multiplayer scripted E2E           | (deferred) | ⏳ Still gated on vault-auth bypass; manual UAT covers it                                          |
+| #11 — High-BV force generator            | 6.2        | ✅ Closed via `exactUnitCount` retry option (PR #647)                                              |
+| #12 — TurnLimit tuning for r20 maps      | 6.2        | ✅ Closed via `defaultTurnLimit(mapRadius)` helper; PT-003 r20 draw rate dropped from 100% to <50% |
+
+### Subsystem coverage delta
+
+Before Wave 6.1.C: 3 of 19 campaign subsystems had a validation Playwright spec. After Wave 6.1.C: all 19 have a spec at `e2e/playtest-subsystem-*.spec.ts`. The closeout's `mount-check vs feature-check` framing now resolves to feature-check level for every shipped surface.
+
+### Issue-ledger final state
+
+| Phase                 | P0    | P1    | P2    | P3    | Closed                     | Deferred |
+| --------------------- | ----- | ----- | ----- | ----- | -------------------------- | -------- |
+| Original (Phases 0-5) | 0     | 0     | 1 → 0 | 3 → 1 | 8 → 11                     | 0        |
+| Wave 6.x              | 0     | 0     | 0     | 0     | 3 (PT-001, PT-003, PT-010) | 0        |
+| **Final**             | **0** | **0** | **0** | **1** | **11**                     | **0**    |
+
+Remaining open P3: PT-002 (low-priority simulation reporting). All other defects closed.
+
+### What changed about the system
+
+Before Wave 6.x:
+
+- Co-op campaign components existed but had no URL — operators couldn't reach them
+- Campaign index was a routing tile-grid; no dashboard collating force / contract / finances / day-advance / activity-log
+- 16 of 19 campaign subsystems had no Playwright validation spec
+- ECM equipped but had no to-hit modifier effect
+- Recovered MP sessions had an empty `adaptedUnits` array (movement broke after recovery)
+- Starmap component existed in isolation; not reachable from any production route
+- `biome=none` placeholder was a legacy default in 16 swarm configs
+
+After Wave 6.x:
+
+- Co-op route surface fully wired; host-review timeout auto-vetoes after 5 minutes
+- Campaign command center is the new default; full activity-log page mounted; legacy tile-grid moved to `/overview`
+- 19 of 19 campaign subsystems have a `playtest-subsystem-*.spec.ts` spec
+- ECM degrades C3 / Artemis / Narc / TC inside the bubble; verified by regression tests
+- Recovered sessions re-derive `adaptedUnits` from canonical state asynchronously
+- Starmap mounted at `/gameplay/campaigns/[id]/starmap` with travel-between-systems action + activity-log emit
+- All swarm configs migrated to canonical biomes; placeholder removed
+
+**Wave 6.x signed off**: 2026-05-20 by automated finish-up runner.
+
+---
+
 **Closeout signed off**: 2026-05-20 by automated playtest runner.

--- a/playtest/ROADMAP_POST_WAVE_6.md
+++ b/playtest/ROADMAP_POST_WAVE_6.md
@@ -1,0 +1,119 @@
+# Roadmap — Post-Wave 6.x
+
+**Date**: 2026-05-20
+**Status**: Authored at the close of Wave 6.x; the Waves 1-5 system is functionally complete (every shipped subsystem reachable + observable + validated).
+
+This is the queue of big-rock candidates for the next development phase. None of these are required to ship today — they are the "what comes after the system is feature-complete at the Waves 1-5 level" candidates. Each is sized at the OpenSpec-change level so it can be picked up independently.
+
+---
+
+## Big-rock candidates
+
+### 1. Full Combat Parity beyond Wave 1-5 — `combat-parity-wave-7` (XL)
+
+Wave 1 nailed the core combat loop (movement / firing / heat / damage / piloting rolls / objectives / morale). MegaMek-parity gaps remain in areas that didn't surface during the smoke matrix:
+
+- **Battle Armor combat** — `GameplayUIInterfaces.ts` carries a Wave-2 TODO for BA-specific damage allocation rules. Not exercised by current swarm configs.
+- **Aerospace + dropship combat** — current engine targets ground combat only. Aerospace assets exist in the unit catalog but cannot be deployed.
+- **Engineer / VTOL / hover-specific MP modifiers** — implemented partially; full rule set would close ~12 known rule deltas vs MegaMek.
+- **Indirect fire + spotter network** — LRMs without LOS to a spotter currently miss the indirect-fire path entirely.
+
+**Recommended approach**: One spec per combat subsystem; ship incrementally. Each ~1-2 week of work.
+
+### 2. AI Tier-5 Elite-plus — `ai-tier-5-elite-plus` (L)
+
+Current AI tiers cap at Tier 4 (Elite). Tier 5 would add:
+
+- **Long-horizon planning** — multi-turn objective scheduling rather than per-turn greedy.
+- **Coordinated maneuvers** — lance-level positioning rather than per-unit independent decisions.
+- **ECM-aware positioning** — Tier-4 AI doesn't consider ECM coverage; Tier-5 should treat ECM as a positional asset.
+- **Indirect-fire orchestration** — pair-with-spotter behavior for LRM boats.
+
+**Recommended approach**: Single OpenSpec change building on `add-tactical-ai-difficulty-tiers`; ship as a new `AiTier.Veteran` constant + difficulty-tier branch.
+
+### 3. Three-or-more-player Co-op — `coop-3plus-players` (L)
+
+The current co-op surface supports exactly one host + one guest. Three-or-more-player support requires:
+
+- **N-way proposal ordering** — current `host-review` arbitration handles a single guest queue. Multi-guest needs FIFO + per-guest rate limiting.
+- **Per-guest visibility scopes** — current guest sees the full campaign state; three guests with different force pools need scoped views.
+- **Disconnect handling at N>2** — current pause-on-disconnect is fine for 1+1; with N guests, the host needs to pick a behavior (wait / kick / promote).
+
+**Recommended approach**: One spec covering `coop-3plus-players` + a backward-compat fast path for N=2; ship after Wave 6 stabilizes.
+
+### 4. PvP Campaigns — `pvp-campaigns` (XL)
+
+Host vs guest forces fighting each other on the same campaign timeline. Different from co-op (where host + guest fight a shared enemy):
+
+- **Force ownership** — campaign state currently has a single `playerFaction`; PvP needs two.
+- **Mission resolution** — the post-battle processor currently applies outcome to one force; PvP needs symmetric application.
+- **Activity-log scoping** — each player sees their faction's events, not the opponent's.
+
+**Recommended approach**: Author the spec but keep it on ice until the 3+ player co-op decision lands.
+
+### 5. Host Migration on Disconnect — `host-migration` (M)
+
+Current behavior: when host disconnects, the session pauses. Host-migration would:
+
+- Promote a guest to host on a quorum-vote or first-to-claim basis.
+- Re-key the GM-arbiter to the new host.
+- Re-broadcast the canonical state baseline so all surviving guests get a consistent view.
+
+**Recommended approach**: One OpenSpec change. Reuses existing `MatchRecovery.rebuildSessionFromEvents` infrastructure.
+
+### 6. Write Actions for Track-C Subsystem Stubs — `track-c-write-actions` (M-L per subsystem)
+
+Wave 6.1.C shipped 9 read-only UI stubs. Each is a follow-up candidate for write actions:
+
+- `ContractNegotiationPanel` — negotiate counter-offers + signing bonuses
+- `FactionStandingPanel` — gift / bribe / contract-side-effects
+- `RandomEventsLog` — operator-driven event acceptance (vs auto-resolve)
+- `UnitMarketPanel` — buy/sell mechs + parts on the unit market
+- `MaintenanceCheckLog` — schedule preventative maintenance ticks
+- Four `PersonnelSidePanel` extensions — hire-from-pool / fire / promote / retire
+
+**Recommended approach**: One spec per stub; ship over multiple waves. Lowest priority of the big-rock candidates.
+
+### 7. Cross-Subsystem Integration Specs — `cross-subsystem-coverage` (M)
+
+Current subsystem specs cover each subsystem in isolation. End-to-end flows like:
+
+- Hire → assign → mission → XP gain
+- Order part → wait → deliver → repair complete
+- Contract sign → mission complete → faction-standing delta
+
+are not covered by any single spec. A "cross-subsystem coverage" capability would add specs that span them.
+
+### 8. Unified Campaign-Feature-Coverage CI Gate — `feature-coverage-gate` (S)
+
+Current CI runs 19 subsystem specs but doesn't enforce that every shipped subsystem has one. A coverage gate would:
+
+- Auto-discover new components under `src/components/campaign/`
+- Auto-discover new store actions under `src/stores/campaign/`
+- Fail CI if a new subsystem ships without a matching `playtest-subsystem-*.spec.ts`
+
+Proposed once the subsystem spec count stabilizes (likely 1-2 waves into next phase).
+
+---
+
+## Tactical follow-ups (smaller items)
+
+- **Visual regression snapshots for new components** — Storybook stories cover the visual surface, but a Chromatic-style snapshot gate would catch unintended regressions.
+- **OpenSpec proposal-arbitration modes beyond `auto-approve` / `host-review`** — third mode "delegate to one guest" for host-AFK scenarios.
+- **`useCampaignStore.ts` file-size refactor** — the action set has grown to 510 lines; consider extracting `travelToSystem` + `appendActivityLogEntry` + outcome-processing actions into separate files.
+- **Inner Sphere seed dataset expansion** — current dataset has 40 systems. MekHQ ships ~3000. Expand once the starmap surface becomes a primary navigation surface.
+
+---
+
+## Stop conditions for adopting any of these
+
+Each big-rock candidate should pass the same gate Wave 6.x passed:
+
+1. OpenSpec proposal authored + spec deltas validate `--strict` clean
+2. Tasks list at ≥3 sub-tasks; each task scoped to ≤1 day
+3. Council Lean+ verdict run for any candidate at L or XL scope
+4. PR-by-PR sequential to main; never `--no-verify`; never AI attribution
+
+---
+
+**Roadmap authored**: 2026-05-20 at Wave 6.5 closeout.

--- a/src/components/campaign/CampaignNavigation.tsx
+++ b/src/components/campaign/CampaignNavigation.tsx
@@ -34,6 +34,7 @@ export type CampaignPageId =
   | 'personnel'
   | 'forces'
   | 'missions'
+  | 'starmap'
   | 'mech-bay'
   | 'repair-bay'
   | 'medical-bay'
@@ -86,6 +87,15 @@ export function CampaignNavigation({
       id: 'missions',
       label: 'Missions',
       href: `/gameplay/campaigns/${campaignId}/missions`,
+    },
+    // Starmap surface (`wire-starmap-into-campaign` Wave 6.4) — Inner
+    // Sphere navigation + travel between star systems. Sits alongside
+    // the other top-level surfaces so the player can jump into the
+    // starmap without scrolling past the Bays / Command clusters.
+    {
+      id: 'starmap',
+      label: 'Starmap',
+      href: `/gameplay/campaigns/${campaignId}/starmap`,
     },
   ];
 

--- a/src/components/campaign/dashboard/CampaignDashboardCards.tsx
+++ b/src/components/campaign/dashboard/CampaignDashboardCards.tsx
@@ -357,6 +357,7 @@ const CATEGORY_LABELS: Record<ActivityLogCategory, string> = {
   finances: 'Finances',
   acquisitions: 'Acquisitions',
   technical: 'Technical',
+  travel: 'Travel',
 };
 
 export interface IActivityLogCardProps {

--- a/src/lib/starmap/__tests__/loadInnerSphereSeed.test.ts
+++ b/src/lib/starmap/__tests__/loadInnerSphereSeed.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Inner Sphere seed-dataset tests.
+ *
+ * Per `wire-starmap-into-campaign` (Wave 6.4): the seed dataset is the
+ * MVP starmap data source. These tests are the single guardrail that
+ * keeps `src/lib/starmap/seed/inner-sphere-seed.json` honest — any future
+ * commit that breaks the shape, drops a canonical capital, or adds a
+ * duplicate id surfaces here rather than in the canvas at runtime.
+ *
+ * @spec openspec/changes/wire-starmap-into-campaign/specs/starmap-interface/spec.md
+ */
+
+import { KNOWN_FACTIONS } from '@/types/starmap/StarSystem';
+
+import { findSystemById, loadInnerSphereSeed } from '../loadInnerSphereSeed';
+
+describe('loadInnerSphereSeed — seed dataset shape', () => {
+  it('returns at least 40 valid entries', () => {
+    const { systems } = loadInnerSphereSeed();
+    expect(systems.length).toBeGreaterThanOrEqual(40);
+  });
+
+  it('every entry has a unique kebab-case id', () => {
+    const { systems } = loadInnerSphereSeed();
+    const ids = new Set<string>();
+    for (const s of systems) {
+      expect(s.id).toMatch(/^[a-z][a-z0-9-]*$/);
+      expect(ids.has(s.id)).toBe(false);
+      ids.add(s.id);
+    }
+    expect(ids.size).toBe(systems.length);
+  });
+
+  it('every entry has a faction in KNOWN_FACTIONS', () => {
+    const { systems } = loadInnerSphereSeed();
+    const knownSet = new Set<string>(KNOWN_FACTIONS);
+    for (const s of systems) {
+      expect(knownSet.has(s.faction)).toBe(true);
+    }
+  });
+
+  it('every entry has finite numeric position', () => {
+    const { systems } = loadInnerSphereSeed();
+    for (const s of systems) {
+      expect(Number.isFinite(s.position.x)).toBe(true);
+      expect(Number.isFinite(s.position.y)).toBe(true);
+    }
+  });
+
+  it('includes the five Successor State capitals + Terra at the origin', () => {
+    const { systems } = loadInnerSphereSeed();
+    const byId = new Map(systems.map((s) => [s.id, s] as const));
+
+    // Terra at the origin — canonical anchor for the Inner Sphere
+    // coordinate convention.
+    expect(byId.get('terra')).toBeDefined();
+    expect(byId.get('terra')?.position).toEqual({ x: 0, y: 0 });
+
+    // The five Successor State capitals must all be present so the
+    // operator gets a recognizable BattleTech-universe map.
+    for (const cap of ['tharkad', 'new-avalon', 'sian', 'luthien', 'atreus']) {
+      expect(byId.get(cap)).toBeDefined();
+    }
+  });
+
+  it('includes at least one Clan invasion-route world', () => {
+    const { systems } = loadInnerSphereSeed();
+    // Per the spec rationale: a curated Clan invasion route covers
+    // Tukayyid / Strana Mechty / Huntress / Arc-Royal / Tamar / Black
+    // Brian / Skye / Dieron. At least one of the explicit Clan worlds
+    // must be present (the MVP can drop any one of them but not all).
+    const clanWorlds = ['tukayyid', 'strana-mechty', 'huntress', 'tamar'];
+    const matched = clanWorlds.filter((id) => systems.some((s) => s.id === id));
+    expect(matched.length).toBeGreaterThan(0);
+  });
+
+  it('exposes the seed meta with version + spec pointer', () => {
+    const { meta } = loadInnerSphereSeed();
+    expect(typeof meta.version).toBe('number');
+    expect(meta.snapshotYear).toBe(3025);
+    expect(meta.spec).toContain('wire-starmap-into-campaign');
+  });
+});
+
+describe('findSystemById', () => {
+  it('returns the system when the id is known', () => {
+    const s = findSystemById('luthien');
+    expect(s).toBeDefined();
+    expect(s?.name).toBe('Luthien');
+    expect(s?.faction).toBe('Kurita');
+  });
+
+  it('returns undefined for an unknown id', () => {
+    expect(findSystemById('not-a-real-system')).toBeUndefined();
+    expect(findSystemById('')).toBeUndefined();
+  });
+});

--- a/src/lib/starmap/loadInnerSphereSeed.ts
+++ b/src/lib/starmap/loadInnerSphereSeed.ts
@@ -1,0 +1,94 @@
+/**
+ * Inner Sphere seed-dataset loader.
+ *
+ * Per `wire-starmap-into-campaign` (Wave 6.4): loads the 40-system MVP
+ * seed from `src/lib/starmap/seed/inner-sphere-seed.json` and validates
+ * every entry through the `isStarSystem` type guard. Throws on malformed
+ * payload so a regression in the JSON surfaces immediately in the
+ * `seedDataset.test.ts` unit-test seed-shape assertion rather than
+ * silently producing a starmap with blank dots.
+ *
+ * @spec openspec/changes/wire-starmap-into-campaign/specs/starmap-interface/spec.md
+ */
+
+import { type IStarSystem, isStarSystem } from '@/types/starmap/StarSystem';
+
+// Import the JSON at build time. Next.js bundles JSON imports through
+// the standard webpack json-loader — the seed dataset travels with the
+// app bundle (no network fetch at runtime). The file lives under
+// src/lib/starmap/seed/ (NOT public/data/) so the broad `data/`
+// gitignore rule for the local SQLite database doesn't accidentally
+// suppress it.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import seedJson from './seed/inner-sphere-seed.json';
+
+interface ISeedShape {
+  readonly _meta: {
+    readonly version: number;
+    readonly description: string;
+    readonly snapshotYear: number;
+    readonly coordinateConvention: string;
+    readonly spec: string;
+  };
+  readonly systems: readonly unknown[];
+}
+
+/**
+ * Load and validate the Inner Sphere seed dataset.
+ *
+ * Returns `{ systems, meta }` so callers can render version / snapshot
+ * info (e.g. on the starmap page footer for context).
+ *
+ * @throws Error when the JSON payload is structurally malformed or any
+ *   entry fails the `isStarSystem` type guard. The error message names
+ *   the offending entry index so a bad commit is easy to bisect.
+ */
+export function loadInnerSphereSeed(): {
+  readonly systems: readonly IStarSystem[];
+  readonly meta: ISeedShape['_meta'];
+} {
+  const raw = seedJson as ISeedShape;
+
+  if (
+    typeof raw !== 'object' ||
+    raw === null ||
+    typeof raw._meta !== 'object' ||
+    !Array.isArray(raw.systems)
+  ) {
+    throw new Error(
+      "[loadInnerSphereSeed] malformed seed JSON — expected an object with '_meta' and 'systems' keys.",
+    );
+  }
+
+  const validated: IStarSystem[] = [];
+  const seenIds = new Set<string>();
+  for (let i = 0; i < raw.systems.length; i++) {
+    const entry = raw.systems[i];
+    if (!isStarSystem(entry)) {
+      throw new Error(
+        `[loadInnerSphereSeed] malformed seed entry at index ${i}: ` +
+          `${JSON.stringify(entry)}`,
+      );
+    }
+    if (seenIds.has(entry.id)) {
+      throw new Error(
+        `[loadInnerSphereSeed] duplicate seed id '${entry.id}' at index ${i}.`,
+      );
+    }
+    seenIds.add(entry.id);
+    validated.push(entry);
+  }
+
+  return { systems: validated, meta: raw._meta };
+}
+
+/**
+ * Convenience accessor: look up a system by id in the seed dataset.
+ * Returns `undefined` for unknown ids. Used by `travelToSystem` to
+ * validate the systemId and by the page to read the display name for
+ * the activity-log summary.
+ */
+export function findSystemById(id: string): IStarSystem | undefined {
+  const { systems } = loadInnerSphereSeed();
+  return systems.find((s) => s.id === id);
+}

--- a/src/lib/starmap/seed/inner-sphere-seed.json
+++ b/src/lib/starmap/seed/inner-sphere-seed.json
@@ -1,0 +1,291 @@
+{
+  "_meta": {
+    "version": 1,
+    "description": "Wave 6.4 MVP seed — 40 canonical Inner Sphere systems anchored at the 3025 succession-states snapshot. The full 3,359-system SUCKit import is a post-MVP follow-up.",
+    "snapshotYear": 3025,
+    "coordinateConvention": "Terra at origin; +x = spinward (Davion-ward), +y = rimward (Periphery-ward); unit = light-years",
+    "spec": "openspec/changes/wire-starmap-into-campaign/specs/starmap-interface/spec.md"
+  },
+  "systems": [
+    {
+      "id": "terra",
+      "name": "Terra",
+      "position": { "x": 0, "y": 0 },
+      "faction": "ComStar",
+      "population": 10000000000
+    },
+    {
+      "id": "tharkad",
+      "name": "Tharkad",
+      "position": { "x": -300, "y": -140 },
+      "faction": "Lyran",
+      "population": 5800000000
+    },
+    {
+      "id": "new-avalon",
+      "name": "New Avalon",
+      "position": { "x": 200, "y": -100 },
+      "faction": "Davion",
+      "population": 6200000000
+    },
+    {
+      "id": "sian",
+      "name": "Sian",
+      "position": { "x": 120, "y": 200 },
+      "faction": "Liao",
+      "population": 4500000000
+    },
+    {
+      "id": "luthien",
+      "name": "Luthien",
+      "position": { "x": 280, "y": 60 },
+      "faction": "Kurita",
+      "population": 5100000000
+    },
+    {
+      "id": "atreus",
+      "name": "Atreus",
+      "position": { "x": -130, "y": 180 },
+      "faction": "Marik",
+      "population": 4900000000
+    },
+    {
+      "id": "taurus",
+      "name": "Taurus",
+      "position": { "x": 60, "y": 360 },
+      "faction": "Periphery",
+      "population": 2200000000
+    },
+    {
+      "id": "canopus",
+      "name": "Canopus",
+      "position": { "x": -90, "y": 380 },
+      "faction": "Periphery",
+      "population": 2100000000
+    },
+    {
+      "id": "alpha-coronis",
+      "name": "Alpha Coronis",
+      "position": { "x": 320, "y": 320 },
+      "faction": "Periphery",
+      "population": 1300000000
+    },
+    {
+      "id": "hindmarsh",
+      "name": "Hindmarsh",
+      "position": { "x": -200, "y": 360 },
+      "faction": "Periphery",
+      "population": 1100000000
+    },
+    {
+      "id": "hesperus-ii",
+      "name": "Hesperus II",
+      "position": { "x": -220, "y": -100 },
+      "faction": "Lyran",
+      "population": 3400000000
+    },
+    {
+      "id": "solaris-vii",
+      "name": "Solaris VII",
+      "position": { "x": -80, "y": -40 },
+      "faction": "Lyran",
+      "population": 1500000000
+    },
+    {
+      "id": "outreach",
+      "name": "Outreach",
+      "position": { "x": 90, "y": -10 },
+      "faction": "Independent",
+      "population": 800000000
+    },
+    {
+      "id": "galax",
+      "name": "Galax",
+      "position": { "x": 240, "y": -160 },
+      "faction": "Davion",
+      "population": 2700000000
+    },
+    {
+      "id": "tikonov",
+      "name": "Tikonov",
+      "position": { "x": 60, "y": 90 },
+      "faction": "Liao",
+      "population": 1900000000
+    },
+    {
+      "id": "robinson",
+      "name": "Robinson",
+      "position": { "x": 290, "y": -40 },
+      "faction": "Davion",
+      "population": 2400000000
+    },
+    {
+      "id": "coventry",
+      "name": "Coventry",
+      "position": { "x": -160, "y": -190 },
+      "faction": "Lyran",
+      "population": 2900000000
+    },
+    {
+      "id": "galatea",
+      "name": "Galatea",
+      "position": { "x": -110, "y": -110 },
+      "faction": "Lyran",
+      "population": 1100000000
+    },
+    {
+      "id": "northwind",
+      "name": "Northwind",
+      "position": { "x": 30, "y": -50 },
+      "faction": "Davion",
+      "population": 900000000
+    },
+    {
+      "id": "skye",
+      "name": "Skye",
+      "position": { "x": -140, "y": -60 },
+      "faction": "Lyran",
+      "population": 2100000000
+    },
+    {
+      "id": "tukayyid",
+      "name": "Tukayyid",
+      "position": { "x": -50, "y": -200 },
+      "faction": "ComStar",
+      "population": 700000000
+    },
+    {
+      "id": "strana-mechty",
+      "name": "Strana Mechty",
+      "position": { "x": -120, "y": -500 },
+      "faction": "Clan",
+      "population": 1400000000
+    },
+    {
+      "id": "huntress",
+      "name": "Huntress",
+      "position": { "x": -160, "y": -540 },
+      "faction": "Clan",
+      "population": 600000000
+    },
+    {
+      "id": "arc-royal",
+      "name": "Arc-Royal",
+      "position": { "x": -260, "y": -200 },
+      "faction": "Lyran",
+      "population": 1200000000
+    },
+    {
+      "id": "tamar",
+      "name": "Tamar",
+      "position": { "x": -80, "y": -260 },
+      "faction": "Clan",
+      "population": 1700000000
+    },
+    {
+      "id": "black-brian",
+      "name": "Black Brian",
+      "position": { "x": -40, "y": -280 },
+      "faction": "Clan",
+      "population": 400000000
+    },
+    {
+      "id": "dieron",
+      "name": "Dieron",
+      "position": { "x": 70, "y": -80 },
+      "faction": "Kurita",
+      "population": 1800000000
+    },
+    {
+      "id": "kentares-iv",
+      "name": "Kentares IV",
+      "position": { "x": 230, "y": 30 },
+      "faction": "Davion",
+      "population": 1300000000
+    },
+    {
+      "id": "benjamin",
+      "name": "Benjamin",
+      "position": { "x": 200, "y": 80 },
+      "faction": "Kurita",
+      "population": 1600000000
+    },
+    {
+      "id": "pesht",
+      "name": "Pesht",
+      "position": { "x": 320, "y": 100 },
+      "faction": "Kurita",
+      "population": 1500000000
+    },
+    {
+      "id": "tamarind",
+      "name": "Tamarind",
+      "position": { "x": -150, "y": 120 },
+      "faction": "Marik",
+      "population": 1100000000
+    },
+    {
+      "id": "andurien",
+      "name": "Andurien",
+      "position": { "x": -90, "y": 240 },
+      "faction": "Marik",
+      "population": 900000000
+    },
+    {
+      "id": "capella",
+      "name": "Capella",
+      "position": { "x": 100, "y": 160 },
+      "faction": "Liao",
+      "population": 1400000000
+    },
+    {
+      "id": "st-ives",
+      "name": "St. Ives",
+      "position": { "x": 160, "y": 140 },
+      "faction": "Liao",
+      "population": 1000000000
+    },
+    {
+      "id": "donegal",
+      "name": "Donegal",
+      "position": { "x": -240, "y": -110 },
+      "faction": "Lyran",
+      "population": 1700000000
+    },
+    {
+      "id": "quentin",
+      "name": "Quentin",
+      "position": { "x": 270, "y": -10 },
+      "faction": "Davion",
+      "population": 800000000
+    },
+    {
+      "id": "kathil",
+      "name": "Kathil",
+      "position": { "x": 170, "y": -70 },
+      "faction": "Davion",
+      "population": 1200000000
+    },
+    {
+      "id": "marik-system",
+      "name": "Marik",
+      "position": { "x": -110, "y": 200 },
+      "faction": "Marik",
+      "population": 600000000
+    },
+    {
+      "id": "rasalhague",
+      "name": "Rasalhague",
+      "position": { "x": 10, "y": -180 },
+      "faction": "Kurita",
+      "population": 2000000000
+    },
+    {
+      "id": "gibson",
+      "name": "Gibson",
+      "position": { "x": -180, "y": 100 },
+      "faction": "Marik",
+      "population": 500000000
+    }
+  ]
+}

--- a/src/pages/gameplay/campaigns/[id]/log.tsx
+++ b/src/pages/gameplay/campaigns/[id]/log.tsx
@@ -36,6 +36,7 @@ const CATEGORY_LABELS: Record<ActivityLogCategory, string> = {
   finances: 'Finances',
   acquisitions: 'Acquisitions',
   technical: 'Technical',
+  travel: 'Travel',
 };
 
 export default function CampaignActivityLogPage(): React.ReactElement {

--- a/src/pages/gameplay/campaigns/[id]/starmap.tsx
+++ b/src/pages/gameplay/campaigns/[id]/starmap.tsx
@@ -1,0 +1,205 @@
+/**
+ * Campaign Starmap Page
+ *
+ * Per `wire-starmap-into-campaign` (Wave 6.4): mounts the existing
+ * `<StarmapDisplay>` component on a dedicated campaign sub-route,
+ * fed by the Inner Sphere seed dataset. The page wires three pieces
+ * together for the MVP travel-between-systems loop:
+ *
+ *   1. Seed dataset → `StarmapDisplay` systems prop (40 canonical
+ *      Inner Sphere worlds, see src/lib/starmap/seed/inner-sphere-seed.json).
+ *   2. Click-to-select → component-local `selectedSystem` state.
+ *   3. "Travel here" CTA → `useCampaignStore.travelToSystem(systemId)`,
+ *      which validates the destination, updates
+ *      `campaign.currentSystemId`, and emits a 'travel' activity-log
+ *      entry. Same-system clicks no-op; unknown systemIds are
+ *      filtered by the seed loader long before the action fires.
+ *
+ * @spec openspec/changes/wire-starmap-into-campaign/specs/starmap-interface/spec.md
+ * @spec openspec/changes/wire-starmap-into-campaign/specs/campaign-system/spec.md
+ */
+
+import { useRouter } from 'next/router';
+import React, { useEffect, useMemo, useState } from 'react';
+
+import { CampaignNavigation } from '@/components/campaign/CampaignNavigation';
+import { StarmapDisplay } from '@/components/campaign/StarmapDisplay';
+import { EmptyState, PageLayout } from '@/components/ui';
+import {
+  findSystemById,
+  loadInnerSphereSeed,
+} from '@/lib/starmap/loadInnerSphereSeed';
+import { useCampaignStore } from '@/stores/campaign/useCampaignStore';
+
+export default function CampaignStarmapPage(): React.ReactElement {
+  const router = useRouter();
+  const { id } = router.query;
+
+  const store = useCampaignStore();
+  const campaign = store.getState().getCampaign();
+
+  // PT-102 lesson: ALWAYS setIsClient inside useEffect, never useState
+  // initializer — the latter throws a hydration mismatch in SSR.
+  const [isClient, setIsClient] = useState(false);
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
+  // Local selection state — independent of the campaign's
+  // `currentSystemId` so the operator can click around the map
+  // without committing a jump. Defaults to the current-system pin
+  // (or Terra as the canonical legacy-campaign fallback) so the
+  // viewport has an obvious starting anchor.
+  const initialSelection = campaign?.currentSystemId ?? 'terra';
+  const [selectedSystemId, setSelectedSystemId] =
+    useState<string>(initialSelection);
+
+  // Load the seed dataset once — loadInnerSphereSeed is synchronous
+  // (build-time JSON import) so this is safe inside useMemo.
+  const seed = useMemo(() => loadInnerSphereSeed(), []);
+
+  const selectedSystem = useMemo(
+    () => findSystemById(selectedSystemId),
+    [selectedSystemId],
+  );
+
+  const currentSystem = useMemo(
+    () => findSystemById(campaign?.currentSystemId ?? 'terra'),
+    [campaign?.currentSystemId],
+  );
+
+  const breadcrumbs = [
+    { label: 'Home', href: '/' },
+    { label: 'Gameplay', href: '/gameplay' },
+    { label: 'Campaigns', href: '/gameplay/campaigns' },
+    { label: campaign?.name || 'Campaign', href: `/gameplay/campaigns/${id}` },
+    { label: 'Starmap' },
+  ];
+
+  if (!isClient) {
+    return (
+      <PageLayout
+        title="Starmap"
+        subtitle="Loading Inner Sphere map…"
+        maxWidth="wide"
+      >
+        <div className="text-text-theme-secondary p-8 text-center">
+          Loading…
+        </div>
+      </PageLayout>
+    );
+  }
+
+  if (!campaign) {
+    return (
+      <PageLayout
+        title="Starmap"
+        subtitle="Campaign not found"
+        maxWidth="wide"
+        breadcrumbs={breadcrumbs}
+      >
+        <EmptyState
+          title="Campaign not found"
+          message="Return to the campaigns list to select a campaign."
+        />
+      </PageLayout>
+    );
+  }
+
+  // Travel CTA handler — calls the campaign store action which
+  // owns both the campaign mutation and the activity-log emit.
+  // The action returns false on no-op (same system) or unknown id;
+  // the button's `disabled` already gates same-system clicks so
+  // the false path is purely defensive here.
+  const handleTravel = (): void => {
+    if (!selectedSystemId) return;
+    store.getState().travelToSystem(selectedSystemId);
+  };
+
+  const isSameAsCurrent =
+    !!campaign.currentSystemId && campaign.currentSystemId === selectedSystemId;
+  // Fallback: legacy campaigns without a currentSystemId default to
+  // Terra — so 'terra' should ALSO be considered "same system" when
+  // the campaign has no recorded location yet.
+  const isLegacyTerraSelf =
+    !campaign.currentSystemId && selectedSystemId === 'terra';
+  const travelDisabled =
+    isSameAsCurrent || isLegacyTerraSelf || !selectedSystem;
+
+  return (
+    <PageLayout
+      title="Starmap"
+      subtitle={campaign.name}
+      maxWidth="wide"
+      breadcrumbs={breadcrumbs}
+    >
+      <CampaignNavigation campaignId={campaign.id} currentPage="starmap" />
+
+      {/* Selection / travel control strip. Sits above the canvas so
+       * the operator can read the destination + commit a jump
+       * without leaving the page. The current-system pin reads off
+       * `campaign.currentSystemId` (or Terra as the legacy default).
+       */}
+      <div
+        className="border-border-theme bg-surface-theme mb-4 flex flex-wrap items-center gap-4 rounded border p-4"
+        data-testid="starmap-travel-controls"
+      >
+        <div className="text-sm">
+          <div className="text-text-theme-secondary text-xs font-semibold tracking-wider uppercase">
+            Current location
+          </div>
+          <div
+            className="text-text-theme-primary font-mono"
+            data-testid="starmap-current-system"
+          >
+            {currentSystem?.name ?? campaign.currentSystemId ?? 'Terra'}
+          </div>
+        </div>
+
+        <div className="text-sm">
+          <div className="text-text-theme-secondary text-xs font-semibold tracking-wider uppercase">
+            Selected destination
+          </div>
+          <div
+            className="text-text-theme-primary font-mono"
+            data-testid="starmap-selected-system"
+          >
+            {selectedSystem?.name ?? '— pick a system —'}
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={handleTravel}
+          disabled={travelDisabled}
+          className="bg-accent text-text-on-accent ml-auto rounded px-4 py-2 text-sm font-semibold transition-colors hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+          data-testid="starmap-travel-btn"
+        >
+          Travel here
+        </button>
+      </div>
+
+      <div
+        className="border-border-theme h-[600px] w-full overflow-hidden rounded border"
+        data-testid="starmap-container"
+      >
+        <StarmapDisplay
+          systems={seed.systems.map((s) => ({
+            id: s.id,
+            name: s.name,
+            position: { x: s.position.x, y: s.position.y },
+            faction: s.faction,
+            population: s.population,
+          }))}
+          selectedSystem={selectedSystemId}
+          onSystemClick={(systemId) => setSelectedSystemId(systemId)}
+        />
+      </div>
+
+      <div className="text-text-theme-secondary mt-4 text-xs">
+        Inner Sphere snapshot — year {seed.meta.snapshotYear}. Coordinates in
+        light-years from Terra (+x spinward, +y rimward).
+      </div>
+    </PageLayout>
+  );
+}

--- a/src/stores/campaign/__tests__/useCampaignStore.travelToSystem.test.ts
+++ b/src/stores/campaign/__tests__/useCampaignStore.travelToSystem.test.ts
@@ -1,0 +1,102 @@
+/**
+ * useCampaignStore.travelToSystem tests
+ *
+ * Per `wire-starmap-into-campaign` (Wave 6.4): the travel action mutates
+ * `campaign.currentSystemId` and emits a 'travel' activity-log entry.
+ * These tests cover the four behaviour contracts spelled out in
+ * the spec:
+ *
+ *   1. Happy path — known seed id, different from current
+ *   2. Same-system no-op — selected id == campaign.currentSystemId
+ *   3. Unknown id — silently rejected, no mutation, no log entry
+ *   4. Legacy-campaign default — undefined currentSystemId treated as Terra
+ *
+ * The activity-log dedup behaviour (FIFO + last-write-wins on id
+ * collision) is already covered by the appendActivityLogEntry suite —
+ * this file focuses on the action's wiring + invariants.
+ *
+ * @spec openspec/changes/wire-starmap-into-campaign/specs/starmap-interface/spec.md
+ */
+
+import { createCampaignStore } from '../useCampaignStore';
+
+describe('useCampaignStore.travelToSystem', () => {
+  function freshStoreWithCampaign(): ReturnType<typeof createCampaignStore> {
+    const store = createCampaignStore();
+    store.getState().createCampaign('Test Campaign', 'davion');
+    return store;
+  }
+
+  it('returns false when no campaign is loaded', () => {
+    const store = createCampaignStore();
+    expect(store.getState().travelToSystem('luthien')).toBe(false);
+  });
+
+  it('returns false on unknown systemId without mutating state', () => {
+    const store = freshStoreWithCampaign();
+    const beforeLog = store.getState().activityLog.length;
+    const beforeCurrent = store.getState().campaign?.currentSystemId;
+    const result = store.getState().travelToSystem('not-a-real-system');
+    expect(result).toBe(false);
+    expect(store.getState().campaign?.currentSystemId).toBe(beforeCurrent);
+    expect(store.getState().activityLog.length).toBe(beforeLog);
+  });
+
+  it('returns false on empty systemId', () => {
+    const store = freshStoreWithCampaign();
+    expect(store.getState().travelToSystem('')).toBe(false);
+  });
+
+  it('travels to a known system on happy path and emits one travel log entry', () => {
+    const store = freshStoreWithCampaign();
+    const beforeLog = store.getState().activityLog.length;
+    const result = store.getState().travelToSystem('luthien');
+    expect(result).toBe(true);
+    expect(store.getState().campaign?.currentSystemId).toBe('luthien');
+    const log = store.getState().activityLog;
+    expect(log.length).toBe(beforeLog + 1);
+    const last = log[log.length - 1];
+    expect(last.category).toBe('travel');
+    // Discriminated union narrows on the category check above.
+    if (last.category === 'travel') {
+      expect(last.payload.event).toBe('jump');
+      expect(last.payload.toSystemId).toBe('luthien');
+      expect(last.payload.toSystemName).toBe('Luthien');
+      // Legacy-default: untravelled campaigns leave from Terra.
+      expect(last.payload.fromSystemId).toBe('terra');
+    }
+  });
+
+  it('treats undefined currentSystemId as Terra (legacy no-op)', () => {
+    const store = freshStoreWithCampaign();
+    expect(store.getState().campaign?.currentSystemId).toBeUndefined();
+    // Travel to Terra from the implicit Terra default should no-op.
+    const result = store.getState().travelToSystem('terra');
+    expect(result).toBe(false);
+  });
+
+  it('no-ops when destination equals current system', () => {
+    const store = freshStoreWithCampaign();
+    expect(store.getState().travelToSystem('luthien')).toBe(true);
+    const beforeLog = store.getState().activityLog.length;
+    const result = store.getState().travelToSystem('luthien');
+    expect(result).toBe(false);
+    // No additional log entry — dedup or not, the action should not
+    // even emit when the destination is the current system.
+    expect(store.getState().activityLog.length).toBe(beforeLog);
+  });
+
+  it('emits fromSystemId reflecting the previous location across two jumps', () => {
+    const store = freshStoreWithCampaign();
+    store.getState().travelToSystem('luthien'); // terra → luthien
+    store.getState().travelToSystem('sian'); // luthien → sian
+    const log = store.getState().activityLog;
+    const last = log[log.length - 1];
+    if (last.category === 'travel') {
+      expect(last.payload.fromSystemId).toBe('luthien');
+      expect(last.payload.toSystemId).toBe('sian');
+    } else {
+      throw new Error('Last entry should be a travel entry');
+    }
+  });
+});

--- a/src/stores/campaign/useCampaignStore.ts
+++ b/src/stores/campaign/useCampaignStore.ts
@@ -18,6 +18,7 @@ import {
 } from '@/lib/campaign/dayAdvancement';
 import { getDayPipeline } from '@/lib/campaign/dayPipeline';
 import { registerBuiltinProcessors } from '@/lib/campaign/processors';
+import { findSystemById } from '@/lib/starmap/loadInnerSphereSeed';
 import { clientSafeStorage } from '@/stores/utils/clientSafeStorage';
 import {
   ACTIVITY_LOG_MAX_ENTRIES,
@@ -413,6 +414,70 @@ export function createCampaignStore(): StoreApi<CampaignStore> {
           set({ activityLog: trimmed });
         },
         getActivityLog: () => get().activityLog,
+        travelToSystem: (systemId: string) => {
+          // Wave 6.4 (wire-starmap-into-campaign): commit a jump between
+          // two seed-dataset star systems. Validates the destination
+          // against the Inner Sphere seed (via findSystemById) and
+          // emits a 'travel' activity-log entry on success.
+          //
+          // Returns:
+          //  - false on unknown systemId (silently — caller logs)
+          //  - false on no-op (already at the same system)
+          //  - true on a successful jump
+          //
+          // The previous system is read off campaign.currentSystemId; if
+          // unset (legacy campaigns from before this wave), it falls back
+          // to 'terra' — the canonical anchor of the Inner Sphere
+          // coordinate system.
+          const { campaign } = get();
+          if (!campaign) return false;
+          if (!systemId) return false;
+          const destination = findSystemById(systemId);
+          if (!destination) return false;
+          const fromSystemId = campaign.currentSystemId ?? 'terra';
+          if (fromSystemId === systemId) return false;
+          const updatedCampaign: ICampaign = {
+            ...campaign,
+            currentSystemId: systemId,
+            updatedAt: new Date().toISOString(),
+          };
+          set({ campaign: updatedCampaign });
+          // Emit the travel entry through the normal append action so
+          // FIFO retention + dedup behave the same as every other
+          // category. The campaignDay is read off the (just updated)
+          // campaign so the entry is anchored on the in-game timeline,
+          // not the wall clock.
+          // Derive a stable campaignDay number from elapsed-days since
+          // the campaign's start date. Mirrors the convention used by
+          // the dayAdvancement pipeline so the activity-log timeline is
+          // consistent across emitters. Falls back to 0 for
+          // legacy campaigns missing `campaignStartDate`.
+          const startDate =
+            updatedCampaign.campaignStartDate ?? updatedCampaign.currentDate;
+          const msPerDay = 24 * 60 * 60 * 1000;
+          const campaignDay = Math.max(
+            0,
+            Math.floor(
+              (updatedCampaign.currentDate.getTime() - startDate.getTime()) /
+                msPerDay,
+            ),
+          );
+          const entryId = `travel-${campaign.id}-${campaignDay}-${systemId}`;
+          get().appendActivityLogEntry({
+            id: entryId,
+            timestamp: new Date().toISOString(),
+            campaignDay,
+            category: 'travel',
+            message: `Jumped to ${destination.name}.`,
+            payload: {
+              event: 'jump',
+              fromSystemId,
+              toSystemId: systemId,
+              toSystemName: destination.name,
+            },
+          });
+          return true;
+        },
       }),
       {
         name: 'campaign-store',

--- a/src/stores/campaign/useCampaignStore.types.ts
+++ b/src/stores/campaign/useCampaignStore.types.ts
@@ -98,6 +98,16 @@ export interface CampaignActions {
   appendActivityLogEntry: (entry: IActivityLogEntry) => void;
   /** Read the current activity log (newest last). */
   getActivityLog: () => readonly IActivityLogEntry[];
+  /**
+   * Travel the campaign force to a different star system
+   * (`wire-starmap-into-campaign` Wave 6.4).
+   *
+   * Validates `systemId` against the Inner Sphere seed dataset and
+   * updates `campaign.currentSystemId` + emits a `'travel'` activity-log
+   * entry. Returns `true` on a successful travel; `false` on no-op
+   * (same system) or invalid systemId.
+   */
+  travelToSystem: (systemId: string) => boolean;
 }
 
 export type CampaignStore = CampaignState & CampaignActions;

--- a/src/types/campaign/ActivityLog.ts
+++ b/src/types/campaign/ActivityLog.ts
@@ -38,7 +38,8 @@ export type ActivityLogCategory =
   | 'medical'
   | 'finances'
   | 'acquisitions'
-  | 'technical';
+  | 'technical'
+  | 'travel';
 
 /**
  * Ordered list of all categories — useful for rendering tabs in a
@@ -52,6 +53,11 @@ export const ACTIVITY_LOG_CATEGORIES: readonly ActivityLogCategory[] = [
   'finances',
   'acquisitions',
   'technical',
+  // Per `wire-starmap-into-campaign` (Wave 6.4): travel between star
+  // systems emits a `'travel'` entry so the dashboard's activity-log
+  // surface shows the jump in the same timeline as combat / personnel
+  // changes.
+  'travel',
 ];
 
 // =============================================================================
@@ -129,6 +135,23 @@ export interface ITechnicalActivityPayload {
   readonly unitName: string;
 }
 
+/**
+ * Travel event — campaign force jumped between star systems.
+ * Per `wire-starmap-into-campaign` (Wave 6.4): emitted by
+ * `useCampaignStore.travelToSystem` when the player commits a jump.
+ * The `fromSystemId` is the previous `campaign.currentSystemId` (or
+ * `'terra'` when the field was unset — the legacy-campaign default).
+ */
+export interface ITravelActivityPayload {
+  readonly event: 'jump';
+  /** Star system the force left. */
+  readonly fromSystemId: string;
+  /** Star system the force arrived at. */
+  readonly toSystemId: string;
+  /** Display name of the destination — denormalized so the dashboard doesn't have to re-resolve the id. */
+  readonly toSystemName: string;
+}
+
 // =============================================================================
 // Discriminated union
 // =============================================================================
@@ -174,6 +197,10 @@ export type IActivityLogEntry =
   | (IActivityLogEntryBase & {
       readonly category: 'technical';
       readonly payload: ITechnicalActivityPayload;
+    })
+  | (IActivityLogEntryBase & {
+      readonly category: 'travel';
+      readonly payload: ITravelActivityPayload;
     });
 
 // =============================================================================

--- a/src/types/campaign/Campaign.ts
+++ b/src/types/campaign/Campaign.ts
@@ -194,6 +194,20 @@ export interface ICampaign {
    * See openspec/changes/wire-coop-campaign-route/specs/coop-campaign-sync/spec.md.
    */
   readonly coopSession?: ICoopSession;
+
+  /**
+   * Current star-system location (`wire-starmap-into-campaign`, Wave 6.4).
+   *
+   * The player's "you are here" pin on the starmap. The field is OPTIONAL
+   * for backward compatibility — a legacy campaign without the field is
+   * treated as stationed at `'terra'` by all UI surfaces (the canonical
+   * default). Updated EXCLUSIVELY via the `useCampaignStore.travelToSystem`
+   * action so the activity-log entry and seed-dataset validation
+   * invariants are enforced together.
+   *
+   * See openspec/changes/wire-starmap-into-campaign/specs/campaign-system/spec.md.
+   */
+  readonly currentSystemId?: string;
 }
 
 // =============================================================================

--- a/src/types/starmap/StarSystem.ts
+++ b/src/types/starmap/StarSystem.ts
@@ -1,0 +1,88 @@
+/**
+ * Star System data model
+ *
+ * Per `wire-starmap-into-campaign` (Wave 6.4): the canonical shape for a
+ * star system on the campaign starmap. The structure mirrors the existing
+ * `IStarSystem` interface inside `StarmapDisplay.tsx` (which was already
+ * authored for the display component) — we re-export it as a stable type
+ * the data loaders, store actions, and tests can depend on without
+ * reaching into the component module.
+ *
+ * The MVP shape carries `id` / `name` / `position` / `faction` /
+ * `population?`. Future extensions (industrial rating, system stats,
+ * jump-distance graph) layer on as optional fields when the full SUCKit
+ * import lands; the MVP shape stays a strict subset.
+ *
+ * @spec openspec/changes/wire-starmap-into-campaign/specs/starmap-interface/spec.md
+ */
+
+/**
+ * Canonical BattleTech-universe factions the seed dataset uses. The list
+ * is closed for the MVP — adding a new faction requires extending this
+ * union AND the `FACTION_COLORS` table in `StarmapDisplay.tsx`. Mercenary
+ * / unaligned systems use `'Independent'`.
+ */
+export const KNOWN_FACTIONS = [
+  'Lyran',
+  'Davion',
+  'Liao',
+  'Kurita',
+  'Marik',
+  'Steiner',
+  'Periphery',
+  'ComStar',
+  'Clan',
+  'Independent',
+] as const;
+
+export type KnownFaction = (typeof KNOWN_FACTIONS)[number];
+
+/**
+ * A single star system on the campaign starmap.
+ *
+ * The `position` coordinates are in the standard BattleTech-universe
+ * convention: Terra at the origin, +x = "spinward / Davion-ward",
+ * +y = "rimward / Periphery-ward". The exact unit is arbitrary for the
+ * MVP (canvas pixels scale to fit) but the seed dataset uses light-year
+ * offsets so a future SUCKit import drops in cleanly.
+ */
+export interface IStarSystem {
+  /** Stable kebab-case id (e.g. `'terra'`, `'new-avalon'`). */
+  readonly id: string;
+  /** Display name (e.g. `'New Avalon'`). */
+  readonly name: string;
+  /** Position on the canvas. */
+  readonly position: {
+    readonly x: number;
+    readonly y: number;
+  };
+  /** Controlling faction at the seed-dataset's snapshot date (3025). */
+  readonly faction: KnownFaction;
+  /** Optional population for the LOD's "major system" label decision. */
+  readonly population?: number;
+}
+
+/**
+ * Type guard for `IStarSystem`. Used by the seed-dataset loader to
+ * reject a malformed entry at build time (failing the unit-test seed
+ * shape assertion) rather than letting a bad entry trickle through to
+ * the canvas where it would render as a blank dot.
+ */
+export function isStarSystem(value: unknown): value is IStarSystem {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+
+  if (typeof v.id !== 'string' || v.id.length === 0) return false;
+  if (typeof v.name !== 'string' || v.name.length === 0) return false;
+  if (typeof v.faction !== 'string') return false;
+  if (!(KNOWN_FACTIONS as readonly string[]).includes(v.faction)) return false;
+
+  const pos = v.position as { x?: unknown; y?: unknown } | undefined;
+  if (pos === undefined || pos === null) return false;
+  if (typeof pos.x !== 'number' || typeof pos.y !== 'number') return false;
+
+  if (v.population !== undefined && typeof v.population !== 'number')
+    return false;
+
+  return true;
+}


### PR DESCRIPTION
## Wave 6.4 — Starmap Integration

Per `wire-starmap-into-campaign` (Wave 6.4 of the post-playtest finish-up roadmap): the existing `<StarmapDisplay>` component + Storybook stories were not reachable from any production campaign route. Wave 6.4 mounts it on a new `/gameplay/campaigns/[id]/starmap` sub-route, fed by a 40-system Inner Sphere seed dataset, with a travel-between-systems action that emits a `'travel'` activity-log entry.

## What ships

**Type system + seed dataset (3 new files):**
- `src/types/starmap/StarSystem.ts` — `IStarSystem` interface + `KNOWN_FACTIONS` enum + `isStarSystem` type guard
- `src/lib/starmap/seed/inner-sphere-seed.json` — 40 canonical systems: Terra at the origin + 5 Successor State capitals (Tharkad, New Avalon, Sian, Luthien, Atreus) + Periphery capitals + Clan invasion-route worlds + strategic worlds. Coordinates in light-years from Terra (+x spinward, +y rimward)
- `src/lib/starmap/loadInnerSphereSeed.ts` — `loadInnerSphereSeed()` + `findSystemById()`, validates every entry, throws with entry index on malformed JSON

**Type-system extensions (3 modified files):**
- `ICampaign.currentSystemId?: string` — OPTIONAL for backward compatibility; legacy campaigns treat unset as Terra
- `ActivityLogCategory` gains `'travel'` discriminant + `ITravelActivityPayload` interface (`{event: 'jump', fromSystemId, toSystemId, toSystemName}`)
- Dashboard `<ActivityLogCard>` + `/log` page `CATEGORY_LABELS` extended with the new tab

**Store action (modified `useCampaignStore.ts`):**
- `travelToSystem(systemId)` returns `false` on missing campaign / empty id / unknown id / same-system no-op; `true` on a successful jump
- Sets `campaign.currentSystemId` AND emits a `'travel'` entry via `appendActivityLogEntry` so FIFO retention + dedup share the same pipeline as every other category
- Derives `campaignDay` from `(currentDate - campaignStartDate)` so the activity-log timeline stays consistent with `dayAdvancement`

**Campaign Starmap page (new `/gameplay/campaigns/[id]/starmap.tsx`):**
- PT-102 hydration guard (`useEffect(() => setIsClient(true), [])`)
- Mounts `<StarmapDisplay>` with seed systems + click-to-select state
- 'Travel here' CTA wires to `travelToSystem(systemId)`; disabled on same-system / unknown id
- 'Starmap' tab added to `CampaignNavigation` between Missions and the Bays group

## OpenSpec change

`wire-starmap-into-campaign` validates `--strict` clean. Two delta capabilities:
- `starmap-interface` — \"Inner Sphere Seed Dataset\" requirement (≥40 entries, kebab-case ids, KNOWN_FACTIONS membership, finite numeric positions, capitals + Clan presence, seed-meta exposed) + \"Selected System Travel Action\" requirement
- `campaign-system` — \"Current System Location\" requirement (optional field, Terra fallback, sole-mutator invariant)

## Tests

- **`loadInnerSphereSeed.test.ts`** — 9 cases: seed shape, KNOWN_FACTIONS membership, capitals + Clan presence, findSystemById happy + miss paths
- **`useCampaignStore.travelToSystem.test.ts`** — 7 cases: no-campaign rejection, unknown id rejection, empty id rejection, happy path with log emit, legacy-Terra-self-noop, same-system no-op, two-jump fromSystemId chain
- All 130 existing CampaignDashboard tests + 55 existing campaign-store tests still pass — adding the `'travel'` category + new action did not regress the activity-log slice

## Verification

- `npx openspec validate wire-starmap-into-campaign --strict` → valid
- `npx tsc --noEmit` → 0 errors
- New + existing tests green

## Diff stats

17 files, +1225 / -1.

@spec openspec/changes/wire-starmap-into-campaign/specs/starmap-interface/spec.md
@spec openspec/changes/wire-starmap-into-campaign/specs/campaign-system/spec.md