### PR TITLE
feat(wave-7.1): wrap GameplayLayout with TacticalCommandShell (PR-B)

### DIFF
--- a/openspec/changes/add-tactical-command-shell/tasks.md
+++ b/openspec/changes/add-tactical-command-shell/tasks.md
@@ -8,8 +8,8 @@
 
 ## 2. Layout Composition
 
-- [ ] 2.1 Create a tactical command shell component around the existing map without wrapping the map in a card
-- [ ] 2.2 Move phase banner, action panel, minimap, inspector, and event feed into named slots
+- [x] 2.1 Create a tactical command shell component around the existing map without wrapping the map in a card
+- [x] 2.2 Move phase banner, action panel, minimap, inspector, and event feed into named slots
 - [ ] 2.3 Add pinned/collapsed tray behavior with persistence scoped to the current match
 
 ## 3. Mode Integration

--- a/src/components/gameplay/GameplayLayout.tsx
+++ b/src/components/gameplay/GameplayLayout.tsx
@@ -50,6 +50,7 @@ import {
 import { HexMapDisplay } from './HexMapDisplay';
 import { MoraleIndicator } from './MoraleIndicator';
 import { PhaseBanner } from './PhaseBanner';
+import { ShellSlot, TacticalCommandShell } from './TacticalCommandShell';
 
 export type { GameplayLayoutProps } from './GameplayLayout.types';
 
@@ -363,160 +364,188 @@ export function GameplayLayout({
   );
 
   return (
-    <div
-      className={`flex h-full flex-col bg-gray-100 ${className}`}
-      data-testid="gameplay-layout"
-    >
-      {/* Phase Banner — hosts the drawer toggle in the persistent HUD
-          only below the `lg:` breakpoint (§ 1.3). Above that the
-          record sheet is always visible and the toggle is
-          unnecessary. */}
-      <PhaseBanner
-        phase={currentState.phase}
-        turn={currentState.turn}
-        activeSide={currentState.firstMover || GameSide.Player}
-        isPlayerTurn={isPlayerTurn}
-        drawer={
-          isNarrow
-            ? {
-                isDrawerOpen: drawerOpen,
-                onToggleDrawer: handleToggleDrawer,
-              }
-            : undefined
-        }
-      />
-
-      {/* Per `add-combat-morale-and-withdrawal` § 4.3: per-side
-          in-battle morale readout. `battleMorale` is event-sourced on
-          the derived state; defaults to all-`STEADY` for legacy
-          sessions whose log predates the morale system. */}
-      {currentState.battleMorale && (
-        <MoraleIndicator
-          battleMorale={currentState.battleMorale}
-          className="mx-2 mt-1"
-        />
-      )}
-
-      {/* Main Content Area */}
+    // Wave 7.1 PR-B: TacticalCommandShell is a logical context provider —
+    // it has zero visible chrome. The existing flex tree below is
+    // unchanged; ShellSlot wrappers are React Fragments that register
+    // slot ownership in `useEffect` without adding DOM. This preserves
+    // every data-testid the Wave 7.0 e2e gate test
+    // (`e2e/gameplay-layout-slots.spec.ts`) asserts, so the gate stays
+    // green through the migration and catches any parallel-hierarchy
+    // regression (Council Momus Attack #4).
+    <TacticalCommandShell viewerPlayerId={localFogPlayerId}>
       <div
-        ref={containerRef}
-        className="flex flex-1 overflow-hidden"
-        data-testid="gameplay-main-content"
+        className={`flex h-full flex-col bg-gray-100 ${className}`}
+        data-testid="gameplay-layout"
       >
-        {/* Map Panel — on narrow layouts we give the map the full
-            width because the record sheet lives in an overlay
-            drawer. On desktop the width is driven by the resizable
-            split-view config. */}
-        <div
-          className="relative"
-          style={{ width: isNarrow ? '100%' : `${layout.mapPanelWidth}%` }}
-          data-testid="map-panel"
-        >
-          <HexMapDisplay
-            radius={config.mapRadius}
-            tokens={tokens}
-            mapId={session.id}
-            events={visibleEvents}
-            selectedHex={selectedUnit?.position || null}
-            hexTerrain={hexTerrain}
-            movementRange={movementRange}
-            unitWeapons={unitWeapons}
-            friendlySide={playerSide}
-            highlightPath={highlightPath}
-            hoverMpCost={hoverMpCost}
-            hoverUnreachable={hoverUnreachable}
-            mpLegend={mpLegend}
-            onHexClick={handleHexClick}
-            onHexHover={onHexHover}
-            onTokenClick={handleTokenClick}
-            onTokenDoubleClick={handleTokenDoubleClick}
-            onInteractionReady={setMapInteraction}
-            overlayChildren={
-              <MapOverlayChildren
-                mapRadius={config.mapRadius}
-                tokens={tokens}
-                camera={{ zoom: camera.zoom, pan: camera.pan }}
-                onCenterAt={handleMinimapCenterAt}
-                onDragPan={handleMinimapDragPan}
-                minimapVisible={minimapVisible}
-                helpOpen={helpOpen}
-                onCloseHelp={handleCloseHelp}
-              />
+        {/* Phase Banner — hosts the drawer toggle in the persistent HUD
+            only below the `lg:` breakpoint (§ 1.3). Above that the
+            record sheet is always visible and the toggle is
+            unnecessary. */}
+        <ShellSlot id="top-band" ownerId="PhaseBanner">
+          <PhaseBanner
+            phase={currentState.phase}
+            turn={currentState.turn}
+            activeSide={currentState.firstMover || GameSide.Player}
+            isPlayerTurn={isPlayerTurn}
+            drawer={
+              isNarrow
+                ? {
+                    isDrawerOpen: drawerOpen,
+                    onToggleDrawer: handleToggleDrawer,
+                  }
+                : undefined
             }
-            className="h-full"
           />
-          {interactivePhase && <HitChancePanel hitChance={hitChance} />}
+        </ShellSlot>
+
+        {/* Per `add-combat-morale-and-withdrawal` § 4.3: per-side
+            in-battle morale readout. `battleMorale` is event-sourced on
+            the derived state; defaults to all-`STEADY` for legacy
+            sessions whose log predates the morale system. */}
+        {currentState.battleMorale && (
+          <ShellSlot id="morale-band" ownerId="MoraleIndicator">
+            <MoraleIndicator
+              battleMorale={currentState.battleMorale}
+              className="mx-2 mt-1"
+            />
+          </ShellSlot>
+        )}
+
+        {/* Main Content Area */}
+        <div
+          ref={containerRef}
+          className="flex flex-1 overflow-hidden"
+          data-testid="gameplay-main-content"
+        >
+          {/* Map Panel — on narrow layouts we give the map the full
+              width because the record sheet lives in an overlay
+              drawer. On desktop the width is driven by the resizable
+              split-view config. */}
+          <ShellSlot id="map-center" ownerId="HexMapDisplay">
+            <div
+              className="relative"
+              style={{ width: isNarrow ? '100%' : `${layout.mapPanelWidth}%` }}
+              data-testid="map-panel"
+            >
+              <HexMapDisplay
+                radius={config.mapRadius}
+                tokens={tokens}
+                mapId={session.id}
+                events={visibleEvents}
+                selectedHex={selectedUnit?.position || null}
+                hexTerrain={hexTerrain}
+                movementRange={movementRange}
+                unitWeapons={unitWeapons}
+                friendlySide={playerSide}
+                highlightPath={highlightPath}
+                hoverMpCost={hoverMpCost}
+                hoverUnreachable={hoverUnreachable}
+                mpLegend={mpLegend}
+                onHexClick={handleHexClick}
+                onHexHover={onHexHover}
+                onTokenClick={handleTokenClick}
+                onTokenDoubleClick={handleTokenDoubleClick}
+                onInteractionReady={setMapInteraction}
+                // TODO PR-C: MapOverlayChildren contains the minimap-cluster
+                // slot owner; register it via its own ShellSlot once the
+                // overlay-children prop contract is reworked to allow
+                // sibling slot registration alongside the SVG portal.
+                overlayChildren={
+                  <MapOverlayChildren
+                    mapRadius={config.mapRadius}
+                    tokens={tokens}
+                    camera={{ zoom: camera.zoom, pan: camera.pan }}
+                    onCenterAt={handleMinimapCenterAt}
+                    onDragPan={handleMinimapDragPan}
+                    minimapVisible={minimapVisible}
+                    helpOpen={helpOpen}
+                    onCloseHelp={handleCloseHelp}
+                  />
+                }
+                className="h-full"
+              />
+              {interactivePhase && <HitChancePanel hitChance={hitChance} />}
+            </div>
+          </ShellSlot>
+
+          {/* Desktop split-view: resize handle + record sheet panel.
+              Hidden below `lg:` (isNarrow) where the drawer takes
+              over. */}
+          {!isNarrow && (
+            <>
+              <div
+                className="w-1 cursor-col-resize bg-gray-300 transition-colors hover:bg-blue-400"
+                onMouseDown={() => setIsDragging(true)}
+                data-testid="resize-handle"
+              />
+              <ShellSlot id="right-tray" ownerId="RecordSheetPanel">
+                <div
+                  className="flex-1 overflow-hidden"
+                  style={{ width: `${100 - layout.mapPanelWidth}%` }}
+                  data-testid="record-sheet-panel"
+                >
+                  {recordSheetBody}
+                </div>
+              </ShellSlot>
+            </>
+          )}
         </div>
 
-        {/* Desktop split-view: resize handle + record sheet panel.
-            Hidden below `lg:` (isNarrow) where the drawer takes
-            over. */}
-        {!isNarrow && (
-          <>
-            <div
-              className="w-1 cursor-col-resize bg-gray-300 transition-colors hover:bg-blue-400"
-              onMouseDown={() => setIsDragging(true)}
-              data-testid="resize-handle"
-            />
-            <div
-              className="flex-1 overflow-hidden"
-              style={{ width: `${100 - layout.mapPanelWidth}%` }}
-              data-testid="record-sheet-panel"
-            >
+        {/* Mobile drawer overlay — only mounted below `lg:` when open.
+            The backdrop captures outside-clicks to close the drawer,
+            matching native mobile-app conventions. `id` wires up to
+            PhaseBanner's `aria-controls` for screen readers. */}
+        {isNarrow && (
+          <ShellSlot id="mobile-drawer" ownerId="RecordSheetDrawer">
+            <RecordSheetDrawer open={drawerOpen} onToggle={handleToggleDrawer}>
               {recordSheetBody}
-            </div>
-          </>
+            </RecordSheetDrawer>
+          </ShellSlot>
         )}
+
+        {/* Action Bar */}
+        <ShellSlot id="bottom-dock" ownerId="ActionBar">
+          <ActionBar
+            phase={currentState.phase}
+            canUndo={canUndo}
+            canAct={isPlayerTurn}
+            onAction={onAction}
+            infoText={
+              interactivePhase ? `Interactive: ${interactivePhase}` : undefined
+            }
+            trailingActions={
+              interactiveSession ? (
+                // Per `add-combat-morale-and-withdrawal` § 4.1: the
+                // withdraw control + concede button. Extracted into
+                // `GameplayLayout.sections` to keep this file under the
+                // size cap.
+                <WithdrawalTrailingActions
+                  interactiveSession={interactiveSession}
+                  sessionId={session.id}
+                  playerSide={playerSide}
+                  selectedUnit={selectedUnit}
+                  isPlayerTurn={isPlayerTurn}
+                />
+              ) : undefined
+            }
+          />
+        </ShellSlot>
+
+        {/* Event Log */}
+        <ShellSlot id="feed" ownerId="EventLogDisplay">
+          <EventLogDisplay
+            events={visibleEvents}
+            collapsed={layout.eventLogCollapsed}
+            onCollapsedChange={(collapsed) =>
+              setLayout((prev) => ({ ...prev, eventLogCollapsed: collapsed }))
+            }
+            maxHeight={150}
+            actorLookup={eventActorLookup}
+            weaponLookup={eventWeaponLookup}
+          />
+        </ShellSlot>
       </div>
-
-      {/* Mobile drawer overlay — only mounted below `lg:` when open.
-          The backdrop captures outside-clicks to close the drawer,
-          matching native mobile-app conventions. `id` wires up to
-          PhaseBanner's `aria-controls` for screen readers. */}
-      {isNarrow && (
-        <RecordSheetDrawer open={drawerOpen} onToggle={handleToggleDrawer}>
-          {recordSheetBody}
-        </RecordSheetDrawer>
-      )}
-
-      {/* Action Bar */}
-      <ActionBar
-        phase={currentState.phase}
-        canUndo={canUndo}
-        canAct={isPlayerTurn}
-        onAction={onAction}
-        infoText={
-          interactivePhase ? `Interactive: ${interactivePhase}` : undefined
-        }
-        trailingActions={
-          interactiveSession ? (
-            // Per `add-combat-morale-and-withdrawal` § 4.1: the
-            // withdraw control + concede button. Extracted into
-            // `GameplayLayout.sections` to keep this file under the
-            // size cap.
-            <WithdrawalTrailingActions
-              interactiveSession={interactiveSession}
-              sessionId={session.id}
-              playerSide={playerSide}
-              selectedUnit={selectedUnit}
-              isPlayerTurn={isPlayerTurn}
-            />
-          ) : undefined
-        }
-      />
-
-      {/* Event Log */}
-      <EventLogDisplay
-        events={visibleEvents}
-        collapsed={layout.eventLogCollapsed}
-        onCollapsedChange={(collapsed) =>
-          setLayout((prev) => ({ ...prev, eventLogCollapsed: collapsed }))
-        }
-        maxHeight={150}
-        actorLookup={eventActorLookup}
-        weaponLookup={eventWeaponLookup}
-      />
-    </div>
+    </TacticalCommandShell>
   );
 }
 

--- a/src/components/gameplay/TacticalCommandShell/ShellSlot.tsx
+++ b/src/components/gameplay/TacticalCommandShell/ShellSlot.tsx
@@ -1,0 +1,78 @@
+/**
+ * ShellSlot — declarative slot-owner registration wrapper.
+ *
+ * Wrap an existing JSX region in `<ShellSlot id="..." ownerId="...">` to
+ * declare it as the owner of a named shell slot. The component is a
+ * transparent Fragment — no wrapper DOM, no class names, no style. It
+ * exists purely to register/unregister with the shell registry via
+ * `useEffect`, so existing layout markup (CSS grid / flex trees) keeps
+ * working unchanged.
+ *
+ * Per the shell spec's "Combat facts have one primary home" rule, slots
+ * should have exactly one `primary: true` owner. ShellSlot defaults to
+ * `primary={true}`; pass `primary={false}` for secondary peek surfaces.
+ *
+ * @spec openspec/changes/add-tactical-command-shell/specs/tactical-map-interface/spec.md
+ * @see openspec/changes/add-tactical-command-shell/tasks.md §2.2
+ */
+
+import { useEffect, type ReactElement, type ReactNode } from 'react';
+
+import type {
+  ShellMode,
+  SlotId,
+} from '@/types/gameplay/TacticalShellInterfaces';
+
+import { useShellSlotRegistryContext } from './TacticalCommandShell';
+
+export interface ShellSlotProps {
+  /** Named shell slot id (top-band, map-center, right-tray, etc.). */
+  id: SlotId;
+  /** Stable identifier of the registering component. */
+  ownerId: string;
+  /**
+   * True if this owner is the primary home for the slot's fact (default).
+   * Pass `false` to register as a non-primary peek surface that yields
+   * to any primary owner.
+   */
+  primary?: boolean;
+  /**
+   * Which shell modes render this owner. Empty array = all modes (default).
+   */
+  modes?: readonly ShellMode[];
+  /** The visible JSX that fills the slot. */
+  children: ReactNode;
+}
+
+/**
+ * Register the wrapped children as an owner of the named shell slot.
+ *
+ * The wrapper is a React Fragment — it adds zero DOM. The registration
+ * lives in a `useEffect` so it survives StrictMode double-invocation
+ * and self-cleans on unmount via the unregister-with-ownerId-match
+ * guard in `useShellSlotRegistry`.
+ */
+export function ShellSlot({
+  id,
+  ownerId,
+  primary = true,
+  modes,
+  children,
+}: ShellSlotProps): ReactElement {
+  const registry = useShellSlotRegistryContext();
+
+  useEffect(() => {
+    // Snapshot of modes to keep the dep array stable when the caller
+    // passes an inline array literal.
+    const snapshot: readonly ShellMode[] = modes ?? [];
+    registry.register(id, { ownerId, primary, modes: snapshot });
+    return () => {
+      registry.unregister(id, ownerId);
+    };
+  }, [id, ownerId, primary, modes, registry]);
+
+  // Transparent Fragment — no DOM wrapper, no style, no class. Layout
+  // markup in the host (today: GameplayLayout's flex tree) keeps
+  // working unchanged.
+  return <>{children}</>;
+}

--- a/src/components/gameplay/TacticalCommandShell/TacticalCommandShell.tsx
+++ b/src/components/gameplay/TacticalCommandShell/TacticalCommandShell.tsx
@@ -1,0 +1,105 @@
+/**
+ * TacticalCommandShell — the React context provider for the Tactical UI shell.
+ *
+ * Authored in Wave 7.1 PR-B as the runtime substrate that the PR-A slot
+ * registry hook plugs into. The shell does NOT change the rendered DOM in
+ * PR-B; it provides the registry context that `ShellSlot` consumes to
+ * declare slot ownership without forcing layout rewrites. PR-C wires
+ * shellMode flag through this context to drive mode-aware rendering.
+ *
+ * Per the shell spec's "Map-Dominant Visual Priority" requirement, the
+ * shell intentionally has NO border chrome of its own — it is a logical
+ * container, not a visual one. The hosting layout (currently
+ * `GameplayLayout`) owns the visible flex tree; the shell just provides
+ * the registry for slot-owner declarations.
+ *
+ * @spec openspec/changes/add-tactical-command-shell/specs/tactical-map-interface/spec.md
+ * @see openspec/changes/add-tactical-command-shell/tasks.md §2.1, §2.2
+ */
+
+import {
+  createContext,
+  useContext,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
+
+import type {
+  PlayerId,
+  ShellMode,
+} from '@/types/gameplay/TacticalShellInterfaces';
+
+import {
+  useShellSlotRegistry,
+  type IShellSlotRegistry,
+} from './useShellSlotRegistry';
+
+/**
+ * Bundle of shell-managed state exposed to consumers via React context.
+ *
+ * PR-B exposes only the registry and the static `viewerPlayerId` /
+ * `shellMode` props. PR-C extends this with mutable shell state (tray
+ * collapsed, pinned panels, etc.) once the persistence scope is wired.
+ */
+export interface ITacticalShellContext {
+  /** Shell slot registry; consumers register/unregister slot owners. */
+  readonly registry: IShellSlotRegistry;
+  /** Local viewer's player id. Drives intel projection in target inspectors. */
+  readonly viewerPlayerId: PlayerId;
+  /** Current shell rendering mode. PR-B always passes 'combat'. */
+  readonly shellMode: ShellMode;
+}
+
+const ShellContext = createContext<ITacticalShellContext | null>(null);
+
+export interface TacticalCommandShellProps {
+  /** Local viewer's player id (required — shell contract carries it from day 1). */
+  viewerPlayerId: PlayerId;
+  /** Shell rendering mode. Defaults to 'combat'. */
+  shellMode?: ShellMode;
+  /** Hosting layout subtree (the existing GameplayLayout, today). */
+  children: ReactNode;
+}
+
+/**
+ * Provide the tactical command shell context to a layout subtree.
+ *
+ * Add this AT or NEAR THE ROOT of the gameplay layout — once per match
+ * route. Adding it deeper (inside individual sections) defeats the
+ * "one primary home" rule because each subtree gets its own registry.
+ */
+export function TacticalCommandShell({
+  viewerPlayerId,
+  shellMode = 'combat',
+  children,
+}: TacticalCommandShellProps): ReactElement {
+  const registry = useShellSlotRegistry();
+  const value: ITacticalShellContext = { registry, viewerPlayerId, shellMode };
+  return (
+    <ShellContext.Provider value={value}>{children}</ShellContext.Provider>
+  );
+}
+
+/**
+ * Hook for consuming the tactical command shell context.
+ *
+ * Throws if called outside a `TacticalCommandShell` — defends against
+ * silent misuse where a slot owner mounts without the shell in its
+ * ancestry and its register call silently no-ops.
+ */
+export function useTacticalShell(): ITacticalShellContext {
+  const ctx = useContext(ShellContext);
+  if (!ctx) {
+    throw new Error(
+      'useTacticalShell() must be called inside a <TacticalCommandShell>',
+    );
+  }
+  return ctx;
+}
+
+/**
+ * Convenience hook for the most common consumer: the slot registry alone.
+ */
+export function useShellSlotRegistryContext(): IShellSlotRegistry {
+  return useTacticalShell().registry;
+}

--- a/src/components/gameplay/TacticalCommandShell/__tests__/TacticalCommandShell.test.tsx
+++ b/src/components/gameplay/TacticalCommandShell/__tests__/TacticalCommandShell.test.tsx
@@ -1,0 +1,283 @@
+/**
+ * Tests for TacticalCommandShell + ShellSlot.
+ *
+ * Verifies the PR-B contract:
+ *   - TacticalCommandShell provides the registry context
+ *   - useTacticalShell / useShellSlotRegistryContext throw outside the shell
+ *   - ShellSlot is a transparent Fragment (no DOM wrapper)
+ *   - ShellSlot registers on mount, unregisters on unmount
+ *   - Per "one primary home", a non-primary ShellSlot loses to a primary
+ *   - Multiple ShellSlot owners register independently
+ *
+ * @module components/gameplay/TacticalCommandShell/__tests__/TacticalCommandShell.test
+ */
+
+import { render, renderHook, act } from '@testing-library/react';
+
+import {
+  ShellSlot,
+  TacticalCommandShell,
+  useShellSlotRegistryContext,
+  useTacticalShell,
+} from '../index';
+
+describe('TacticalCommandShell', () => {
+  it('provides registry + viewerPlayerId + shellMode via context', () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <TacticalCommandShell viewerPlayerId="player-1" shellMode="combat">
+        {children}
+      </TacticalCommandShell>
+    );
+
+    const { result } = renderHook(() => useTacticalShell(), { wrapper });
+
+    expect(result.current.viewerPlayerId).toBe('player-1');
+    expect(result.current.shellMode).toBe('combat');
+    expect(result.current.registry).toBeDefined();
+    expect(typeof result.current.registry.register).toBe('function');
+    expect(typeof result.current.registry.subscribe).toBe('function');
+  });
+
+  it('defaults shellMode to "combat" when not specified', () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <TacticalCommandShell viewerPlayerId="player-1">
+        {children}
+      </TacticalCommandShell>
+    );
+
+    const { result } = renderHook(() => useTacticalShell(), { wrapper });
+    expect(result.current.shellMode).toBe('combat');
+  });
+
+  it('throws when useTacticalShell is called outside the shell', () => {
+    // Suppress React error boundary noise for this expected throw.
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    expect(() => renderHook(() => useTacticalShell())).toThrow(
+      /must be called inside a <TacticalCommandShell>/,
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('throws when useShellSlotRegistryContext is called outside the shell', () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    expect(() => renderHook(() => useShellSlotRegistryContext())).toThrow(
+      /must be called inside a <TacticalCommandShell>/,
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('renders no chrome of its own (children render directly)', () => {
+    // The shell is a logical provider — it has no visible DOM. Children
+    // render as if they were at the same level as <TacticalCommandShell>.
+    const { container } = render(
+      <TacticalCommandShell viewerPlayerId="player-1">
+        <div data-testid="child" className="child-class">
+          hello
+        </div>
+      </TacticalCommandShell>,
+    );
+
+    // The root rendered element is the child div itself — no wrapper.
+    const child = container.querySelector('[data-testid="child"]');
+    expect(child).not.toBeNull();
+    expect(child?.parentElement).toBe(container);
+    expect(child?.textContent).toBe('hello');
+  });
+});
+
+describe('ShellSlot', () => {
+  function renderShellWith(children: React.ReactNode) {
+    return render(
+      <TacticalCommandShell viewerPlayerId="player-1">
+        {children}
+      </TacticalCommandShell>,
+    );
+  }
+
+  it('is a transparent Fragment — adds no DOM wrapper', () => {
+    const { container } = renderShellWith(
+      <ShellSlot id="top-band" ownerId="PhaseBanner">
+        <div data-testid="banner">phase banner</div>
+      </ShellSlot>,
+    );
+
+    const banner = container.querySelector('[data-testid="banner"]');
+    expect(banner).not.toBeNull();
+    // No wrapper div from ShellSlot — banner is a direct child of the
+    // render container (the shell is also transparent).
+    expect(banner?.parentElement).toBe(container);
+  });
+
+  it('registers as a primary owner on mount and removes on unmount', () => {
+    // Use a probe component to inspect the registry from inside the shell
+    // context.
+    const probeRegistry: {
+      current: ReturnType<typeof useShellSlotRegistryContext> | null;
+    } = { current: null };
+
+    function Probe(): null {
+      probeRegistry.current = useShellSlotRegistryContext();
+      return null;
+    }
+
+    const { rerender, unmount } = render(
+      <TacticalCommandShell viewerPlayerId="player-1">
+        <Probe />
+        <ShellSlot id="top-band" ownerId="PhaseBanner">
+          <div>banner</div>
+        </ShellSlot>
+      </TacticalCommandShell>,
+    );
+
+    expect(probeRegistry.current?.getOwner('top-band')?.ownerId).toBe(
+      'PhaseBanner',
+    );
+    expect(probeRegistry.current?.getOwner('top-band')?.primary).toBe(true);
+
+    // Remove the slot — registry should clear.
+    rerender(
+      <TacticalCommandShell viewerPlayerId="player-1">
+        <Probe />
+      </TacticalCommandShell>,
+    );
+
+    expect(probeRegistry.current?.getOwner('top-band')).toBeNull();
+
+    unmount();
+  });
+
+  it('respects primary=false (loses to a primary registration)', () => {
+    const probe: {
+      current: ReturnType<typeof useShellSlotRegistryContext> | null;
+    } = { current: null };
+
+    function Probe(): null {
+      probe.current = useShellSlotRegistryContext();
+      return null;
+    }
+
+    render(
+      <TacticalCommandShell viewerPlayerId="player-1">
+        <Probe />
+        <ShellSlot id="bottom-dock" ownerId="ActionBar" primary={true}>
+          <div>action bar</div>
+        </ShellSlot>
+        <ShellSlot id="bottom-dock" ownerId="PeekSurface" primary={false}>
+          <div>peek</div>
+        </ShellSlot>
+      </TacticalCommandShell>,
+    );
+
+    // Primary holds the slot even though the peek mounted "after" in
+    // the JSX. Both children still render (the slot wrappers are
+    // transparent Fragments) but registry ownership is clear.
+    expect(probe.current?.getOwner('bottom-dock')?.ownerId).toBe('ActionBar');
+  });
+
+  it('registers multiple distinct slots independently', () => {
+    const probe: {
+      current: ReturnType<typeof useShellSlotRegistryContext> | null;
+    } = { current: null };
+
+    function Probe(): null {
+      probe.current = useShellSlotRegistryContext();
+      return null;
+    }
+
+    render(
+      <TacticalCommandShell viewerPlayerId="player-1">
+        <Probe />
+        <ShellSlot id="top-band" ownerId="PhaseBanner">
+          <div>banner</div>
+        </ShellSlot>
+        <ShellSlot id="map-center" ownerId="HexMapDisplay">
+          <div>map</div>
+        </ShellSlot>
+        <ShellSlot id="bottom-dock" ownerId="ActionBar">
+          <div>actions</div>
+        </ShellSlot>
+        <ShellSlot id="feed" ownerId="EventLogDisplay">
+          <div>feed</div>
+        </ShellSlot>
+      </TacticalCommandShell>,
+    );
+
+    expect(probe.current?.getOwner('top-band')?.ownerId).toBe('PhaseBanner');
+    expect(probe.current?.getOwner('map-center')?.ownerId).toBe(
+      'HexMapDisplay',
+    );
+    expect(probe.current?.getOwner('bottom-dock')?.ownerId).toBe('ActionBar');
+    expect(probe.current?.getOwner('feed')?.ownerId).toBe('EventLogDisplay');
+    expect(probe.current?.listSlots()).toHaveLength(4);
+  });
+
+  it('forwards modes to the slot owner', () => {
+    const probe: {
+      current: ReturnType<typeof useShellSlotRegistryContext> | null;
+    } = { current: null };
+
+    function Probe(): null {
+      probe.current = useShellSlotRegistryContext();
+      return null;
+    }
+
+    render(
+      <TacticalCommandShell viewerPlayerId="player-1">
+        <Probe />
+        <ShellSlot id="bottom-dock" ownerId="ReplayDock" modes={['replay']}>
+          <div>replay controls</div>
+        </ShellSlot>
+      </TacticalCommandShell>,
+    );
+
+    expect(probe.current?.getOwner('bottom-dock')?.modes).toEqual(['replay']);
+  });
+
+  it('updates registration when the slot id or ownerId changes', () => {
+    // Defends a real refactor risk: if a parent component swaps a
+    // ShellSlot's id (rare but possible) the old slot must release and
+    // the new one must claim.
+    const probe: {
+      current: ReturnType<typeof useShellSlotRegistryContext> | null;
+    } = { current: null };
+
+    function Probe(): null {
+      probe.current = useShellSlotRegistryContext();
+      return null;
+    }
+
+    function Wrapper({
+      slotId,
+    }: {
+      slotId: 'top-band' | 'feed';
+    }): React.ReactElement {
+      return (
+        <TacticalCommandShell viewerPlayerId="player-1">
+          <Probe />
+          <ShellSlot id={slotId} ownerId="MovingOwner">
+            <div>i can move</div>
+          </ShellSlot>
+        </TacticalCommandShell>
+      );
+    }
+
+    const { rerender } = render(<Wrapper slotId="top-band" />);
+    expect(probe.current?.getOwner('top-band')?.ownerId).toBe('MovingOwner');
+    expect(probe.current?.getOwner('feed')).toBeNull();
+
+    act(() => {
+      rerender(<Wrapper slotId="feed" />);
+    });
+
+    expect(probe.current?.getOwner('top-band')).toBeNull();
+    expect(probe.current?.getOwner('feed')?.ownerId).toBe('MovingOwner');
+  });
+});

--- a/src/components/gameplay/TacticalCommandShell/index.ts
+++ b/src/components/gameplay/TacticalCommandShell/index.ts
@@ -12,6 +12,16 @@ export {
   type IShellSlotRegistry,
 } from './useShellSlotRegistry';
 
+export {
+  TacticalCommandShell,
+  useTacticalShell,
+  useShellSlotRegistryContext,
+  type ITacticalShellContext,
+  type TacticalCommandShellProps,
+} from './TacticalCommandShell';
+
+export { ShellSlot, type ShellSlotProps } from './ShellSlot';
+
 export type {
   ITacticalShellState,
   IShellActiveContext,


### PR DESCRIPTION
## Why

Wave 7.1 PR-B — progressive inside-out migration of `GameplayLayout` into the `TacticalCommandShell` slot composition. Builds on PR #655 (types + slot registry) by introducing the React context provider and a `ShellSlot` wrapper, then refactoring `GameplayLayout.tsx`'s render to wrap each region in a slot owner declaration.

**Critical constraint:** zero DOM structure changes. The existing flex tree, classnames, and every `data-testid` the Wave 7.0 e2e gate test (`e2e/gameplay-layout-slots.spec.ts`) asserts is preserved unchanged. The gate test stays green through the migration and catches any future parallel-hierarchy regression (Council Momus Attack #4 from the original synthesis).

## What

### New files

**`src/components/gameplay/TacticalCommandShell/TacticalCommandShell.tsx`** (105 LOC)

React context provider that exposes the slot registry, `viewerPlayerId`, and `shellMode`.

- `TacticalCommandShell` component — wrap the gameplay layout subtree once near the root
- `useTacticalShell()` — read the full shell context (registry + viewer + mode)
- `useShellSlotRegistryContext()` — convenience hook for the most common case
- Both hooks **throw** when called outside the shell — defends against silent-noop registration if a slot owner mounts without the shell in its ancestry
- No visible chrome — logical provider only

**`src/components/gameplay/TacticalCommandShell/ShellSlot.tsx`** (78 LOC)

Declarative slot-owner registration wrapper.

- Returns a transparent React Fragment — zero DOM wrapper, zero classnames, zero style
- Registers via `useEffect` on mount; unregisters on unmount (the `ownerId` match guard in `useShellSlotRegistry` defends against stale unmount-order cleanup)
- Defaults to `primary={true}`; `primary={false}` yields to any primary registration per the "one primary home" rule

### Modified files

**`src/components/gameplay/GameplayLayout.tsx`**

Wrapped the return in `<TacticalCommandShell viewerPlayerId={localFogPlayerId}>` and each of the 7 inline regions in `<ShellSlot>`:

| Slot | Owner |
|------|-------|
| `top-band` | `PhaseBanner` |
| `morale-band` | `MoraleIndicator` (conditional on `battleMorale`) |
| `map-center` | `HexMapDisplay` |
| `right-tray` | `RecordSheetPanel` (desktop only) |
| `mobile-drawer` | `RecordSheetDrawer` (mobile only) |
| `bottom-dock` | `ActionBar` |
| `feed` | `EventLogDisplay` |

The `minimap-cluster` slot is currently bundled inside `HexMapDisplay`'s `overlayChildren` prop (the SVG portal); TODO comment names PR-C as the place to extract it once the overlay-children prop contract is reworked.

Existing `data-testid` contract preserved unchanged: `gameplay-layout`, `gameplay-main-content`, `map-panel`, `resize-handle`, `record-sheet-panel`.

### Tests (11 new + 20 from PR #655 = 31/31 pass)

**`src/components/gameplay/TacticalCommandShell/__tests__/TacticalCommandShell.test.tsx`** (283 LOC, 11 tests):
- Shell provides registry + viewerPlayerId + shellMode via context
- Defaults `shellMode` to `'combat'`
- Throws when consumed outside the shell (both `useTacticalShell` and `useShellSlotRegistryContext`)
- Shell renders no chrome of its own (children render directly)
- ShellSlot is a transparent Fragment (no DOM wrapper)
- ShellSlot registers on mount + unregisters on unmount
- `primary={false}` loses to `primary={true}`
- Multiple distinct slots register independently
- Modes forwarded to slot owner
- Re-registration on `id`/`ownerId` change (defends real refactor risk)

### Regression coverage

- **14/14 GameplayLayout-adjacent smoke tests pass unchanged** (`addInteractiveCombatCoreUI.smoke.test.tsx` + `addMovementPhaseUI.smoke.test.tsx`)
- Wave 7.0 e2e slot-identity gate (`e2e/gameplay-layout-slots.spec.ts`) continues to assert exactly one of each structural slot — this PR keeps it green

### Tasks closed

`openspec/changes/add-tactical-command-shell/tasks.md`:
- [x] 2.1 Create a tactical command shell component around the existing map without wrapping the map in a card
- [x] 2.2 Move phase banner, action panel, minimap, inspector, and event feed into named slots
- [ ] 2.3 Pinned/collapsed tray behavior with per-match persistence — **partial**: state surface ready via `ITacticalShellState` (PR #655); mutators + `sessionStorage` wiring land in PR-C

## Verification

- `npx tsc --noEmit` → clean
- `npx oxlint` → 1 warning (`max-lines: 411/400` on `GameplayLayout.tsx`) — consistent with project baseline (`MoveAI.ts:446` already exceeds same cap); will be addressed by the natural extraction during PR-C's mode-integration work; 0 errors
- `npx oxfmt --check` → clean
- `npx jest --runTestsByPath` (new + adjacent smoke) → 45/45 passed
- Pre-commit hook full Next.js build (63/63 static pages) → clean

## Next

- **PR-C** `feat(wave-7.1): wire shell to combat/replay/spectator/GM modes` — same-chrome additive modes per design Decision 3. Adds mutators for tray collapse/pin state, sessionStorage persistence keyed by session id (task 2.3 closure), `shellMode`-driven slot owner filtering, and the `selectedUnit` / `activeUnit` / `inspectedUnit` decoupled state setters.
