### PR TITLE
feat(wave-7.1): ITacticalShellState + slot registry (PR-A)

### DIFF
--- a/openspec/changes/add-tactical-command-shell/tasks.md
+++ b/openspec/changes/add-tactical-command-shell/tasks.md
@@ -1,9 +1,9 @@
 ## 1. Shell Contract
 
-- [ ] 1.1 Define `ITacticalShellState`, shell modes, slot ids, and primary-home mapping in gameplay UI types
+- [x] 1.1 Define `ITacticalShellState`, shell modes, slot ids, and primary-home mapping in gameplay UI types
   > **Note (Wave 7.0 gate):** `ITacticalShellState` MUST distinguish three independent unit references — `selectedUnit` (clicked token), `activeUnit` (whose turn it is), and `inspectedUnit` (open in right-tray record sheet). Action dock binds to `activeUnit`; inspector binds to `inspectedUnit`; map highlight binds to `selectedUnit`. No cross-coupling. This avoids the MegaMek PR #5540 → #5573 firing-arc regression where a single `currentEntity` reference silently broke arc redraw on cross-selection.
   > **Note (Wave 7.0 gate):** `ITacticalShellState` MUST carry `viewerPlayerId` and `opponentVisibilityScopes` from day one (see spec.md `Per-Viewer Visibility Scope` requirement). These fields are forward-compat hooks for co-op N≥2 and PvP campaigns — they may be defaulted in single-viewer matches but the type surface lands now to avoid a future breaking change to the shell contract.
-- [ ] 1.2 Add a shell slot registry that maps phase, actions, inspectors, lenses, event feed, minimap, and replay controls to owners
+- [x] 1.2 Add a shell slot registry that maps phase, actions, inspectors, lenses, event feed, minimap, and replay controls to owners
   > **Note (Wave 7.0 gate):** This task creates the slot-registry surface. Lens additions in `add-tactical-map-lenses-feed-replay` that extend `src/components/gameplay/HexMapDisplay/useMapLayerState.ts` MUST wait for this slot registry to land — sequencing constraint to avoid a collision between shell ownership of the lens-control surface and lens-id extensions to the underlying layer state.
 
 ## 2. Layout Composition

