### PR TITLE
docs(openspec): author combat-parity-wave-7 sub-specs (Wave 8/9 backlog)

### DIFF
--- a/openspec/changes/add-aerospace-deployment/design.md
+++ b/openspec/changes/add-aerospace-deployment/design.md
@@ -1,0 +1,173 @@
+# Design: Add Aerospace Deployment
+
+## Reference Material
+
+- MegaMek `Aero.java` (99KB, 3111 LOC) — canonical aerospace combat + movement + altitude + velocity model
+- MegaMek `Aero.java:182-310` — altitude tracking, altitude loss, surface-to-orbit transition
+- MegaMek `Aero.java:687-720` — `setCurrentVelocity` / `setNextVelocity` velocity carry between turns
+- MegaMek `Aero.java:1463-1510` — control-roll trigger conditions (thrust above safeThrust, velocity > 2× safeThrust, etc.)
+- MegaMek `Aero.java:1502-1520` — stall conditions in atmospheric flight
+- MegaMek `Aero.java:1912-1945` — vector-based velocity for space combat
+- MegaMek `Aero.java:2448-2460` — altitude vs elevation distinction
+- Local `openspec/specs/movement-system/spec.md:402-456` — existing 2D-simplified aero model (becomes legacy fallback)
+- Local `openspec/specs/combat-resolution/spec.md:445-497` — existing aerospace dispatch / damage / control-roll (extended here)
+- Local `openspec/specs/aerospace-unit-system/spec.md:338-352` — existing minimal `Aerospace Combat State` (extended here via `unit-entity-model` delta)
+- Local `src/types/gameplay/GameplayUIInterfaces.ts:298-307` — existing `IAerospaceToken.velocity` TODO
+
+## Architecture Decisions
+
+### Decision A: New `aerospace-deployment` capability, not delta on `aerospace-unit-system`
+
+**Choice**: airborne flight + combat mechanics live in a new `aerospace-deployment` capability. `aerospace-unit-system` stays construction-focused (1351 LOC of chassis/armor/thrust/fuel rules).
+
+**Rationale**: same pattern as `add-battle-armor-combat` separating BA combat from BA construction. The construction spec is well-bounded; combat behavior is its own domain. Folding ~25 combat-flight requirements into a 1351-LOC construction spec pushes it past 1800 LOC and conflates two distinct concerns. The split also lets the Apply wave's scope be self-contained — Wave 9 doesn't have to load + understand the entire 1351-LOC construction spec to implement combat.
+
+**Alternatives considered**:
+- *Modify `combat-resolution` to absorb air-to-air / air-to-ground / dogfight*: rejected — `combat-resolution` is already 1264 LOC; the per-unit-type-combat pattern (BA, aerospace) is the cleaner factoring.
+- *Bundle into existing `movement-system`*: rejected — movement-system is correctly focused on land/2D movement; aerospace flight is a parallel domain with its own combat tables and altitude tier.
+
+### Decision B: 3D-tactical model opt-in via `scenarioOptions.aerospaceMode`
+
+**Choice**: `scenarioOptions.aerospaceMode: '2d-simplified' | '3d-tactical'`. Existing scenarios default to `2d-simplified` (preserves Phase 6 behavior). New scenarios may set `3d-tactical` to opt into the full deployment rules.
+
+**Rationale**: 25-40 file change is too large to flip-default on a single release. Opt-in lets Wave 9 ship the 3D engine without breaking Wave 5-7 scenarios that exercise the 2D path. After 2-3 weeks of 3D bake-in, the default may flip — that's a separate (trivial) Wave 10+ change.
+
+**Alternatives considered**:
+- *Flip default immediately*: rejected — high regression risk to existing playtest scenarios.
+- *Drop 2D-simplified entirely*: rejected — existing 2D code is shipping, deleting it breaks live scenarios.
+- *Make 3D-tactical the only mode and rewrite scenarios*: rejected — that's a much bigger Apply scope, beyond Wave-9 sizing.
+
+### Decision C: Altitude scale 0-10 matching MegaMek
+
+**Choice**: altitude 0-10 with tactical-map ceiling at 10; altitude 11+ exits the tactical map (orbit transition, out of scope this change).
+
+**Rationale**: MegaMek parity. Players importing MegaMek scenarios expect altitude 5 to mean what they think it means. Inventing a new scale (e.g., 0-5) creates a parity friction cost forever.
+
+**Alternatives considered**:
+- *Use altitude bands (Low/Med/High) without numbers*: rejected — too coarse; thrust-cost for changing altitude needs integer arithmetic.
+- *Use real-world altitude units (km / ft)*: rejected — game-design, not simulation; bands are the right abstraction for tactical play.
+
+### Decision D: Velocity persists across turns; forced forward motion enforced
+
+**Choice**: `currentVelocity` and `nextVelocity` separate fields. `currentVelocity` is the velocity FROM the previous turn (forcing forward motion this turn). `nextVelocity` is the velocity AFTER thrust spent this turn (used as next-turn's `currentVelocity`). Forced forward motion: must move at least `currentVelocity` hexes; failing triggers a control roll.
+
+**Rationale**: matches MegaMek's velocity model exactly (`Aero.setCurrentVelocity` / `setNextVelocity` are explicit separate fields). Forced forward motion makes velocity meaningful — without it, velocity has no tactical consequence.
+
+**Alternatives considered**:
+- *Single velocity field*: rejected — loses the "what was my velocity entering this turn" data needed for the forced-forward check, and breaks event-log replay reconstruction.
+- *No forced forward motion*: rejected — turns velocity into a meaningless number; loses the tactical "high velocity = committed to this direction" rule.
+
+### Decision E: Air-to-air requires SAME hex and altitude band ±2
+
+**Choice**: two airborne aero may engage in air-to-air combat when they share a hex and their altitude differs by ≤ 2. Cross-altitude engagement (e.g., low vs high) is not possible without a closing maneuver first.
+
+**Rationale**: MegaMek allows cross-altitude shots with progressively-larger to-hit penalties; the simpler "same-hex within ±2 altitude" rule is more playable on the tactical map without losing fighter-combat character. Cross-altitude shots beyond ±2 can be added in a future polish change if needed.
+
+**Alternatives considered**:
+- *Allow any-altitude shots with deep penalty*: rejected — too permissive; makes high-altitude bombers safe sniping platforms.
+- *Require same-altitude exactly*: rejected — too restrictive; pilots maneuvering for engagement should have a ±1 band of forgiveness.
+
+### Decision F: Dogfight commits both units to same hex for the engagement turn
+
+**Choice**: when a dogfight is initiated (mutual declaration during movement phase), both units commit to the same hex for the rest of the turn; they may not move further. Both get a forward-arc shot at each other at the end of the movement phase. Disengagement next turn requires breakaway thrust.
+
+**Rationale**: tactical dogfights ARE close-quarters engagements; mutual commitment is the realism. Disengagement-via-thrust is a thematic consequence — you must accelerate away.
+
+**Alternatives considered**:
+- *Allow both to continue moving after dogfight shots*: rejected — defeats the dogfight committment; turns it into a sequence of pass-by attacks.
+- *Make dogfight non-consensual (single-side initiation)*: rejected — both sides need to be willing for the dogfight to commit, otherwise the defender just keeps moving.
+
+### Decision G: Bombs deviate with a separate event type
+
+**Choice**: bomb drops emit a new `AerospaceBombDropped` event with `{ declaredHex, deviatedHex, scatterRoll, damage, bombType }` fields. Bomb damage is then applied to the deviated hex via the existing damage pipeline.
+
+**Rationale**: bombs deviate differently from weapons (random scatter from declared target); a separate event keeps the replay log clean and makes it obvious in the columnar formatter that a bomb was dropped (not just a weapon fired).
+
+**Alternatives considered**:
+- *Fold into `WeaponDamageApplied`*: rejected — replays would have to back-compute "this WeaponDamageApplied event came from a bomb" from context, fragile.
+- *Use existing weapon-fired event for declaration + WeaponDamageApplied for impact*: rejected — declaration vs impact two-step is the right shape, but bombs warrant their own discriminator for filter UX.
+
+### Decision H: Ground-to-air uses altitude-tier penalty; indirect-fire weapons ineligible
+
+**Choice**: ground unit firing at airborne aero applies a flat altitude-tier penalty: low=+1, med=+2, high=+3. Indirect-fire weapons (LRM in Indirect mode) SHALL NOT engage airborne targets — they need lock-on / line-of-sight which indirect fire lacks.
+
+**Rationale**: MegaMek allows AAA-rated weapons to engage airborne targets more easily, but the simple tier penalty captures the playable essence. Indirect-fire ineligibility is canonical — you can't pop a missile arc-shot into an airborne fighter that's not where you aimed by the time the missiles arrive.
+
+**Alternatives considered**:
+- *AAA weapon distinction*: rejected — adds weapon-flag work without much tactical payoff for Wave-9. Future polish change can add it.
+- *Allow indirect-fire vs airborne*: rejected — non-canonical and tactically broken.
+
+## Data Flow
+
+```
+Scenario starts with mapEnvironment='atmospheric', aerospaceMode='3d-tactical'
+Aero A starts grounded (altitude 0, velocity 0)
+              ↓
+Turn 1 — A declares takeoff:
+  ├─ Pay 2 thrust → altitude 1
+  ├─ Set currentVelocity = safeThrust (initial flight velocity)
+  ├─ Pay control roll (mandatory on takeoff)
+  └─ Emit AerospaceTakeoff event
+              ↓
+Turn 2 — A is airborne at altitude 1, velocity 6
+  ├─ Forced forward motion: must move ≥ 6 hexes in facing direction
+  ├─ A spends 2 thrust to ascend to altitude 2 (no velocity change)
+  ├─ A spends 1 thrust to turn ≤60°
+  ├─ A spends 3 thrust to accelerate (nextVelocity = 9)
+  └─ Total thrust spent = 6. ≤ safeThrust=6, no control roll.
+              ↓
+Turn 3 — A at altitude 2, currentVelocity = 9, nextVelocity = 9
+  ├─ Forced forward: must move ≥ 9 hexes
+  ├─ Halfway, enemy aero E at same hex, altitude 1
+  ├─ Altitude difference = 1 (within ±2)
+  ├─ A and E both eligible for air-to-air engagement
+  ├─ A declares forward-arc shot at E (to-hit base 4, +0 forward arc, +1 alt diff)
+  └─ E's facing puts A in E's aft arc → E declares aft-arc shot (+3 modifier)
+              ↓
+End of movement phase — air-to-air resolution
+  ├─ A's hit roll succeeds → aerospaceResolveDamage(E, A.weapons)
+  ├─ E's hit roll fails → no damage
+  ├─ Emit AerospaceAirToAirAttack events for both shots
+              ↓
+Turn 4 — A's currentVelocity = 9, no thrust spent yet
+  ├─ A intends to bomb ground hex G (declared)
+  ├─ A moves over G mid-path
+  ├─ Bomb drops with deviation roll 2d6 = 8 → deviates 1 hex south
+  ├─ Bomb hits deviated hex
+  ├─ Emit AerospaceBombDropped { declaredHex: G, deviatedHex: G-south, scatterRoll: 8, damage: 20, bombType: 'HE' }
+  └─ Bomb damage applied to ground units in deviated hex
+              ↓
+Turn 5 — A wants to disengage, decelerate, land
+  ├─ Spend 5 thrust to decelerate from 9 → 4
+  ├─ Descend 2 altitude bands (free, +1 velocity gravity assist → 5)
+  ├─ Net velocity for landing = 5; with safeThrust 6, valid landing speed
+  ├─ At altitude 1, declare landing transition
+  └─ Land — rolling on runway 5 hexes, altitude 0, velocity 0 at end
+```
+
+## File Changes (Apply estimate — informational; not part of this change)
+
+- New:
+  - `src/lib/movement/aerospaceMovement.ts` — thrust accounting, velocity carry, turn cost, altitude cost, stall/crash detection (~800-1000 LOC)
+  - `src/lib/combat/aerospaceCombat.ts` — air-to-air, air-to-ground, ground-to-air resolvers; dogfight resolution (~600-800 LOC)
+  - `src/lib/combat/bombResolution.ts` — bomb deviation table + damage (~200-300 LOC)
+- Modified:
+  - `src/engine/InteractiveSession.ts` — aerospace movement-declaration handlers, altitude transitions, control-roll triggers, dogfight commitment
+  - `src/lib/combat/combatResolution.ts` — aerospace dispatch branches (air-to-air, air-to-ground, ground-to-air)
+  - `src/types/gameplay/CombatInterfaces.ts` — extend `IAerospaceCombatState` with `altitude`, `currentVelocity`, `nextVelocity`, `airborneState: 'grounded' | 'airborne' | 'taking-off' | 'landing'`; add ~15 new event types
+  - `src/types/gameplay/GameplayUIInterfaces.ts` — resolve existing `IAerospaceToken.velocity` TODO, add takeoff/landing/dogfight UI hints
+  - `src/components/gameplay/UnitToken.tsx` (or hex-board equivalent) — altitude badge, velocity arrow, airborne vs grounded indicator
+  - `src/components/gameplay/AttackDeclarationPanel.tsx` — air-to-air, air-to-ground, dogfight action buttons
+  - `src/components/gameplay/MovementDeclarationPanel.tsx` — thrust budget, altitude controls, dogfight initiation
+  - `src/services/combat/replays/eventLogFormatter.ts` — ~15 new event types columnar formatting
+- Deleted: none (2D-simplified path stays as legacy fallback)
+
+## Risks
+
+- **R1 (high)**: scope is 3-5× ground vehicle scope; the Apply wave will be the largest single OpenSpec change since `add-tactical-ai-difficulty-tiers`. Mitigation: explicit Apply deferral to dedicated Wave (likely Wave 9); break Apply into 3 sub-waves (Movement / Combat / UI).
+- **R2 (medium)**: 2D-simplified vs 3D-tactical mode coexistence creates dual code paths in the resolver. Mitigation: clean dispatch on `scenarioOptions.aerospaceMode` — single branch at session-init time, never per-attack.
+- **R3 (medium)**: parity testing against MegaMek requires aerospace-scenario regression harness. Mitigation: include 5-8 scenarios from MegaMek's own test set as part of the Apply wave; gate-merge on parity ratios.
+- **R4 (medium)**: altitude/velocity state on the event log adds ~30 bytes per aero unit per turn. Mitigation: only emit altitude/velocity events when they change (delta-emit); steady-state flight has zero per-turn cost.
+- **R5 (low)**: hex-board rendering needs altitude/velocity widgets. Mitigation: dedicated Apply-wave Storybook pass; widgets are well-bounded UI work.
+- **R6 (low)**: dogfight commitment can be exploited (lock a flagship-aero in a dogfight to take it out of play). Mitigation: dogfight commitment is ONE turn; disengagement is available next turn with breakaway thrust cost.
+- **R7 (low)**: bomb deviation may surprise players who expected pinpoint accuracy. Mitigation: declare-hex highlighting + deviated-hex outcome UI feedback; consider showing a scatter cone preview on the declaration UI.

--- a/openspec/changes/add-aerospace-deployment/proposal.md
+++ b/openspec/changes/add-aerospace-deployment/proposal.md
@@ -1,0 +1,103 @@
+# Change: Add Aerospace Deployment
+
+## Why
+
+Aerospace units are constructed end-to-end today via the `aerospace-unit-system` capability (1351-LOC spec covering chassis, tonnage, armor-by-arc, thrust ratings, fuel, structural integrity, BLK round-trip, BV calculation, customizer UI). They have a minimal `Aerospace Combat State` requirement (combatState shape only). The `combat-resolution` capability ships `Aerospace Combat Dispatch`, `Aerospace Damage Chain`, and `Aerospace Control Roll` requirements — damage-side coverage. The `movement-system` capability ships `Aerospace 2D Simplified Movement`, `Fuel Consumption per Turn`, and `Fly-Over Strafe Movement` for Phase 6 simplification — a 2D no-altitude model.
+
+What is missing — the gap surfaced by the Wave 7 OMO Council Librarian's sizing assessment (3-5× ground vehicle scope, MegaMek `Aero.java` is 99KB) — is the **deployment-and-flight layer**: the 3D thrust/velocity/altitude model, atmospheric vs space rule distinction, full aero-to-aero combat, aero-to-ground attack envelope (strafing as it exists today is a 2D path-attack — the airborne fighter envelope is bigger), dogfighting, landing/takeoff transitions, ground-grounded interaction, off-map exit and re-entry orchestration tied to the new altitude state.
+
+The current 2D-simplified model was always meant as Phase-6 expediency. The 3D thrust/velocity/altitude model is what tabletop-canonical Aerospace combat actually looks like — and players importing MegaMek-derived aerospace scenarios need parity. This change establishes the spec authority for **a single deployment mode**: atmospheric 3D with altitude levels 0-10 (matching MegaMek Aero's altitude scale), velocity in thrust points carried between turns, the control-roll-on-velocity-mismatch rule, the dogfight resolution, the air-to-ground attack table, the strafe envelope at altitude.
+
+**Scope discipline**: Aerospace **deployment + flight + combat** for ASF, conventional fighters, and small craft on the **standard tactical map**. Out: dropships, jumpships, warships (each gets its own Wave-8+ change). Out: AeroTech II strategic-map operations / jump-point combat (separate domain entirely). Out: orbit-to-surface bombardment (artillery domain). Out: VTOL/hover (those are ground units with `movement-system` jurisdiction — a small delta change `update-vtol-hover-mp-modifiers` is named as a future follow-up). Bombs ARE in (bomb-bay loadout already exists in `aerospace-unit-system` — Apply wave needs to wire the runtime drop). Atmospheric vs space rules ARE in (rule deltas between the two — space removes altitude bands, changes thrust mechanics, removes terrain).
+
+**Apply deferral**: per the prompt, this change authors the spec only; Apply wave is deferred to its own dedicated Wave (likely Wave 9). The Apply work is sized at 3-5× ground-vehicle scope and would risk swamping Wave 7's other work.
+
+## What Changes
+
+### Capability deltas
+
+- **NEW `aerospace-deployment`** — first-class capability for airborne aerospace combat:
+
+  - ADDED **Altitude Bands**: altitude levels 0–10 representing nap-of-earth (0 = grounded), low (1–3), medium (4–6), high (7–10). Tactical map = altitudes 0–10; orbit transition at altitude 11+ leaves the tactical map for the strategic layer (out of scope this change). Mirrors MegaMek `Aero` altitude scale.
+  - ADDED **Velocity in Thrust Points**: `currentVelocity` and `nextVelocity` in thrust points. Velocity persists across turns; movement next turn = `currentVelocity` hexes minimum (forced forward motion). Velocity changes by ±1 per thrust point spent (accelerate or decelerate). Atmospheric units halve velocity at altitude 0 (grounded landing); space units have no velocity halving.
+  - ADDED **Safe vs Max Thrust Discrimination**: `safeThrust` is the unit's construction stat; `maxThrust = floor(safeThrust × 1.5)`. Spending more than safeThrust per turn SHALL require a Control Roll. Spending more than maxThrust SHALL be forbidden (movement rejected).
+  - ADDED **Atmospheric vs Space Rule Toggle**: each scenario SHALL carry a `mapEnvironment: 'atmospheric' | 'space'` flag. Atmospheric environment SHALL apply terrain effects, gravity-driven altitude loss for grounded aero, velocity-halving at altitude 0; space SHALL not. The toggle SHALL be scenario-level, not per-unit.
+  - ADDED **Forced Forward Motion**: an aero unit with `currentVelocity > 0` MUST move at least `currentVelocity` hexes in its facing direction each turn or take a control roll. Failing to move sufficient distance is treated as a stall.
+  - ADDED **Turn Cost**: turning is limited to ≤ 60° per thrust point spent on turning. Sharper turns require multiple thrust points consumed in sequence. Mirrors MegaMek `Aero` turn-cost mechanics.
+  - ADDED **Altitude Change Cost**: ascending one altitude band costs 2 thrust points; descending one altitude band is free but applies a +1 thrust to the unit's velocity (gravity assist). At altitude 0 the unit is grounded; ascending from 0 requires "takeoff" (2 thrust + control roll). Mirrors `Aero.checkAscend()` / `checkDescend()`.
+  - ADDED **Stall and Crash Conditions**: failing a control roll while at altitude > 1 SHALL drop altitude by 1; failing at altitude 1 SHALL crash the unit (destroy). At velocity 0 in atmospheric environment, a control roll SHALL fail automatically. Mirrors MegaMek's stall/crash check chain.
+  - ADDED **Air-to-Ground Attack Envelope**: an airborne aero may declare air-to-ground attacks against ground targets within its movement path this turn. To-hit modifier: `+2 base` (per existing strafe rule) + altitude modifier (`+0 at low, +1 at medium, +2 at high`). Available weapons: Nose-arc + Wing-arc forward firing weapons. Mirrors MegaMek's air-to-ground attack table.
+  - ADDED **Air-to-Air Combat**: two airborne aero units in the same hex AND within ±2 altitude bands SHALL be eligible for air-to-air combat. To-hit modifier: `+0 base for forward-arc shot`, `+1 each for left/right-wing-arc shot`, `+3 for aft-arc shot`. Hit-location uses the existing `aerospaceResolveDamage()` per `combat-resolution`. Velocity differential applies an additional `+1` per 2 hexes of velocity difference. Mirrors MegaMek Aero combat tables.
+  - ADDED **Dogfight Initiation**: opposing airborne aero in the same hex at same altitude SHALL be able to initiate a dogfight (mutually-declared, multi-round close-combat exchange). Dogfights resolve at the end of the movement phase using simultaneous declarations; both sides SHALL get a forward-arc shot at each other. Mirrors MegaMek's dogfight resolution.
+  - ADDED **Strafe Path Update**: strafe path attacks SHALL apply altitude modifier to the existing `Fly-Over Strafe Movement` to-hit penalty in addition to the existing +2.
+  - ADDED **Landing and Takeoff**: a grounded aero (altitude 0) SHALL be a stationary or rolling-on-runway unit; takeoff transitions to airborne with altitude 1 + initial velocity = safeThrust (paid in thrust points). Landing transitions from altitude 1 + velocity ≤ safeThrust to altitude 0 (rolling on runway over N hexes equal to landing-velocity).
+  - ADDED **Bomb Drop Resolution**: aero with bombs loaded SHALL be able to declare bomb-drop attacks against ground hexes during movement. Bombs follow a deviation table (2d6 scatter from declared target hex per altitude). Bomb damage SHALL apply to the deviated hex per the existing bomb explosives rules. Mirrors MegaMek `BombType` resolution.
+  - ADDED **Off-Map Exit / Re-Entry Tied to Altitude**: extends the existing 2D `AerospaceExited` / `AerospaceEntered` events to record exit altitude and velocity; re-entry SHALL preserve altitude and velocity from exit.
+
+- **MODIFIED `combat-resolution`** — extend the existing `Aerospace Combat Dispatch` to handle the 3D model:
+  - ADDED **Air-to-Air Dispatch**: when both attacker and target are airborne aero, route to the air-to-air resolver (delegates to existing `aerospaceResolveDamage` for damage application but uses air-to-air to-hit modifiers).
+  - ADDED **Air-to-Ground Dispatch**: when attacker is airborne aero and target is a ground unit, route to the air-to-ground resolver.
+  - ADDED **Ground-to-Air Dispatch**: when attacker is a ground unit and target is airborne aero, apply altitude-tier to-hit penalty: `+1 low`, `+2 medium`, `+3 high`; legal weapon types: any direct-fire weapon with sufficient range; indirect-fire weapons SHALL NOT engage airborne targets.
+
+- **MODIFIED `unit-entity-model`** — formalize aerospace altitude + velocity at the entity-model level:
+  - MODIFIED **Component References**: aerospace units' component references SHALL include `altitude`, `currentVelocity`, `nextVelocity` as part of the runtime combat-state shape (previously combat-state held only `currentSI`, `armorByArc`, `heat`, `fuelRemaining`, `controlRollsFailed`, `thrustPenalty`, `offMap`, `offMapReturnTurn` per `aerospace-unit-system`).
+
+- **MODIFIED `movement-system`** — supersede the 2D-simplified aerospace movement with a 3D model when `mapEnvironment` is set:
+  - MODIFIED **Aerospace 2D Simplified Movement**: remains valid as a fallback when `scenarioOptions.aerospaceMode === '2d-simplified'` (legacy). When `aerospaceMode === '3d-tactical'` (new default), the aerospace-deployment 3D rules SHALL apply.
+  - MODIFIED **Fly-Over Strafe Movement**: gain the altitude-modifier to-hit per the new `Strafe Path Update` requirement in `aerospace-deployment`.
+
+### Code touch points (Apply Wave — DEFERRED to its own future wave)
+
+This change authors the spec only. The Apply wave is estimated at ~25-40 files, ~3000-5000 LOC, across engine/movement/combat/types/event-log/UI. Likely structure:
+
+- `src/engine/InteractiveSession.ts` — aerospace movement-declaration handlers, altitude transitions, control-roll triggers
+- `src/lib/movement/aerospaceMovement.ts` (new) — thrust accounting, velocity carry, turn cost, altitude change cost, stall/crash detection (~800-1000 LOC)
+- `src/lib/combat/aerospaceCombat.ts` (new) — air-to-air, air-to-ground, ground-to-air resolvers; dogfight resolution (~600-800 LOC)
+- `src/lib/combat/bombResolution.ts` (new) — bomb deviation table + damage (~200-300 LOC)
+- `src/lib/combat/combatResolution.ts` — aerospace dispatch branches
+- `src/types/gameplay/CombatInterfaces.ts` — extend `IAerospaceCombatState` with altitude/velocity, add ~15 new event types
+- `src/types/gameplay/GameplayUIInterfaces.ts` — resolve the existing `IAerospaceToken.velocity` TODO, add takeoff/landing/dogfight UI hints
+- `src/components/gameplay/UnitToken.tsx` — render altitude badge, velocity arrow, airborne vs grounded indicator
+- `src/components/gameplay/AttackDeclarationPanel.tsx` — air-to-air, air-to-ground, dogfight action buttons
+- `src/components/gameplay/MovementDeclarationPanel.tsx` — thrust budget, altitude change controls, dogfight initiation
+- `src/services/combat/replays/eventLogFormatter.ts` — ~15 new event types columnar formatting
+
+## Capabilities
+
+### New
+
+- `aerospace-deployment` — airborne aero combat: altitude/velocity model, atmospheric vs space, air-to-air, air-to-ground, ground-to-air, dogfight, landing/takeoff, bomb drop, off-map tied to altitude
+
+### Modified
+
+- `combat-resolution` — air-to-air / air-to-ground / ground-to-air dispatch branches
+- `unit-entity-model` — formalize aerospace altitude + velocity in entity component references
+- `movement-system` — 2D-simplified becomes legacy fallback; 3D-tactical is new default when scenario `mapEnvironment` is set; strafe altitude modifier
+
+## Impact
+
+- **Affected source files (Apply estimate)**: ~25-40 files, ~3000-5000 LOC. Single largest scope change in Wave 7 batch — explicitly deferred Apply to a dedicated future wave per the Council Librarian's sizing.
+- **No new transport** — existing Zustand stores + typed event-log + JSONL replay.
+- **No DB migration**.
+- **Storybook deltas (Apply wave)**: 5-8 stories — altitude badge, velocity arrow, takeoff/landing animations, dogfight engagement marker, bomb-drop deviation indicator.
+- **Test footprint estimate (Apply wave)**: ~100-150 new unit tests + 10-15 scenario tests (takeoff/landing roundtrip, air-to-air at altitude 5, air-to-ground strafe across 3 hexes, dogfight resolution, bomb-drop deviation accuracy against MegaMek parity).
+- **Performance**: aerospace altitude state adds ~30 bytes per aero unit per turn to the event log; replay JSONL grows ~5-10% for aero-heavy scenarios. Acceptable.
+
+## Non-Goals
+
+- **Dropships, JumpShips, WarShips, Space Stations** — each gets its own future change. Their combat is a superset of aerospace deployment and includes capital weapons, bay attacks, K-F drive considerations, multi-crew piloting.
+- **AeroTech II strategic-map operations** — out; strategic-map jump-point combat is a separate domain.
+- **Orbit-to-surface bombardment** — out; artillery / capital-from-orbit is a future `add-orbital-bombardment` change.
+- **VTOL/hover ground units** — out; those are ground units governed by `movement-system`. A small future delta change `update-vtol-hover-mp-modifiers` SHALL handle the VTOL hover/MP modifier audit; noted as the next follow-up after this change ships.
+- **Atmospheric environment terrain effects on aero** — beyond altitude-band terrain (mountains blocking low-altitude flight); detailed weather, ECM clouds, etc. are out. Core terrain effects (mountains forcing altitude ≥ peak elevation; water for landing crashes; smoke columns blocking LOS at certain altitudes) ARE in.
+- **Conversion of existing 2D-simplified scenarios** — they continue to work via the `aerospaceMode: '2d-simplified'` legacy flag. Migration to 3D mode is opt-in per scenario.
+- **Crew quality / aerospace pilot skills** — Pilot skill enters via existing `personnel-system`. This change does NOT introduce new pilot stats.
+- **AI heuristics for aerospace** — bot decision-making (when to ascend, when to engage, when to disengage) is a follow-up `add-aerospace-ai` change once the engine path stabilizes.
+
+## Open Questions
+
+- **Should hex-distance vs facing-distance be the basis for forced forward motion?** Decision: hex-distance projected onto the facing vector (allows ±60° drift while satisfying forward motion). Documented in spec.
+- **Should a grounded aero (altitude 0) be hit-able by ground-fire normally?** Decision: YES — grounded aero is treated as a ground unit for hit-location and is engageable by direct-fire weapons. The aero loses its altitude-tier to-hit bonus when grounded. Documented in spec.
+- **Should dogfight engagements lock both units in the same hex for the whole dogfight (preventing other movement)?** Decision: dogfight commits both units to the same hex for the engagement turn only; they may disengage next turn via mutual breakaway. Documented in spec.
+- **Should bombs use a separate JSONL event variant or fold into existing `WeaponDamageApplied`?** Decision: separate event variant `AerospaceBombDropped` carrying `{ declaredHex, deviatedHex, scatterRoll, damage, bombType }` — bombs deviate differently from weapons; separate event keeps the replay clean.
+- **Should the 3D-tactical mode become default for ALL scenarios, or opt-in via flag?** Decision: opt-in via `scenarioOptions.aerospaceMode === '3d-tactical'` for Wave 9. New scenarios may default to `3d-tactical`; legacy scenarios stay on `2d-simplified`. After 3 Apply-wave bake-in waves, consider flipping the default.

--- a/openspec/changes/add-aerospace-deployment/specs/aerospace-deployment/spec.md
+++ b/openspec/changes/add-aerospace-deployment/specs/aerospace-deployment/spec.md
@@ -1,0 +1,433 @@
+# Spec Delta: Aerospace Deployment (NEW capability)
+
+## ADDED Requirements
+
+### Requirement: Scenario Aerospace Mode Toggle
+
+Each scenario SHALL carry an `aerospaceMode: '2d-simplified' | '3d-tactical'` flag. The 2D-simplified mode SHALL preserve the existing `movement-system → Aerospace 2D Simplified Movement` Phase-6 behavior. The 3D-tactical mode SHALL apply the full aerospace-deployment rules in this capability. The default value for legacy scenarios SHALL be `'2d-simplified'`; new scenarios MAY opt in to `'3d-tactical'`.
+
+#### Scenario: Legacy scenario uses 2D-simplified by default
+
+- **GIVEN** a scenario authored before this change ships
+- **WHEN** session-init reads `scenarioOptions.aerospaceMode`
+- **THEN** the value SHALL be `'2d-simplified'` (default)
+- **AND** the existing Phase-6 aerospace movement rules SHALL apply unchanged
+
+#### Scenario: New scenario opts into 3D-tactical
+
+- **GIVEN** a scenario explicitly sets `aerospaceMode: '3d-tactical'`
+- **WHEN** session-init reads the value
+- **THEN** the 3D-tactical rules in this capability SHALL apply
+- **AND** the 2D-simplified path SHALL NOT be reachable for that scenario
+
+#### Scenario: Mode dispatch at session-init only
+
+- **GIVEN** any scenario with `aerospaceMode` set
+- **WHEN** session begins
+- **THEN** the dispatch path SHALL be selected once at session-init
+- **AND** the per-attack resolver SHALL NOT re-check `aerospaceMode` on every action
+
+### Requirement: Scenario Environment Toggle
+
+Each scenario SHALL carry a `mapEnvironment: 'atmospheric' | 'space'` flag. Atmospheric environment SHALL apply terrain effects, velocity halving at landing, gravity assist on altitude descent, and stall conditions at velocity 0. Space environment SHALL omit those rules.
+
+#### Scenario: Atmospheric stall at velocity 0
+
+- **GIVEN** a scenario with `mapEnvironment: 'atmospheric'`
+- **WHEN** an airborne aero's `currentVelocity` reaches 0
+- **THEN** a control roll SHALL be triggered automatically with reason `'Atmospheric stall at velocity 0'`
+- **AND** the control roll SHALL auto-fail
+
+#### Scenario: Space environment — no stall at velocity 0
+
+- **GIVEN** a scenario with `mapEnvironment: 'space'`
+- **WHEN** an aero's velocity reaches 0
+- **THEN** no control roll SHALL be triggered (no stall in vacuum)
+
+#### Scenario: Atmospheric gravity assist on descent
+
+- **GIVEN** an atmospheric scenario
+- **WHEN** an airborne aero descends one altitude band
+- **THEN** `nextVelocity` SHALL be increased by +1 (gravity assist)
+
+#### Scenario: Space environment — no gravity assist on descent
+
+- **GIVEN** a space scenario
+- **WHEN** an aero descends one altitude band
+- **THEN** `nextVelocity` SHALL be unchanged (no gravity in vacuum)
+
+### Requirement: Altitude Bands
+
+Tactical-map airborne aero units SHALL operate at altitude levels 0 through 10. Altitude 0 SHALL represent a grounded unit. Altitudes 1-3 SHALL be the low tier; 4-6 medium; 7-10 high. Altitudes 11+ SHALL be considered orbit transition and are out of scope for the tactical map (the resolver SHALL reject altitude increases beyond 10 with an `AerospaceOrbitTransitionAttempted` warning event).
+
+#### Scenario: Altitude tier classification
+
+- **GIVEN** an airborne aero at altitude 5
+- **WHEN** the altitude tier is computed
+- **THEN** the tier SHALL be `'medium'`
+
+#### Scenario: Orbit transition rejected
+
+- **GIVEN** an aero at altitude 10
+- **WHEN** the player attempts to ascend one more band
+- **THEN** the ascent SHALL be rejected
+- **AND** an `AerospaceOrbitTransitionAttempted` event SHALL be emitted
+- **AND** the aero SHALL remain at altitude 10
+
+#### Scenario: Grounded aero is altitude 0
+
+- **GIVEN** an aero in `airborneState: 'grounded'`
+- **WHEN** combat state is read
+- **THEN** `altitude` SHALL equal 0
+
+### Requirement: Velocity in Thrust Points
+
+Airborne aero SHALL carry two velocity fields: `currentVelocity` (the velocity entering this turn, drives forced-forward motion) and `nextVelocity` (the velocity at end of turn after thrust spending, becomes next turn's `currentVelocity`). Velocity SHALL be denominated in thrust points (each thrust point spent on acceleration changes velocity by ±1). At end of turn, `currentVelocity ← nextVelocity` for the next turn.
+
+#### Scenario: Velocity carries across turns
+
+- **GIVEN** an aero ending turn 3 with `nextVelocity = 8`
+- **WHEN** turn 4 begins
+- **THEN** `currentVelocity` SHALL equal 8
+
+#### Scenario: Thrust accelerates velocity
+
+- **GIVEN** an aero with `currentVelocity = 6` on turn 4
+- **WHEN** the pilot spends 3 thrust on acceleration
+- **THEN** `nextVelocity` SHALL be `6 + 3 = 9`
+
+#### Scenario: Thrust decelerates velocity
+
+- **GIVEN** an aero with `currentVelocity = 9`
+- **WHEN** the pilot spends 5 thrust on deceleration
+- **THEN** `nextVelocity` SHALL be `9 - 5 = 4`
+
+### Requirement: Safe vs Max Thrust
+
+The unit's `safeThrust` SHALL be its construction-time thrust rating. `maxThrust` SHALL equal `floor(safeThrust × 1.5)`. Spending more than safeThrust in a single turn SHALL trigger a control roll at end-of-turn. Spending more than maxThrust SHALL be forbidden — the movement declaration SHALL be rejected.
+
+#### Scenario: Thrust within safeThrust — no control roll
+
+- **GIVEN** an aero with `safeThrust = 6, maxThrust = 9`
+- **WHEN** the pilot spends 6 thrust total this turn
+- **THEN** no control roll SHALL be triggered
+
+#### Scenario: Thrust > safeThrust triggers control roll
+
+- **GIVEN** the same aero
+- **WHEN** the pilot spends 8 thrust this turn (above safe, below max)
+- **THEN** a control roll SHALL be triggered at end of turn
+- **AND** the control roll SHALL include `+2` modifier (one per excess thrust above safe)
+
+#### Scenario: Thrust > maxThrust rejected
+
+- **GIVEN** the same aero
+- **WHEN** the pilot attempts to spend 10 thrust (above max)
+- **THEN** the movement declaration SHALL be rejected with reason `'Thrust exceeds max'`
+
+### Requirement: Forced Forward Motion
+
+An aero with `currentVelocity > 0` MUST move at least `currentVelocity` hexes in its facing direction during the movement phase. Failing to move sufficient distance SHALL trigger a control roll with reason `'Insufficient forward motion at velocity'`. Hex-distance SHALL be measured as the projection onto the facing vector, permitting ±60° drift while satisfying the forward requirement.
+
+#### Scenario: Sufficient forward motion
+
+- **GIVEN** an aero with `currentVelocity = 6, facing = N`
+- **WHEN** the pilot moves 6 hexes due-N
+- **THEN** the forced-forward check SHALL pass
+- **AND** no control roll SHALL be triggered
+
+#### Scenario: Insufficient forward motion
+
+- **GIVEN** the same aero
+- **WHEN** the pilot moves only 4 hexes due-N
+- **THEN** a control roll SHALL be triggered with reason `'Insufficient forward motion at velocity'`
+
+#### Scenario: Projected distance via drift
+
+- **GIVEN** an aero with `currentVelocity = 6, facing = N`
+- **WHEN** the pilot moves 7 hexes diagonally (NE at 60° drift)
+- **THEN** the N-projected distance SHALL be `7 × cos(60°) = 3.5 → 3`
+- **AND** the forced-forward check SHALL FAIL (3 < 6)
+
+### Requirement: Turn Cost
+
+Turning the aero's facing SHALL cost one thrust point per ≤60° turn. Sharper turns SHALL require multiple thrust points consumed sequentially (e.g., a 180° turn costs 3 thrust). Turns may interleave with hex movement (i.e., turn at a hex boundary, then move).
+
+#### Scenario: 60° turn costs 1 thrust
+
+- **WHEN** the pilot turns from N to NE
+- **THEN** 1 thrust SHALL be deducted from the turn budget
+
+#### Scenario: 180° turn costs 3 thrust
+
+- **WHEN** the pilot turns from N to S
+- **THEN** 3 thrust SHALL be deducted (3 × 60° = 180°)
+
+### Requirement: Altitude Change Cost
+
+Ascending one altitude band SHALL cost 2 thrust points. Descending one altitude band SHALL be free; in atmospheric environment, descending SHALL increase `nextVelocity` by +1 per band descended (gravity assist). Ascending from altitude 0 (taking off) SHALL be a separate `Takeoff` action subject to its own rules.
+
+#### Scenario: Ascend 0→2 costs 4 thrust
+
+- **GIVEN** an airborne aero at altitude 0 (already taken off this turn — see Takeoff requirement)
+- **WHEN** the pilot ascends 2 bands during this turn
+- **THEN** 4 thrust SHALL be deducted
+
+#### Scenario: Descend 5→3 gains 2 velocity (atmospheric)
+
+- **GIVEN** an atmospheric aero at altitude 5 with `nextVelocity = 6`
+- **WHEN** the pilot descends 2 bands
+- **THEN** no thrust SHALL be deducted for the descent
+- **AND** `nextVelocity` SHALL increase to 8 (+2 gravity assist)
+
+#### Scenario: Descend in space — no velocity change
+
+- **GIVEN** a space-environment aero at altitude 5 with `nextVelocity = 6`
+- **WHEN** the pilot descends 2 bands
+- **THEN** `nextVelocity` SHALL remain 6 (no gravity in vacuum)
+
+### Requirement: Takeoff and Landing
+
+A grounded aero (altitude 0, `airborneState: 'grounded'`) SHALL transition to airborne via a Takeoff action: 2 thrust spent, altitude set to 1, `currentVelocity` set to `safeThrust`, mandatory control roll. Landing transitions an airborne aero at altitude 1 with `currentVelocity ≤ safeThrust` to grounded: the aero SHALL roll on a runway for N hexes equal to landing velocity, then settle at altitude 0 with velocity 0.
+
+#### Scenario: Takeoff transition
+
+- **GIVEN** an aero at altitude 0, `airborneState: 'grounded'`, safeThrust = 6
+- **WHEN** the pilot declares Takeoff
+- **THEN** 2 thrust SHALL be deducted
+- **AND** altitude SHALL become 1
+- **AND** `currentVelocity` SHALL become 6
+- **AND** `airborneState` SHALL become `'taking-off'` for the current turn, then `'airborne'` next turn
+- **AND** an `AerospaceTakeoff` event SHALL be emitted
+- **AND** a mandatory control roll SHALL be performed
+
+#### Scenario: Landing transition
+
+- **GIVEN** an airborne aero at altitude 1, currentVelocity = 4, safeThrust = 6
+- **WHEN** the pilot declares Landing
+- **THEN** `airborneState` SHALL become `'landing'`
+- **AND** the aero SHALL move 4 hexes forward in facing direction
+- **AND** altitude SHALL become 0
+- **AND** `currentVelocity` SHALL become 0
+- **AND** an `AerospaceLanding` event SHALL be emitted
+
+#### Scenario: Landing rejected at high velocity
+
+- **GIVEN** an airborne aero at altitude 1 with currentVelocity = 9, safeThrust = 6
+- **WHEN** the pilot attempts Landing
+- **THEN** the action SHALL be rejected with reason `'Landing velocity exceeds safeThrust'`
+- **AND** the pilot SHALL decelerate first
+
+### Requirement: Stall and Crash
+
+A failed control roll while at altitude > 1 SHALL cause the aero to drop altitude by 1 band. A failed control roll at altitude 1 SHALL crash the aero to altitude 0 with crash damage equal to `currentVelocity × 5` applied equally to all armor arcs, and SHALL set `airborneState: 'grounded'`. In atmospheric environment, velocity 0 SHALL auto-fail any control roll (stall).
+
+#### Scenario: Control roll fail at altitude 5 — drop 1
+
+- **GIVEN** an airborne aero at altitude 5 failing a control roll
+- **WHEN** the failure resolves
+- **THEN** altitude SHALL become 4
+- **AND** an `AerospaceControlRollFailed { newAltitude: 4 }` event SHALL be emitted
+
+#### Scenario: Control roll fail at altitude 1 — crash
+
+- **GIVEN** an airborne aero at altitude 1, currentVelocity = 4, failing a control roll
+- **WHEN** the failure resolves
+- **THEN** altitude SHALL become 0
+- **AND** crash damage SHALL be `4 × 5 = 20` applied equally to all arcs (5 per arc)
+- **AND** an `AerospaceCrashed { damagePerArc: 5 }` event SHALL be emitted
+- **AND** `airborneState` SHALL become `'grounded'`
+
+### Requirement: Air-to-Air Combat
+
+Two airborne aero units in the same hex AND with altitude difference ≤ 2 SHALL be eligible for air-to-air combat. To-hit modifiers: forward-arc shot +0, left/right-wing-arc shot +1, aft-arc shot +3. Velocity differential SHALL add +1 per 2 hexes of velocity difference between attacker and target. Hit-location + damage SHALL delegate to `aerospaceResolveDamage` per the existing `combat-resolution` capability.
+
+#### Scenario: Forward-arc air-to-air shot
+
+- **GIVEN** attacker A at altitude 5, target T at altitude 5, same hex, A's facing places T in forward arc
+- **WHEN** A declares an air-to-air attack
+- **THEN** the to-hit base SHALL be A's pilot gunnery skill
+- **AND** the arc modifier SHALL be +0
+
+#### Scenario: Aft-arc shot — +3
+
+- **GIVEN** A at altitude 5, T at altitude 5, same hex, A's facing places T in aft arc
+- **WHEN** A declares an air-to-air attack
+- **THEN** the arc modifier SHALL be +3
+
+#### Scenario: Velocity differential modifier
+
+- **GIVEN** A with currentVelocity = 9, T with currentVelocity = 3 (diff 6)
+- **WHEN** A declares an air-to-air attack
+- **THEN** the velocity-differential modifier SHALL be `floor(6/2) = +3`
+
+#### Scenario: Altitude diff > 2 — ineligible
+
+- **GIVEN** A at altitude 7, T at altitude 3 (diff 4)
+- **WHEN** A attempts an air-to-air attack
+- **THEN** the attack SHALL be rejected with reason `'Altitude difference exceeds engagement window (±2)'`
+
+### Requirement: Air-to-Ground Combat
+
+An airborne aero SHALL be able to declare air-to-ground attacks against ground units in hexes the aero passes over during its movement path this turn. To-hit modifier: +2 base (extends the existing `Fly-Over Strafe Movement` rule) + altitude tier (low +0, med +1, high +2). Eligible weapons: Nose-arc + Wing-arc forward-firing weapons.
+
+#### Scenario: Air-to-ground at low altitude
+
+- **GIVEN** ASF at altitude 2 (low tier) strafing a ground hex containing enemy mech
+- **WHEN** the attack resolves
+- **THEN** the to-hit modifier SHALL be +2 (base strafe) + 0 (low) = +2
+
+#### Scenario: Air-to-ground at high altitude
+
+- **GIVEN** ASF at altitude 8 (high tier) strafing a ground hex
+- **WHEN** the attack resolves
+- **THEN** the to-hit modifier SHALL be +2 (base strafe) + 2 (high) = +4
+
+#### Scenario: Aft-arc weapon ineligible for air-to-ground
+
+- **GIVEN** ASF with weapon mounted in Aft arc
+- **WHEN** the pilot attempts to fire it air-to-ground
+- **THEN** the attack SHALL be rejected with reason `'Aft-arc weapon cannot fire air-to-ground'`
+
+### Requirement: Ground-to-Air Combat
+
+A ground unit SHALL be able to fire at an airborne aero target with a to-hit penalty based on altitude tier: low +1, medium +2, high +3. Eligible weapons: any direct-fire weapon with sufficient range. Indirect-fire weapons (LRM in Indirect mode, Arrow IV indirect, etc.) SHALL NOT engage airborne targets — they SHALL be rejected with reason `'Indirect-fire weapons cannot engage airborne targets'`.
+
+#### Scenario: AC/20 fires at airborne aero at high altitude
+
+- **GIVEN** a mech with AC/20 within range of airborne ASF at altitude 8
+- **WHEN** the pilot declares the attack
+- **THEN** the to-hit penalty SHALL include +3 (high tier)
+
+#### Scenario: LRM in Indirect mode rejected
+
+- **GIVEN** a mech with LRM-15 in `weapon.mode: 'Indirect'` targeting an airborne aero
+- **WHEN** the pilot attempts the attack
+- **THEN** the attack SHALL be rejected
+- **AND** a warning event SHALL be emitted: `'Indirect-fire weapons cannot engage airborne targets'`
+
+### Requirement: Dogfight Resolution
+
+Two opposing airborne aero in the same hex at the same altitude SHALL be eligible for dogfight initiation. Mutual declaration during the movement phase SHALL commit both units to the current hex for the remainder of the turn (no further movement). At end of movement phase, before air-to-air resolution, each dogfighter SHALL receive one forward-arc shot at the other. Disengagement SHALL be available next turn (either side may decline a continued dogfight).
+
+#### Scenario: Mutual dogfight initiation
+
+- **GIVEN** A and B in the same hex at same altitude
+- **WHEN** A declares Dogfight against B AND B declares Dogfight against A
+- **THEN** both units SHALL set `dogfightWith` to each other's ID
+- **AND** both units SHALL be locked to the current hex for the turn
+- **AND** an `AerospaceDogfightInitiated` event SHALL be emitted
+
+#### Scenario: Dogfight shots resolve at end of movement phase
+
+- **GIVEN** A and B engaged in a dogfight
+- **WHEN** the movement phase ends
+- **THEN** A SHALL receive one forward-arc shot at B
+- **AND** B SHALL receive one forward-arc shot at A
+- **AND** both shots SHALL resolve through `aerospaceResolveDamage`
+
+#### Scenario: Unilateral dogfight declaration — not committed
+
+- **GIVEN** A declares Dogfight against B but B does NOT reciprocate
+- **WHEN** the movement phase resolves
+- **THEN** no dogfight SHALL be initiated
+- **AND** A and B may continue moving normally
+
+#### Scenario: Disengagement next turn
+
+- **GIVEN** A and B engaged in a dogfight last turn
+- **WHEN** the new turn begins
+- **THEN** either side MAY decline a continued dogfight by not re-declaring
+- **AND** if declined, both units SHALL be free to move
+- **AND** an `AerospaceDogfightDisengaged` event SHALL be emitted
+
+### Requirement: Bomb Drop Resolution
+
+An airborne aero with bombs loaded in its bomb bay SHALL be able to declare a bomb-drop attack against a ground hex during the movement phase. Bombs SHALL deviate from the declared target hex per a 2d6 scatter table, with deviation distance scaling by altitude tier: low 0-1 hex, medium 1-2 hex, high 2-3 hex. Bomb damage SHALL apply to the deviated hex per the existing bomb explosives rules.
+
+#### Scenario: Bomb at low altitude — minimal deviation
+
+- **GIVEN** an aero at altitude 2 dropping an HE bomb at declared hex G
+- **WHEN** the scatter roll is computed
+- **THEN** deviation distance SHALL be 0-1 hex (low-tier scatter)
+
+#### Scenario: Bomb at high altitude — large deviation
+
+- **GIVEN** an aero at altitude 9 dropping an HE bomb at declared hex G
+- **WHEN** the scatter roll is computed
+- **THEN** deviation distance SHALL be 2-3 hexes (high-tier scatter)
+
+#### Scenario: Bomb-drop event records both hexes
+
+- **GIVEN** a bomb drop with declared = G, deviated = G-southeast, scatter roll = 8
+- **WHEN** the bomb resolves
+- **THEN** an `AerospaceBombDropped { declaredHex: G, deviatedHex: G-SE, scatterRoll: 8, damage, bombType }` event SHALL be emitted
+
+### Requirement: Off-Map Exit and Re-Entry Tied to Altitude
+
+Existing `AerospaceExited` events SHALL include `exitAltitude` and `exitVelocity` fields. Re-entry SHALL preserve both altitude and velocity from exit. The existing 2-turn re-entry delay rule SHALL remain unchanged.
+
+#### Scenario: Exit records altitude + velocity
+
+- **GIVEN** an aero exits the board at altitude 5, currentVelocity 8
+- **WHEN** the `AerospaceExited` event is emitted
+- **THEN** the event SHALL include `exitAltitude: 5, exitVelocity: 8`
+
+#### Scenario: Re-entry preserves altitude + velocity
+
+- **GIVEN** an aero in off-map state with `exitAltitude: 5, exitVelocity: 8`
+- **WHEN** the re-entry timer elapses and the pilot returns at a board edge
+- **THEN** the aero SHALL re-enter at altitude 5 with currentVelocity = 8
+
+### Requirement: Grounded Aero Behaves as Ground Unit
+
+A grounded aero (altitude 0, `airborneState: 'grounded'`) SHALL be hit-able by ground-fire weapons normally and SHALL NOT receive any altitude-tier to-hit bonus when targeted. Its hit-location table SHALL be the standard aerospace arc table (Nose, Wings, Aft).
+
+#### Scenario: Grounded aero hit by ground attacker
+
+- **GIVEN** a grounded ASF (altitude 0)
+- **WHEN** a mech fires at it with a Large Laser
+- **THEN** no altitude-tier penalty SHALL apply
+- **AND** hit-location SHALL roll against the standard aerospace arc table
+
+## Data Model
+
+### Extended Interface: IAerospaceCombatState
+
+```typescript
+interface IAerospaceCombatState {
+  // Existing (from aerospace-unit-system → Aerospace Combat State)
+  currentSI: number;
+  armorByArc: { nose: number; leftWing: number; rightWing: number; aft: number };
+  heat: number;
+  fuelRemaining: number;
+  controlRollsFailed: number;
+  thrustPenalty: number;
+  offMap: boolean;
+  offMapReturnTurn?: number;
+
+  // NEW (this change)
+  altitude: number;                                                            // 0-10
+  currentVelocity: number;                                                     // forced-forward source
+  nextVelocity: number;                                                        // end-of-turn velocity
+  airborneState: 'grounded' | 'taking-off' | 'airborne' | 'landing';
+  dogfightWith?: string;                                                        // entityId of dogfight opponent this turn
+}
+```
+
+### Event Types: AerospaceDeploymentEvent
+
+```typescript
+type AerospaceDeploymentEvent =
+  | { kind: 'AerospaceTakeoff';                  unitId: string; }
+  | { kind: 'AerospaceLanding';                  unitId: string; rollHexes: number; }
+  | { kind: 'AerospaceControlRollFailed';        unitId: string; newAltitude: number; reason: string; }
+  | { kind: 'AerospaceCrashed';                  unitId: string; damagePerArc: number; }
+  | { kind: 'AerospaceOrbitTransitionAttempted'; unitId: string; }
+  | { kind: 'AerospaceAirToAirAttack';           attackerId: string; targetId: string; attackerArc: 'forward' | 'left' | 'right' | 'aft'; targetArc: 'forward' | 'left' | 'right' | 'aft'; velocityDiff: number; toHitFinal: number; outcome: 'hit' | 'miss'; }
+  | { kind: 'AerospaceAirToGroundAttack';        attackerId: string; targetId: string; altitudeTier: 'low' | 'med' | 'high'; toHitFinal: number; outcome: 'hit' | 'miss'; }
+  | { kind: 'AerospaceGroundToAirAttack';        attackerId: string; targetId: string; altitudeTier: 'low' | 'med' | 'high'; toHitFinal: number; outcome: 'hit' | 'miss'; }
+  | { kind: 'AerospaceDogfightInitiated';        unitAId: string; unitBId: string; }
+  | { kind: 'AerospaceDogfightDisengaged';       unitAId: string; unitBId: string; }
+  | { kind: 'AerospaceBombDropped';              attackerId: string; declaredHex: IHexCoordinate; deviatedHex: IHexCoordinate; scatterRoll: number; damage: number; bombType: string; };
+```

--- a/openspec/changes/add-aerospace-deployment/specs/combat-resolution/spec.md
+++ b/openspec/changes/add-aerospace-deployment/specs/combat-resolution/spec.md
@@ -1,0 +1,76 @@
+# Spec Delta: Combat Resolution — Aerospace Deployment Dispatch
+
+## ADDED Requirements
+
+### Requirement: Air-to-Air Dispatch
+
+When both the attacker and the target are airborne aerospace units (`airborneState === 'airborne'` or `'taking-off'` or `'landing'`), the combat resolver SHALL route the attack to the air-to-air resolver in `aerospace-deployment`. The air-to-air resolver SHALL handle to-hit modifier calculation and delegate damage application to the existing `aerospaceResolveDamage` per the existing `Aerospace Damage Chain` requirement.
+
+#### Scenario: Two airborne aero — air-to-air dispatch
+
+- **GIVEN** attacker A and target T both in `airborneState: 'airborne'`
+- **WHEN** A declares an attack against T
+- **THEN** the resolver SHALL invoke the air-to-air resolver
+- **AND** the existing `aerospaceResolveDamage` SHALL be invoked for damage application
+
+#### Scenario: Grounded aero attacker bypasses air-to-air
+
+- **GIVEN** A is a grounded aero (`airborneState: 'grounded'`), T is airborne
+- **WHEN** A declares an attack at T
+- **THEN** the resolver SHALL route through Ground-to-Air Dispatch (A is treated as a ground unit)
+
+### Requirement: Air-to-Ground Dispatch
+
+When the attacker is an airborne aerospace unit and the target is a ground unit (BattleMech, Vehicle, Infantry, Battle Armor, ProtoMek, grounded Aero), the combat resolver SHALL route the attack to the air-to-ground resolver in `aerospace-deployment`. The resolver SHALL apply the +2 base strafe penalty + altitude-tier modifier per `aerospace-deployment → Air-to-Ground Combat`.
+
+#### Scenario: Airborne ASF fires at ground mech — air-to-ground
+
+- **GIVEN** A is `airborneState: 'airborne'` at altitude 5, T is a ground mech
+- **WHEN** A declares a forward-arc weapon attack at T's hex during movement
+- **THEN** the resolver SHALL invoke the air-to-ground resolver
+- **AND** the to-hit penalty SHALL include +2 (strafe) + 1 (medium altitude) = +3
+
+### Requirement: Ground-to-Air Dispatch
+
+When the attacker is a ground unit and the target is an airborne aerospace unit, the combat resolver SHALL route the attack to the ground-to-air resolver in `aerospace-deployment`. The resolver SHALL apply the altitude-tier penalty (low +1, med +2, high +3) and SHALL reject indirect-fire weapons with a warning event.
+
+#### Scenario: Ground mech fires at airborne aero — ground-to-air
+
+- **GIVEN** A is a mech with PPC, T is airborne aero at altitude 8 (high tier)
+- **WHEN** A declares the attack
+- **THEN** the resolver SHALL invoke the ground-to-air resolver
+- **AND** the to-hit penalty SHALL include +3 (high altitude)
+
+#### Scenario: Indirect-fire weapon rejected against airborne target
+
+- **GIVEN** A is a mech with LRM-15 in `weapon.mode: 'Indirect'`, T is airborne aero
+- **WHEN** A attempts the attack
+- **THEN** the resolver SHALL reject the attack
+- **AND** a warning event SHALL be emitted: `'Indirect-fire weapons cannot engage airborne targets'`
+- **AND** no ammo or heat SHALL be consumed (attack fully rejected, not auto-miss)
+
+### Requirement: Aerospace Dispatch Matrix Completeness
+
+The combat resolver's aerospace dispatch SHALL cover all combinations of (attacker airborne-state × target airborne-state) for aerospace units per the following matrix:
+
+| Attacker | Target | Dispatch |
+|---|---|---|
+| Airborne aero | Airborne aero | Air-to-Air |
+| Airborne aero | Ground unit | Air-to-Ground |
+| Airborne aero | Grounded aero | Air-to-Ground (grounded aero treated as ground unit) |
+| Grounded aero | Airborne aero | Ground-to-Air |
+| Grounded aero | Ground unit | Standard ground-combat dispatch (per existing `combat-resolution`) |
+| Ground unit | Airborne aero | Ground-to-Air |
+| Ground unit | Grounded aero | Standard ground-combat dispatch with `aerospaceResolveDamage` for hit-location |
+
+#### Scenario: Grounded aero vs airborne aero — ground-to-air
+
+- **GIVEN** A is a grounded aero, T is airborne
+- **WHEN** A declares an attack at T
+- **THEN** the resolver SHALL invoke the ground-to-air resolver (A treated as ground)
+
+#### Scenario: Airborne aero vs grounded aero — air-to-ground
+
+- **GIVEN** A is airborne, T is grounded aero
+- **WHEN** A declares an attack at T
+- **THEN** the resolver SHALL invoke the air-to-ground resolver (T treated as ground unit)

--- a/openspec/changes/add-aerospace-deployment/specs/movement-system/spec.md
+++ b/openspec/changes/add-aerospace-deployment/specs/movement-system/spec.md
@@ -1,0 +1,68 @@
+# Spec Delta: Movement System — Aerospace Mode Toggle + Strafe Altitude
+
+## MODIFIED Requirements
+
+### Requirement: Aerospace 2D Simplified Movement
+
+Aerospace units SHALL move under a 2D-simplified flight model when `scenarioOptions.aerospaceMode === '2d-simplified'` (legacy default). When `scenarioOptions.aerospaceMode === '3d-tactical'` (new), the 3D thrust/velocity/altitude rules in `aerospace-deployment` SHALL apply instead, and this 2D rule SHALL NOT be used.
+
+#### Scenario: 2D-simplified mode — legacy flying unit range
+
+- **GIVEN** an ASF with safeThrust 6 in a scenario with `aerospaceMode: '2d-simplified'`
+- **WHEN** computing legal movement for the turn
+- **THEN** the unit SHALL be allowed to move up to `2 × safeThrust = 12 hexes`
+- **AND** the path SHALL be a straight line from the current hex plus at most one ≤ 60° turn
+
+#### Scenario: 2D-simplified mode — no altitude tracking
+
+- **GIVEN** any flying unit in a `'2d-simplified'` scenario
+- **WHEN** reading combat state
+- **THEN** the unit SHALL NOT have an altitude property in use
+- **AND** line-of-sight SHALL always treat flying units as "above the board"
+
+#### Scenario: 2D-simplified mode — reaching board edge exits unit
+
+- **GIVEN** a flying unit whose path reaches a board-edge hex in `'2d-simplified'` mode
+- **WHEN** movement is resolved
+- **THEN** an `AerospaceExited` event SHALL fire
+- **AND** the unit SHALL enter off-map state for the scenario-defined return delay (default 2 turns)
+
+#### Scenario: 2D-simplified mode — re-entry from off-map
+
+- **GIVEN** a flying unit in off-map state whose return delay has elapsed
+- **WHEN** its owner chooses a board-edge re-entry hex
+- **THEN** an `AerospaceEntered` event SHALL fire
+- **AND** the unit SHALL resume movement with the facing it had at exit
+
+#### Scenario: 3D-tactical mode — this 2D rule does NOT apply
+
+- **GIVEN** a scenario with `aerospaceMode: '3d-tactical'`
+- **WHEN** an aerospace unit's movement resolves
+- **THEN** the rules in `aerospace-deployment` SHALL apply
+- **AND** this `Aerospace 2D Simplified Movement` rule SHALL NOT be used for that unit
+
+### Requirement: Fly-Over Strafe Movement
+
+The system SHALL allow a flying unit to declare a strafe path during movement, applying attacks to ground units in the path hexes. The base +2 to-hit penalty SHALL apply in 2D-simplified mode; in 3D-tactical mode (`aerospaceMode === '3d-tactical'`), the altitude-tier modifier (low +0, med +1, high +2) from `aerospace-deployment → Air-to-Ground Combat` SHALL be added on top of the base +2.
+
+#### Scenario: 2D-simplified strafe — base +2 only
+
+- **GIVEN** an ASF in `'2d-simplified'` mode strafing 4 hexes, 2 of which contain enemy ground units
+- **WHEN** the player declares strafe on those hexes
+- **THEN** Nose or Wing weapons SHALL fire at ground units in those hexes during movement
+- **AND** each strafed shot SHALL add +2 to-hit penalty
+- **AND** an `AerospaceFlyOver` event SHALL record affected hexes and damage applied
+
+#### Scenario: 3D-tactical strafe — base +2 + altitude modifier
+
+- **GIVEN** an ASF at altitude 8 (high tier) in `'3d-tactical'` mode strafing 2 ground hexes
+- **WHEN** the player declares strafe
+- **THEN** each strafed shot SHALL add +2 base + 2 (high altitude) = +4 to-hit penalty
+- **AND** an `AerospaceAirToGroundAttack` event SHALL fire (per `aerospace-deployment`) instead of the legacy `AerospaceFlyOver`
+
+#### Scenario: 3D-tactical strafe at low altitude — minimal penalty
+
+- **GIVEN** an ASF at altitude 1 (low tier) in `'3d-tactical'` mode strafing a ground hex
+- **WHEN** the player declares strafe
+- **THEN** the to-hit penalty SHALL be +2 base + 0 (low altitude) = +2
+- **AND** the per-attack to-hit SHALL match the 2D-simplified penalty in this special case

--- a/openspec/changes/add-aerospace-deployment/specs/unit-entity-model/spec.md
+++ b/openspec/changes/add-aerospace-deployment/specs/unit-entity-model/spec.md
@@ -1,0 +1,30 @@
+# Spec Delta: Unit Entity Model — Aerospace Altitude + Velocity
+
+## MODIFIED Requirements
+
+### Requirement: Component References
+
+The unit entity SHALL reference components by type. Aerospace units' component references SHALL additionally include the runtime combat-state fields `altitude`, `currentVelocity`, `nextVelocity`, and `airborneState` introduced by the `aerospace-deployment` capability. These fields SHALL be part of the aerospace unit's combat-state slice (per the extended `IAerospaceCombatState` interface in `aerospace-deployment`).
+
+#### Scenario: Component composition for non-aerospace units (unchanged)
+
+- **WHEN** a unit contains components
+- **THEN** engine, gyro, cockpit SHALL be single references
+- **AND** equipment SHALL be array of placed items
+- **AND** armor SHALL be allocation per location
+
+#### Scenario: Aerospace unit combat-state includes altitude + velocity
+
+- **GIVEN** an aerospace unit (`IAerospace | IConventionalFighter | ISmallCraft`) entering combat
+- **WHEN** combat state is initialized
+- **THEN** `unit.combatState.aero` SHALL include `altitude: number`, `currentVelocity: number`, `nextVelocity: number`, `airborneState: 'grounded' | 'taking-off' | 'airborne' | 'landing'`
+- **AND** these fields SHALL be in addition to the existing `currentSI`, `armorByArc`, `heat`, `fuelRemaining`, `controlRollsFailed`, `thrustPenalty`, `offMap`, `offMapReturnTurn` fields per the existing `aerospace-unit-system → Aerospace Combat State` requirement
+
+#### Scenario: Grounded aero default combat-state
+
+- **GIVEN** an aerospace unit that has not yet taken off in a scenario
+- **WHEN** combat state is initialized
+- **THEN** `altitude` SHALL be 0
+- **AND** `currentVelocity` SHALL be 0
+- **AND** `nextVelocity` SHALL be 0
+- **AND** `airborneState` SHALL be `'grounded'`

--- a/openspec/changes/add-aerospace-deployment/tasks.md
+++ b/openspec/changes/add-aerospace-deployment/tasks.md
@@ -1,0 +1,116 @@
+# Tasks: Add Aerospace Deployment
+
+> **Apply Wave is DEFERRED to its own dedicated wave** (estimated Wave 9; sized at 3-5× ground vehicle scope per the Wave 7 OMO Council Librarian assessment). This change authors the spec only.
+
+## 1. Scenario environment + mode flag
+
+- [ ] 1.1 Define `IScenarioOptions.mapEnvironment: 'atmospheric' | 'space'` and `IScenarioOptions.aerospaceMode: '2d-simplified' | '3d-tactical'` in `src/types/scenario/ScenarioOptions.ts`
+- [ ] 1.2 Default values: `mapEnvironment = 'atmospheric'`, `aerospaceMode = '2d-simplified'` (preserves existing Phase-6 behavior; new scenarios may opt in to 3D)
+- [ ] 1.3 At session-init, route to 2D-simplified path vs 3D-tactical path once based on `aerospaceMode`; do NOT re-check per-attack
+
+## 2. Aero combat state extension
+
+- [ ] 2.1 Extend `IAerospaceCombatState` in `src/types/gameplay/CombatInterfaces.ts` with `altitude: number` (0-10), `currentVelocity: number`, `nextVelocity: number`, `airborneState: 'grounded' | 'taking-off' | 'airborne' | 'landing'`, `dogfightWith?: string` (entityId of dogfight opponent this turn)
+- [ ] 2.2 Resolve the existing TODO at `src/types/gameplay/GameplayUIInterfaces.ts:299-307` by populating `IAerospaceToken.velocity` from `combatState.aero.currentVelocity`
+- [ ] 2.3 Unit-test: initial state for a grounded aero is `{ altitude: 0, currentVelocity: 0, nextVelocity: 0, airborneState: 'grounded' }`
+
+## 3. Altitude bands + transitions
+
+- [ ] 3.1 Implement altitude transitions in `src/lib/movement/aerospaceMovement.ts`: `ascendAltitude` (2 thrust per band), `descendAltitude` (free, +1 to nextVelocity gravity assist)
+- [ ] 3.2 Implement `takeoff` (2 thrust + control roll, set altitude=1, currentVelocity=safeThrust); emit `AerospaceTakeoff`
+- [ ] 3.3 Implement `landing` (descend from altitude 1 with velocity ≤ safeThrust, rolling on N hexes = velocity, set altitude=0); emit `AerospaceLanding`
+- [ ] 3.4 Reject altitude > 10 (orbit transition out of scope this change); emit error event `AerospaceOrbitTransitionAttempted` and revert
+- [ ] 3.5 Unit-test: takeoff from altitude 0; ascend 0→2 costs 4 thrust; descend 5→3 is free + boosts nextVelocity +2; landing requires velocity ≤ safeThrust
+
+## 4. Velocity + thrust accounting
+
+- [ ] 4.1 Implement thrust budgeting per turn: `thrustBudget = maxThrust` (= floor(safeThrust × 1.5)); thrust spent on (a) accelerating ±velocity, (b) turning ≤60° per thrust, (c) altitude changes, (d) takeoff/landing
+- [ ] 4.2 Spending > safeThrust triggers control roll at end of turn; spending > maxThrust SHALL be rejected outright
+- [ ] 4.3 Enforce forced forward motion: must move ≥ currentVelocity hexes in facing direction; failing triggers control roll with reason `'Insufficient forward motion at velocity'`
+- [ ] 4.4 At end of turn: `currentVelocity ← nextVelocity` for next turn's forced-forward check
+- [ ] 4.5 Unit-test: thrust=8 budget allows accel +3 + turn 60° + ascend 2; thrust=10 rejected as > max; velocity 9 forces ≥9 hexes forward
+
+## 5. Atmospheric vs space rule deltas
+
+- [ ] 5.1 Atmospheric: velocity halved upon landing (velocity → floor(velocity/2)); at velocity 0 in atmospheric environment, control roll auto-fails (stall)
+- [ ] 5.2 Space: no velocity halving; no terrain effects; no gravity assist; control rolls only from thrust > safeThrust
+- [ ] 5.3 Atmospheric: terrain at hex elevation H blocks low-altitude flight (altitude < H+1); attempting to fly into terrain forces altitude ≥ H+1
+- [ ] 5.4 Unit-test: atmospheric stall at velocity=0 auto-fails control roll; space scenario with velocity=0 passes (no stall in vacuum)
+
+## 6. Control roll triggers + stall/crash
+
+- [ ] 6.1 Per-attack-type control roll triggers: spent > safeThrust (+1 per excess thrust), velocity > 2 × safeThrust (+1 per excess), insufficient forward motion (auto-trigger), damage exceeding 10% of SI (existing rule from `combat-resolution`), atmospheric stall (auto-fail at velocity 0)
+- [ ] 6.2 Failed control roll at altitude > 1: drop altitude by 1, emit `AerospaceControlRollFailed`
+- [ ] 6.3 Failed control roll at altitude 1: crash to altitude 0 with crash damage = currentVelocity × 5 to all arcs equally; emit `AerospaceCrashed`
+- [ ] 6.4 Unit-test: 2 control-roll failures in 2 turns from altitude 5 → altitude 3; failure at altitude 1 → crash + damage application
+
+## 7. Air-to-air combat
+
+- [ ] 7.1 Implement air-to-air dispatch in `src/lib/combat/aerospaceCombat.ts`: eligible when both attacker and target are airborne AND in same hex AND altitude diff ≤ 2
+- [ ] 7.2 To-hit base: pilot gunnery skill; arc modifiers: forward +0, left/right wing +1, aft +3
+- [ ] 7.3 Velocity differential: +1 per 2 hexes of velocity difference (faster relative motion = harder shot)
+- [ ] 7.4 Hit-location + damage: delegate to existing `aerospaceResolveDamage()` per `combat-resolution`
+- [ ] 7.5 Emit `AerospaceAirToAirAttack { attackerId, targetId, attackerArc, targetArc, velocityDiff, toHitFinal, outcome }`
+- [ ] 7.6 Unit-test: same-hex, same-altitude, forward-arc shot → base only; aft shot → +3 mod; velocity 9 vs velocity 3 → +3 velocity diff mod
+
+## 8. Air-to-ground combat (extends existing strafe)
+
+- [ ] 8.1 Implement air-to-ground in `aerospaceCombat.ts`: eligible when attacker is airborne, target is ground unit in attacker's movement path this turn (extends existing strafe rule from `movement-system`)
+- [ ] 8.2 To-hit modifier: existing +2 strafe penalty + altitude tier (low +0, med +1, high +2); legal weapons: Nose-arc + Wing-arc forward-firing
+- [ ] 8.3 Emit `AerospaceAirToGroundAttack { attackerId, targetId, altitudeTier, toHitFinal, outcome }`
+- [ ] 8.4 Unit-test: ASF at altitude 6 strafing 2 ground hexes → +2 base +1 alt = +3 to-hit per shot
+
+## 9. Ground-to-air combat
+
+- [ ] 9.1 Implement ground-to-air in `aerospaceCombat.ts` (dispatched from `combat-resolution`): eligible when attacker is ground unit, target is airborne aero
+- [ ] 9.2 To-hit modifier: altitude tier (low +1, med +2, high +3); legal weapons: any direct-fire weapon within range
+- [ ] 9.3 Reject indirect-fire weapons (LRM in Indirect mode) attempting to engage airborne targets — emit warning event
+- [ ] 9.4 Emit `AerospaceGroundToAirAttack { attackerId, targetId, altitudeTier, toHitFinal, outcome }`
+- [ ] 9.5 Unit-test: AC/20 mech firing at airborne aero at altitude 7 → +3 to-hit; LRM in Indirect mode → rejected
+
+## 10. Dogfight resolution
+
+- [ ] 10.1 Dogfight initiation: both opposing airborne aero in same hex, same altitude, both pilots declare dogfight during movement-phase
+- [ ] 10.2 On mutual declaration: both units commit to the current hex for the turn; further movement SHALL be rejected; set `dogfightWith` on both sides
+- [ ] 10.3 At end of movement phase, before air-to-air resolution: each dogfighter gets one forward-arc shot at the other; arcs auto-resolve to forward-arc
+- [ ] 10.4 Disengagement: next turn, either side may decline dogfight; both units may move normally
+- [ ] 10.5 Emit `AerospaceDogfightInitiated { unitAId, unitBId }`, `AerospaceDogfightDisengaged { unitAId, unitBId }`
+- [ ] 10.6 Unit-test: A and B in same hex altitude 5; both declare dogfight; both get forward-arc shots; next turn both disengage; movement allowed
+
+## 11. Bomb drop resolution
+
+- [ ] 11.1 Implement `src/lib/combat/bombResolution.ts`: airborne aero with bombs in bomb-bay may declare a bomb-drop attack on a ground hex during movement
+- [ ] 11.2 Bomb scatter table: 2d6 roll mapped to scatter direction + distance per altitude tier (low: 0-1 hex; med: 1-2; high: 2-3)
+- [ ] 11.3 Apply bomb damage to the deviated hex per existing bomb explosive rules; multiple ground units in deviated hex split damage
+- [ ] 11.4 Emit `AerospaceBombDropped { attackerId, declaredHex, deviatedHex, scatterRoll, damage, bombType }`
+- [ ] 11.5 Unit-test: 2d6=8 from altitude 5 → 1 hex scatter direction-N; damage applies to N hex
+
+## 12. Combat-resolution dispatch update
+
+- [ ] 12.1 In `src/lib/combat/combatResolution.ts`: extend the existing `Aerospace Combat Dispatch` to branch on attacker/target type matrix per the new `aerospace-deployment` spec
+- [ ] 12.2 Existing `aerospaceResolveDamage` continues to handle damage application (per existing `combat-resolution`); the new dispatch routes to-hit calc through air-to-air / air-to-ground / ground-to-air resolvers
+- [ ] 12.3 Unit-test: dispatch matrix covers all 9 cells (BattleMech/Vehicle/Aerospace × BattleMech/Vehicle/Aerospace as attacker/target), with aerospace cells delegating correctly
+
+## 13. Off-map exit + re-entry tied to altitude
+
+- [ ] 13.1 Extend existing `AerospaceExited` event to include `exitAltitude` and `exitVelocity` fields
+- [ ] 13.2 Re-entry SHALL preserve altitude and velocity; existing 2-turn re-entry-delay rule unchanged
+- [ ] 13.3 Unit-test: ASF exits at altitude 5, velocity 8; re-enters 2 turns later at altitude 5, velocity 8
+
+## 14. Spec deltas
+
+- [ ] 14.1 Author `openspec/changes/add-aerospace-deployment/specs/aerospace-deployment/spec.md` (NEW capability — full 3D aerospace combat surface per the proposal)
+- [ ] 14.2 Author `openspec/changes/add-aerospace-deployment/specs/combat-resolution/spec.md` (MODIFIED — air-to-air / air-to-ground / ground-to-air dispatch)
+- [ ] 14.3 Author `openspec/changes/add-aerospace-deployment/specs/unit-entity-model/spec.md` (MODIFIED — aerospace altitude + velocity in entity model)
+- [ ] 14.4 Author `openspec/changes/add-aerospace-deployment/specs/movement-system/spec.md` (MODIFIED — 2D becomes legacy fallback, strafe altitude modifier)
+- [ ] 14.5 `npx openspec validate add-aerospace-deployment --strict` passes clean
+- [ ] 14.6 `npm run build`, lint, typecheck, jest, scenario tests pass on CI (Apply wave gate — DEFERRED)
+- [ ] 14.7 Archive the change to `openspec/changes/archive/YYYY-MM-DD-add-aerospace-deployment/` after Apply-wave PR merge; sync the 4 deltas into source-of-truth specs (NEVER `--skip-specs`)
+
+## 15. Documentation + follow-up notes
+
+- [ ] 15.1 Add a `playtest/wave-9/AEROSPACE_DEPLOYMENT_NOTES.md` section: scenarios to add (Aero-vs-Aero dogfight, Aero strafe-vs-mech-column, Aero bomb-drop-on-fortified-position, Aero takeoff-engage-land cycle); MegaMek parity gates
+- [ ] 15.2 Spec the VTOL/hover follow-up — `update-vtol-hover-mp-modifiers` (small delta to `movement-system` capturing VTOL hover MP, VTOL airborne-but-not-aerospace state). Note in `_followups.md` placeholder in archive folder
+- [ ] 15.3 Spec the future Dropship combat follow-up (`add-dropship-combat`) as the next aerospace deployment layer
+- [ ] 15.4 Spec the future aerospace AI heuristics follow-up (`add-aerospace-ai`) for bot fighter decision-making once the engine path stabilizes
+- [ ] 15.5 Capture parity-test budget for Aero combat against MegaMek scenario set — 5-8 scenarios with hit/miss/damage ratios within 5% of MegaMek baseline

--- a/openspec/changes/add-battle-armor-combat/design.md
+++ b/openspec/changes/add-battle-armor-combat/design.md
@@ -1,0 +1,144 @@
+# Design: Add Battle Armor Combat
+
+## Reference Material
+
+- MegaMek `BattleArmor.java` (68KB) — squad state, dead-trooper tracking, `calculateSwarmDamage`, `rollHitLocation`, `getTrooperAtLocation`
+- MegaMek `SwarmAttack.java` + `SwarmAttackHandler.java` (~100 LOC) — swarm declaration + attach state mutation
+- MegaMek `SwarmWeaponAttackHandler.java` (~90 LOC) — damage-while-attached resolution
+- MegaMek `LegAttack.java` + `LegAttackHandler.java` (~125 LOC) — leg attack damage + crit math
+- MegaMek `BAVibroClawAttackAction.java` — vibroclaw attack action shape
+- MegaMek `BrushOffAttackAction.java` — brush-off declaration
+- MegaMek `Entity.java:8362-8380` — `checkDislodgeSwarmers` (drop-prone PSR)
+- Local `src/types/gameplay/GameplayUIInterfaces.ts:312-324` — existing `IBattleArmorToken` with the unresolved TODO
+
+## Architecture Decisions
+
+### Decision A: New `battle-armor-combat` capability, not delta on `battle-armor-unit-system`
+
+**Choice**: combat mechanics live in a separate `battle-armor-combat` capability. `battle-armor-unit-system` stays construction-focused.
+
+**Rationale**: the existing 820-LOC `battle-armor-unit-system` spec is well-bounded around construction (chassis, equipment mounting, BLK round-trip, BV calculation, customizer UI). Adding ~12 combat requirements to it would push it past 1100 LOC and conflate two distinct domains. The existing `BA Combat State` section (lines 766-791) is minimal — just trooper-array + swarmingUnitId — and lives there because the squad's runtime shape needs to round-trip from construction state. The new capability cross-references that existing state but is the canonical source for combat mechanics going forward.
+
+**Alternatives considered**:
+- *Modify `battle-armor-unit-system` and remove its `Non-Goals → Combat mechanics` line*: rejected — splits the responsibility unclearly; the construction spec's Non-Goals are correct as-stated.
+- *Bundle BA combat into the existing `combat-resolution` spec*: rejected — `combat-resolution` is already 1264 LOC; further bloat hurts readability. Per-unit-type combat capabilities (already exists for `aerospace`, conventional pattern is forming) is the cleaner mental model.
+
+### Decision B: Squad-damage allocation uses re-roll loop, not weighted distribution
+
+**Choice**: each damage point rolls d6 against trooper slots; if the rolled trooper is dead, re-roll. Matches MegaMek `BattleArmor.rollHitLocation()` line 666 (`loc = Compute.d6()` in a `while` loop until alive trooper is found).
+
+**Rationale**: MegaMek parity is the priority. Players importing MegaMek-derived scenarios expect identical damage distributions. A weighted approach (e.g., divide by living-trooper-count) would skew slightly differently on small squads and break replay parity against MegaMek logs.
+
+**Alternatives considered**:
+- *Weighted random across living troopers (no re-roll)*: rejected — non-canonical, breaks parity.
+- *Fill the most-damaged trooper first*: rejected — non-canonical, conceptually wrong (swarm fire is dispersed).
+
+### Decision C: Swarm damage uses `calculateSwarmDamage` formula verbatim
+
+**Choice**: `sum(squad-mounted non-missile non-infantry-attack non-body-mounted weapon damage × shootingStrength) + vibroClaws + (myomerBooster ? troopers × 2 : 0)`. The `× shootingStrength` accounts for "each surviving trooper hits" on a squad-mounted weapon.
+
+**Rationale**: MegaMek parity. The formula is in `BattleArmor.calculateSwarmDamage()` lines 1502-1540, which I've read verbatim. Body-mounted weapons (per-trooper, not squad-shared) are excluded because they fire forward, not at the swarmed mech. Missile weapons are excluded because they can't be aimed point-blank in a swarm clinch.
+
+**Alternatives considered**:
+- *Include missile weapons in swarm fire*: rejected — non-canonical.
+- *Average damage instead of sum*: rejected — non-canonical; swarm fire is meant to be devastating, that's the tactical role.
+
+### Decision D: Leg attack hit-location fallback to other leg
+
+**Choice**: roll for leg location (`Mek.LOC_LEFT_LEG` or `Mek.LOC_RIGHT_LEG`); if the rolled leg has 0 internal, hit the other leg. Mirrors MegaMek `LegAttackHandler.java` lines 88-94.
+
+**Rationale**: parity, and a sensible rule — the troopers physically wrap the leg; if one leg is gone, they wrap the other.
+
+**Alternatives considered**:
+- *Miss when leg destroyed*: rejected — non-canonical; the attack should always hit one of the legs.
+
+### Decision E: Brush-off + drop-prone as alternatives in the same phase
+
+**Choice**: the targeted mech declares EITHER brush-off OR drop-prone per turn, not both. Brush-off requires the mech to forfeit one weapon attack that turn; drop-prone is a standalone movement action with a PSR.
+
+**Rationale**: matches MegaMek; both actions consume similar "attention budget" so allowing both per turn would be too generous.
+
+**Alternatives considered**:
+- *Allow both per turn*: rejected — too strong against swarmers.
+- *Auto-select the better one*: rejected — player tactical choice should be explicit.
+
+### Decision F: `mountedOn` resolves the existing TODO; transport rules deferred
+
+**Choice**: this change resolves the `IBattleArmorToken.mountedOn` TODO by formalizing `mountedOn` as a combat-state field driven by transport state. Render-side: when set, the BA token renders as a passenger badge on the host. Transport-side: this change does NOT define HOW BA squads mount/dismount (that's `add-ba-transport-rules`, a future change). Assumed prerequisite: `mountedOn` is set by some upstream system, and combat-state read-side honors it.
+
+**Rationale**: closing the TODO needs the render-side contract pinned. The mounting transport rules are a separate domain (load/unload phase, magnetic-clamp eligibility, mechanized-chassis-capacity, dismount-when-host-takes-Y-damage rules) and would balloon this change past 200 LOC.
+
+**Alternatives considered**:
+- *Bundle transport rules into this change*: rejected — scope creep; transport is its own 200+ LOC domain.
+- *Leave the TODO alone*: rejected — render-side BA passenger handling is a Wave-7 visible bug.
+
+### Decision G: Anti-Mek skill source is `personnel-system` + `lib/spa/catalog`
+
+**Choice**: BA pilot's Anti-Mek skill rating + SPAs drive swarm/leg-attack to-hit. The new spec references the existing `personnel-system` for the pilot stat and the existing `lib/spa/catalog` for `MISC_HUMAN_TRO_MEK` (and any other Anti-Mek SPAs).
+
+**Rationale**: don't re-define pilot stats here. Cross-spec reference keeps the spec footprint small and ensures pilot-stat changes flow through naturally.
+
+**Alternatives considered**:
+- *Hardcode Anti-Mek = 4*: rejected — non-canonical and breaks pilot-progression integration.
+- *Author a new SPA in this change*: rejected — `HUMAN_TRO_MEK` already exists per MegaMek `OptionsConstants`; only the Anti-Mek skill stat needs a cross-reference, not creation.
+
+## Data Flow
+
+```
+BA squad B has 4 troopers, attached to host mech M via swarm
+              ↓
+B declares squad-fire-while-swarming (W = SwarmWeaponAttack)
+              ↓
+Resolver: B.unitType === BATTLE_ARMOR && W kind === SwarmWeaponAttack
+              ↓
+SwarmWeaponAttackHandler resolves:
+  ├─ Roll d6 per damage point against host M location table
+  ├─ For each hit:
+  │     ├─ Determine M location (CT/LT/RT front/rear)
+  │     ├─ Apply damage to M armor → internal
+  │     └─ Emit AttackResolved + WeaponDamageApplied
+  └─ Compute B's outgoing swarm damage = calculateSwarmDamage(B)
+       = sum(non-missile non-body squad weapons × shootingStrength)
+       + vibroClaws + (myomer ? troopers × 2 : 0)
+              ↓
+Apply outgoing damage to M
+              ↓
+Emit BASwarmDamageApplied { attackerId: B.id, hostId: M.id, damage, weapons: [...] }
+              ↓
+NEXT: enemy E fires at M with autocannon for 12 damage
+              ↓
+Resolver: M has swarmers (M.combatState.swarmedByUnitIds.includes(B.id))
+              ↓
+For each hit roll on M's CT/LT/RT (mounted-trooper-able):
+   ├─ Some hits go to M armor (normal)
+   ├─ Other hits (e.g. CT rear) translate via getTrooperAtLocation
+   │   → trooper 5 takes the damage
+   ├─ Apply damage to B.combatState.squad.troopers[5].armor
+   └─ Emit BATrooperKilled if armor → 0
+              ↓
+At end of turn: if B.getNumberActiveTroopers() === 0
+              ↓
+Auto-emit BASwarmDetached { hostId: M.id, reason: 'Squad destroyed' }
+```
+
+## File Changes (Apply estimate — informational; not part of this change)
+
+- New:
+  - `src/lib/combat/baCombat.ts` — squad damage allocator, swarm damage calculator, leg-attack damage helper, trooper-location-on-host adapter (~300-400 LOC)
+- Modified:
+  - `src/engine/InteractiveSession.ts` — register the 3 BA action handlers (SwarmAttack, LegAttack, BAVibroClawAttack), brush-off declaration
+  - `src/lib/combat/combatResolution.ts` — BA dispatch branch + 7 new event emissions
+  - `src/types/gameplay/CombatInterfaces.ts` — `IBASquadCombatState` formalization, 7 BACombatEvent variants, swarm/leg/vibroclaw attack context types
+  - `src/types/gameplay/GameplayUIInterfaces.ts` — resolve TODO on `IBattleArmorToken.mountedOn`, add `passengerBadge` render hint
+  - `src/components/gameplay/UnitToken.tsx` (or hex-board equivalent) — passenger badge rendering
+  - `src/components/gameplay/AttackDeclarationPanel.tsx` — swarm/leg/vibroclaw action buttons for BA attackers
+  - `src/services/combat/replays/eventLogFormatter.ts` — 7 new event types in the columnar formatter
+- Deleted: none
+
+## Risks
+
+- **R1 (medium)**: passenger-badge rendering interacts with the existing hex-token layer and z-ordering. Mitigation: the spec pins the render contract (`passengerBadge` rendering hint); the Apply wave's UI work needs storybook story coverage before shipping to playtest.
+- **R2 (medium)**: squad-damage allocation parity against MegaMek needs harness validation on a representative scenario set. Mitigation: include a 5-scenario regression harness in the Apply wave (proposal Open Questions section flagged the test footprint).
+- **R3 (low)**: the swarm-while-attached damage formula has edge cases around BA squads with mixed Body + Squad mounted weapons. Mitigation: spec'd verbatim against MegaMek; tests cover the body-mounted-excluded case explicitly.
+- **R4 (low)**: the new event types interact with the JSONL event-log replay path (per `replay-library` capability). Mitigation: spec the round-trip explicitly + extend the columnar formatter in the same Apply wave.
+- **R5 (low)**: `mountedOn` for passenger-badge requires upstream transport system to populate the field. Mitigation: spec is explicit that this change defines the read-side contract; transport rules are deferred to a follow-up. The field already exists in `IBattleArmorToken` so no shape change is needed — only the render-side contract is new.

--- a/openspec/changes/add-battle-armor-combat/proposal.md
+++ b/openspec/changes/add-battle-armor-combat/proposal.md
@@ -1,0 +1,82 @@
+# Change: Add Battle Armor Combat
+
+## Why
+
+Battle Armor (BA) squads are constructed end-to-end today via the `battle-armor-unit-system` capability (820 LOC spec covering chassis, weight classes, manipulators, equipment mounting, BLK round-trip, BV 2.0 calculation, customizer UI). But combat mechanics are explicitly out-of-scope of that spec — line 9: "Combat mechanics (damage resolution, swarm attacks, anti-mech tactics) are OUT OF SCOPE". The same gap surfaces in code: `src/types/gameplay/GameplayUIInterfaces.ts:317` carries a `TODO: wire from battlearmor combat-behavior proposal` on the `mountedOn?: string` field of `IBattleArmorToken`. That TODO is the surfacing of a deeper gap — there is no spec authority for any BA-vs-mech, BA-vs-vehicle, BA-vs-BA, or mech-fire-vs-BA-squad mechanic.
+
+A playtest that includes a BA squad on the table today has no defined behavior for: how anti-personnel fire allocates damage across troopers; how a BA squad swarms a mech and what damage they deal each turn while attached; how mech and BA tactical interactions resolve (leg attacks, anti-mech vibroclaw attacks, brush-off attempts); how dead troopers reduce squad firepower; how mounted-on-host (BA riding a mech) renders as a passenger badge rather than a standalone token.
+
+MegaMek implements all of this across `BattleArmor.java` (68KB), `BAVibroClawAttackAction.java`, `LegAttack.java` + `LegAttackHandler.java`, `SwarmAttack.java` + `SwarmAttackHandler.java`, `SwarmWeaponAttackHandler.java`, `BrushOffAttackAction.java`, `BattleArmor.calculateSwarmDamage()`, `BattleArmor.rollHitLocation()`, and `BattleArmor.getTrooperAtLocation()`. The squad-damage / dead-trooper / swarm-state pattern is concentrated; the per-attack handlers are small (~100 LOC each). This change establishes spec authority for the combat surface so the Apply wave can implement the per-attack handlers + the squad-state machinery without re-deriving rules from Java each PR.
+
+**Scope discipline**: BA construction is OUT — `battle-armor-unit-system` owns it. Anti-mech vibroclaw, leg attack, swarm-attach, swarm-detach, swarm-fire-while-attached, brush-off, conventional-infantry-vs-BA, mech-fire-vs-BA, squad-damage allocation, mounted-trooper rendering are IN. BA pilot SPAs (Anti-Mek skill, etc.) carry over from the existing SPA catalog — this change only references them, doesn't re-define. Magnetic-clamp-mount / mechanized BA riding host vehicles is IN as the `mountedOn` host relationship at combat-state level (transport-rules out of scope; assume host already exists). BA construction-time equipment that affects combat (vibroclaws, myomer booster, magnetic clamps) is referenced for its combat side-effect only.
+
+## What Changes
+
+### Capability deltas
+
+- **NEW `battle-armor-combat`** — first-class combat capability for BA squads:
+  - ADDED **BA Squad Combat State**: per-trooper alive/armor/equipment-destroyed tracking, swarm-attach pointer (`swarmingUnitId | mountedOn`), mimetic/stealth state-this-turn flags. Builds on the existing minimal `BA Squad Combat State` requirement already in `battle-armor-unit-system` (which only covers swarm-on and dead-trooper retention) — promoted to first-class with full per-attack semantics.
+  - ADDED **Squad Damage Allocation**: anti-personnel and weapon-fire damage SHALL roll d6 per damage point against trooper slots; rerolls SHALL skip dead troopers; the "second roll is same trooper triggers crit" Tactical Operations rule SHALL be supported behind an options flag. Mirrors MegaMek `BattleArmor.rollHitLocation()`.
+  - ADDED **Swarm Attack — To-Hit**: a BA squad SHALL be able to declare a swarm attack against a mech via the dedicated `SwarmAttack` weapon. To-hit base is the attacker's Anti-Mek skill from `lib/spa/catalog`; resolution mirrors `SwarmAttackHandler`. Failed swarm SHALL leave the attacker in the same hex; successful swarm SHALL establish the `swarmingUnitId` link.
+  - ADDED **Swarm Attack — Damage While Attached**: while a BA squad is attached as a swarmer to a host mech, the squad SHALL fire its squad weapons at the host each turn using `SwarmWeaponAttackHandler` rules. Damage formula: `sum(squad-mounted non-missile non-infantry-weapon damage × shootingStrength) + (vibroClaws × 1) + (myomerBooster ? troopers × 2 : 0)`. Mirrors `BattleArmor.calculateSwarmDamage()`.
+  - ADDED **Swarm Attack — Hit-Location vs Mounted Host**: damage applied to a host mech with attached swarmers SHALL use the mounted-trooper-location adapter from MegaMek `getTrooperAtLocation` — RT-front → trooper 1, LT-front → trooper 2, RT-rear → trooper 3, LT-rear → trooper 4, CT-front → trooper 6, CT-rear → trooper 5 — so fire targeting the host mech's torsos can secondarily hit the attached squad's individual troopers.
+  - ADDED **Leg Attack**: a BA squad SHALL be able to declare a leg attack against a mech via the `LegAttack` infantry attack action. Damage = `4 + vibroClaws + (myomerBooster ? troopers × 2 : 0)`. Hit-location SHALL be a leg per `rollHitLocation`; if the rolled leg is destroyed, the other leg SHALL be hit. Critical-hit modifier: `−2` if the targeted location's armor type is `HARDENED`; `+1` if the attacker has the `HUMAN_TRO_MEK` SPA. Mirrors `LegAttackHandler`.
+  - ADDED **Vibroclaw Attack**: a BA trooper SHALL be able to make a melee vibroclaw attack against an adjacent enemy. Damage = `missilesHit(shootingStrength) × vibroClaws` per `BAVibroClawAttackAction`. Targets must have vibroclaws ≥ 1; UI MUST hide the action when vibroclaws == 0.
+  - ADDED **Brush-Off Attempt**: a mech with attached swarmers MAY declare a brush-off attack each turn; the brush-off uses the mech pilot's skill rating; success detaches the squad and applies brush-off damage (per `BrushOffAttackAction`). Failure leaves the swarmer attached.
+  - ADDED **Dislodge by Prone**: a mech with attached swarmers MAY drop prone instead of brushing off; PSR target = base + 0; success detaches the swarmer; failure inflicts pilot damage as a normal failed-PSR. Mirrors `Entity.checkDislodgeSwarmers()`.
+  - ADDED **Dead Trooper Effects on Squad Fire**: when calculating outgoing squad fire from a BA squad, dead troopers SHALL reduce `shootingStrength` proportionally. A squad with `getNumberActiveTroopers() / squadSize < 0.75` SHALL be marked `dmgModerate`; `< 0.9` SHALL be `dmgLight`.
+  - ADDED **Mounted-Trooper Passenger Badge**: when `IBattleArmorToken.mountedOn` is set (BA squad mounted as passenger on a friendly mech via magnetic clamps or mechanized chassis), the BA token SHALL render as a passenger badge attached to the host's token rather than as a standalone hex token. The mountedOn relationship SHALL be transport-state-driven, not BA-spec-driven.
+  - ADDED **Anti-Mek Skill Source**: the BA pilot's Anti-Mek skill rating SHALL drive base to-hit for swarm and leg attacks; reference `personnel-system` for the pilot stat and `lib/spa/catalog` for SPA modifiers.
+
+- **MODIFIED `combat-resolution`** — add the BA combat dispatch + event-log requirements:
+  - ADDED **BA Combat Dispatch**: when an attack's attacker has `unitType === BATTLE_ARMOR` AND the weapon is `SwarmAttack` | `LegAttack` | `BAVibroClawAttack`, the resolver SHALL route to the corresponding BA-specific handler. When a non-BA attacker fires at a BA target, the resolver SHALL apply squad-damage allocation per `Squad Damage Allocation` instead of mech-style hit-location tables.
+  - ADDED **BA Combat Event Coverage**: typed event log SHALL emit `BASwarmAttached`, `BASwarmDetached`, `BASwarmDamageApplied`, `BALegAttackResolved`, `BAVibroclawAttackResolved`, `BATrooperKilled`, `BABrushOffAttempted`. Each event carries stable fields including `attackerId`, `targetId | hostId`, `trooperIndex` (when applicable), `damage`, `criticalHit?`, `outcome: 'hit' | 'miss' | 'detached'`. Pairs with the event-log line-format suite (project memory: `project_event_log_line_format_suite`).
+
+### Code touch points (Apply Wave — not in this change)
+
+- `src/engine/InteractiveSession.ts` — register `SwarmAttack`, `LegAttack`, `BAVibroClawAttack` action handlers
+- `src/lib/combat/baCombat.ts` (new) — squad damage allocator, swarm damage calculator, leg-attack damage helper
+- `src/lib/combat/combatResolution.ts` — BA dispatch branch + 7 new event types
+- `src/types/gameplay/CombatInterfaces.ts` — `IBASquadCombatState` (formalize the existing trooper-array shape), `BACombatEvent` discriminator + 7 variants, `attackerLegAttackContext`, `attackerSwarmContext`
+- `src/types/gameplay/GameplayUIInterfaces.ts` — resolve the TODO on `IBattleArmorToken.mountedOn`; add `passengerBadge` render hint
+- `src/components/gameplay/UnitToken.tsx` — render passenger badge when `mountedOn` is set
+- `src/components/gameplay/AttackDeclarationPanel.tsx` — surface swarm/leg/vibroclaw action buttons for BA attackers
+- `src/services/combat/replays/eventLogFormatter.ts` — extend columnar formatter for 7 new event types
+
+## Capabilities
+
+### New
+
+- `battle-armor-combat` — BA squad combat state, swarm + leg + vibroclaw + brush-off mechanics, anti-personnel squad-damage allocation, mounted-trooper rendering
+
+### Modified
+
+- `combat-resolution` — adds BA dispatch + 7 typed event variants
+- `battle-armor-unit-system` — references the new `battle-armor-combat` capability for BA combat behavior (existing minimal `BA Combat State` section can stay as construction-time state; combat-time semantics move to the new capability). NO delta in this change — the existing requirements are not modified, only the new capability is the canonical source for combat mechanics going forward.
+
+## Impact
+
+- **Affected source files (Apply estimate)**: ~10 files, ~700-1000 LOC across engine/handlers/types/event-log/UI. The new `src/lib/combat/baCombat.ts` is the biggest single addition (~300-400 LOC).
+- **No new transport** — uses existing Zustand stores + typed event log.
+- **No DB migration**.
+- **Storybook deltas (Apply wave)**: 2-3 stories — passenger-badge BA token, swarmed-mech token, vibroclaw-action button visibility.
+- **Test footprint estimate (Apply wave)**: ~40-60 new unit tests + 5-8 scenario tests (swarm-attach-detach-damage cycle, leg-attack-on-already-destroyed-leg, anti-personnel damage to half-dead squad, mounted-trooper hit-location adapter).
+
+## Non-Goals
+
+- **BA construction changes** — the existing `battle-armor-unit-system` is canonical for chassis, weight classes, equipment mounting, BLK round-trip. This change references BA construction data but does not modify it.
+- **BA transport (mechanized BA riding host)** — assumed to exist via `mountedOn` field on combat state. The actual mounting/dismounting transport rules (magnetic clamps, host can move with passengers, dismount triggers, etc.) live in a future `add-ba-transport-rules` change.
+- **Conventional infantry-vs-mech combat** — out; conventional infantry has its own spec (`infantry-unit-system` exists at 0 LOC for combat — that's a future `add-infantry-combat` follow-up).
+- **BA-vs-aerospace** — out; aerospace combat is the third change in this Wave 7 batch.
+- **BA squad command unit specialties (Newtsuit, Anti-VTOL Light Suit Mods, etc.)** — out; these are construction-time chassis variants already covered by `battle-armor-unit-system`.
+- **BA stealth / mimetic camouflage to-hit modifiers** — out for this change; the squad-state field already exists per the existing `BA Squad Combat State` requirement. A follow-up `add-ba-stealth-modifiers` change spec'd separately can wire the to-hit consumer.
+- **BA-vs-Aerospace ground-attack rules (BA on the ground gets strafed by ASF)** — handled by `aerospace-combat` change (#3 in this batch).
+- **BA AI heuristics (when to swarm vs when to fire)** — out; bot decision-making is a follow-up.
+- **MekHQ-side BA repair / replacement / promotion-on-anti-mek-kills** — out; campaign-side handled by existing campaign specs.
+
+## Open Questions
+
+- **Should the swarm-fire damage formula include missile-flagged BA squad weapons (e.g., BA SRM-2)?** Decision: NO — mirrors MegaMek `calculateSwarmDamage` which explicitly `continue`s on `F_MISSILE`. Missile weapons can't be aimed point-blank at the swarmed mech during the swarm clinch. Documented in spec.
+- **Should the "second roll same trooper triggers crit" Tactical Operations rule be on by default?** Decision: behind options flag `gameOptions.tacOps_ba_crit_slots`, default `false` for Wave-7 compatibility. Players opt in for grittier games. Mirrors MegaMek `ADVANCED_COMBAT_TAC_OPS_BA_CRITICAL_SLOTS`.
+- **Should brush-off attack damage to the squad be applied at brush-off time or end-of-turn?** Decision: at brush-off time, mirrors MegaMek `BrushOffAttackAction` resolution order. Documented in spec.
+- **Should a destroyed swarmer (all troopers dead) auto-detach from the host?** Decision: YES — when `getNumberActiveTroopers() === 0`, the resolver SHALL emit `BASwarmDetached` with reason `'Squad destroyed'`. Documented in spec.

--- a/openspec/changes/add-battle-armor-combat/specs/battle-armor-combat/spec.md
+++ b/openspec/changes/add-battle-armor-combat/specs/battle-armor-combat/spec.md
@@ -1,0 +1,330 @@
+# Spec Delta: Battle Armor Combat (NEW capability)
+
+## ADDED Requirements
+
+### Requirement: BA Squad Combat State
+
+Each Battle Armor squad entering combat SHALL carry an `IBASquadCombatState` slice tracking per-trooper liveness + armor, the swarm-attach pointer in both directions, the mounted-on-host pointer (if mounted as a passenger), and the per-turn flags for mimetic and stealth activation.
+
+#### Scenario: Combat state initialization
+
+- **GIVEN** a 4-trooper BA squad with 5 armor per trooper entering combat
+- **WHEN** the engine initializes combat state
+- **THEN** `state.troopers` SHALL be a 4-element array
+- **AND** each element SHALL have `{ index, alive: true, armorRemaining: 5, equipmentDestroyed: [] }`
+- **AND** `state.swarmingUnitId` SHALL be `undefined`
+- **AND** `state.swarmedByUnitIds` SHALL be `[]`
+- **AND** `state.mountedOn` SHALL be `undefined`
+- **AND** `state.mimeticActiveThisTurn` SHALL be `false`
+
+#### Scenario: Dead trooper retention
+
+- **GIVEN** a 4-trooper squad where trooper index 2 was killed last turn
+- **WHEN** combat state is read this turn
+- **THEN** `state.troopers[2].alive` SHALL be `false`
+- **AND** `state.troopers[2]` SHALL still occupy index 2 (no array compaction)
+- **AND** `getNumberActiveTroopers(state)` SHALL return 3
+
+#### Scenario: Dead trooper effects on squad fire
+
+- **GIVEN** a squad with 2 of 4 troopers dead (50% active)
+- **WHEN** the squad fires a squad-mounted weapon
+- **THEN** `shootingStrength` SHALL be 2 (alive count)
+- **AND** `isDmgModerate(state)` SHALL be `true` (`2/4 = 0.5 < 0.75`)
+- **AND** `isDmgLight(state)` SHALL be `true` (`< 0.9`)
+
+### Requirement: Squad Damage Allocation
+
+Damage applied to a BA squad target SHALL be allocated by rolling d6 per damage point against trooper slots. Rolls that land on a dead trooper SHALL be re-rolled until an alive trooper is selected. Damage SHALL reduce the trooper's `armorRemaining`. When `armorRemaining` reaches 0, the trooper SHALL be marked `alive: false` and a `BATrooperKilled` event SHALL be emitted.
+
+#### Scenario: Distribute 4 damage on full 4-trooper squad
+
+- **GIVEN** a full 4-trooper squad with 5 armor per trooper
+- **WHEN** an enemy weapon deals 4 damage to the squad
+- **THEN** the resolver SHALL roll 4 d6 rolls and apply 1 damage per roll
+- **AND** each roll's resulting trooper SHALL have armor reduced by 1
+
+#### Scenario: Re-roll skips dead troopers
+
+- **GIVEN** a squad with trooper index 3 already dead
+- **WHEN** a damage allocation roll lands on trooper 3
+- **THEN** the resolver SHALL re-roll until an alive trooper is selected
+- **AND** the damage SHALL be applied to the newly selected trooper
+
+#### Scenario: Trooper killed when armor reaches 0
+
+- **GIVEN** trooper index 1 with 2 armor remaining
+- **WHEN** 2 damage points are allocated to trooper 1
+- **THEN** `troopers[1].armorRemaining` SHALL equal 0
+- **AND** `troopers[1].alive` SHALL be set to `false`
+- **AND** a `BATrooperKilled { trooperIndex: 1 }` event SHALL be emitted
+
+#### Scenario: Tactical Operations BA Crit Slots option
+
+- **GIVEN** the game option `tacOps_ba_crit_slots === true`
+- **WHEN** two consecutive d6 rolls during a single damage allocation produce the same trooper index
+- **AND** the attacker is NOT conventional infantry
+- **THEN** the second hit SHALL be flagged `criticalHit: true`
+- **AND** an equipment slot on the rolled trooper SHALL be marked destroyed
+
+### Requirement: Swarm Attack — Declaration and Attach
+
+A BA squad SHALL be able to declare a swarm attack against a mech in the same hex using the `SwarmAttack` action. To-hit base SHALL derive from the attacker pilot's Anti-Mek skill (per `personnel-system`) with terrain and dead-trooper modifiers. On success, the resolver SHALL set the bidirectional swarm pointer (`attacker.swarmingUnitId = target.id` AND `target.swarmedByUnitIds.push(attacker.id)`) and emit `BASwarmAttached`. On failure, no state change SHALL occur except the consumed attack action.
+
+#### Scenario: Successful swarm attach
+
+- **GIVEN** a BA squad B in the same hex as Locust mech L, no current swarmer on L
+- **WHEN** B declares `SwarmAttack` against L
+- **AND** the to-hit roll succeeds
+- **THEN** `B.combatState.squad.swarmingUnitId` SHALL equal `L.id`
+- **AND** `L.combatState.swarmedByUnitIds` SHALL include `B.id`
+- **AND** a `BASwarmAttached { attackerId: B.id, hostId: L.id }` event SHALL be emitted
+
+#### Scenario: Failed swarm — no state change
+
+- **GIVEN** B and L in the same hex, no current swarmer
+- **WHEN** B declares `SwarmAttack` and the roll fails
+- **THEN** the swarm pointers SHALL remain unchanged
+- **AND** an `AttackResolved { outcome: 'miss', reason: 'Swarm attack failed' }` event SHALL be emitted
+
+#### Scenario: Cannot swarm when host already has swarmer
+
+- **GIVEN** L already has a swarmer attached
+- **WHEN** a different BA squad B2 attempts to declare `SwarmAttack` against L
+- **THEN** the action SHALL be rejected at the UI layer with reason `'Target already has a swarmer'`
+
+### Requirement: Swarm Fire While Attached
+
+While a BA squad is attached to a host mech via swarm, the squad SHALL fire its squad-mounted non-missile weapons at the host each turn. Damage applies without a to-hit roll. The damage formula is the sum of `squadWeaponDamage × shootingStrength` for each eligible weapon, plus the squad's vibroclaws count (0, 1, or 2), plus `troopers × 2` if the squad has a Myomer Booster. Missile weapons, body-mounted (per-trooper) weapons, and Infantry-Attack weapons SHALL be excluded.
+
+#### Scenario: Basic swarm damage calculation
+
+- **GIVEN** a 4-trooper squad with one squad-mounted Small Laser (damage 3) and no vibroclaws / no myomer
+- **AND** all 4 troopers are alive
+- **WHEN** the squad's swarm fire resolves
+- **THEN** total damage SHALL be `3 × 4 = 12`
+
+#### Scenario: Vibroclaws add flat squad damage
+
+- **GIVEN** the same squad with 2 vibroclaws
+- **WHEN** the swarm fire resolves
+- **THEN** total damage SHALL be `12 + 2 = 14`
+
+#### Scenario: Myomer Booster adds per-trooper damage
+
+- **GIVEN** the same squad with 2 vibroclaws AND Myomer Booster
+- **WHEN** the swarm fire resolves with 4 active troopers
+- **THEN** total damage SHALL be `12 + 2 + (4 × 2) = 22`
+
+#### Scenario: Missile weapons excluded
+
+- **GIVEN** a squad with one squad-mounted SRM-2 (a missile weapon)
+- **WHEN** swarm fire resolves
+- **THEN** the SRM-2 SHALL NOT contribute damage (`F_MISSILE` excluded per MegaMek parity)
+
+#### Scenario: Body-mounted weapons excluded
+
+- **GIVEN** a squad with one Body-mounted Machine Gun on each trooper
+- **WHEN** swarm fire resolves
+- **THEN** the Body-mounted MGs SHALL NOT contribute damage (per-trooper weapons can't aim point-blank in a swarm clinch)
+
+#### Scenario: Dead troopers reduce damage
+
+- **GIVEN** a squad with one squad Small Laser, 2 of 4 troopers dead
+- **WHEN** swarm fire resolves
+- **THEN** total damage SHALL be `3 × 2 = 6` (shootingStrength = 2, not 4)
+
+### Requirement: Anti-Personnel Fire on Mounted Troopers
+
+When a non-BA attacker fires at a host mech with attached swarmers, hits to the mounted-trooper locations (CT, LT, RT — front and rear) SHALL be routed to the corresponding trooper via the mounted-trooper-location adapter. The adapter mapping SHALL be: RT-front → trooper 1, LT-front → trooper 2, RT-rear → trooper 3, LT-rear → trooper 4, CT-front → trooper 6, CT-rear → trooper 5.
+
+#### Scenario: CT-rear hit routes to trooper 5
+
+- **GIVEN** host mech L with attached squad B (all 4 troopers alive, 5 armor each)
+- **WHEN** an enemy PPC (10 damage) hits L's CT-rear
+- **THEN** the damage SHALL be routed to trooper 5
+- **AND** `troopers[5].armorRemaining` SHALL be reduced by 5 (if trooper had 5 armor)
+- **AND** trooper 5 SHALL die (`armorRemaining → 0`), `BATrooperKilled` emitted
+- **AND** the 5 excess damage SHALL be lost (does NOT pass to host)
+
+#### Scenario: Dead mounted-trooper routes damage to host
+
+- **GIVEN** host L with attached squad B, but trooper 5 already dead
+- **WHEN** an enemy hit lands on CT-rear of L
+- **THEN** the damage SHALL be applied to L's CT-rear armor normally (no trooper to absorb)
+
+#### Scenario: Non-trooper locations route to host normally
+
+- **GIVEN** host L with attached squad B
+- **WHEN** an enemy hit lands on L's Head, an Arm, or a Leg
+- **THEN** the damage SHALL be applied to L's armor normally (those locations have no mounted trooper)
+
+### Requirement: Leg Attack
+
+A BA squad SHALL be able to declare a `LegAttack` against a mech in the same hex. Damage = `4 + vibroClaws + (myomerBooster ? activeTroopers × 2 : 0)`. The attack SHALL roll for a leg location; if the rolled leg is destroyed (internal 0), the other leg SHALL be hit. Critical-hit modifier SHALL be `−2` if the targeted location's armor type is Hardened; `+1` if the attacker pilot has the `MISC_HUMAN_TRO_MEK` SPA.
+
+#### Scenario: Basic leg attack
+
+- **GIVEN** a 4-trooper BA squad with 1 vibroclaw, no myomer booster
+- **WHEN** the squad declares a `LegAttack` against an Atlas
+- **AND** the to-hit roll succeeds
+- **THEN** damage SHALL be `4 + 1 + 0 = 5`
+- **AND** a leg location SHALL be rolled and damage applied to that leg
+- **AND** a `BALegAttackResolved { hitLocation, damage: 5, critModifier: 0 }` event SHALL be emitted
+
+#### Scenario: Myomer booster boosts leg-attack damage
+
+- **GIVEN** the same squad with Myomer Booster and 4 active troopers
+- **WHEN** the leg attack resolves
+- **THEN** damage SHALL be `4 + 1 + (4 × 2) = 13`
+
+#### Scenario: Destroyed leg fallback
+
+- **GIVEN** a mech with destroyed left leg (internal 0)
+- **WHEN** the leg-attack roll lands on the left leg
+- **THEN** the resolver SHALL fall through and hit the right leg instead
+
+#### Scenario: Hardened armor reduces crit chance
+
+- **GIVEN** the target leg has Hardened armor
+- **WHEN** the crit modifier is computed
+- **THEN** `critModifier` SHALL include `−2`
+
+#### Scenario: HUMAN_TRO_MEK SPA increases crit chance
+
+- **GIVEN** the attacker pilot has `MISC_HUMAN_TRO_MEK` SPA
+- **WHEN** the crit modifier is computed
+- **THEN** `critModifier` SHALL include `+1`
+
+### Requirement: Vibroclaw Attack
+
+A BA trooper with `vibroClaws ≥ 1` SHALL be able to make a vibroclaw melee attack against an adjacent enemy. Damage = `missilesHit(shootingStrength) × vibroClaws` (cluster-table lookup against the squad's surviving trooper count). UI MUST hide the vibroclaw action button when the squad's `vibroClaws === 0`.
+
+#### Scenario: Vibroclaw damage on full squad
+
+- **GIVEN** a 4-trooper squad with 2 vibroclaws (squad-level)
+- **AND** `missilesHit(4)` returns 3 on the cluster table
+- **WHEN** the vibroclaw attack resolves
+- **THEN** damage SHALL be `3 × 2 = 6`
+
+#### Scenario: Vibroclaw button hidden when vibroClaws == 0
+
+- **GIVEN** a BA squad with `vibroClaws === 0`
+- **WHEN** the attack-declaration UI renders for this squad
+- **THEN** the Vibroclaw action button SHALL NOT be visible
+
+### Requirement: Brush-Off and Drop-Prone Dislodge
+
+A mech with attached swarmers SHALL be permitted to declare EITHER a brush-off attack OR a drop-prone dislodge per turn, but not both. Brush-off SHALL use the mech pilot's piloting skill rating as the to-hit base, SHALL consume one of the mech's weapon-attack slots for the turn, and on success SHALL detach the targeted swarmer plus apply 1 damage per surviving trooper to that swarmer. Drop-prone SHALL be a movement-phase action gated by a PSR; success SHALL detach all swarmers; failure SHALL inflict pilot damage per normal failed-PSR.
+
+#### Scenario: Successful brush-off
+
+- **GIVEN** mech L with attached swarmer B (4 troopers)
+- **WHEN** L declares Brush-Off and succeeds
+- **THEN** the swarm pointer SHALL be cleared on both sides
+- **AND** 4 damage SHALL be allocated to B (1 per surviving trooper, via `allocateSquadDamage`)
+- **AND** a `BASwarmDetached { reason: 'BrushedOff' }` event SHALL be emitted
+- **AND** one of L's weapon-attack slots SHALL be marked consumed
+
+#### Scenario: Failed brush-off
+
+- **GIVEN** the same setup
+- **WHEN** L declares Brush-Off and fails
+- **THEN** the swarm pointer SHALL remain
+- **AND** the weapon-attack slot SHALL still be marked consumed
+- **AND** a `BABrushOffAttempted { outcome: 'miss' }` event SHALL be emitted
+
+#### Scenario: Drop-prone success detaches all swarmers
+
+- **GIVEN** mech L with two attached swarmers B1 and B2
+- **WHEN** L drops prone and the PSR succeeds
+- **THEN** both swarmers SHALL be detached
+- **AND** `L.combatState.swarmedByUnitIds` SHALL equal `[]`
+- **AND** two `BASwarmDetached { reason: 'DroppedProne' }` events SHALL be emitted (one per swarmer)
+
+#### Scenario: Auto-detach when squad destroyed
+
+- **GIVEN** swarmer B attached to L, all 4 troopers in B are killed by enemy fire this turn
+- **WHEN** end-of-turn cleanup runs
+- **THEN** the swarm pointer SHALL be cleared on both sides
+- **AND** a `BASwarmDetached { hostId: L.id, attackerId: B.id, reason: 'SquadDestroyed' }` event SHALL be emitted
+
+#### Scenario: Cannot declare both brush-off and drop-prone same turn
+
+- **GIVEN** mech L declared Brush-Off this turn
+- **WHEN** L attempts to also declare Drop-Prone-Dislodge
+- **THEN** the second declaration SHALL be rejected with reason `'Already attempted Brush-Off this turn'`
+
+### Requirement: Mounted-Trooper Passenger Badge
+
+When a BA squad's `combatState.mountedOn` is set to a host unit ID (BA mounted as passenger via magnetic clamps or mechanized chassis), the BA token SHALL render as a passenger badge attached to the host's token rather than as a standalone hex token. The badge SHALL display the trooper count and squad name; the BA token SHALL NOT occupy its own hex while mounted.
+
+#### Scenario: Mounted-on host suppresses standalone token
+
+- **GIVEN** a BA squad B with `combatState.mountedOn === 'mech-host-1'`
+- **WHEN** the hex board renders
+- **THEN** B SHALL NOT have a standalone hex token at its position
+- **AND** the host token for `mech-host-1` SHALL display a passenger badge for B
+
+#### Scenario: Badge updates when troopers die
+
+- **GIVEN** B mounted on host with 4 troopers
+- **WHEN** 2 troopers die
+- **THEN** the passenger badge SHALL show trooper count `2/4`
+
+#### Scenario: Dismount restores standalone token
+
+- **GIVEN** B was mounted on a host
+- **WHEN** `combatState.mountedOn` is cleared (dismount triggered by upstream transport logic — out of this spec's scope)
+- **THEN** B SHALL render as a standalone hex token at its dismount hex
+
+### Requirement: Anti-Mek Skill Source
+
+The to-hit base for swarm and leg attacks SHALL derive from the BA pilot's Anti-Mek skill rating (per `personnel-system`). SPA modifiers SHALL come from `lib/spa/catalog` — relevant SPAs include `MISC_HUMAN_TRO_MEK` (mentioned in the Leg Attack requirement above) and any Anti-Mek-specific SPAs already in the catalog.
+
+#### Scenario: Anti-Mek skill drives swarm to-hit
+
+- **GIVEN** BA pilot P with Anti-Mek skill 4
+- **WHEN** P's squad declares a swarm attack
+- **THEN** the to-hit base SHALL be 4
+
+#### Scenario: Anti-Mek skill drives leg-attack to-hit
+
+- **GIVEN** BA pilot P with Anti-Mek skill 4
+- **WHEN** P's squad declares a leg attack
+- **THEN** the to-hit base SHALL be 4
+
+## Data Model
+
+### Interface: IBASquadCombatState
+
+```typescript
+interface IBASquadCombatState {
+  readonly troopers: ITrooperState[];
+  swarmingUnitId?: string;          // ID of host this squad is attached to (as swarmer)
+  swarmedByUnitIds: string[];       // IDs of BA squads attached to THIS unit (when this state is on a host mech, e.g.)
+  mountedOn?: string;               // ID of friendly host this squad is mounted on (passenger)
+  mimeticActiveThisTurn: boolean;
+  stealthActiveThisTurn: boolean;
+}
+
+interface ITrooperState {
+  readonly index: number;           // 1-6 (per MegaMek LOC_TROOPER_1..LOC_TROOPER_6)
+  alive: boolean;
+  armorRemaining: number;
+  equipmentDestroyed: string[];     // Equipment IDs marked destroyed by crit hits
+}
+```
+
+### Event Types: BACombatEvent
+
+```typescript
+type BACombatEvent =
+  | { kind: 'BASwarmAttached';        attackerId: string; hostId: string; }
+  | { kind: 'BASwarmDetached';        attackerId: string; hostId: string; reason: 'BrushedOff' | 'DroppedProne' | 'SquadDestroyed'; }
+  | { kind: 'BASwarmDamageApplied';   attackerId: string; hostId: string; totalDamage: number; perWeapon: { weaponId: string; damage: number }[]; }
+  | { kind: 'BALegAttackResolved';    attackerId: string; targetId: string; hitLocation: MekLocation; damage: number; critModifier: number; }
+  | { kind: 'BAVibroclawAttackResolved'; attackerId: string; targetId: string; damage: number; missileHits: number; vibroClawCount: number; }
+  | { kind: 'BATrooperKilled';        squadId: string; trooperIndex: number; }
+  | { kind: 'BABrushOffAttempted';    hostId: string; targetSwarmerId: string; outcome: 'hit' | 'miss'; };
+```

--- a/openspec/changes/add-battle-armor-combat/specs/combat-resolution/spec.md
+++ b/openspec/changes/add-battle-armor-combat/specs/combat-resolution/spec.md
@@ -1,0 +1,77 @@
+# Spec Delta: Combat Resolution — Battle Armor Combat Dispatch
+
+## ADDED Requirements
+
+### Requirement: Battle Armor Combat Dispatch
+
+The combat resolver SHALL route attacks involving Battle Armor units to BA-specific handlers per the following dispatch table:
+
+| Attacker | Target | Weapon kind | Handler |
+|---|---|---|---|
+| BA | Mek | `SwarmAttack` | `swarmAttachResolver` |
+| BA (swarmed) | Mek host | `SwarmWeaponAttack` | `swarmFireResolver` |
+| BA | Mek | `LegAttack` | `legAttackResolver` |
+| BA | Any adjacent | `BAVibroClawAttack` | `vibroclawResolver` |
+| Mek | (swarmed by BA) | (brush-off declared) | `brushOffResolver` |
+| Non-BA | BA squad | (any weapon) | apply `allocateSquadDamage` instead of mech hit-location |
+| Non-BA | Mek with mounted BA | (hits to CT/LT/RT) | route via `getTrooperAtLocation` adapter |
+
+#### Scenario: BA-attacker SwarmAttack routes correctly
+
+- **GIVEN** attacker A has `unitType === BATTLE_ARMOR` and weapon kind is `SwarmAttack`
+- **WHEN** the resolver processes the attack
+- **THEN** the `swarmAttachResolver` SHALL be invoked (not the mech weapon handler)
+
+#### Scenario: Non-BA attacker fires at BA target — squad damage allocation
+
+- **GIVEN** attacker A is a mech, target T has `unitType === BATTLE_ARMOR`
+- **WHEN** A's weapon hits T
+- **THEN** the resolver SHALL invoke `allocateSquadDamage(T.combatState.squad, damage, rng)` instead of mech hit-location
+- **AND** emitted events SHALL include per-trooper damage allocations + any `BATrooperKilled` events
+
+#### Scenario: Non-BA attacker hits host mech with mounted-trooper at location
+
+- **GIVEN** host mech L has swarmer B attached, A fires a hit landing on L's CT-rear
+- **WHEN** damage is applied
+- **THEN** the resolver SHALL consult `getTrooperAtLocation(CT_rear, ...)` → trooper 5
+- **AND** if trooper 5 is alive, damage SHALL be routed to that trooper (per `Anti-Personnel Fire on Mounted Troopers` in `battle-armor-combat`)
+- **AND** if trooper 5 is dead, damage SHALL be applied to L's CT-rear armor normally
+
+#### Scenario: Mek brush-off declaration consumes weapon slot
+
+- **GIVEN** mek L with attached swarmer B declares Brush-Off
+- **WHEN** the resolver processes the declaration
+- **THEN** one of L's weapon-attack slots for the turn SHALL be marked consumed
+- **AND** the `brushOffResolver` SHALL be invoked
+
+### Requirement: Battle Armor Combat Event Coverage
+
+The typed combat event log SHALL emit one or more of seven BA-specific event variants whenever a BA-related attack resolves: `BASwarmAttached`, `BASwarmDetached`, `BASwarmDamageApplied`, `BALegAttackResolved`, `BAVibroclawAttackResolved`, `BATrooperKilled`, `BABrushOffAttempted`. Each event SHALL carry stable fields per the discriminated-union definition in `battle-armor-combat`.
+
+#### Scenario: Swarm-attached emits BASwarmAttached
+
+- **GIVEN** B's `SwarmAttack` against L succeeds
+- **WHEN** the resolver records the result
+- **THEN** a `BASwarmAttached { attackerId: B.id, hostId: L.id }` event SHALL be emitted
+
+#### Scenario: Squad destroyed mid-swarm emits both BATrooperKilled and BASwarmDetached
+
+- **GIVEN** swarmer B attached to L, last surviving trooper killed by enemy fire
+- **WHEN** the trooper-killing damage is applied
+- **THEN** a `BATrooperKilled` event SHALL be emitted for that trooper
+- **AND** at end-of-turn cleanup, a `BASwarmDetached { reason: 'SquadDestroyed' }` event SHALL be emitted
+- **AND** the two events SHALL be ordered: trooper kill first, detach second
+
+#### Scenario: Brush-off attempt emits BABrushOffAttempted regardless of outcome
+
+- **GIVEN** L declares Brush-Off against B
+- **WHEN** the resolver processes the attempt
+- **THEN** a `BABrushOffAttempted` event SHALL be emitted with `outcome: 'hit' | 'miss'`
+- **AND** on hit, an additional `BASwarmDetached { reason: 'BrushedOff' }` SHALL be emitted
+
+#### Scenario: Event log replay round-trips BA events
+
+- **GIVEN** a JSONL event log containing all 7 BA event variants
+- **WHEN** the replay loader replays the log
+- **THEN** all 7 event types SHALL be parsed without loss
+- **AND** the columnar formatter SHALL render each with its stable fields per the line-format suite (pairs with `project_event_log_line_format_suite`)

--- a/openspec/changes/add-battle-armor-combat/tasks.md
+++ b/openspec/changes/add-battle-armor-combat/tasks.md
@@ -1,0 +1,99 @@
+# Tasks: Add Battle Armor Combat
+
+## 1. BA squad combat state (formalize existing minimal shape)
+
+- [ ] 1.1 Define `IBASquadCombatState` in `src/types/gameplay/CombatInterfaces.ts` with fields `{ troopers: ITrooperState[], swarmingUnitId?: string, swarmedByUnitIds: string[], mountedOn?: string, mimeticActiveThisTurn: boolean, stealthActiveThisTurn: boolean }`. `ITrooperState` = `{ index, alive, armorRemaining, equipmentDestroyed: string[] }`
+- [ ] 1.2 Provide a helper `getNumberActiveTroopers(state)` returning `state.troopers.filter(t => t.alive).length`
+- [ ] 1.3 Provide helpers `isDmgLight(state)` / `isDmgModerate(state)` per the existing MegaMek thresholds (`< 0.9` and `< 0.75` of squad size respectively)
+- [ ] 1.4 Unit-test initial state population, dead-trooper-retention, helper thresholds
+
+## 2. Squad damage allocation
+
+- [ ] 2.1 Implement `allocateSquadDamage(squad: IBASquadCombatState, totalDamage: number, rng: IDiceRoller, options: { tacOpsCritSlots: boolean })` in `src/lib/combat/baCombat.ts`. Returns `{ allocations: { trooperIndex, damage, criticalHit }[], events: BACombatEvent[] }`
+- [ ] 2.2 For each damage point: roll d6, re-roll if the resulting trooper is dead, apply damage to that trooper's armor
+- [ ] 2.3 If `tacOpsCritSlots && previousRollLocation === currentRollLocation && !isAttackingConvInfantry` → flag `criticalHit: true`
+- [ ] 2.4 When a trooper's armor drops to 0, mark `alive: false` and emit `BATrooperKilled`
+- [ ] 2.5 Unit-test: 4 damage on a full squad distributes 4 troopers; 4 damage with one dead trooper distributes among the 3 alive
+
+## 3. Swarm attack — to-hit + state machine
+
+- [ ] 3.1 Add `SwarmAttack` action handler in `src/engine/InteractiveSession.ts`. Eligible only when attacker is BA (`unitType === BATTLE_ARMOR`), target is a mech in the same hex, target has no current swarmer
+- [ ] 3.2 To-hit base: attacker pilot's Anti-Mek skill (from `personnel-system`), plus terrain modifiers, plus per-trooper-dead penalty (each dead trooper = +1 to-hit, per MegaMek convention — confirm during Apply against `Compute.getSwarmMekBaseToHit`)
+- [ ] 3.3 On success: set `attacker.combatState.squad.swarmingUnitId = target.id`, append `target.combatState.swarmedByUnitIds.push(attacker.id)`, emit `BASwarmAttached { attackerId, hostId }`
+- [ ] 3.4 On failure: attacker remains in the same hex as the target; emit `AttackResolved { outcome: 'miss', reason: 'Swarm attack failed' }`
+- [ ] 3.5 Unit test: success path attaches both sides of the swarm pointer; failure path leaves both unchanged
+
+## 4. Swarm fire while attached
+
+- [ ] 4.1 Implement `calculateSwarmDamage(squad: IBASquadCombatState, squadDef: IBattleArmor)` in `src/lib/combat/baCombat.ts`:
+  - Sum non-missile non-body-mounted non-InfantryAttack squad weapons × shootingStrength
+  - + vibroClaws (squad-level, max 2)
+  - + (myomerBooster ? activeTroopers × 2 : 0)
+- [ ] 4.2 Register `SwarmWeaponAttack` action: fires every turn the squad is attached; damage applies to the host without a to-hit roll (auto-hit)
+- [ ] 4.3 Hit location on host: roll d6 per damage point against the host's standard mech hit-location table (front-side)
+- [ ] 4.4 Emit `BASwarmDamageApplied { attackerId, hostId, totalDamage, perWeapon: [{ weaponId, damage }] }`
+- [ ] 4.5 Unit test: 4-trooper squad with one squad-mounted SmallLaser (damage 3) → `3 × 4 = 12` swarm damage; with vibroclaws +2 → 14; with myomer +8 → 22
+
+## 5. Swarm fire absorption + trooper hits (mounted-trooper adapter)
+
+- [ ] 5.1 Implement `getTrooperAtLocation(hostLocation: MekLocation, isRear: boolean, squad: IBASquadCombatState)` per MegaMek's mapping: RT-front→1, LT-front→2, RT-rear→3, LT-rear→4, CT-front→6, CT-rear→5
+- [ ] 5.2 When non-BA attacker fires at a swarmed host mech: for each hit roll, if the location is one of the mounted-trooper locations (CT/LT/RT) AND the rolled trooper is alive, route damage to the trooper instead of the host armor
+- [ ] 5.3 Emit `BATrooperKilled` if the routed damage destroys the trooper
+- [ ] 5.4 Unit test: enemy fires PPC (10 dmg) at host CT-rear → trooper 5 takes 10 dmg → if trooper 5 armor was 4, trooper 5 dies + 6 dmg lost (NOT carried to host)
+
+## 6. Leg attack
+
+- [ ] 6.1 Register `LegAttack` action handler. Eligible only when attacker is BA in same hex as a mech target
+- [ ] 6.2 To-hit base: attacker pilot's Anti-Mek skill + terrain + dead-trooper penalty
+- [ ] 6.3 Damage formula: `4 + vibroClaws + (myomerBooster ? activeTroopers × 2 : 0)` per MegaMek `LegAttackHandler` line 103
+- [ ] 6.4 Hit location: roll for `LOC_LEFT_LEG` or `LOC_RIGHT_LEG`; if rolled leg has 0 internal, hit the other leg
+- [ ] 6.5 Critical modifier: `−2` if target's armor at the hit location is `HARDENED`; `+1` if attacker pilot has `MISC_HUMAN_TRO_MEK` SPA
+- [ ] 6.6 Emit `BALegAttackResolved { attackerId, targetId, hitLocation, damage, critModifier }`
+- [ ] 6.7 Unit test: leg attack on mech with destroyed left leg rolls left first → falls through to right; armor type `HARDENED` reduces crit; HUMAN_TRO_MEK adds crit
+
+## 7. Vibroclaw attack
+
+- [ ] 7.1 Register `BAVibroClawAttack` action handler. Eligible when attacker is BA with `vibroClaws ≥ 1` and target is adjacent
+- [ ] 7.2 Damage formula: `missilesHit(shootingStrength) × vibroClaws` per MegaMek `BAVibroClawAttackAction.calcDamage`
+- [ ] 7.3 UI MUST hide the vibroclaw action button when attacker `vibroClaws === 0`
+- [ ] 7.4 Emit `BAVibroclawAttackResolved { attackerId, targetId, damage, missileHits, vibroClawCount }`
+- [ ] 7.5 Unit test: 4-trooper squad with 2 vibroclaws + missilesHit(4) = 3 → damage = 6
+
+## 8. Brush-off + drop-prone dislodge
+
+- [ ] 8.1 Register `BrushOffAttack` action — eligible when target mech has `swarmedByUnitIds.length > 0`; only one swarmer can be brushed off per attempt; consumes one weapon attack slot for the turn
+- [ ] 8.2 To-hit: mech pilot's piloting skill rating
+- [ ] 8.3 On success: detach the swarmer (clear both sides of the pointer), apply brush-off damage `1 per trooper` to the squad via `allocateSquadDamage`
+- [ ] 8.4 On failure: swarmer stays attached, brush-off attack slot wasted
+- [ ] 8.5 Register `DropProneDislodge` — drops the mech prone with a PSR; success detaches; failure inflicts pilot damage per normal failed-PSR
+- [ ] 8.6 Emit `BASwarmDetached { hostId, attackerId, reason: 'BrushedOff' | 'DroppedProne' | 'SquadDestroyed' }`
+- [ ] 8.7 Auto-emit `BASwarmDetached { reason: 'SquadDestroyed' }` when `getNumberActiveTroopers(squad) === 0` at end-of-turn
+- [ ] 8.8 Unit test: brush-off success path detaches both sides + applies brush-off damage; brush-off failure leaves state intact
+
+## 9. Mounted-trooper passenger badge (resolve TODO)
+
+- [ ] 9.1 Remove the `TODO: wire from battlearmor combat-behavior proposal` from `src/types/gameplay/GameplayUIInterfaces.ts:317`; replace with a JSDoc reference to this change
+- [ ] 9.2 Add `IBattleArmorToken.passengerBadge?: { hostTokenId: string, slot: 'shoulder' | 'side' | 'back' }` for renderer hints
+- [ ] 9.3 In `UnitToken.tsx` (hex-board renderer): when `token.mountedOn` is set, render a small BA badge attached to the host token; do NOT render the BA token at its own hex
+- [ ] 9.4 Unit test (rendering): BA token with `mountedOn` set + host token in scene → only host renders at hex; BA badge is a child of host's render group
+
+## 10. Combat-resolution dispatch + event-log
+
+- [ ] 10.1 In `combatResolution.ts`: when `attacker.unitType === BATTLE_ARMOR` AND weapon kind is `SwarmAttack|LegAttack|BAVibroClawAttack`, route to BA-specific handler
+- [ ] 10.2 When non-BA attacker fires at BA target (`target.unitType === BATTLE_ARMOR`): apply `allocateSquadDamage` instead of mech hit-location table
+- [ ] 10.3 Extend `src/services/combat/replays/eventLogFormatter.ts` with the 7 new event types (BASwarmAttached, BASwarmDetached, BASwarmDamageApplied, BALegAttackResolved, BAVibroclawAttackResolved, BATrooperKilled, BABrushOffAttempted)
+- [ ] 10.4 Scenario test: 4-trooper BA squad swarms a Locust, fires squad weapons next turn, takes 2 trooper kills from enemy mech fire next turn, squad destroyed turn 4 with auto-detach event
+
+## 11. Spec deltas
+
+- [ ] 11.1 Author `openspec/changes/add-battle-armor-combat/specs/battle-armor-combat/spec.md` (NEW capability — first-class BA combat surface per the proposal)
+- [ ] 11.2 Author `openspec/changes/add-battle-armor-combat/specs/combat-resolution/spec.md` (MODIFIED — BA dispatch + 7 typed events)
+- [ ] 11.3 `npx openspec validate add-battle-armor-combat --strict` passes clean
+- [ ] 11.4 `npm run build`, lint, typecheck, jest, scenario tests pass on CI (Apply wave gate)
+- [ ] 11.5 Archive the change to `openspec/changes/archive/YYYY-MM-DD-add-battle-armor-combat/` after PR merge; sync the 2 deltas into source-of-truth specs (NEVER `--skip-specs`)
+
+## 12. Documentation + follow-up notes
+
+- [ ] 12.1 Add a `playtest/wave-7/BA_COMBAT_NOTES.md` section: scenarios to add to `playtest-scenarios.spec.ts` (BA-swarm-vs-Locust, BA-leg-vs-Atlas, anti-personnel-fire-vs-half-dead-squad)
+- [ ] 12.2 Spec the future BA-transport follow-up — `add-ba-transport-rules` covering magnetic clamp mount/dismount, mechanized-chassis capacity, host-damage-triggered dismount. Note in `_followups.md` placeholder in archive folder
+- [ ] 12.3 Note BA stealth / mimetic to-hit modifiers as a separate Wave-8 follow-up (`add-ba-stealth-modifiers`)

--- a/openspec/changes/add-indirect-fire-and-spotter-network/design.md
+++ b/openspec/changes/add-indirect-fire-and-spotter-network/design.md
@@ -1,0 +1,120 @@
+# Design: Add Indirect Fire and Spotter Network
+
+## Reference Material
+
+- MegaMek `ComputeToHit.java:340-440` — canonical spotter election + indirect-mode flag detection
+- MegaMek `ComputeAttackerToHitMods.java:172-177` — +1 spotter-fire penalty (added to the spotter's OWN attacks)
+- MegaMek `ArtilleryWeaponIndirectFireHandler.java` — artillery (OUT of scope this change; informs Arrow IV follow-up)
+- MegaMek `OptionsConstants.java:209` + `PilotOptions.java:98` — `MISC_FORWARD_OBSERVER` ability
+- MegaMek `LRMHandler.java` — generic LRM resolution; no indirect-specific branching, lives in the to-hit calculator
+- Local helper `src/utils/gameplay/indirectFire.ts` (374 LOC) — orphan today, becomes the engine-helper layer
+
+## Architecture Decisions
+
+### Decision A: Resolver invokes the helper, not the to-hit calculator
+
+**Choice**: `InteractiveSession.computeIndirectFireContext` is the **only** caller of the existing `evaluateIndirectFire` helper. The to-hit calculator (`toHit/calculate.ts`) consumes the resolution result as plain data.
+
+**Rationale**: keeps the helper pure (no dependency on engine types) and keeps the to-hit calculator pure (no dependency on the spotter election algorithm). The engine layer owns the "what is the world today" question; the helper answers "given this world snapshot, is this attack permitted and what's the penalty?"; the to-hit calculator answers "add this penalty to the to-hit number". Three layers, three responsibilities.
+
+**Alternatives considered**:
+- *Inline the helper into the to-hit calculator*: rejected — the to-hit calculator already has 14 modifier sources; folding spotter election inside it makes the calculator a god-function.
+- *Have the helper read `gameState` directly*: rejected — couples the helper to the engine type tree, breaks the existing 594 LOC of unit tests that pass in synthetic `ISpotterCandidate[]`.
+
+### Decision B: Spotter election is deterministic
+
+**Choice**: `(lowest movement penalty → closest to target → lowest entityId)` tiebreak. Same shape as MegaMek's `findSpotter` but explicitly enumerated in the spec so a test can lock the order.
+
+**Rationale**: replays must be deterministic (project memory: `project_replay_viewer_bundle`, `project_replay_library`). If two equally-eligible spotters could be elected and the choice were non-deterministic, two replays of the same JSONL event log could diverge on which spotter was "selected" (cosmetic event field) even though hit/miss outcomes match.
+
+**Alternatives considered**:
+- *Pick whichever spotter the player explicitly designates via UI*: rejected for v1 — that's a player-affordance feature, lives in a separate "indirect-fire-UI" follow-up change. Deterministic auto-pick is the engine baseline.
+- *Random tiebreak*: rejected — non-deterministic by design.
+
+### Decision C: Liveness check at resolution, not at to-hit
+
+**Choice**: spotter election happens at to-hit. Spotter destruction during the same attack window (e.g., the spotter is killed by a higher-initiative attack between the to-hit roll and damage resolution) invalidates the indirect attack — auto-miss, ammo and heat still consumed, typed event `IndirectFireSpotterLost`.
+
+**Rationale**: matches MegaMek behavior (the `Compute.findSpotter` call runs again at resolution time and bails). Auto-miss-with-cost is intuitive — the missiles fly into the sky with no terminal guidance.
+
+**Alternatives considered**:
+- *Re-elect a new spotter on the fly*: rejected — too generous to LRM boats; lets them benefit from cheap-tactic "fire-then-have-spotter-die-but-still-hit" cheese.
+- *Auto-hit without spotter penalty*: rejected — nonsensical; the missiles need terminal guidance.
+
+### Decision D: FORWARD_OBSERVER cancels the spotter-walked penalty only
+
+**Choice**: the FO SPA removes the +1 spotter-walked penalty when the spotter walked, but the +1 base indirect-fire penalty still applies.
+
+**Rationale**: matches MegaMek `GUNNERY_OBLIQUE_ATTACKER` and `MISC_FORWARD_OBSERVER` semantics — the SPA represents training to keep one eye on the target while moving, not magic terminal guidance.
+
+**Alternatives considered**:
+- *FO cancels both penalties*: rejected — too strong; would make FO mandatory on every LRM boat's spotter.
+- *FO is a tag bonus (cancels minimum range)*: rejected — that's a separate SPA in MegaMek (`GUNNERY_OBLIQUE_ATTACKER` gives +1 base when LOS is clear; out of scope here).
+
+### Decision E: NARC / iNarc enable indirect without LOS spotter
+
+**Choice**: a target marked with friendly NARC or iNarc may be attacked indirectly even when no friendly unit has LOS. The "basis" field on the spotter-selected event records `'narc'` or `'inarc'` instead of `'los'`.
+
+**Rationale**: matches MegaMek exactly (`ComputeToHit.java:374-378`). The NARC beacon serves as the terminal-guidance signal; the LRMs home on the beacon.
+
+**Alternatives considered**:
+- *Require both NARC and LOS spotter*: rejected — defeats the point of NARC tactical doctrine.
+- *Apply additional penalty for NARC-only indirect*: rejected — MegaMek doesn't apply one; introducing one creates a parity gap.
+
+### Decision F: Weapon `mode` field on combat state, not on construction
+
+**Choice**: `weapon.mode: 'Direct' | 'Indirect'` is a **runtime combat state** field per weapon mount, not a construction-time field. Defaults to `'Direct'`; the player toggles per turn before declaring attacks.
+
+**Rationale**: matches MegaMek where weapon modes are runtime (`weapon.curMode()`). Toggling is reversible turn-to-turn. Persisting in construction state would lock the player into a single mode for a chassis variant.
+
+**Alternatives considered**:
+- *Auto-detect mode from LOS*: rejected — players sometimes have LOS but prefer indirect (e.g., to avoid intervening woods penalty); the player's tactical choice has to be explicit.
+
+## Data Flow
+
+```
+Player declares LRM attack against hex H from attacker A
+              ↓
+InteractiveSession.computeIndirectFireContext(A.id, weapon.id, H)
+  ├─ A has LOS to H?  → return { isIndirect: false, permitted: true }
+  ├─ Weapon mode === 'Indirect'?  → continue
+  ├─ Weapon family is indirect-eligible (LRM/MML-LRM/Mortar/NLRM)?
+  │     → no: return { permitted: false, reason: 'Weapon does not support indirect fire' }
+  ├─ NARC/iNarc on target?
+  │     → yes: spotter = target itself, basis = 'narc'
+  ├─ Else: enumerate friendly units with LOS to H
+  │     → none: return { permitted: false, reason: 'No valid spotter' }
+  │     → ≥1: pick by (lowest move-penalty → closest → lowest id)
+  ├─ Semi-guided LRM ammo + active TAG on target this turn?
+  │     → yes: basis = 'semi-guided-tag'
+  └─ FO SPA on spotter pilot?  → cancel spotter-walked +1
+                ↓
+Compute toHitPenalty: +1 (base) + (+1 if spotter walked and !FO)
+                ↓
+Emit IndirectFireSpotterSelected (or NarcOverride / ForwardObserver event)
+                ↓
+toHit/calculate.ts adds penalty to running to-hit number
+                ↓
+Resolver rolls hit/miss
+                ↓
+Before damage application: re-validate spotter is alive
+  ├─ Dead: emit IndirectFireSpotterLost, force auto-miss (skip damage), still consume ammo + heat
+  └─ Alive: continue normal damage application
+```
+
+## File Changes (Apply estimate — informational; not part of this change)
+
+- New: none (no new source files needed at engine layer; the helper module already exists)
+- Modified:
+  - `src/engine/InteractiveSession.ts` — add `computeIndirectFireContext`
+  - `src/utils/gameplay/toHit/calculate.ts` — accept + apply `IIndirectFireResolution`
+  - `src/lib/combat/combatResolution.ts` — emit 4 new event variants, liveness re-check
+  - `src/types/gameplay/CombatInterfaces.ts` — `IIndirectFireResolution`, event variants, `weapon.mode`
+  - `src/lib/spa/catalog/gunnerySPAs.ts` — register `FORWARD_OBSERVER`
+- Deleted: none
+
+## Risks
+
+- **R1 (medium)**: the existing 594 LOC of `indirectFire.test.ts` tests the helper in isolation; the Apply wave must add resolver-level scenario tests (LRM boat + spotter + dead spotter + FO + NARC) to validate the integration. Test count estimate ~30-50 new tests is realistic.
+- **R2 (low)**: weapon `mode` toggle requires UI work. The mode toggle is in scope for this spec; the UI Storybook stories are an Apply-wave deliverable.
+- **R3 (low)**: deterministic spotter election may surprise players used to MegaMek's hidden random tiebreaks. Mitigation: surface the spotter ID in the attack-resolution tooltip so players see who was elected and why.

--- a/openspec/changes/add-indirect-fire-and-spotter-network/proposal.md
+++ b/openspec/changes/add-indirect-fire-and-spotter-network/proposal.md
@@ -1,0 +1,80 @@
+# Change: Add Indirect Fire and Spotter Network
+
+## Why
+
+The Wave 7 OMO Council adversary review confirmed via grep that **zero indirect-fire / spotter combat logic is wired into `src/engine/`**. The utility module at `src/utils/gameplay/indirectFire.ts` (374 LOC) exists and ships with 594 LOC of unit tests — but it is an orphan: no production code in `src/engine/`, `src/lib/combat/`, or `src/services/` imports it. `grep -rn "import.*indirectFire" src/` returns nothing.
+
+The current `openspec/specs/indirect-fire-system/spec.md` (102 LOC) already documents the helper-level mechanics — spotter selection, LRM-only support, +1 base / +1 spotter-walked penalties, semi-guided + TAG, Arrow IV deferred. What it does **not** document is the **integration contract**: how the combat resolver invokes the spotter pipeline, how the `InteractiveSession` exposes spotter candidates each turn, how the to-hit calculator consumes the result, what happens when a spotter dies mid-turn after being elected, and how the typed combat-event log records spotter selection + indirect-fire flags. Those gaps are the reason a LRM boat in a real playtest still has no observable indirect-fire behavior — the helper produces results no one reads.
+
+This change closes that gap end-to-end with a delta to `indirect-fire-system` (expanding it from helper-level to engine-integration-level), a delta to `combat-resolution` (adding the dispatch + event-log requirements), and a delta to `weapon-system` (adding the indirect-mode toggle + range/min-range behavior). It also adds the **Forward Observer** pilot SPA — MegaMek `MISC_FORWARD_OBSERVER` (`PilotOptions.java:98`) — which cancels the spotter movement penalty when active.
+
+**Scope discipline**: Arrow IV / artillery-from-orbit / mortar-indirect / counter-battery fire are all OUT. Standard LRM + Mek Mortar indirect, semi-guided with TAG, FO ability, NARC/iNarc as auto-spotter, and the engine wiring around them are IN. Arrow IV remains the placeholder requirement already in `indirect-fire-system/spec.md` for a future change (`add-arrow-iv-artillery`).
+
+## What Changes
+
+### Capability deltas
+
+- **MODIFIED `indirect-fire-system`** — expand from helper-level to engine-integration-level:
+  - ADDED **Engine Integration Contract**: `InteractiveSession.computeIndirectFireContext(attackerId, weaponId, targetHex)` SHALL return an `IIndirectFireResolution` consumed by the to-hit pipeline before the attack roll resolves. The contract enumerates spotter candidates from the current `gameState`, runs the existing `evaluateIndirectFire` helper, and produces a stable `spotterId | undefined` plus a `toHitPenalty` integer for the attack pipeline. Today no caller invokes the helper from inside the resolver.
+  - ADDED **Spotter Liveness Check**: a spotter selected at to-hit time but destroyed before the resolution step SHALL invalidate the indirect attack (auto-miss with the typed `IndirectFireSpotterLost` event); the attacker SHALL still consume ammo/heat.
+  - ADDED **NARC / iNarc Spotter Override**: a target that is NARC-marked or iNarc-marked by a friendly unit SHALL be treated as a valid spotter source even when no friendly unit has LOS. Mirrors MegaMek `ComputeToHit.java:374-378`.
+  - ADDED **Forward Observer SPA**: pilots with the `FORWARD_OBSERVER` SPA SHALL act as spotters without the +1 spotter-walked penalty regardless of their movement type that turn. Mirrors MegaMek `OptionsConstants.MISC_FORWARD_OBSERVER`.
+  - ADDED **Indirect-Eligible Weapon Catalog**: the spec SHALL enumerate exactly which weapon families may fire indirectly — LRM, LRM-IMP (Improved), MML (in LRM mode), Mek Mortar, NLRM (Streak NOT eligible). Mirrors MegaMek `ComputeToHit.java:384-388`. The existing requirement says "LRM weapons" which is too narrow.
+  - ADDED **Spotter-Election Determinism**: when more than one valid spotter exists, the resolver SHALL pick the spotter with (a) the lowest movement penalty, (b) ties broken by closest range to the target, (c) further ties broken by the lowest `entityId`. This makes replays + tests deterministic. Mirrors MegaMek `Compute.findSpotter()` shape.
+  - ADDED **Min-Range Calculation Origin**: minimum-range penalty SHALL be measured **attacker-to-target** (not spotter-to-target). The existing spec asserts this implicitly via "range SHALL be calculated from the attacker to the target" — promote to a top-level requirement to prevent future drift.
+  - MODIFIED **Semi-Guided LRM with TAG**: clarify that TAG designation must be from the **current turn** (not a stale tag) and that semi-guided LRM falls back to standard indirect (not standard direct) when TAG is absent.
+
+- **MODIFIED `combat-resolution`** — add dispatch + event-log requirements for indirect attacks:
+  - ADDED **Indirect-Fire Dispatch**: when an attack's `weapon.curMode === 'Indirect'`, the resolver SHALL call `computeIndirectFireContext` before `computeToHit` and SHALL fold the penalty + spotter into the attack record.
+  - ADDED **Indirect-Fire Event Coverage**: the typed event log SHALL emit `IndirectFireSpotterSelected`, `IndirectFireSpotterLost`, `IndirectFireForwardObserver`, and `IndirectFireNarcOverride` events with stable fields `{ attackerId, spotterId | null, weaponId, ammoId, targetHex, toHitPenalty, basis: 'los' | 'narc' | 'inarc' | 'semi-guided-tag' }`. Pairs with the event-log line-format suite (project memory: `project_event_log_line_format_suite`).
+
+- **MODIFIED `weapon-system`** — add the indirect-mode toggle + interaction with min-range:
+  - ADDED **Weapon Indirect Mode Toggle**: indirect-eligible weapons SHALL expose a `mode: 'Direct' | 'Indirect'` field defaulting to `Direct`. Toggling to `Indirect` for a non-eligible weapon SHALL be rejected at the UI layer and SHALL be ignored if it reaches the resolver.
+  - ADDED **Mode Persistence**: weapon mode SHALL be part of the per-weapon combat state slice and SHALL serialize/deserialize round-trip through the existing event-log replay path.
+
+### Code touch points (Apply Wave — not in this change)
+
+The Apply wave will need to touch (estimate, for proposal completeness):
+
+- `src/engine/InteractiveSession.ts` — add `computeIndirectFireContext`, plumb into existing to-hit call
+- `src/utils/gameplay/toHit/calculate.ts` — consume `IIndirectFireResolution`, apply penalty
+- `src/lib/combat/combatResolution.ts` — emit the four new event types
+- `src/types/gameplay/CombatInterfaces.ts` — add `IIndirectFireResolution`, `IndirectFireSpotterSelected | Lost | ForwardObserver | NarcOverride` event variants, `weapon.mode` field
+- `src/lib/spa/catalog/gunnerySPAs.ts` — register `FORWARD_OBSERVER` SPA
+- `src/components/gameplay/WeaponPanel.tsx` (or equivalent) — render the indirect-mode toggle on LRM/MML/Mek Mortar
+- `src/services/combat/replays/eventLogFormatter.ts` (or equivalent) — extend the columnar formatter for the 4 new event types
+
+## Capabilities
+
+### Modified
+
+- `indirect-fire-system` — expands from helper-level to engine-integration-level; adds NARC override, FO SPA, deterministic spotter election, eligible-weapon catalog, min-range origin, current-turn TAG requirement
+- `combat-resolution` — adds indirect-fire dispatch step + 4 typed event variants
+- `weapon-system` — adds the `mode: 'Direct' | 'Indirect'` toggle with eligibility validation + persistence round-trip
+
+### New
+
+(None — `indirect-fire-system` already exists as a capability)
+
+## Impact
+
+- **Affected source files (Apply estimate)**: ~8 files, ~600-900 LOC across engine/resolver/types/event-log/SPA-catalog/UI. The orphan `src/utils/gameplay/indirectFire.ts` (374 LOC + 594 LOC tests) becomes the helper layer consumed by the new resolver code — keep, don't rewrite.
+- **No new transport** — uses the existing Zustand stores + typed event-log.
+- **No DB migration** — combat state is in-memory + event-log file (per `replay-library` capability).
+- **Storybook deltas**: 1-2 stories for the weapon-mode toggle and the FO badge in the spotter-selection HUD (Apply wave only).
+- **Test footprint estimate (Apply wave)**: ~30-50 new unit tests + 3-5 scenario tests; the existing 594-LOC `indirectFire.test.ts` is retained and exercised through the resolver, not directly.
+
+## Non-Goals
+
+- **Arrow IV artillery** — remains a placeholder requirement in `indirect-fire-system` for the future `add-arrow-iv-artillery` change. Out of this change's scope: deviation tables, scatter rolls, area damage, counter-battery observation.
+- **Artillery from orbit / Aerospace artillery bay** — out; bundled with the future `add-aerospace-artillery` change.
+- **Mek Mortar smoke / smoke-grenade indirect** — indirect dispatch routes mortar through the same pipeline, but smoke ammo's area effect remains the responsibility of the existing ammunition catalog. The new event variants record `ammoId` for downstream consumers.
+- **Counter-battery fire** — separate spec needed for the observer pipeline.
+- **Indirect-fire AI heuristics** — bot decision-making to choose indirect vs direct is out; the AI advisor will be updated in a follow-up change once the resolver path stabilizes.
+- **Munitions overhaul** — Improved-NARC, Listen-Kill, Anti-TSM, FASCAM are all already-modeled ammo types or out-of-scope; this change does not introduce new ammo families.
+
+## Open Questions
+
+- **Should the Forward Observer SPA cost mirror MegaMek's XP cost?** Decision: defer to the SPA catalog's existing cost normalization (post-archive note); the spec requires the SPA to exist + behave as specified, leaves the catalog cost to the existing `add-spa-progression` change.
+- **Should NARC-marked enemies be visible to all friendly units as spotter sources, or only the unit that fired the NARC?** Decision: all friendly units, mirroring MegaMek (`te.isNarcedBy(ae.getOwner().getTeam())`). Recorded in the requirement.
+- **Should `IndirectFireSpotterLost` auto-miss also refund the spotter's +1 spotting-fire penalty if the spotter took fire and survived but the resolver subsequently invalidated it?** Decision: no — the spotter penalty applies for the entire turn once the spotter declared the spot. Liveness check only affects the firing attack's hit/miss.

--- a/openspec/changes/add-indirect-fire-and-spotter-network/specs/combat-resolution/spec.md
+++ b/openspec/changes/add-indirect-fire-and-spotter-network/specs/combat-resolution/spec.md
@@ -1,0 +1,85 @@
+# Spec Delta: Combat Resolution — Indirect Fire Dispatch
+
+## ADDED Requirements
+
+### Requirement: Indirect-Fire Dispatch
+
+The combat resolver SHALL invoke `InteractiveSession.computeIndirectFireContext` before `computeToHit` whenever an attack's weapon mode is `'Indirect'` OR the attacker has no line of sight to the target. The returned `IIndirectFireResolution` SHALL be folded into the attack record and the `toHitPenalty` SHALL be added to the running to-hit number.
+
+#### Scenario: Indirect mode triggers dispatch
+
+- **GIVEN** attacker A has weapon W toggled to `mode: 'Indirect'`
+- **WHEN** A declares an attack against hex H
+- **THEN** the resolver SHALL call `computeIndirectFireContext(A.id, W.id, H)` before `computeToHit`
+- **AND** the resolution SHALL be attached to the attack record as `attackRecord.indirectFire = IIndirectFireResolution`
+
+#### Scenario: No LOS triggers dispatch even when mode is Direct
+
+- **GIVEN** attacker A has weapon W in `mode: 'Direct'`
+- **AND** A has no line of sight to target hex H
+- **WHEN** A declares an attack against H
+- **THEN** the resolver SHALL call `computeIndirectFireContext` to check whether indirect resolution is available
+- **AND** if the resolution is `{ permitted: true, isIndirect: true }`, the attack SHALL proceed as indirect
+- **AND** if the resolution is `{ permitted: false }`, the attack SHALL be rejected with the resolution's `reason` field
+
+#### Scenario: LOS + Direct mode bypasses dispatch
+
+- **GIVEN** attacker A has line of sight to target T
+- **AND** weapon W is in `mode: 'Direct'`
+- **WHEN** A declares an attack against T
+- **THEN** the resolver SHALL NOT call `computeIndirectFireContext`
+- **AND** the attack SHALL resolve via the existing direct-fire pipeline
+
+### Requirement: Indirect-Fire Event Coverage
+
+The typed combat event log SHALL emit one of four event variants whenever an indirect-fire resolution is computed: `IndirectFireSpotterSelected` (basis='los'), `IndirectFireNarcOverride` (basis='narc' or 'inarc'), `IndirectFireForwardObserver` (FO SPA cancelled the spotter-walked penalty), or `IndirectFireSpotterLost` (spotter destroyed before damage resolution).
+
+#### Scenario: LOS spotter selected — emits IndirectFireSpotterSelected
+
+- **GIVEN** an indirect attack resolves with a friendly LOS spotter elected
+- **WHEN** `computeIndirectFireContext` completes
+- **THEN** an `IndirectFireSpotterSelected` event SHALL be emitted with fields `{ attackerId, spotterId, weaponId, ammoId, targetHex, toHitPenalty, basis: 'los' }`
+
+#### Scenario: NARC override — emits IndirectFireNarcOverride
+
+- **GIVEN** an indirect attack resolves via NARC override (no LOS spotter, target NARC-marked by friendly team)
+- **WHEN** `computeIndirectFireContext` completes
+- **THEN** an `IndirectFireNarcOverride` event SHALL be emitted with fields `{ attackerId, spotterId: null, weaponId, ammoId, targetHex, toHitPenalty, basis: 'narc' | 'inarc' }`
+
+#### Scenario: Forward Observer SPA active — emits IndirectFireForwardObserver
+
+- **GIVEN** an indirect attack with a walking spotter whose pilot has the `FORWARD_OBSERVER` SPA
+- **WHEN** the resolver cancels the +1 spotter-walked penalty
+- **THEN** an `IndirectFireForwardObserver` event SHALL be emitted with fields `{ attackerId, spotterId, weaponId, basis: 'los', penaltyCancelled: 1 }`
+- **AND** this event SHALL be emitted in addition to (not instead of) the `IndirectFireSpotterSelected` event
+
+#### Scenario: Spotter destroyed mid-attack — emits IndirectFireSpotterLost
+
+- **GIVEN** a spotter elected at to-hit time
+- **WHEN** the spotter is destroyed by an intervening attack before damage resolution
+- **THEN** an `IndirectFireSpotterLost` event SHALL be emitted with fields `{ attackerId, spotterId, weaponId, ammoId, targetHex, reason: 'Spotter destroyed before resolution' }`
+- **AND** the attack outcome SHALL be `'auto-miss'` with ammo + heat still consumed
+
+#### Scenario: Event log replay round-trips indirect events
+
+- **GIVEN** an indirect-fire attack with all four event types in the JSONL event log
+- **WHEN** the replay loader replays the log
+- **THEN** the four event types SHALL be parsed without loss
+- **AND** the columnar formatter SHALL render each with its stable fields per the line-format suite
+
+### Requirement: Spotter-Fire Penalty on Elected Spotter
+
+The spotter unit elected for an indirect-fire attack SHALL receive a +1 to-hit modifier on any of its OWN direct-fire attacks during the same turn, mirroring MegaMek's `ComputeAttackerToHitMods.java:172-177` rule. This penalty SHALL apply for the entire turn once the spotter has been elected, even if a subsequent indirect attack invalidates the spotter via liveness check.
+
+#### Scenario: Spotter takes its own attack — +1 penalty
+
+- **GIVEN** spotter S was elected for attacker A's indirect attack
+- **WHEN** S subsequently fires its own direct attack on a different target
+- **THEN** S's to-hit calculation SHALL include `+1 spotting-fire` modifier
+- **AND** the modifier SHALL be tagged in the to-hit breakdown as `'Spotting for indirect fire'`
+
+#### Scenario: Penalty persists after spotter-lost auto-miss
+
+- **GIVEN** S was elected as spotter and S was subsequently destroyed before A's damage step
+- **WHEN** S's earlier own-attacks are replayed
+- **THEN** the +1 spotting-fire penalty SHALL still apply (the penalty is fixed at election time, not retroactively cancelled)

--- a/openspec/changes/add-indirect-fire-and-spotter-network/specs/indirect-fire-system/spec.md
+++ b/openspec/changes/add-indirect-fire-and-spotter-network/specs/indirect-fire-system/spec.md
@@ -1,0 +1,206 @@
+# Spec Delta: Indirect Fire System
+
+## ADDED Requirements
+
+### Requirement: Engine Integration Contract
+
+The combat engine SHALL expose a single integration point `InteractiveSession.computeIndirectFireContext(attackerId, weaponId, targetHex)` that returns an `IIndirectFireResolution` consumed by the to-hit pipeline before each attack roll resolves. The contract SHALL enumerate spotter candidates from the current `gameState`, invoke the existing `evaluateIndirectFire` helper, and produce a stable `spotterId | null`, an `IndirectFireBasis` discriminator, and an integer `toHitPenalty` for the attack pipeline.
+
+#### Scenario: Resolver invokes the contract before to-hit calculation
+
+- **GIVEN** an attacker A declares an LRM-15 attack against hex H
+- **AND** A has no line of sight to H
+- **WHEN** the resolver begins the attack pipeline
+- **THEN** `InteractiveSession.computeIndirectFireContext(A.id, weapon.id, H)` SHALL be called before `computeToHit` runs
+- **AND** the returned `IIndirectFireResolution.toHitPenalty` SHALL be added to the running to-hit number by `computeToHit`
+- **AND** the returned `spotterId` SHALL be recorded in the attack record for replay determinism
+
+#### Scenario: Helper remains pure and engine-independent
+
+- **GIVEN** the existing `src/utils/gameplay/indirectFire.ts` helper
+- **WHEN** the engine integration is added
+- **THEN** the helper SHALL NOT import any engine type (`InteractiveSession`, `gameState`, etc.)
+- **AND** the helper SHALL continue to operate on synthetic `ISpotterCandidate[]` inputs as today
+- **AND** the existing 594-LOC `indirectFire.test.ts` SHALL continue to pass without modification
+
+### Requirement: Spotter Liveness Check
+
+A spotter elected at to-hit time but destroyed before damage resolution SHALL invalidate the indirect attack. The system SHALL emit a typed `IndirectFireSpotterLost` event, force the attack to auto-miss, and SHALL still consume ammunition and heat for the attempted attack.
+
+#### Scenario: Spotter destroyed between to-hit and damage
+
+- **GIVEN** attacker A declares an indirect LRM attack at target T, with spotter S elected
+- **AND** the to-hit roll succeeds
+- **WHEN** a higher-initiative attack destroys S before A's damage resolves
+- **THEN** the resolver SHALL re-validate `S.combatState.destroyed === true`
+- **AND** the attack SHALL convert to an auto-miss
+- **AND** an `IndirectFireSpotterLost` event SHALL be emitted with reason `'Spotter destroyed before resolution'`
+- **AND** A's LRM ammo SHALL be decremented as if the attack fired
+- **AND** A's heat SHALL be added as if the attack fired
+
+#### Scenario: Spotter survives — no penalty change
+
+- **GIVEN** attacker A's indirect attack is in progress with spotter S
+- **WHEN** S takes damage but is not destroyed by the time A's attack resolves
+- **THEN** the indirect attack SHALL proceed normally
+- **AND** no `IndirectFireSpotterLost` event SHALL be emitted
+
+### Requirement: NARC / iNarc Spotter Override
+
+A target marked by friendly NARC or iNarc beacons SHALL be a valid indirect-fire target even when no friendly unit has line of sight. The marking team SHALL be the same team as the attacker. The `IIndirectFireResolution.basis` SHALL be `'narc'` or `'inarc'` respectively, and `spotterId` SHALL be `null` (no spotter unit was elected). No spotter-walked penalty SHALL apply in this case; the base +1 indirect-fire penalty SHALL still apply.
+
+#### Scenario: NARC-marked target without LOS spotter
+
+- **GIVEN** target T is NARC-marked by a friendly unit (same team as attacker A)
+- **AND** no friendly unit has LOS to T
+- **WHEN** A declares an indirect LRM attack at T
+- **THEN** `computeIndirectFireContext` SHALL return `{ permitted: true, isIndirect: true, basis: 'narc', spotterId: null, toHitPenalty: 1 }`
+- **AND** an `IndirectFireNarcOverride` event SHALL be emitted
+
+#### Scenario: iNarc behaves identically with different basis tag
+
+- **GIVEN** target T is iNarc-marked by a friendly unit (same team as A)
+- **AND** no friendly unit has LOS to T
+- **WHEN** A declares an indirect LRM attack at T
+- **THEN** the resolution basis SHALL be `'inarc'`
+- **AND** the basis tag SHALL be carried through to the `IndirectFireNarcOverride` event payload
+
+#### Scenario: NARC by enemy team does not enable indirect
+
+- **GIVEN** target T is NARC-marked by a team different from A's team
+- **WHEN** A declares an indirect LRM attack at T
+- **THEN** the NARC mark SHALL NOT be honored as a spotter override
+- **AND** the resolver SHALL fall back to LOS-spotter election; if none exists, the attack SHALL be rejected
+
+### Requirement: Forward Observer SPA
+
+Pilots with the `FORWARD_OBSERVER` Special Piloting Ability SHALL act as spotters without the +1 spotter-walked penalty regardless of their movement type that turn. The base +1 indirect-fire penalty SHALL still apply.
+
+#### Scenario: FO spotter walked — no penalty add
+
+- **GIVEN** spotter S whose pilot has the `FORWARD_OBSERVER` SPA
+- **AND** S walked during the movement phase
+- **WHEN** S is elected as the spotter for an indirect attack
+- **THEN** `toHitPenalty` SHALL be 1 (base only)
+- **AND** an `IndirectFireForwardObserver` event SHALL be emitted recording that the FO ability cancelled the penalty
+
+#### Scenario: FO spotter ran — still ineligible
+
+- **GIVEN** spotter candidate S whose pilot has the `FORWARD_OBSERVER` SPA
+- **AND** S ran during the movement phase
+- **WHEN** the resolver enumerates spotter candidates
+- **THEN** S SHALL NOT be eligible (FO does not override the run/jump ineligibility from `Spotter Movement Penalty`)
+
+### Requirement: Indirect-Eligible Weapon Catalog
+
+The system SHALL define a single source-of-truth catalog of weapon families that may fire indirectly: LRM, LRM (Improved), MML loaded with LRM ammo, Mek Mortar, NLRM. Streak LRM, ATM, MRM, ROCKET LAUNCHER, and direct-fire energy/ballistic weapons SHALL NOT be eligible. Attempts to fire an ineligible weapon indirectly SHALL be rejected.
+
+#### Scenario: LRM-15 toggle to indirect mode succeeds
+
+- **WHEN** a user toggles an LRM-15 weapon's mode to `'Indirect'`
+- **THEN** the toggle SHALL be accepted
+
+#### Scenario: AC/20 toggle to indirect mode is rejected
+
+- **WHEN** a user toggles an AC/20 weapon's mode to `'Indirect'`
+- **THEN** the toggle SHALL be rejected at the UI layer with reason `'AC/20 cannot fire indirectly'`
+- **AND** if the toggle bypasses the UI and reaches the resolver, the weapon SHALL be treated as `'Direct'` mode for that attack
+
+#### Scenario: MML loaded with SRM is ineligible
+
+- **GIVEN** an MML mount currently loaded with SRM-2 ammo
+- **WHEN** the user attempts to toggle indirect mode
+- **THEN** the toggle SHALL be rejected with reason `'MML cannot fire indirectly with SRM ammo loaded'`
+
+#### Scenario: Streak SRM/LRM never eligible
+
+- **WHEN** a user attempts to toggle indirect mode on Streak SRM-2 or Streak LRM-5
+- **THEN** the toggle SHALL be rejected; Streak weapons require lock-on which precludes indirect fire
+
+### Requirement: Spotter-Election Determinism
+
+When more than one valid spotter candidate exists for the same attack, the resolver SHALL elect a single spotter using the following ordered tiebreak: (1) lowest movement penalty (Stationary < Walked < Ran/Jumped — note Ran/Jumped is ineligible, so this reduces to Stationary preferred over Walked); (2) ties broken by closest hex range to the target; (3) further ties broken by the lowest `entityId` lexicographically.
+
+#### Scenario: Two equally-eligible stationary spotters — closer wins
+
+- **GIVEN** two spotters S1 and S2, both stationary, both with valid LOS to target T
+- **AND** S1 is 4 hexes from T, S2 is 7 hexes from T
+- **WHEN** the resolver elects a spotter
+- **THEN** S1 SHALL be elected
+
+#### Scenario: Equally-close stationary spotters — lowest id wins
+
+- **GIVEN** two spotters S1 (id=`'mek-12'`) and S2 (id=`'mek-3'`), both stationary, both 5 hexes from T
+- **WHEN** the resolver elects a spotter
+- **THEN** S2 SHALL be elected (`'mek-12'` > `'mek-3'` lexicographically)
+
+#### Scenario: Stationary preferred over walked
+
+- **GIVEN** S1 (walked) and S2 (stationary), both with valid LOS
+- **WHEN** the resolver elects a spotter
+- **THEN** S2 SHALL be elected (lower movement penalty wins)
+
+### Requirement: Min-Range Calculation Origin
+
+The minimum-range penalty for an indirect attack SHALL be measured from the attacker to the target, not from the spotter to the target.
+
+#### Scenario: Attacker within min-range despite distant spotter
+
+- **GIVEN** attacker A is 3 hexes from target T (within LRM min-range of 6)
+- **AND** spotter S is 10 hexes from T
+- **WHEN** the indirect attack resolves
+- **THEN** the min-range penalty SHALL apply (attacker-to-target = 3, below the 6-hex min)
+- **AND** the spotter's distance to T SHALL NOT affect the min-range calculation
+
+#### Scenario: Attacker outside min-range with nearby spotter
+
+- **GIVEN** A is 12 hexes from T (clear of min-range)
+- **AND** S is 2 hexes from T
+- **WHEN** the indirect attack resolves
+- **THEN** no min-range penalty SHALL apply
+
+## MODIFIED Requirements
+
+### Requirement: LRM Indirect Fire Mode
+
+LRM-family weapons (LRM, LRM Improved, MML loaded with LRM ammo, Mek Mortar, NLRM) SHALL support indirect fire, allowing attacks against targets without direct line of sight provided either (a) a friendly spotter unit has LOS to the target, or (b) the target is NARC-marked or iNarc-marked by a friendly unit. The set of eligible weapon families SHALL be the catalog defined by the `Indirect-Eligible Weapon Catalog` requirement.
+
+#### Scenario: Indirect fire with valid LOS spotter
+
+- **WHEN** an LRM weapon fires indirectly at a target
+- **AND** a friendly unit has line of sight to the target
+- **THEN** the spotter MUST NOT have run or jumped that turn (stationary or walked only; FO SPA does not override this)
+- **AND** the attack SHALL be resolved using the standard to-hit calculation plus indirect-fire modifiers
+
+#### Scenario: Indirect fire with no spotter and no NARC
+
+- **WHEN** an LRM weapon attempts indirect fire and no friendly unit has LOS to the target and the target is not NARC/iNarc-marked by a friendly unit
+- **THEN** the indirect-fire attack SHALL NOT be permitted
+- **AND** `computeIndirectFireContext` SHALL return `{ permitted: false, reason: 'No valid spotter and no NARC override' }`
+
+#### Scenario: Direct-fire ineligible weapon attempts indirect
+
+- **WHEN** a non-eligible weapon (e.g., AC/20, PPC, large laser) attempts indirect fire
+- **THEN** the attack SHALL be rejected per the `Indirect-Eligible Weapon Catalog` requirement
+
+### Requirement: Semi-Guided LRM with TAG
+
+Semi-guided LRM attacks SHALL require TAG designation that was set **during the current turn** by any friendly unit (not a stale designation from a prior turn). When TAG is present, the semi-guided hit table SHALL be used. When TAG is absent, semi-guided LRM SHALL fall back to **standard indirect fire** behavior (LOS spotter or NARC override required) — NOT to standard direct fire.
+
+#### Scenario: Semi-guided LRM with current-turn TAG
+
+- **WHEN** a semi-guided LRM fires at a TAG-designated target whose TAG was set this turn
+- **THEN** the attack SHALL use the semi-guided hit table
+- **AND** the `IIndirectFireResolution.basis` SHALL be `'semi-guided-tag'`
+
+#### Scenario: Semi-guided LRM with stale TAG designation
+
+- **GIVEN** target T was TAG-designated on a previous turn but not the current turn
+- **WHEN** a semi-guided LRM fires at T
+- **THEN** the TAG designation SHALL be considered absent
+- **AND** the weapon SHALL fall back to standard indirect-fire rules
+
+#### Scenario: Semi-guided LRM without TAG and without spotter
+
+- **WHEN** a semi-guided LRM fires at a target with no current-turn TAG and no friendly LOS spotter and no NARC mark
+- **THEN** the attack SHALL be rejected with reason `'No valid spotter, no NARC, no current-turn TAG'`

--- a/openspec/changes/add-indirect-fire-and-spotter-network/specs/weapon-system/spec.md
+++ b/openspec/changes/add-indirect-fire-and-spotter-network/specs/weapon-system/spec.md
@@ -1,0 +1,88 @@
+# Spec Delta: Weapon System — Indirect Mode Toggle
+
+## ADDED Requirements
+
+### Requirement: Weapon Indirect Mode Toggle
+
+Indirect-eligible weapons SHALL expose a runtime combat-state field `mode: 'Direct' | 'Indirect'` that defaults to `'Direct'`. The toggle SHALL be per-weapon-mount and SHALL be reversible turn-to-turn. Toggling to `'Indirect'` on a non-eligible weapon SHALL be rejected at the UI layer with a validation error and SHALL be treated as `'Direct'` if the toggle bypasses the UI and reaches the resolver.
+
+#### Scenario: Default mode on weapon construction
+
+- **GIVEN** an LRM-15 weapon mount on a freshly constructed mech
+- **WHEN** the unit enters combat
+- **THEN** `weapon.mode` SHALL equal `'Direct'`
+
+#### Scenario: Toggle to indirect on eligible weapon
+
+- **GIVEN** an LRM-15 weapon in `'Direct'` mode
+- **WHEN** the player toggles the weapon mode via the UI
+- **THEN** `weapon.mode` SHALL become `'Indirect'`
+- **AND** subsequent attacks with this weapon SHALL pass through the indirect-fire dispatch
+
+#### Scenario: Toggle reversibility
+
+- **GIVEN** an LRM-15 in `'Indirect'` mode on turn 3
+- **WHEN** the player toggles back to `'Direct'` on turn 4
+- **THEN** `weapon.mode` SHALL become `'Direct'`
+- **AND** subsequent attacks SHALL use the direct-fire pipeline
+
+#### Scenario: Toggle on non-eligible weapon rejected
+
+- **GIVEN** an AC/20 weapon mount
+- **WHEN** the player attempts to toggle `mode: 'Indirect'`
+- **THEN** the UI SHALL render a validation error `'AC/20 cannot fire indirectly'`
+- **AND** `weapon.mode` SHALL remain `'Direct'`
+
+#### Scenario: Resolver ignores bad mode value
+
+- **GIVEN** a manually-constructed combat state where an AC/20's `weapon.mode` has been set to `'Indirect'` (e.g., via a corrupt save)
+- **WHEN** the resolver processes the attack
+- **THEN** the resolver SHALL treat `weapon.mode` as `'Direct'` (silent fallback)
+- **AND** SHALL emit a warning event `'IndirectModeIgnored'` with the weapon family and resolved fallback
+
+### Requirement: Weapon Mode Persistence
+
+The `weapon.mode` field SHALL be part of the per-weapon combat state slice and SHALL round-trip through the JSONL event-log replay path (per the `replay-library` capability). The per-attack event payload SHALL carry the resolved `mode` so replays render the attack's indirect/direct flag without re-deriving it.
+
+#### Scenario: Mode persists across the same turn
+
+- **GIVEN** the player toggles LRM-15 to `'Indirect'` mid-turn
+- **WHEN** the player declares two LRM-15 attacks in the same turn
+- **THEN** both attack records SHALL carry `weapon.mode === 'Indirect'`
+
+#### Scenario: Mode persists across turn boundaries within a session
+
+- **GIVEN** weapon mode toggled to `'Indirect'` on turn 3
+- **WHEN** turn 4 begins
+- **THEN** `weapon.mode` SHALL still equal `'Indirect'` (no auto-reset)
+- **AND** the player must explicitly toggle back to `'Direct'` to revert
+
+#### Scenario: Event-log replay restores mode
+
+- **GIVEN** a JSONL event log containing attacks with `weapon.mode: 'Indirect'`
+- **WHEN** the replay loader replays the log
+- **THEN** the reconstructed attack records SHALL carry `weapon.mode === 'Indirect'`
+- **AND** the per-attack indirect-fire events SHALL be re-emitted in their original sequence
+
+### Requirement: MML Mode Eligibility by Loaded Ammo
+
+For Multi-Missile Launcher (MML) mounts, indirect-mode eligibility SHALL depend on the currently loaded ammo. MML loaded with LRM ammo IS eligible; MML loaded with SRM ammo IS NOT. Switching the loaded ammo between LRM and SRM SHALL re-evaluate the eligibility and SHALL auto-revert `mode` to `'Direct'` if the new ammo makes the weapon ineligible.
+
+#### Scenario: MML loaded with LRM ammo — eligible
+
+- **GIVEN** an MML-5 with LRM-5 ammo loaded
+- **WHEN** the player toggles `mode: 'Indirect'`
+- **THEN** the toggle SHALL succeed
+
+#### Scenario: MML loaded with SRM ammo — ineligible
+
+- **GIVEN** an MML-5 with SRM-5 ammo loaded
+- **WHEN** the player toggles `mode: 'Indirect'`
+- **THEN** the toggle SHALL be rejected
+
+#### Scenario: Switching MML ammo from LRM to SRM auto-reverts mode
+
+- **GIVEN** an MML-5 in `'Indirect'` mode with LRM-5 ammo loaded
+- **WHEN** the player switches the loaded ammo to SRM-5
+- **THEN** `weapon.mode` SHALL auto-revert to `'Direct'`
+- **AND** the UI SHALL render a notice `'Mode reverted to Direct: SRM ammo cannot fire indirectly'`

--- a/openspec/changes/add-indirect-fire-and-spotter-network/tasks.md
+++ b/openspec/changes/add-indirect-fire-and-spotter-network/tasks.md
@@ -1,0 +1,58 @@
+# Tasks: Add Indirect Fire and Spotter Network
+
+## 1. Engine integration contract (indirect-fire-system delta)
+
+- [ ] 1.1 Add `IIndirectFireResolution` type to `src/types/gameplay/CombatInterfaces.ts` with fields `{ permitted, isIndirect, spotterId | null, basis: 'los' | 'narc' | 'inarc' | 'semi-guided-tag', toHitPenalty, reason? }`
+- [ ] 1.2 Implement `InteractiveSession.computeIndirectFireContext(attackerId, weaponId, targetHex)` in `src/engine/InteractiveSession.ts`; enumerates `ISpotterCandidate[]` from current `gameState`, calls existing `evaluateIndirectFire` helper, returns `IIndirectFireResolution`
+- [ ] 1.3 Add unit tests for `computeIndirectFireContext` covering: no-LOS-no-spotter (rejected), no-LOS-with-spotter (permitted, basis='los'), LOS-on-attacker (direct, isIndirect=false), spotter-walked penalty math, multi-spotter election tiebreak (move-pen → range → id)
+
+## 2. Forward Observer SPA
+
+- [ ] 2.1 Register `FORWARD_OBSERVER` SPA in `src/lib/spa/catalog/gunnerySPAs.ts` with metadata `{ category: 'gunnery', cost: 200, prerequisites: [] }` (cost from existing SPA-catalog normalization)
+- [ ] 2.2 Wire `IIndirectFireResolution` to consult `spotterPilot.spas.includes('FORWARD_OBSERVER')`; cancel the +1 spotter-walked add when true (base +1 still applies)
+- [ ] 2.3 Add unit test: spotter pilot with FO SPA + walking spotter → toHitPenalty === 1 (not 2)
+
+## 3. NARC / iNarc spotter override
+
+- [ ] 3.1 Extend `IIndirectFireRequest` (existing in `src/utils/gameplay/indirectFire.ts`) with `targetNarcMarkedByTeam: boolean`, `targetINarcMarkedByTeam: boolean` flags read from target combat state
+- [ ] 3.2 In `computeIndirectFireContext`, when no friendly unit has LOS but target is NARC/iNarc-marked by the attacker's team, set basis to `'narc'` / `'inarc'` and treat the target itself as the implicit spotter (spotterId=null, no spotter-walked penalty)
+- [ ] 3.3 Add unit test: no-LOS + NARC-marked-target → permitted, basis='narc', spotterId=null, toHitPenalty=1 (base only)
+
+## 4. Indirect-eligible weapon catalog + mode toggle
+
+- [ ] 4.1 Define `INDIRECT_ELIGIBLE_WEAPON_FAMILIES = ['LRM', 'LRM_IMP', 'MML_LRM', 'MEK_MORTAR', 'NLRM']` constant in `src/utils/gameplay/indirectFire.ts`; `MML_LRM` denotes MML loaded with LRM ammo (not SRM); the constant SHALL be the single source of truth for eligibility checks
+- [ ] 4.2 Reject attempts to toggle mode on non-eligible weapons at the UI layer (return validation error) and ignore at the resolver (treat as `'Direct'`)
+- [ ] 4.3 Add `weapon.mode: 'Direct' | 'Indirect'` to per-weapon combat state slice in `CombatInterfaces.ts`; default `'Direct'`
+- [ ] 4.4 Persist mode in event-log replay round-trip (extend the per-attack event payload)
+- [ ] 4.5 Add unit test: toggle on LRM-10 succeeds; toggle on AC/20 throws; toggle on MML loaded with SRM ammo throws
+
+## 5. Combat-resolution dispatch + event log
+
+- [ ] 5.1 In `src/lib/combat/combatResolution.ts` resolver: when `weapon.mode === 'Indirect'` OR `attacker.losToTarget === false`, invoke `computeIndirectFireContext` before `computeToHit`
+- [ ] 5.2 Add typed event variants to `src/types/gameplay/CombatInterfaces.ts`:
+  - `IndirectFireSpotterSelected` (basis='los')
+  - `IndirectFireSpotterLost` (auto-miss outcome, basis at time of selection)
+  - `IndirectFireForwardObserver` (FO cancelled spotter-walked)
+  - `IndirectFireNarcOverride` (basis='narc' | 'inarc')
+- [ ] 5.3 Emit the appropriate event when `computeIndirectFireContext` resolves; consumed by event-log formatter
+- [ ] 5.4 Extend `src/services/combat/replays/eventLogFormatter.ts` (or equivalent columnar formatter from `project_event_log_line_format_suite`) to render the 4 new event types
+- [ ] 5.5 Add scenario test: full LRM-15 indirect attack with valid spotter — assert event sequence `[IndirectFireSpotterSelected, AttackResolved(hit), WeaponDamageApplied]`
+
+## 6. Spotter liveness re-check
+
+- [ ] 6.1 Between hit-roll and damage-application in `combatResolution.ts`, if the elected spotter's `entityState.destroyed === true`, short-circuit: emit `IndirectFireSpotterLost` with reason `'Spotter destroyed before resolution'`, mark attack as miss, still consume ammo + heat
+- [ ] 6.2 Add scenario test: spotter elected at to-hit, then a higher-initiative attack kills the spotter, then LRM attack resolves → auto-miss, IndirectFireSpotterLost event present, ammo decremented
+
+## 7. Spec deltas
+
+- [ ] 7.1 Author `openspec/changes/add-indirect-fire-and-spotter-network/specs/indirect-fire-system/spec.md` covering ADDED + MODIFIED requirements per the proposal's capability section
+- [ ] 7.2 Author `openspec/changes/add-indirect-fire-and-spotter-network/specs/combat-resolution/spec.md` adding indirect-fire dispatch + event-log requirements
+- [ ] 7.3 Author `openspec/changes/add-indirect-fire-and-spotter-network/specs/weapon-system/spec.md` adding weapon mode toggle + persistence
+- [ ] 7.4 `npx openspec validate add-indirect-fire-and-spotter-network --strict` passes clean
+- [ ] 7.5 `npm run build`, lint, typecheck, jest, scenario tests pass on CI (Apply wave gate)
+- [ ] 7.6 Archive the change to `openspec/changes/archive/YYYY-MM-DD-add-indirect-fire-and-spotter-network/` after PR merge; sync the 3 deltas into source-of-truth specs (NEVER `--skip-specs`)
+
+## 8. Documentation + follow-up notes
+
+- [ ] 8.1 Add a `playtest/wave-7/INDIRECT_FIRE_NOTES.md` section noting (a) which LRM/MML/Mortar scenarios should be added to `playtest-scenarios.spec.ts`, (b) the parity ratio between MegaMek's spotter election and ours on a 5-scenario regression set
+- [ ] 8.2 Spec the future Arrow IV follow-up — leave a `_followups.md` placeholder in the archive folder noting that artillery deviation tables / scatter / counter-battery / Aerospace artillery bays are the next layer


### PR DESCRIPTION
## Why

OMO Council Lean+ verdict on the post-Wave-6.x next-execution question landed a **dual-track plan**: Apply Track ships the 7 Codex-authored tactical-UI specs (Wave 7); Author Track (this PR) specs out combat-parity-wave-7 so Wave 8 opens with all three sub-specs ready to Apply.

These three changes close the four combat-engine gaps `playtest/ROADMAP_POST_WAVE_6.md` big-rock #1 named:

- **Indirect fire + spotter network** — Council Momus's kill-condition verification (`grep -r indirect|spotter src/engine/`) confirmed **zero** indirect-fire/spotter combat logic exists; the only "indirect" mention in `InteractiveSession.ts` is a comment about session finalization. Without this, LRM boats without LOS to their target silently miss the indirect-fire path — a core BattleTech tactic absent from real play.
- **Battle Armor combat** — closes the Wave-2 TODO surface; BA squad damage allocation, swarming attacks, leg attacks, and BA-vs-BA combat.
- **Aerospace deployment** — authors the spec, defers Apply to Wave 9 (Librarian sized MegaMek's `Aero.java` at 99KB / 3-5× ground-vehicle scope; keeps it as a dedicated wave).

VTOL/hover MP modifiers are named as a Wave-9 follow-up (`update-vtol-hover-mp-modifiers`) in the aerospace change's Non-Goals — small enough to fold into Wave 9 startup without a separate council.

## What changes

**Spec-only changes — no source code touched.** All three changes follow the project convention of NEVER `--skip-specs`; each tasks.md explicitly names the archive + source-of-truth sync.

### `add-indirect-fire-and-spotter-network` (L sizing, Wave-8 Apply candidate)

- New capability: `indirect-fire-system` (8 ADDED + 2 MODIFIED requirements)
- Modified: `combat-resolution` (3 ADDED), `weapon-system` (3 ADDED)

Covers: indirect LRM/SRM fire targeting without LOS, spotter selection + validation, forward-observer ability, spotter penalty (+1 to spotter's own fire), Arrow IV homing flagged for follow-up. Engine integration grounded in MegaMek's [ArtilleryWeaponIndirectFireHandler.java](https://github.com/MegaMek/megamek/blob/274571a2/megamek/src/megamek/common/weapons/handlers/artillery/ArtilleryWeaponIndirectFireHandler.java) (400+ line handler, 6-7 phases).

### `add-battle-armor-combat` (M-L sizing, Wave-8 Apply candidate)

- New capability: `battle-armor-combat` (11 ADDED requirements + data model)
- Modified: `combat-resolution` (2 ADDED)

Covers: BA-vs-mech (swarm attacks, leg attacks, mounted-trooper damage), BA-vs-BA (squad damage allocation, trooper rolls). BA construction is explicitly out of scope (named as a separate `add-battle-armor-construction` follow-up if surface gaps emerge during Apply). Grounded in MegaMek's `BattleArmor.java` (68KB), `InfantryCombatTables.java`, `InfantryCombatAction.java`.

### `add-aerospace-deployment` (XL sizing, Wave-9 Apply — explicitly deferred)

- New capability: `aerospace-deployment` (16 ADDED requirements + data model)
- Modified: `combat-resolution` (4 ADDED), `unit-entity-model` (1 MODIFIED), `movement-system` (2 MODIFIED)

Covers: airborne movement (thrust-point system, velocity, altitude), atmospheric vs space rules, strafing attacks, ground attacks from altitude, fighter combat. Dropships and warships explicitly out of scope (each gets its own wave). Grounded in MegaMek's `Aero.java` (99KB) and `AeroSpaceFighter.java`.

## Verification

- `npx openspec validate add-indirect-fire-and-spotter-network --strict` → clean
- `npx openspec validate add-battle-armor-combat --strict` → clean
- `npx openspec validate add-aerospace-deployment --strict` → clean
- Rebased onto `main` post-PR-#653 merge; no conflicts (Author Track's files are entirely under `openspec/changes/add-*/` — zero overlap with the gates).

## Next

After this merges:
- Wave 7 UI Apply (PR-A through PR-J) proceeds on schedule with combat-parity specs sitting on main, ready for Wave 8.
- Wave 8 opens with `add-indirect-fire-and-spotter-network` + `add-battle-armor-combat` Apply candidates; Wave 9 opens with `add-aerospace-deployment` + `update-vtol-hover-mp-modifiers`.
