### PR TITLE
chore(wave-7.0): pre-apply gates for Tactical UI Wave 7

### DIFF
--- a/e2e/gameplay-layout-slots.spec.ts
+++ b/e2e/gameplay-layout-slots.spec.ts
@@ -1,0 +1,116 @@
+/**
+ * GameplayLayout slot identity regression gate
+ *
+ * Locks in the slot-identity contract for the tactical-combat GameplayLayout
+ * BEFORE Wave 7.1 PR-B refactors it into the TacticalCommandShell slot model.
+ *
+ * The failure mode this catches (Council Momus Attack #4):
+ *   Shell migration produces a parallel layout hierarchy — e.g. shell wraps
+ *   GameplayLayout instead of replacing it, leaving two `[data-testid="gameplay-layout"]`
+ *   elements mounted simultaneously. The visual surface looks correct but the
+ *   slot contract is silently broken (focus order, screen reader nav, event
+ *   binding, persistence scope all duplicate). No existing test mounts the
+ *   layout end-to-end and asserts cardinality, so the failure ships.
+ *
+ * This gate asserts each named structural slot resolves to EXACTLY ONE
+ * element (or zero on viewports that don't render it). After Wave 7.1's
+ * migration the test re-runs against the slot-composition shell; any
+ * cardinality drift fails the gate. Visual regression coverage is the
+ * separate concern of `e2e/visual-regression.spec.ts`.
+ *
+ * @spec openspec/changes/add-tactical-command-shell/tasks.md (Wave 7.0 gate)
+ * @tags @smoke @game @wave-7-gate
+ */
+
+import { test, expect } from '@playwright/test';
+
+import { GameSessionPage } from './pages/game.page';
+
+test.describe('GameplayLayout slot identity @smoke @game @wave-7-gate', () => {
+  test.beforeEach(async ({ page }) => {
+    const session = new GameSessionPage(page);
+    await session.navigate('demo');
+    await session.waitForGameLoaded();
+  });
+
+  test('root layout container resolves exactly once', async ({ page }) => {
+    // Parallel-hierarchy guard: shell migration must REPLACE GameplayLayout's
+    // root, not wrap it. A duplicate testid means the old layout is still
+    // mounted alongside the new shell.
+    const roots = page.locator('[data-testid="gameplay-layout"]');
+    await expect(roots).toHaveCount(1);
+  });
+
+  test('main content slot resolves exactly once', async ({ page }) => {
+    const mainContent = page.locator('[data-testid="gameplay-main-content"]');
+    await expect(mainContent).toHaveCount(1);
+  });
+
+  test('map-center slot (map-panel) resolves exactly once', async ({
+    page,
+  }) => {
+    // The map is the canonical center slot — its identity is the most
+    // load-bearing for hex-click coordinate routing.
+    const mapPanel = page.locator('[data-testid="map-panel"]');
+    await expect(mapPanel).toHaveCount(1);
+    await expect(mapPanel.first()).toBeVisible();
+  });
+
+  test('right-tray slot (record-sheet-panel) resolves on desktop width', async ({
+    page,
+  }) => {
+    // Desktop viewport (1280px from playwright.config.ts) renders the
+    // split-pane record-sheet-panel; mobile uses RecordSheetDrawer instead.
+    // This test runs in the `chromium` project (1280x720). The mobile
+    // project skips it via the visibility check.
+    const recordSheet = page.locator('[data-testid="record-sheet-panel"]');
+    const viewport = page.viewportSize();
+    if (viewport && viewport.width >= 1024) {
+      await expect(recordSheet).toHaveCount(1);
+    } else {
+      // Mobile: record-sheet-panel is replaced by the drawer; either absent
+      // or present-but-collapsed. We don't assert on absence to keep this
+      // robust against the drawer's rendering choice.
+      const count = await recordSheet.count();
+      expect(count).toBeLessThanOrEqual(1);
+    }
+  });
+
+  test('no duplicate slot ids anywhere in the gameplay layout subtree', async ({
+    page,
+  }) => {
+    // Defense-in-depth against parallel-hierarchy bugs that miss the
+    // narrow per-slot assertions above. Walks every data-testid below the
+    // root and asserts each structural slot appears at most once. Per-unit
+    // / per-action testids on children are allowed to repeat — they live
+    // inside list containers and are list items, not slots.
+    const rootHandle = page.locator('[data-testid="gameplay-layout"]');
+    await expect(rootHandle).toHaveCount(1);
+
+    const allIds = await rootHandle
+      .locator('[data-testid]')
+      .evaluateAll((nodes) =>
+        (nodes as HTMLElement[]).map((node) =>
+          node.getAttribute('data-testid'),
+        ),
+      );
+
+    // The layout shell's own structural slots — none of these should ever
+    // duplicate. 0 is acceptable on viewports that don't render the slot
+    // (e.g. record-sheet-panel on mobile); duplicates are not.
+    const structuralSlots = [
+      'gameplay-main-content',
+      'map-panel',
+      'record-sheet-panel',
+      'resize-handle',
+    ];
+
+    for (const slot of structuralSlots) {
+      const count = allIds.filter((id) => id === slot).length;
+      expect(
+        count,
+        `slot "${slot}" appeared ${count} times`,
+      ).toBeLessThanOrEqual(1);
+    }
+  });
+});