--- a/src/components/gameplay/TacticalCommandShell/__tests__/useShellSlotRegistry.test.tsx
+++ b/src/components/gameplay/TacticalCommandShell/__tests__/useShellSlotRegistry.test.tsx
@@ -1,0 +1,231 @@
+/**
+ * Tests for useShellSlotRegistry.
+ *
+ * Covers the "one primary home" invariant from the shell spec's
+ * `Combat facts have one primary home` scenario, plus the
+ * register / unregister / subscribe contract.
+ *
+ * @module components/gameplay/TacticalCommandShell/__tests__/useShellSlotRegistry.test
+ */
+
+import { renderHook, act } from '@testing-library/react';
+
+import type { ISlotOwner } from '@/types/gameplay/TacticalShellInterfaces';
+
+import { useShellSlotRegistry } from '../useShellSlotRegistry';
+
+function makeOwner(ownerId: string, primary: boolean): ISlotOwner {
+  return { ownerId, primary, modes: [] };
+}
+
+describe('useShellSlotRegistry', () => {
+  it('registers a primary owner and returns it from getOwner', () => {
+    const { result } = renderHook(() => useShellSlotRegistry());
+
+    act(() => {
+      result.current.register('top-band', makeOwner('PhaseBanner', true));
+    });
+
+    const owner = result.current.getOwner('top-band');
+    expect(owner).not.toBeNull();
+    expect(owner?.ownerId).toBe('PhaseBanner');
+    expect(owner?.primary).toBe(true);
+  });
+
+  it('returns null from getOwner for an unregistered slot', () => {
+    const { result } = renderHook(() => useShellSlotRegistry());
+
+    expect(result.current.getOwner('feed')).toBeNull();
+  });
+
+  it('lets a primary owner replace any prior owner (primary or not)', () => {
+    const { result } = renderHook(() => useShellSlotRegistry());
+
+    act(() => {
+      result.current.register('right-tray', makeOwner('PrevPrimary', true));
+    });
+
+    act(() => {
+      result.current.register('right-tray', makeOwner('NewPrimary', true));
+    });
+
+    expect(result.current.getOwner('right-tray')?.ownerId).toBe('NewPrimary');
+  });
+
+  it('drops a non-primary registration when a primary already holds the slot', () => {
+    // Defends the spec's "each fact SHALL have exactly one primary slot
+    // owner" invariant — a downstream component that tries to register
+    // itself as secondary CANNOT take ownership.
+    const { result } = renderHook(() => useShellSlotRegistry());
+
+    act(() => {
+      result.current.register(
+        'bottom-dock',
+        makeOwner('TacticalActionDock', true),
+      );
+    });
+
+    act(() => {
+      result.current.register('bottom-dock', makeOwner('SecondaryPeek', false));
+    });
+
+    expect(result.current.getOwner('bottom-dock')?.ownerId).toBe(
+      'TacticalActionDock',
+    );
+  });
+
+  it('allows a non-primary owner to take an empty slot', () => {
+    // A peek surface CAN claim a slot if nothing primary is there yet —
+    // the primary registration that arrives later will replace it.
+    const { result } = renderHook(() => useShellSlotRegistry());
+
+    act(() => {
+      result.current.register('left-tray', makeOwner('PeekOnly', false));
+    });
+
+    expect(result.current.getOwner('left-tray')?.ownerId).toBe('PeekOnly');
+    expect(result.current.getOwner('left-tray')?.primary).toBe(false);
+
+    act(() => {
+      result.current.register('left-tray', makeOwner('LensTray', true));
+    });
+
+    expect(result.current.getOwner('left-tray')?.ownerId).toBe('LensTray');
+    expect(result.current.getOwner('left-tray')?.primary).toBe(true);
+  });
+
+  it('unregister only removes the matching ownerId', () => {
+    // Defends against stale unmount-order cleanup: a component that
+    // unmounts AFTER being replaced by a primary must not yank the
+    // primary's registration on its way out.
+    const { result } = renderHook(() => useShellSlotRegistry());
+
+    act(() => {
+      result.current.register('feed', makeOwner('EventLog', true));
+    });
+
+    // Stale cleanup attempt by an unrelated owner — must be a no-op.
+    act(() => {
+      result.current.unregister('feed', 'SomethingElse');
+    });
+    expect(result.current.getOwner('feed')?.ownerId).toBe('EventLog');
+
+    // Real cleanup — clears the slot.
+    act(() => {
+      result.current.unregister('feed', 'EventLog');
+    });
+    expect(result.current.getOwner('feed')).toBeNull();
+  });
+
+  it('listSlots returns only slots with current owners', () => {
+    const { result } = renderHook(() => useShellSlotRegistry());
+
+    expect(result.current.listSlots()).toEqual([]);
+
+    act(() => {
+      result.current.register('map-center', makeOwner('HexMapDisplay', true));
+      result.current.register('top-band', makeOwner('PhaseBanner', true));
+    });
+
+    const slots = result.current.listSlots();
+    expect(slots).toContain('map-center');
+    expect(slots).toContain('top-band');
+    expect(slots).toHaveLength(2);
+  });
+
+  it('notifies subscribers on register and unregister', () => {
+    const { result } = renderHook(() => useShellSlotRegistry());
+    const listener = jest.fn();
+
+    let unsubscribe = () => {};
+    act(() => {
+      unsubscribe = result.current.subscribe(listener);
+    });
+
+    act(() => {
+      result.current.register(
+        'minimap-cluster',
+        makeOwner('MapOverlayChildren', true),
+      );
+    });
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.unregister('minimap-cluster', 'MapOverlayChildren');
+    });
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      unsubscribe();
+    });
+
+    act(() => {
+      result.current.register('feed', makeOwner('Anything', true));
+    });
+    // listener was unsubscribed before the third register; count stays at 2.
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it('drops a non-primary registration silently without notifying', () => {
+    // No state change means no subscriber notification — important so
+    // shell re-renders are driven only by real ownership changes.
+    const { result } = renderHook(() => useShellSlotRegistry());
+    const listener = jest.fn();
+
+    act(() => {
+      result.current.register('top-band', makeOwner('PhaseBanner', true));
+      result.current.subscribe(listener);
+    });
+
+    act(() => {
+      result.current.register('top-band', makeOwner('PeekAttempt', false));
+    });
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(result.current.getOwner('top-band')?.ownerId).toBe('PhaseBanner');
+  });
+
+  it('keeps the registry handle identity-stable across re-renders', () => {
+    // Important: a fresh handle on every render would mean every
+    // subscribe/unsubscribe cycle in a slot owner would tear down and
+    // rebuild every render, defeating the registry's whole purpose.
+    const { result, rerender } = renderHook(() => useShellSlotRegistry());
+
+    const handleFirst = result.current;
+    rerender();
+    rerender();
+
+    expect(result.current).toBe(handleFirst);
+  });
+
+  it('survives a listener that unsubscribes during dispatch', () => {
+    // The dispatcher snapshots the listener set before iterating so a
+    // listener removing itself can't desync the loop.
+    const { result } = renderHook(() => useShellSlotRegistry());
+    const survivor = jest.fn();
+    const selfRemover = jest.fn();
+
+    let removeSelf = () => {};
+    act(() => {
+      removeSelf = result.current.subscribe(() => {
+        selfRemover();
+        removeSelf();
+      });
+      result.current.subscribe(survivor);
+    });
+
+    act(() => {
+      result.current.register('top-band', makeOwner('PhaseBanner', true));
+    });
+
+    expect(selfRemover).toHaveBeenCalledTimes(1);
+    expect(survivor).toHaveBeenCalledTimes(1);
+
+    // Second dispatch: the self-remover is gone; only the survivor fires.
+    act(() => {
+      result.current.unregister('top-band', 'PhaseBanner');
+    });
+    expect(selfRemover).toHaveBeenCalledTimes(1);
+    expect(survivor).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/components/gameplay/TacticalCommandShell/index.ts
+++ b/src/components/gameplay/TacticalCommandShell/index.ts
@@ -1,0 +1,31 @@
+/**
+ * Tactical Command Shell barrel — public exports for Wave 7 consumers.
+ *
+ * PR-A (this commit): types + slot registry hook only. The shell
+ * component itself (which wraps GameplayLayout) ships in PR-B.
+ *
+ * @see openspec/changes/add-tactical-command-shell/
+ */
+
+export {
+  useShellSlotRegistry,
+  type IShellSlotRegistry,
+} from './useShellSlotRegistry';
+
+export type {
+  ITacticalShellState,
+  IShellActiveContext,
+  ISlotOwner,
+  ShellMode,
+  SlotId,
+  OpponentIntelTier,
+  UnitId,
+  PlayerId,
+} from '@/types/gameplay/TacticalShellInterfaces';
+
+export {
+  createDefaultShellState,
+  ALL_SLOT_IDS,
+  ALL_SHELL_MODES,
+  ALL_OPPONENT_INTEL_TIERS,
+} from '@/types/gameplay/TacticalShellInterfaces';

--- a/src/components/gameplay/TacticalCommandShell/useShellSlotRegistry.ts
+++ b/src/components/gameplay/TacticalCommandShell/useShellSlotRegistry.ts
@@ -1,0 +1,132 @@
+/**
+ * Shell slot registry hook for the Tactical Command Shell.
+ *
+ * Provides a stable registry handle that downstream Wave 7 surfaces use to
+ * declare ownership of named layout slots. The registry is the *only*
+ * mediator between shell-managed slot allocation and the components that
+ * fill those slots — no component reaches "across" the shell to claim
+ * coordinates directly (per PR #639's directive that engine state, not
+ * screen coordinates, owns the contract).
+ *
+ * Per the shell spec's "one primary home" rule
+ * (openspec/changes/add-tactical-command-shell/specs/tactical-map-interface/spec.md
+ * `Combat facts have one primary home`), each slot SHALL have at most one
+ * owner with `primary: true`. The registry enforces this by allowing a
+ * primary registration to replace any prior owner; non-primary
+ * registrations are dropped if a primary already holds the slot
+ * (downstream secondary-peek tracking is out of scope for PR-A and ships
+ * in a later wave).
+ *
+ * The hook is intentionally minimal in PR-A:
+ *   - PR-A (this file): types + register/unregister/getOwner/listSlots/subscribe
+ *   - PR-B: wraps GameplayLayout with the shell; calls register at slot mount
+ *   - PR-C: wires shellMode flag into the registry to filter per-mode owners
+ *
+ * @spec openspec/changes/add-tactical-command-shell/tasks.md §1.2
+ */
+
+import { useMemo, useRef } from 'react';
+
+import type {
+  ISlotOwner,
+  SlotId,
+} from '@/types/gameplay/TacticalShellInterfaces';
+
+/**
+ * Public surface of the shell slot registry. Stable across re-renders —
+ * the returned object is memoized once per hook lifetime and never
+ * replaced.
+ */
+export interface IShellSlotRegistry {
+  /**
+   * Register an owner for a slot. Primary registrations replace any prior
+   * owner; non-primary registrations are dropped if a primary already
+   * holds the slot.
+   */
+  register(slot: SlotId, owner: ISlotOwner): void;
+  /**
+   * Remove an owner from a slot, but only if its `ownerId` matches the
+   * current registration. No-op otherwise (defends against stale
+   * unmount-order cleanup after a primary replaced a secondary).
+   */
+  unregister(slot: SlotId, ownerId: string): void;
+  /** Read the current owner for a slot, or null if unregistered. */
+  getOwner(slot: SlotId): ISlotOwner | null;
+  /** List slots that currently have an owner. */
+  listSlots(): readonly SlotId[];
+  /**
+   * Subscribe to registry changes. Returns an unsubscribe function. Used
+   * by the shell renderer to re-evaluate slot assignments without React
+   * re-render churn from per-owner state.
+   */
+  subscribe(listener: () => void): () => void;
+}
+
+/**
+ * Create a shell slot registry handle. The hook returns the same registry
+ * object across every render of the host component; the underlying
+ * storage is a ref-backed Map and a ref-backed listener Set so identity
+ * stays stable.
+ */
+export function useShellSlotRegistry(): IShellSlotRegistry {
+  const ownersRef = useRef<Map<SlotId, ISlotOwner>>(new Map());
+  const listenersRef = useRef<Set<() => void>>(new Set());
+
+  // Memoize the public registry object exactly once. All mutations and
+  // reads go through closures over the refs above, so the closure can
+  // observe ref state changes without re-running this useMemo.
+  return useMemo<IShellSlotRegistry>(() => {
+    function notify(): void {
+      // Snapshot the listener set before iteration so a listener that
+      // unsubscribes during dispatch can't desync the loop.
+      const snapshot = Array.from(listenersRef.current);
+      for (const listener of snapshot) {
+        listener();
+      }
+    }
+
+    return {
+      register(slot, owner) {
+        const current = ownersRef.current.get(slot);
+        // Per "one primary home": primary always wins. Non-primary loses
+        // to an existing primary, but takes an empty slot.
+        if (owner.primary) {
+          ownersRef.current.set(slot, owner);
+          notify();
+          return;
+        }
+        if (!current) {
+          ownersRef.current.set(slot, owner);
+          notify();
+        }
+        // else: drop the non-primary attempt; primary holds the slot.
+      },
+
+      unregister(slot, ownerId) {
+        const current = ownersRef.current.get(slot);
+        if (current && current.ownerId === ownerId) {
+          ownersRef.current.delete(slot);
+          notify();
+        }
+      },
+
+      getOwner(slot) {
+        return ownersRef.current.get(slot) ?? null;
+      },
+
+      listSlots() {
+        return Array.from(ownersRef.current.keys());
+      },
+
+      subscribe(listener) {
+        listenersRef.current.add(listener);
+        return () => {
+          listenersRef.current.delete(listener);
+        };
+      },
+    };
+    // Empty deps: the registry is intentionally stable for the lifetime
+    // of the host component. All state lives in refs above.
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}

--- a/src/types/gameplay/TacticalShellInterfaces.ts
+++ b/src/types/gameplay/TacticalShellInterfaces.ts
@@ -1,0 +1,204 @@
+/**
+ * Tactical Command Shell type contract.
+ *
+ * Authored in Wave 7.1 PR-A as the typed substrate for the border-layout
+ * tactical UI shell defined in
+ * `openspec/changes/add-tactical-command-shell/`. The shell wraps the
+ * existing combat surface (`GameplayLayout`) and exposes a stable slot
+ * contract that downstream Wave 7 changes (action menu, turn rail,
+ * inspectors, lenses, intel UI, accessibility) plug into.
+ *
+ * No component or rendering logic lives in this file — types only. The
+ * slot-registry hook lives at
+ * `src/components/gameplay/TacticalCommandShell/useShellSlotRegistry.ts`
+ * and PR-B wraps `GameplayLayout` with the shell itself.
+ *
+ * @spec openspec/changes/add-tactical-command-shell/specs/tactical-map-interface/spec.md
+ * @see openspec/changes/add-tactical-command-shell/tasks.md §1.1
+ */
+
+/**
+ * Shell rendering mode — drives slot owner selection.
+ *
+ * Per the shell spec `Shell Mode Ownership` requirement, all four modes
+ * SHALL render through the same slot contract; the mode flag drives which
+ * owners populate which slots.
+ */
+export type ShellMode = 'combat' | 'replay' | 'spectator' | 'gm';
+
+/**
+ * Named layout slots in the tactical command shell.
+ *
+ * Per the shell spec `Tactical Command Shell Slots` requirement, the shell
+ * provides these stable border regions plus the center map. Adding a new
+ * slot is a spec change, NOT a downstream-spec extension: per the spec's
+ * "one primary home" invariant, slot allocation is owned exclusively by
+ * the shell so downstream specs cannot fragment the registry.
+ */
+export type SlotId =
+  | 'top-band' // PhaseBanner: phase, round, initiative, match status
+  | 'morale-band' // MoraleIndicator: per-side morale readouts
+  | 'left-tray' // map lenses, objectives, navigation controls
+  | 'map-center' // HexMapDisplay: the canonical battlefield
+  | 'right-tray' // selected-unit + target inspectors, record sheet drawers
+  | 'bottom-dock' // active-unit actions, end/confirm controls
+  | 'feed' // EventLogDisplay: combat feed
+  | 'minimap-cluster' // minimap + hotkey help overlay
+  | 'mobile-drawer'; // mobile-only overlay surface for right-tray content
+
+/**
+ * Per-opponent visibility tier — drives intel projection in target
+ * inspectors, tokens, event feed, and replay.
+ *
+ * Per the opponent-intel spec, redaction SHALL occur in the data adapter
+ * feeding the shell, NEVER in CSS visibility. Hidden exact state SHALL
+ * not be recoverable from labels, tooltips, DOM text, ARIA text, or test
+ * ids.
+ */
+export type OpponentIntelTier =
+  | 'exact' // open information — all visible enemy state shown
+  | 'rough' // band-quantized values (e.g. "lightly damaged")
+  | 'last-known' // stale snapshot of prior visibility
+  | 'hidden' // token absent or silhouette-only
+  | 'unknown'; // never observed
+
+/**
+ * Slot owner declaration registered into the shell slot registry.
+ *
+ * Per the shell spec's "one primary home" rule, each slot SHALL have at
+ * most one owner with `primary: true`. Non-primary registrations are
+ * permitted as secondary peek surfaces (e.g. a minimap can be primary in
+ * `minimap-cluster` but also peek into `left-tray` as secondary).
+ */
+export interface ISlotOwner {
+  /** Stable identifier of the registering component (e.g. "PhaseBanner"). */
+  readonly ownerId: string;
+  /** True if this owner is the primary home for the slot's fact. */
+  readonly primary: boolean;
+  /** Which shell modes render this owner. Empty array = all modes. */
+  readonly modes: readonly ShellMode[];
+}
+
+/** ID of a unit token referenced by the shell. */
+export type UnitId = string;
+
+/** ID of a player participating in the match. */
+export type PlayerId = string;
+
+/**
+ * Active selection / inspection context held by the shell.
+ *
+ * Separated from `ITacticalShellState` so it can be updated at higher
+ * frequency (every hover, every selection) without forcing a re-render of
+ * the slot-allocation state.
+ */
+export interface IShellActiveContext {
+  /** Hex currently under the cursor (axial hex id), if any. */
+  readonly hoveredHexId: string | null;
+  /** Drawer pinned open in the right tray, if any. */
+  readonly pinnedDrawerId: string | null;
+}
+
+/**
+ * Typed state contract for the tactical command shell.
+ *
+ * MUST distinguish three independent unit references (Wave 7.0 gate 4 —
+ * closes the MegaMek PR #5540 / #5573 firing-arc regression precedent
+ * where a single `currentEntity` reference silently broke arc redraw on
+ * cross-selection):
+ *
+ *   - `selectedUnit`   the token the player clicked (drives map highlight)
+ *   - `activeUnit`     whose turn it currently is (drives action dock)
+ *   - `inspectedUnit`  open in the right-tray record sheet (drives inspector)
+ *
+ * MUST carry per-viewer scope from day one (Wave 7.0 gate 1 — forward-compat
+ * with co-op N≥2 and PvP campaigns; adding these fields later would be a
+ * breaking change to every shell consumer):
+ *
+ *   - `viewerPlayerId`             local viewer's player id
+ *   - `opponentVisibilityScopes`   per-opponent intel tier; redaction
+ *                                  happens in the data adapter, NEVER in
+ *                                  CSS visibility (see `OpponentIntelTier`)
+ */
+export interface ITacticalShellState {
+  /** Current shell rendering mode. */
+  readonly shellMode: ShellMode;
+  /** Active selection / inspection focus. */
+  readonly activeContext: IShellActiveContext;
+  /** Left tray collapsed (lenses / objectives / nav). */
+  readonly leftTrayCollapsed: boolean;
+  /** Right tray pinned open vs auto-collapse on deselect. */
+  readonly rightTrayPinned: boolean;
+  /** Active bottom-dock tab id, or null for the phase default. */
+  readonly bottomDockActiveTab: string | null;
+
+  // Unit reference triple — MUST stay decoupled. See file JSDoc above.
+  readonly selectedUnit: UnitId | null;
+  readonly activeUnit: UnitId | null;
+  readonly inspectedUnit: UnitId | null;
+
+  // Per-viewer scope — MUST carry from day one. See file JSDoc above.
+  readonly viewerPlayerId: PlayerId;
+  readonly opponentVisibilityScopes: Readonly<
+    Record<PlayerId, OpponentIntelTier>
+  >;
+}
+
+/**
+ * Default-shaped shell state for a fresh single-viewer combat session.
+ *
+ * Multi-viewer matches (co-op N≥2, PvP) populate
+ * `opponentVisibilityScopes` from the match's opponent-intel policy at
+ * session start; single-viewer scenarios start with an empty map (no
+ * opponents tracked → no per-opponent redaction needed).
+ */
+export function createDefaultShellState(
+  viewerPlayerId: PlayerId,
+): ITacticalShellState {
+  return {
+    shellMode: 'combat',
+    activeContext: { hoveredHexId: null, pinnedDrawerId: null },
+    leftTrayCollapsed: false,
+    rightTrayPinned: false,
+    bottomDockActiveTab: null,
+    selectedUnit: null,
+    activeUnit: null,
+    inspectedUnit: null,
+    viewerPlayerId,
+    opponentVisibilityScopes: {},
+  };
+}
+
+/**
+ * Exhaustive list of all shell slot ids in declaration order. Used by
+ * tests to assert that no slot was forgotten when iterating, and by
+ * downstream specs to enumerate registry coverage.
+ */
+export const ALL_SLOT_IDS: readonly SlotId[] = [
+  'top-band',
+  'morale-band',
+  'left-tray',
+  'map-center',
+  'right-tray',
+  'bottom-dock',
+  'feed',
+  'minimap-cluster',
+  'mobile-drawer',
+];
+
+/** Exhaustive list of all shell modes. */
+export const ALL_SHELL_MODES: readonly ShellMode[] = [
+  'combat',
+  'replay',
+  'spectator',
+  'gm',
+];
+
+/** Exhaustive list of all opponent intel tiers. */
+export const ALL_OPPONENT_INTEL_TIERS: readonly OpponentIntelTier[] = [
+  'exact',
+  'rough',
+  'last-known',
+  'hidden',
+  'unknown',
+];

--- a/src/types/gameplay/__tests__/TacticalShellInterfaces.test.ts
+++ b/src/types/gameplay/__tests__/TacticalShellInterfaces.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for the Tactical Command Shell type contract.
+ *
+ * These tests pin the shape of the public surface so that downstream
+ * Wave 7 changes (action menu, turn rail, inspectors, lenses, intel UI,
+ * accessibility) can rely on the listed slots, modes, and intel tiers
+ * being present and exhaustive.
+ *
+ * @module types/gameplay/__tests__/TacticalShellInterfaces.test
+ */
+
+import {
+  ALL_OPPONENT_INTEL_TIERS,
+  ALL_SHELL_MODES,
+  ALL_SLOT_IDS,
+  createDefaultShellState,
+  type OpponentIntelTier,
+  type ShellMode,
+  type SlotId,
+} from '../TacticalShellInterfaces';
+
+describe('TacticalShellInterfaces', () => {
+  describe('ALL_SLOT_IDS', () => {
+    it('contains the 9 shell slots from the spec', () => {
+      // The shell spec enumerates these slots — adding a new slot is a
+      // spec change first, code change second. This test fails loudly if
+      // the enumeration drifts.
+      expect(ALL_SLOT_IDS).toEqual([
+        'top-band',
+        'morale-band',
+        'left-tray',
+        'map-center',
+        'right-tray',
+        'bottom-dock',
+        'feed',
+        'minimap-cluster',
+        'mobile-drawer',
+      ]);
+    });
+
+    it('contains no duplicates', () => {
+      const unique = new Set<SlotId>(ALL_SLOT_IDS);
+      expect(unique.size).toBe(ALL_SLOT_IDS.length);
+    });
+  });
+
+  describe('ALL_SHELL_MODES', () => {
+    it('contains exactly the 4 modes from the spec', () => {
+      // Per `Shell Mode Ownership` — combat / replay / spectator / GM.
+      // Same shell chrome, mode-switched slot owners.
+      expect(ALL_SHELL_MODES).toEqual(['combat', 'replay', 'spectator', 'gm']);
+    });
+
+    it('contains no duplicates', () => {
+      const unique = new Set<ShellMode>(ALL_SHELL_MODES);
+      expect(unique.size).toBe(ALL_SHELL_MODES.length);
+    });
+  });
+
+  describe('ALL_OPPONENT_INTEL_TIERS', () => {
+    it('contains the 5 tiers from the opponent-intel spec', () => {
+      expect(ALL_OPPONENT_INTEL_TIERS).toEqual([
+        'exact',
+        'rough',
+        'last-known',
+        'hidden',
+        'unknown',
+      ]);
+    });
+
+    it('contains no duplicates', () => {
+      const unique = new Set<OpponentIntelTier>(ALL_OPPONENT_INTEL_TIERS);
+      expect(unique.size).toBe(ALL_OPPONENT_INTEL_TIERS.length);
+    });
+  });
+
+  describe('createDefaultShellState', () => {
+    it('produces a valid combat-mode shell state for a single viewer', () => {
+      const state = createDefaultShellState('player-1');
+
+      expect(state.shellMode).toBe('combat');
+      expect(state.viewerPlayerId).toBe('player-1');
+      expect(state.selectedUnit).toBeNull();
+      expect(state.activeUnit).toBeNull();
+      expect(state.inspectedUnit).toBeNull();
+      expect(state.leftTrayCollapsed).toBe(false);
+      expect(state.rightTrayPinned).toBe(false);
+      expect(state.bottomDockActiveTab).toBeNull();
+      expect(state.activeContext.hoveredHexId).toBeNull();
+      expect(state.activeContext.pinnedDrawerId).toBeNull();
+      expect(state.opponentVisibilityScopes).toEqual({});
+    });
+
+    it('keeps the three unit references independent (not aliases)', () => {
+      // Gate 4: selectedUnit / activeUnit / inspectedUnit MUST be three
+      // independent fields. Setting one MUST NOT implicitly set another.
+      // (This test exercises the shape; mutators that maintain the
+      // invariant ship with PR-B when the shell wraps GameplayLayout.)
+      const state = createDefaultShellState('player-1');
+      const mutated = {
+        ...state,
+        selectedUnit: 'unit-a',
+      };
+
+      expect(mutated.selectedUnit).toBe('unit-a');
+      expect(mutated.activeUnit).toBeNull();
+      expect(mutated.inspectedUnit).toBeNull();
+    });
+
+    it('starts with an empty per-opponent scope map', () => {
+      // Gate 1: viewerPlayerId + opponentVisibilityScopes ship from day
+      // one but are empty for a single-viewer match (no opponents tracked
+      // means no per-opponent redaction needed). Multi-viewer matches
+      // populate the map at session start.
+      const state = createDefaultShellState('player-1');
+      expect(Object.keys(state.opponentVisibilityScopes)).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Why

Wave 7.1 PR-A — the typed substrate for the Tactical Command Shell. First implementation PR after the Phase 7.0 pre-apply gates (PR #653) landed.

Types + slot registry hook only. No existing component changes. PR-B wraps `GameplayLayout` with the shell; PR-C wires mode integration.

## What

### New files

**`src/types/gameplay/TacticalShellInterfaces.ts`** (204 LOC)

The shell type contract. Built directly against the spec at `openspec/changes/add-tactical-command-shell/specs/tactical-map-interface/spec.md` (including the Gate 1 amendment that PR #653 merged).

- `ShellMode` — `'combat' | 'replay' | 'spectator' | 'gm'`
- `SlotId` — the 9 named shell slots (top-band, morale-band, left-tray, map-center, right-tray, bottom-dock, feed, minimap-cluster, mobile-drawer)
- `OpponentIntelTier` — `'exact' | 'rough' | 'last-known' | 'hidden' | 'unknown'`
- `ISlotOwner` — `{ ownerId, primary, modes }` declaration for slot registration
- `ITacticalShellState` — the full state contract with **three decoupled unit references** (`selectedUnit` / `activeUnit` / `inspectedUnit`) per Wave 7.0 Gate 4 + **`viewerPlayerId` + `opponentVisibilityScopes`** carried from day 1 per Wave 7.0 Gate 1
- `createDefaultShellState(viewerPlayerId)` — default-shape factory
- `ALL_SLOT_IDS` / `ALL_SHELL_MODES` / `ALL_OPPONENT_INTEL_TIERS` — exhaustive arrays used by tests + downstream specs

**`src/components/gameplay/TacticalCommandShell/useShellSlotRegistry.ts`** (132 LOC)

Ref-backed identity-stable slot registry hook that enforces the **"one primary home"** rule from the shell spec.

- Primary registrations replace any prior owner
- Non-primary registrations are dropped if a primary already holds the slot (secondary-peek tracking is out of scope for PR-A)
- `unregister` only fires if `ownerId` matches the current registration (defends against stale unmount-order cleanup after a primary replaces a secondary)
- Subscriber dispatch snapshots the listener set before iteration so a listener that unsubscribes during dispatch can't desync the loop

**`src/components/gameplay/TacticalCommandShell/index.ts`** — barrel exports.

### Tests (20/20 pass)

- `src/types/gameplay/__tests__/TacticalShellInterfaces.test.ts` (8 tests) — exhaustive-list invariants + `createDefaultShellState` shape; pins each enum so a future drift fails CI.
- `src/components/gameplay/TacticalCommandShell/__tests__/useShellSlotRegistry.test.tsx` (12 tests) — registry semantics, "one primary home" enforcement, stale-cleanup defense, subscriber dispatch correctness, identity stability across re-renders, listener-self-unsubscribe-during-dispatch safety.

### Tasks closed

`openspec/changes/add-tactical-command-shell/tasks.md`:
- [x] 1.1 Define `ITacticalShellState`, shell modes, slot ids, and primary-home mapping
- [x] 1.2 Add a shell slot registry that maps phase, actions, inspectors, lenses, event feed, minimap, and replay controls to owners

## Verification

- `npx tsc --noEmit` → clean
- `npx oxlint` → 0 warnings, 0 errors on touched files
- `npx oxfmt --check` → clean
- `npx jest --runTestsByPath` → 20/20 passed in 1s
- Pre-commit hook (openspec/docs-only path) — skipped full build correctly; staged TypeScript triggers full build on the upstream side per husky config

## Next

- **PR-B** `feat(wave-7.1): wrap GameplayLayout with TacticalCommandShell` — progressive inside-out migration. Gated by `e2e/gameplay-layout-slots.spec.ts` (Gate 3 from PR #653) which catches the parallel-hierarchy failure mode if PR-B accidentally wraps instead of replacing.
- **PR-C** `feat(wave-7.1): wire shell to combat/replay/spectator/GM modes` — same-chrome additive modes per design Decision 3.