--- a/openspec/changes/add-tactical-command-shell/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/add-tactical-command-shell/specs/tactical-map-interface/spec.md
@@ -54,10 +54,34 @@ The command shell SHALL support combat, replay, spectator, and GM/referee modes 
 
 ### Requirement: Tactical Shell State Contract
 
-The tactical map interface SHALL expose a typed shell state contract for selected slot, pinned panels, collapsed panels, shell mode, and active context.
+The tactical map interface SHALL expose a typed shell state contract for selected slot, pinned panels, collapsed panels, shell mode, active context, viewer player identity, and per-opponent visibility scopes.
 
 #### Scenario: Shell state round-trips through UI actions
 - **GIVEN** `ITacticalShellState` has a collapsed left tray, pinned right inspector, and active bottom dock tab
 - **WHEN** the shell re-renders after map selection changes
 - **THEN** collapsed, pinned, and active tab state SHALL persist
 - **AND** selection-derived content SHALL update without resetting manually chosen shell layout
+
+#### Scenario: Shell distinguishes selected, active, and inspected unit references
+- **GIVEN** the player is inspecting an ally token mid-turn while a different friendly unit holds activation
+- **WHEN** the shell reads its unit-reference state
+- **THEN** `selectedUnit` (the token the player clicked), `activeUnit` (the unit whose turn it currently is), and `inspectedUnit` (the unit whose record sheet is open in the right tray) SHALL be addressable as three independent fields
+- **AND** the action dock SHALL bind to `activeUnit`, the right-tray inspector SHALL bind to `inspectedUnit`, and the map highlight SHALL bind to `selectedUnit` without cross-coupling
+
+### Requirement: Per-Viewer Visibility Scope
+
+The tactical shell state SHALL carry a viewer identity and per-opponent visibility scope so the same shell composition can render correctly for co-op (N≥2 guests) and PvP campaigns without leaking hidden opponent state.
+
+#### Scenario: Shell state scopes per-viewer for co-op and PvP
+- **GIVEN** a co-op or PvP match with two or more opposing players
+- **WHEN** the shell renders for a specific viewer
+- **THEN** `ITacticalShellState.viewerPlayerId` SHALL identify the local viewer
+- **AND** `opponentVisibilityScopes` SHALL map each opposing player id to their visibility tier (`exact`, `rough`, `last-known`, `hidden`, `unknown`)
+- **AND** the shell SHALL NOT leak hidden opponent state across viewer boundaries
+- **AND** redaction SHALL occur in the data adapter that feeds the shell, not in CSS visibility
+
+#### Scenario: PvP shell renders symmetric chrome for two player factions
+- **GIVEN** a PvP match where player A and player B hold opposing forces
+- **WHEN** player B opens the shell on their client
+- **THEN** the same slot contract SHALL render with player B as `viewerPlayerId`
+- **AND** action dock, inspectors, and intel projection SHALL bind to player B's force without requiring a separate component tree

--- a/openspec/changes/add-tactical-command-shell/tasks.md
+++ b/openspec/changes/add-tactical-command-shell/tasks.md
@@ -1,7 +1,10 @@
 ## 1. Shell Contract
 
 - [ ] 1.1 Define `ITacticalShellState`, shell modes, slot ids, and primary-home mapping in gameplay UI types
+  > **Note (Wave 7.0 gate):** `ITacticalShellState` MUST distinguish three independent unit references — `selectedUnit` (clicked token), `activeUnit` (whose turn it is), and `inspectedUnit` (open in right-tray record sheet). Action dock binds to `activeUnit`; inspector binds to `inspectedUnit`; map highlight binds to `selectedUnit`. No cross-coupling. This avoids the MegaMek PR #5540 → #5573 firing-arc regression where a single `currentEntity` reference silently broke arc redraw on cross-selection.
+  > **Note (Wave 7.0 gate):** `ITacticalShellState` MUST carry `viewerPlayerId` and `opponentVisibilityScopes` from day one (see spec.md `Per-Viewer Visibility Scope` requirement). These fields are forward-compat hooks for co-op N≥2 and PvP campaigns — they may be defaulted in single-viewer matches but the type surface lands now to avoid a future breaking change to the shell contract.
 - [ ] 1.2 Add a shell slot registry that maps phase, actions, inspectors, lenses, event feed, minimap, and replay controls to owners
+  > **Note (Wave 7.0 gate):** This task creates the slot-registry surface. Lens additions in `add-tactical-map-lenses-feed-replay` that extend `src/components/gameplay/HexMapDisplay/useMapLayerState.ts` MUST wait for this slot registry to land — sequencing constraint to avoid a collision between shell ownership of the lens-control surface and lens-id extensions to the underlying layer state.
 
 ## 2. Layout Composition
 

--- a/openspec/changes/add-tactical-map-lenses-feed-replay/tasks.md
+++ b/openspec/changes/add-tactical-map-lenses-feed-replay/tasks.md
@@ -1,6 +1,7 @@
 ## 1. Lens Model
 
 - [ ] 1.1 Define tactical lens presets mapped to map layer ids and intensity defaults
+  > **Note (Wave 7.0 gate):** Lens-id extensions to `src/components/gameplay/HexMapDisplay/useMapLayerState.ts` MUST land AFTER `add-tactical-command-shell` task 1.2 (slot registry). The shell owns the lens-control surface (left tray slot); extending `MapLayerId` / `IMapLayerInteractionState` without the slot registry in place risks a collision between shell-side lens ownership and underlying layer-state ownership. Pull request ordering: shell PR-A (types) and PR-B (slot registry + GameplayLayout migration) merge first; this change opens after.
 - [ ] 1.2 Add lens state selectors for movement, attack, intel, terrain, objective, and survival views
 
 ## 2. Pins and Minimap


### PR DESCRIPTION
## Why

OMO Council Lean+ verdict on the post-Wave-6.x next-execution question landed a **dual-track plan**: Apply Track ships the 7 Codex-authored tactical-UI OpenSpec changes from PR #639; Author Track (concurrent) specs out combat-parity-wave-7 (BA, indirect fire + spotter, aerospace).

This PR lands the **four pre-apply gates** that must be in main BEFORE any Wave 7.1 shell-migration PR opens. Each gate addresses a live adversary objection that survived the council cross-attack.

Phase 4.5 Judge VERIFIED the synthesis single-pass. Plan file: `C:\Users\wroll\.claude\plans\working-tree-clean-pr-kind-starfish.md`.

## What changes

### Gate 1 — shell-contract forward-compat amendment

`openspec/changes/add-tactical-command-shell/specs/tactical-map-interface/spec.md`

- Extends `ITacticalShellState` contract with `viewerPlayerId` + `opponentVisibilityScopes` fields
- Adds new `Per-Viewer Visibility Scope` requirement with 2 scenarios (co-op N≥2; PvP symmetric chrome)
- Adds scenario distinguishing `selectedUnit` / `activeUnit` / `inspectedUnit` references

Closes **Oracle + Momus #3** concern about co-op N>2 and PvP lock-in. The shell contract now lands forward-compatible with multi-viewer matches from day one — no future breaking-change PR needed when 3+ player co-op or PvP campaigns ship.

### Gate 2 — useMapLayerState sequencing constraint

`openspec/changes/add-tactical-command-shell/tasks.md` (task 1.2 note)
`openspec/changes/add-tactical-map-lenses-feed-replay/tasks.md` (task 1.1 note)

Lens-id extensions to `src/components/gameplay/HexMapDisplay/useMapLayerState.ts` MUST wait for the shell slot registry to land. Avoids the collision Momus #5 surfaced between shell ownership of the lens-control surface and lens-id extensions to the underlying layer state.

### Gate 3 — Playwright GameplayLayout slot-identity regression gate

`e2e/gameplay-layout-slots.spec.ts` (new, 116 LOC, 5 tests)

Asserts each structural slot data-testid resolves to at most one element across desktop / tablet / mobile viewports. Catches **Momus Attack #4**: shell migration wraps `GameplayLayout` instead of replacing it, leaving duplicate testids mounted simultaneously. No existing test mounted the layout end-to-end and asserted cardinality, so the failure would have shipped silently.

Tagged `@smoke @game @wave-7-gate` — runs on every PR via the smoke project.

### Gate 4 — selectedUnit / activeUnit / inspectedUnit distinction

`openspec/changes/add-tactical-command-shell/tasks.md` (task 1.1 note)

Shell state MUST distinguish three independent unit references. Action dock binds to `activeUnit`; right-tray inspector binds to `inspectedUnit`; map highlight binds to `selectedUnit`. No cross-coupling.

Closes **Librarian anti-precedent**: MegaMek [PR #5540](https://github.com/MegaMek/megamek/pull/5540) → [#5573](https://github.com/MegaMek/megamek/pull/5573) firing-arc regression. A `currentEntity` rename across PhaseDisplay classes silently broke arc redraw on cross-selection because the displayed unit and the firing unit shared a single reference.

## Verification

- `npx openspec validate add-tactical-command-shell --strict` → clean
- `npx openspec validate add-tactical-map-lenses-feed-replay --strict` → clean
- `npx tsc --noEmit` → clean
- `npx oxfmt --check` → clean on touched files
- Pre-commit hook full Next.js build + 63/63 static pages → clean

## Next

After this merges:
- Wave 7.1 PR-A opens: `feat(wave-7.1): ITacticalShellState + slot registry` (types only)
- Wave 7.1 PR-B opens: `feat(wave-7.1): wrap GameplayLayout with TacticalCommandShell` (the migration gated by `e2e/gameplay-layout-slots.spec.ts`)
- Wave 7.1 PR-C opens: `feat(wave-7.1): wire shell to combat/replay/spectator/GM modes`

Concurrent Author Track (running in background worktree): omo-prometheus authoring `add-indirect-fire-and-spotter-network`, `add-battle-armor-combat`, `add-aerospace-deployment` specs for Wave 8.
