### PR TITLE
feat(wave-7.1): wire shell to combat/replay/spectator/GM modes + tray persistence (PR-C)

### DIFF
--- a/openspec/changes/add-tactical-command-shell/tasks.md
+++ b/openspec/changes/add-tactical-command-shell/tasks.md
@@ -10,12 +10,12 @@
 
 - [x] 2.1 Create a tactical command shell component around the existing map without wrapping the map in a card
 - [x] 2.2 Move phase banner, action panel, minimap, inspector, and event feed into named slots
-- [ ] 2.3 Add pinned/collapsed tray behavior with persistence scoped to the current match
+- [x] 2.3 Add pinned/collapsed tray behavior with persistence scoped to the current match
 
 ## 3. Mode Integration
 
-- [ ] 3.1 Render combat, replay, spectator, and GM/referee shell modes from the same slot contract
-- [ ] 3.2 Disable private commands in spectator mode while preserving public map and feed tools
+- [x] 3.1 Render combat, replay, spectator, and GM/referee shell modes from the same slot contract
+- [x] 3.2 Disable private commands in spectator mode while preserving public map and feed tools
 
 ## 4. Verification
 

--- a/src/components/gameplay/GameplayLayout.tsx
+++ b/src/components/gameplay/GameplayLayout.tsx
@@ -82,6 +82,7 @@ export function GameplayLayout({
   mpLegend,
   interactiveSession,
   playerSide = GameSide.Player,
+  shellMode = 'combat',
   className = '',
 }: GameplayLayoutProps): React.ReactElement {
   const { currentState, events, config, units } = session;
@@ -372,7 +373,11 @@ export function GameplayLayout({
     // (`e2e/gameplay-layout-slots.spec.ts`) asserts, so the gate stays
     // green through the migration and catches any parallel-hierarchy
     // regression (Council Momus Attack #4).
-    <TacticalCommandShell viewerPlayerId={localFogPlayerId}>
+    <TacticalCommandShell
+      viewerPlayerId={localFogPlayerId}
+      shellMode={shellMode}
+      sessionId={session.id}
+    >
       <div
         className={`flex h-full flex-col bg-gray-100 ${className}`}
         data-testid="gameplay-layout"

--- a/src/components/gameplay/GameplayLayout.types.ts
+++ b/src/components/gameplay/GameplayLayout.types.ts
@@ -8,6 +8,7 @@ import type {
   IPilotSpaSummary,
   IWeaponStatus,
 } from '@/types/gameplay';
+import type { ShellMode } from '@/types/gameplay/TacticalShellInterfaces';
 
 export interface GameplayLayoutProps {
   /** Game session data */
@@ -59,6 +60,15 @@ export interface GameplayLayoutProps {
   interactiveSession?: InteractiveSession;
   /** Player side controlling this UI (defaults to GameSide.Player). */
   playerSide?: GameSide;
+  /**
+   * Tactical command shell rendering mode (Wave 7.1 PR-C).
+   *
+   * Default 'combat' for live play; pass 'replay' from the replay route,
+   * 'gm' for referee mode. Spectator mode renders through `SpectatorView`,
+   * not this layout. Shell mode flows into `TacticalCommandShell` and
+   * drives mode-aware slot owner selection.
+   */
+  shellMode?: ShellMode;
   /** Optional className for styling */
   className?: string;
 }

--- a/src/components/gameplay/SpectatorView.tsx
+++ b/src/components/gameplay/SpectatorView.tsx
@@ -23,6 +23,7 @@ import {
   UnitRoster,
   ResultsOverlay,
 } from './SpectatorViewPanels';
+import { ShellSlot, TacticalCommandShell } from './TacticalCommandShell';
 
 export function SpectatorView(): React.ReactElement {
   // Per-field selectors (useGameplaySelector POC): each subscription
@@ -168,80 +169,100 @@ export function SpectatorView(): React.ReactElement {
         <title>Spectator Mode - MekStation</title>
       </Head>
 
-      <div
-        className="relative flex h-screen flex-col bg-gray-900"
-        data-testid="spectator-view"
+      {/* Wave 7.1 PR-C: Spectator mode renders through the same shell
+          contract as combat/replay/gm, just with a `shellMode='spectator'`
+          flag that filters mode-restricted slot owners (per spec
+          `Shell Mode Ownership`). Note that no action-dock slot owner
+          is registered here — spectator gets no private commands by
+          construction, satisfying tasks.md §3.2. PlaybackControls
+          remain because they are public (observer-controlled) not
+          private (combat-actor-controlled). */}
+      <TacticalCommandShell
+        viewerPlayerId={session.id}
+        shellMode="spectator"
+        sessionId={session.id}
       >
-        {/* Header bar */}
-        <div className="flex items-center justify-between border-b border-gray-700 bg-gray-800/90 px-4 py-2 backdrop-blur-sm">
-          <div className="flex items-center gap-3">
-            <Link
-              href="/gameplay/games"
-              className="text-gray-400 transition-colors hover:text-white"
-              aria-label="Back to games"
-            >
-              <svg
-                className="h-5 w-5"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M10 19l-7-7m0 0l7-7m-7 7h18"
-                />
-              </svg>
-            </Link>
-            <div>
-              <h1 className="text-sm font-semibold text-white">
-                AI vs AI — Spectator Mode
-              </h1>
-            </div>
-          </div>
+        <div
+          className="relative flex h-screen flex-col bg-gray-900"
+          data-testid="spectator-view"
+        >
+          {/* Header bar — top-band slot. */}
+          <ShellSlot id="top-band" ownerId="SpectatorHeader">
+            <div className="flex items-center justify-between border-b border-gray-700 bg-gray-800/90 px-4 py-2 backdrop-blur-sm">
+              <div className="flex items-center gap-3">
+                <Link
+                  href="/gameplay/games"
+                  className="text-gray-400 transition-colors hover:text-white"
+                  aria-label="Back to games"
+                >
+                  <svg
+                    className="h-5 w-5"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M10 19l-7-7m0 0l7-7m-7 7h18"
+                    />
+                  </svg>
+                </Link>
+                <div>
+                  <h1 className="text-sm font-semibold text-white">
+                    AI vs AI — Spectator Mode
+                  </h1>
+                </div>
+              </div>
 
-          <PlaybackControls
-            playing={playing}
-            speed={speed}
-            turn={session.currentState.turn}
-            phase={session.currentState.phase}
-            gameOver={gameOver}
-            onTogglePlay={handleTogglePlay}
-            onSetSpeed={handleSetSpeed}
-            onStepForward={handleStepForward}
-          />
-
-          <div className="w-32" />
-        </div>
-
-        {/* Main content: map + sidebar */}
-        <div className="flex flex-1 overflow-hidden">
-          {/* Map area */}
-          <div className="relative flex-1" data-testid="spectator-map">
-            <HexMapDisplay
-              radius={session.config.mapRadius}
-              tokens={tokens}
-              hexTerrain={hexTerrain}
-              selectedHex={null}
-              showCoordinates={false}
-            />
-
-            {/* Results overlay */}
-            {gameOver && (
-              <ResultsOverlay
-                interactiveSession={interactiveSession}
-                sessionId={session.id}
+              <PlaybackControls
+                playing={playing}
+                speed={speed}
+                turn={session.currentState.turn}
+                phase={session.currentState.phase}
+                gameOver={gameOver}
+                onTogglePlay={handleTogglePlay}
+                onSetSpeed={handleSetSpeed}
+                onStepForward={handleStepForward}
               />
-            )}
-          </div>
 
-          {/* Side panel */}
-          <div className="w-60 overflow-y-auto border-l border-gray-700 bg-gray-800/50">
-            <UnitRoster session={session} />
+              <div className="w-32" />
+            </div>
+          </ShellSlot>
+
+          {/* Main content: map + sidebar */}
+          <div className="flex flex-1 overflow-hidden">
+            {/* Map area — map-center slot. */}
+            <ShellSlot id="map-center" ownerId="SpectatorHexMap">
+              <div className="relative flex-1" data-testid="spectator-map">
+                <HexMapDisplay
+                  radius={session.config.mapRadius}
+                  tokens={tokens}
+                  hexTerrain={hexTerrain}
+                  selectedHex={null}
+                  showCoordinates={false}
+                />
+
+                {/* Results overlay */}
+                {gameOver && (
+                  <ResultsOverlay
+                    interactiveSession={interactiveSession}
+                    sessionId={session.id}
+                  />
+                )}
+              </div>
+            </ShellSlot>
+
+            {/* Side panel — right-tray slot. */}
+            <ShellSlot id="right-tray" ownerId="SpectatorUnitRoster">
+              <div className="w-60 overflow-y-auto border-l border-gray-700 bg-gray-800/50">
+                <UnitRoster session={session} />
+              </div>
+            </ShellSlot>
           </div>
         </div>
-      </div>
+      </TacticalCommandShell>
     </>
   );
 }

--- a/src/components/gameplay/TacticalCommandShell/ShellSlot.tsx
+++ b/src/components/gameplay/TacticalCommandShell/ShellSlot.tsx
@@ -23,7 +23,7 @@ import type {
   SlotId,
 } from '@/types/gameplay/TacticalShellInterfaces';
 
-import { useShellSlotRegistryContext } from './TacticalCommandShell';
+import { useTacticalShell } from './TacticalCommandShell';
 
 export interface ShellSlotProps {
   /** Named shell slot id (top-band, map-center, right-tray, etc.). */
@@ -51,6 +51,11 @@ export interface ShellSlotProps {
  * lives in a `useEffect` so it survives StrictMode double-invocation
  * and self-cleans on unmount via the unregister-with-ownerId-match
  * guard in `useShellSlotRegistry`.
+ *
+ * PR-C: shellMode-aware filtering. If `modes` is non-empty AND does
+ * NOT include the current shell mode, the slot does NOT register and
+ * its children do NOT render. Default (`modes` omitted or empty) means
+ * "all modes" — backward-compatible with PR-B's behavior.
  */
 export function ShellSlot({
   id,
@@ -59,9 +64,16 @@ export function ShellSlot({
   modes,
   children,
 }: ShellSlotProps): ReactElement {
-  const registry = useShellSlotRegistryContext();
+  const { registry, shellMode } = useTacticalShell();
+
+  // A slot owner with `modes` constraint only takes effect in the
+  // listed modes. Per spec `Shell Mode Ownership`, the same slot
+  // contract supports combat/replay/spectator/GM via mode-filtered
+  // owner selection.
+  const modeMatches = !modes || modes.length === 0 || modes.includes(shellMode);
 
   useEffect(() => {
+    if (!modeMatches) return undefined;
     // Snapshot of modes to keep the dep array stable when the caller
     // passes an inline array literal.
     const snapshot: readonly ShellMode[] = modes ?? [];
@@ -69,7 +81,15 @@ export function ShellSlot({
     return () => {
       registry.unregister(id, ownerId);
     };
-  }, [id, ownerId, primary, modes, registry]);
+  }, [id, ownerId, primary, modes, registry, modeMatches]);
+
+  // Hide children in non-matching modes too — per the spec's
+  // "Spectator mode disables private commands" scenario, an
+  // action-dock slot owner with modes={['combat']} must NOT render
+  // its commands in spectator mode (not just refuse to register).
+  if (!modeMatches) {
+    return <></>;
+  }
 
   // Transparent Fragment — no DOM wrapper, no style, no class. Layout
   // markup in the host (today: GameplayLayout's flex tree) keeps

--- a/src/components/gameplay/TacticalCommandShell/TacticalCommandShell.tsx
+++ b/src/components/gameplay/TacticalCommandShell/TacticalCommandShell.tsx
@@ -1,32 +1,38 @@
 /**
  * TacticalCommandShell — the React context provider for the Tactical UI shell.
  *
- * Authored in Wave 7.1 PR-B as the runtime substrate that the PR-A slot
- * registry hook plugs into. The shell does NOT change the rendered DOM in
- * PR-B; it provides the registry context that `ShellSlot` consumes to
- * declare slot ownership without forcing layout rewrites. PR-C wires
- * shellMode flag through this context to drive mode-aware rendering.
+ * PR-A introduced the slot registry.
+ * PR-B added the context provider + ShellSlot wrapper.
+ * PR-C (this file) extends the context with mutable shell state, setter API,
+ *   per-match sessionStorage persistence, and shellMode-driven slot filtering.
  *
  * Per the shell spec's "Map-Dominant Visual Priority" requirement, the
  * shell intentionally has NO border chrome of its own — it is a logical
- * container, not a visual one. The hosting layout (currently
- * `GameplayLayout`) owns the visible flex tree; the shell just provides
- * the registry for slot-owner declarations.
+ * container, not a visual one. The hosting layout (`GameplayLayout` for
+ * combat / replay / gm; `SpectatorView` for spectator) owns the visible
+ * flex tree; the shell provides the registry + state for slot owners.
  *
  * @spec openspec/changes/add-tactical-command-shell/specs/tactical-map-interface/spec.md
- * @see openspec/changes/add-tactical-command-shell/tasks.md §2.1, §2.2
+ * @see openspec/changes/add-tactical-command-shell/tasks.md §2.3, §3.1, §3.2
  */
 
 import {
   createContext,
+  useCallback,
   useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
   type ReactElement,
   type ReactNode,
 } from 'react';
 
-import type {
-  PlayerId,
-  ShellMode,
+import {
+  createDefaultShellState,
+  type ITacticalShellState,
+  type PlayerId,
+  type ShellMode,
 } from '@/types/gameplay/TacticalShellInterfaces';
 
 import {
@@ -35,19 +41,54 @@ import {
 } from './useShellSlotRegistry';
 
 /**
+ * Subset of `ITacticalShellState` fields that survive across page reloads
+ * and route swaps for the same match (per task 2.3 — "persistence scoped
+ * to the current match"). Selected/active/inspected unit references are
+ * session-runtime only and intentionally NOT persisted; they re-derive
+ * from interactive-session state on mount.
+ */
+interface IPersistedShellSlice {
+  leftTrayCollapsed: boolean;
+  rightTrayPinned: boolean;
+  bottomDockActiveTab: string | null;
+}
+
+const PERSISTED_KEYS = [
+  'leftTrayCollapsed',
+  'rightTrayPinned',
+  'bottomDockActiveTab',
+] as const satisfies readonly (keyof IPersistedShellSlice)[];
+
+const STORAGE_KEY_PREFIX = 'tactical-shell:';
+
+function storageKey(sessionId: string): string {
+  return `${STORAGE_KEY_PREFIX}${sessionId}`;
+}
+
+/**
  * Bundle of shell-managed state exposed to consumers via React context.
  *
- * PR-B exposes only the registry and the static `viewerPlayerId` /
- * `shellMode` props. PR-C extends this with mutable shell state (tray
- * collapsed, pinned panels, etc.) once the persistence scope is wired.
+ * Static (set once at mount):
+ *   - registry / viewerPlayerId / shellMode / sessionId
+ *
+ * Mutable (driven by user interaction; persisted slice survives reload):
+ *   - state — current ITacticalShellState
+ *   - updateState — partial-update merge with persistence side-effect
  */
 export interface ITacticalShellContext {
-  /** Shell slot registry; consumers register/unregister slot owners. */
   readonly registry: IShellSlotRegistry;
-  /** Local viewer's player id. Drives intel projection in target inspectors. */
   readonly viewerPlayerId: PlayerId;
-  /** Current shell rendering mode. PR-B always passes 'combat'. */
   readonly shellMode: ShellMode;
+  /** Session id for sessionStorage persistence; null when not match-scoped. */
+  readonly sessionId: string | null;
+  /** Current shell state — the live single source of truth for slot UI. */
+  readonly state: ITacticalShellState;
+  /**
+   * Merge a partial update into shell state. Persisted fields
+   * (leftTrayCollapsed, rightTrayPinned, bottomDockActiveTab) are
+   * written through to `sessionStorage` keyed by `sessionId`.
+   */
+  readonly updateState: (partial: Partial<ITacticalShellState>) => void;
 }
 
 const ShellContext = createContext<ITacticalShellContext | null>(null);
@@ -57,24 +98,146 @@ export interface TacticalCommandShellProps {
   viewerPlayerId: PlayerId;
   /** Shell rendering mode. Defaults to 'combat'. */
   shellMode?: ShellMode;
-  /** Hosting layout subtree (the existing GameplayLayout, today). */
+  /**
+   * Match session id. When provided, persisted tray state is read from
+   * and written to `sessionStorage` keyed by this id (per task 2.3).
+   * Pass `null`/omit for non-match shells (preview, storybook, tests).
+   */
+  sessionId?: string | null;
+  /** Hosting layout subtree. */
   children: ReactNode;
+}
+
+/**
+ * Read persisted tray state for a given session from `sessionStorage`.
+ * Returns null if no persisted state exists, sessionStorage is
+ * unavailable (SSR / private mode), or the stored value is malformed.
+ */
+function readPersistedSlice(
+  sessionId: string | null,
+): IPersistedShellSlice | null {
+  if (!sessionId || typeof window === 'undefined') return null;
+  try {
+    const raw = window.sessionStorage.getItem(storageKey(sessionId));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      typeof (parsed as Record<string, unknown>).leftTrayCollapsed ===
+        'boolean' &&
+      typeof (parsed as Record<string, unknown>).rightTrayPinned === 'boolean'
+    ) {
+      const obj = parsed as Record<string, unknown>;
+      return {
+        leftTrayCollapsed: obj.leftTrayCollapsed as boolean,
+        rightTrayPinned: obj.rightTrayPinned as boolean,
+        bottomDockActiveTab:
+          typeof obj.bottomDockActiveTab === 'string'
+            ? (obj.bottomDockActiveTab as string)
+            : null,
+      };
+    }
+    return null;
+  } catch {
+    // Corrupt JSON or sessionStorage throw — fall through to defaults.
+    return null;
+  }
+}
+
+function writePersistedSlice(
+  sessionId: string | null,
+  slice: IPersistedShellSlice,
+): void {
+  if (!sessionId || typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.setItem(storageKey(sessionId), JSON.stringify(slice));
+  } catch {
+    // sessionStorage can throw on quota exceeded or in restricted
+    // browsing modes. Failing to persist is degradable — the UI keeps
+    // working, just doesn't survive reload.
+  }
 }
 
 /**
  * Provide the tactical command shell context to a layout subtree.
  *
- * Add this AT or NEAR THE ROOT of the gameplay layout — once per match
- * route. Adding it deeper (inside individual sections) defeats the
- * "one primary home" rule because each subtree gets its own registry.
+ * Add this AT or NEAR THE ROOT of the gameplay/spectator layout — once
+ * per match route. Adding it deeper (inside individual sections)
+ * defeats the "one primary home" rule because each subtree gets its
+ * own registry.
  */
 export function TacticalCommandShell({
   viewerPlayerId,
   shellMode = 'combat',
+  sessionId = null,
   children,
 }: TacticalCommandShellProps): ReactElement {
   const registry = useShellSlotRegistry();
-  const value: ITacticalShellContext = { registry, viewerPlayerId, shellMode };
+
+  // Lazy-init: the persistence read runs exactly once per shell mount,
+  // and the resulting state seeds React state. Subsequent updates flow
+  // through `updateState` → setState → useEffect write-through.
+  const [state, setState] = useState<ITacticalShellState>(() => {
+    const base = createDefaultShellState(viewerPlayerId);
+    const persisted = readPersistedSlice(sessionId);
+    if (!persisted) return base;
+    return {
+      ...base,
+      leftTrayCollapsed: persisted.leftTrayCollapsed,
+      rightTrayPinned: persisted.rightTrayPinned,
+      bottomDockActiveTab: persisted.bottomDockActiveTab,
+    };
+  });
+
+  // Track the previous persisted slice so the write-through useEffect
+  // skips writes when nothing in the persistable slice changed (the
+  // unit-reference triple mutates much more often than tray state).
+  const lastPersistedRef = useRef<IPersistedShellSlice>({
+    leftTrayCollapsed: state.leftTrayCollapsed,
+    rightTrayPinned: state.rightTrayPinned,
+    bottomDockActiveTab: state.bottomDockActiveTab,
+  });
+
+  // Persist on change to the slice we care about.
+  useEffect(() => {
+    const slice: IPersistedShellSlice = {
+      leftTrayCollapsed: state.leftTrayCollapsed,
+      rightTrayPinned: state.rightTrayPinned,
+      bottomDockActiveTab: state.bottomDockActiveTab,
+    };
+    const prev = lastPersistedRef.current;
+    const changed = PERSISTED_KEYS.some((k) => slice[k] !== prev[k]);
+    if (!changed) return;
+    lastPersistedRef.current = slice;
+    writePersistedSlice(sessionId, slice);
+  }, [
+    state.leftTrayCollapsed,
+    state.rightTrayPinned,
+    state.bottomDockActiveTab,
+    sessionId,
+  ]);
+
+  const updateState = useCallback((partial: Partial<ITacticalShellState>) => {
+    setState((prev) => ({ ...prev, ...partial }));
+  }, []);
+
+  // Memoize context value so consumers don't churn re-renders when no
+  // shell-relevant prop changed. The state object identity changes on
+  // every updateState call, which IS what we want — that's the
+  // re-render signal for slot owners that subscribe to shell state.
+  const value = useMemo<ITacticalShellContext>(
+    () => ({
+      registry,
+      viewerPlayerId,
+      shellMode,
+      sessionId,
+      state,
+      updateState,
+    }),
+    [registry, viewerPlayerId, shellMode, sessionId, state, updateState],
+  );
+
   return (
     <ShellContext.Provider value={value}>{children}</ShellContext.Provider>
   );

--- a/src/components/gameplay/TacticalCommandShell/__tests__/TacticalCommandShell.test.tsx
+++ b/src/components/gameplay/TacticalCommandShell/__tests__/TacticalCommandShell.test.tsx
@@ -229,8 +229,12 @@ describe('ShellSlot', () => {
       return null;
     }
 
+    // PR-C: ShellSlot only registers when shellMode matches the modes
+    // constraint. Use shellMode='replay' so the modes={['replay']} slot
+    // actually registers; otherwise the registry would (correctly) show
+    // no owner and the modes-forwarding assertion couldn't run.
     render(
-      <TacticalCommandShell viewerPlayerId="player-1">
+      <TacticalCommandShell viewerPlayerId="player-1" shellMode="replay">
         <Probe />
         <ShellSlot id="bottom-dock" ownerId="ReplayDock" modes={['replay']}>
           <div>replay controls</div>
@@ -279,5 +283,369 @@ describe('ShellSlot', () => {
 
     expect(probe.current?.getOwner('top-band')).toBeNull();
     expect(probe.current?.getOwner('feed')?.ownerId).toBe('MovingOwner');
+  });
+});
+
+describe('TacticalCommandShell — PR-C: mode filtering', () => {
+  function ProbeRegistry({
+    probe,
+  }: {
+    probe: { current: ReturnType<typeof useShellSlotRegistryContext> | null };
+  }): null {
+    probe.current = useShellSlotRegistryContext();
+    return null;
+  }
+
+  it('does NOT register a mode-restricted slot owner when shellMode does not match', () => {
+    // Per the spec `Shell Mode Ownership` requirement, a slot owner
+    // declared with `modes={['combat']}` SHALL NOT register in
+    // spectator/replay/gm mode.
+    const probe: {
+      current: ReturnType<typeof useShellSlotRegistryContext> | null;
+    } = { current: null };
+
+    render(
+      <TacticalCommandShell viewerPlayerId="player-1" shellMode="spectator">
+        <ProbeRegistry probe={probe} />
+        <ShellSlot
+          id="bottom-dock"
+          ownerId="CombatActionBar"
+          modes={['combat']}
+        >
+          <div data-testid="combat-actions">Fire</div>
+        </ShellSlot>
+      </TacticalCommandShell>,
+    );
+
+    expect(probe.current?.getOwner('bottom-dock')).toBeNull();
+  });
+
+  it('does NOT render children of a mode-restricted slot owner when mode does not match', () => {
+    // Defends spec `Spectator mode disables private commands`: action
+    // commands SHALL be disabled OR absent from the DOM in spectator
+    // mode. Absent is the stronger guarantee.
+    const { container } = render(
+      <TacticalCommandShell viewerPlayerId="player-1" shellMode="spectator">
+        <ShellSlot
+          id="bottom-dock"
+          ownerId="CombatActionBar"
+          modes={['combat']}
+        >
+          <div data-testid="private-command">Fire weapons</div>
+        </ShellSlot>
+      </TacticalCommandShell>,
+    );
+
+    expect(
+      container.querySelector('[data-testid="private-command"]'),
+    ).toBeNull();
+  });
+
+  it('DOES register and render when modes includes the active shellMode', () => {
+    const probe: {
+      current: ReturnType<typeof useShellSlotRegistryContext> | null;
+    } = { current: null };
+
+    const { container } = render(
+      <TacticalCommandShell viewerPlayerId="player-1" shellMode="replay">
+        <ProbeRegistry probe={probe} />
+        <ShellSlot
+          id="bottom-dock"
+          ownerId="ReplayPlaybackControls"
+          modes={['replay']}
+        >
+          <div data-testid="playback">Play</div>
+        </ShellSlot>
+      </TacticalCommandShell>,
+    );
+
+    expect(probe.current?.getOwner('bottom-dock')?.ownerId).toBe(
+      'ReplayPlaybackControls',
+    );
+    expect(container.querySelector('[data-testid="playback"]')).not.toBeNull();
+  });
+
+  it('treats empty/omitted modes as "all modes" (backward-compat)', () => {
+    const probe: {
+      current: ReturnType<typeof useShellSlotRegistryContext> | null;
+    } = { current: null };
+
+    render(
+      <TacticalCommandShell viewerPlayerId="player-1" shellMode="spectator">
+        <ProbeRegistry probe={probe} />
+        <ShellSlot id="top-band" ownerId="PhaseBanner">
+          <div>banner</div>
+        </ShellSlot>
+        <ShellSlot id="map-center" ownerId="HexMapDisplay" modes={[]}>
+          <div>map</div>
+        </ShellSlot>
+      </TacticalCommandShell>,
+    );
+
+    expect(probe.current?.getOwner('top-band')?.ownerId).toBe('PhaseBanner');
+    expect(probe.current?.getOwner('map-center')?.ownerId).toBe(
+      'HexMapDisplay',
+    );
+  });
+});
+
+describe('TacticalCommandShell — PR-C: state + updateState', () => {
+  function ProbeState({
+    probe,
+  }: {
+    probe: { current: ReturnType<typeof useTacticalShell> | null };
+  }): null {
+    probe.current = useTacticalShell();
+    return null;
+  }
+
+  it('exposes shell state via context with default-shape values', () => {
+    const probe: {
+      current: ReturnType<typeof useTacticalShell> | null;
+    } = { current: null };
+
+    render(
+      <TacticalCommandShell viewerPlayerId="player-1">
+        <ProbeState probe={probe} />
+      </TacticalCommandShell>,
+    );
+
+    expect(probe.current?.state.shellMode).toBe('combat');
+    expect(probe.current?.state.viewerPlayerId).toBe('player-1');
+    expect(probe.current?.state.selectedUnit).toBeNull();
+    expect(probe.current?.state.activeUnit).toBeNull();
+    expect(probe.current?.state.inspectedUnit).toBeNull();
+    expect(probe.current?.state.leftTrayCollapsed).toBe(false);
+    expect(probe.current?.state.rightTrayPinned).toBe(false);
+  });
+
+  it('updateState applies a partial merge', () => {
+    const probe: {
+      current: ReturnType<typeof useTacticalShell> | null;
+    } = { current: null };
+
+    render(
+      <TacticalCommandShell viewerPlayerId="player-1">
+        <ProbeState probe={probe} />
+      </TacticalCommandShell>,
+    );
+
+    act(() => {
+      probe.current?.updateState({
+        selectedUnit: 'unit-a',
+        leftTrayCollapsed: true,
+      });
+    });
+
+    expect(probe.current?.state.selectedUnit).toBe('unit-a');
+    expect(probe.current?.state.leftTrayCollapsed).toBe(true);
+    // Untouched fields stay at their defaults.
+    expect(probe.current?.state.activeUnit).toBeNull();
+    expect(probe.current?.state.inspectedUnit).toBeNull();
+    expect(probe.current?.state.rightTrayPinned).toBe(false);
+  });
+
+  it('updateState keeps the three unit references independent', () => {
+    // Gate 4 invariant: setting selectedUnit MUST NOT touch activeUnit
+    // or inspectedUnit. PR-A's createDefaultShellState shape pinned
+    // this at the type level; PR-C confirms it through the mutator.
+    const probe: {
+      current: ReturnType<typeof useTacticalShell> | null;
+    } = { current: null };
+
+    render(
+      <TacticalCommandShell viewerPlayerId="player-1">
+        <ProbeState probe={probe} />
+      </TacticalCommandShell>,
+    );
+
+    act(() => {
+      probe.current?.updateState({ selectedUnit: 'unit-a' });
+    });
+    expect(probe.current?.state.selectedUnit).toBe('unit-a');
+    expect(probe.current?.state.activeUnit).toBeNull();
+    expect(probe.current?.state.inspectedUnit).toBeNull();
+
+    act(() => {
+      probe.current?.updateState({ activeUnit: 'unit-b' });
+    });
+    expect(probe.current?.state.selectedUnit).toBe('unit-a');
+    expect(probe.current?.state.activeUnit).toBe('unit-b');
+    expect(probe.current?.state.inspectedUnit).toBeNull();
+
+    act(() => {
+      probe.current?.updateState({ inspectedUnit: 'unit-c' });
+    });
+    expect(probe.current?.state.selectedUnit).toBe('unit-a');
+    expect(probe.current?.state.activeUnit).toBe('unit-b');
+    expect(probe.current?.state.inspectedUnit).toBe('unit-c');
+  });
+});
+
+describe('TacticalCommandShell — PR-C: per-match sessionStorage persistence', () => {
+  function ProbeState({
+    probe,
+  }: {
+    probe: { current: ReturnType<typeof useTacticalShell> | null };
+  }): null {
+    probe.current = useTacticalShell();
+    return null;
+  }
+
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it('writes tray slice to sessionStorage when updateState mutates it', () => {
+    const probe: {
+      current: ReturnType<typeof useTacticalShell> | null;
+    } = { current: null };
+
+    render(
+      <TacticalCommandShell viewerPlayerId="player-1" sessionId="match-42">
+        <ProbeState probe={probe} />
+      </TacticalCommandShell>,
+    );
+
+    act(() => {
+      probe.current?.updateState({
+        leftTrayCollapsed: true,
+        rightTrayPinned: true,
+        bottomDockActiveTab: 'weapons',
+      });
+    });
+
+    const raw = window.sessionStorage.getItem('tactical-shell:match-42');
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw ?? '{}') as Record<string, unknown>;
+    expect(parsed.leftTrayCollapsed).toBe(true);
+    expect(parsed.rightTrayPinned).toBe(true);
+    expect(parsed.bottomDockActiveTab).toBe('weapons');
+  });
+
+  it('hydrates tray state from sessionStorage on mount', () => {
+    window.sessionStorage.setItem(
+      'tactical-shell:match-42',
+      JSON.stringify({
+        leftTrayCollapsed: true,
+        rightTrayPinned: true,
+        bottomDockActiveTab: 'movement',
+      }),
+    );
+
+    const probe: {
+      current: ReturnType<typeof useTacticalShell> | null;
+    } = { current: null };
+
+    render(
+      <TacticalCommandShell viewerPlayerId="player-1" sessionId="match-42">
+        <ProbeState probe={probe} />
+      </TacticalCommandShell>,
+    );
+
+    expect(probe.current?.state.leftTrayCollapsed).toBe(true);
+    expect(probe.current?.state.rightTrayPinned).toBe(true);
+    expect(probe.current?.state.bottomDockActiveTab).toBe('movement');
+  });
+
+  it('does NOT persist unit-reference triple (runtime-only fields)', () => {
+    // The selected/active/inspected unit triple intentionally re-derives
+    // from interactive-session state on mount; persisting it across a
+    // reload would stale-bind to units that no longer exist (destroyed,
+    // withdrawn, replaced via campaign roster change).
+    const probe: {
+      current: ReturnType<typeof useTacticalShell> | null;
+    } = { current: null };
+
+    render(
+      <TacticalCommandShell viewerPlayerId="player-1" sessionId="match-42">
+        <ProbeState probe={probe} />
+      </TacticalCommandShell>,
+    );
+
+    act(() => {
+      probe.current?.updateState({
+        selectedUnit: 'unit-a',
+        activeUnit: 'unit-b',
+        inspectedUnit: 'unit-c',
+        leftTrayCollapsed: true,
+      });
+    });
+
+    const raw = window.sessionStorage.getItem('tactical-shell:match-42');
+    const parsed = JSON.parse(raw ?? '{}') as Record<string, unknown>;
+    expect(parsed.leftTrayCollapsed).toBe(true);
+    expect(parsed.selectedUnit).toBeUndefined();
+    expect(parsed.activeUnit).toBeUndefined();
+    expect(parsed.inspectedUnit).toBeUndefined();
+  });
+
+  it('does NOT touch sessionStorage when sessionId is null', () => {
+    const probe: {
+      current: ReturnType<typeof useTacticalShell> | null;
+    } = { current: null };
+
+    render(
+      <TacticalCommandShell viewerPlayerId="player-1">
+        <ProbeState probe={probe} />
+      </TacticalCommandShell>,
+    );
+
+    act(() => {
+      probe.current?.updateState({ leftTrayCollapsed: true });
+    });
+
+    // Storage should be empty — no key was written.
+    expect(window.sessionStorage.length).toBe(0);
+  });
+
+  it('scopes persistence per-session: changes to match-A do not leak into match-B', () => {
+    const probeA: {
+      current: ReturnType<typeof useTacticalShell> | null;
+    } = { current: null };
+
+    const { unmount } = render(
+      <TacticalCommandShell viewerPlayerId="player-1" sessionId="match-A">
+        <ProbeState probe={probeA} />
+      </TacticalCommandShell>,
+    );
+
+    act(() => {
+      probeA.current?.updateState({ leftTrayCollapsed: true });
+    });
+
+    unmount();
+
+    // Mount a different session — should start with defaults, not
+    // pick up match-A's collapsed=true.
+    const probeB: {
+      current: ReturnType<typeof useTacticalShell> | null;
+    } = { current: null };
+
+    render(
+      <TacticalCommandShell viewerPlayerId="player-1" sessionId="match-B">
+        <ProbeState probe={probeB} />
+      </TacticalCommandShell>,
+    );
+
+    expect(probeB.current?.state.leftTrayCollapsed).toBe(false);
+  });
+
+  it('tolerates malformed sessionStorage payload gracefully', () => {
+    window.sessionStorage.setItem('tactical-shell:match-42', 'not-valid-json');
+
+    const probe: {
+      current: ReturnType<typeof useTacticalShell> | null;
+    } = { current: null };
+
+    render(
+      <TacticalCommandShell viewerPlayerId="player-1" sessionId="match-42">
+        <ProbeState probe={probe} />
+      </TacticalCommandShell>,
+    );
+
+    // Falls back to defaults — does not throw.
+    expect(probe.current?.state.leftTrayCollapsed).toBe(false);
+    expect(probe.current?.state.rightTrayPinned).toBe(false);
   });
 });


### PR DESCRIPTION
## Why

Wave 7.1 PR-C — closes Wave 7.1. Extends `TacticalCommandShell` with mutable shell state, partial-update mutator API, per-match `sessionStorage` persistence, and `shellMode`-driven slot filtering. Wraps `SpectatorView` with the same shell contract so spectator joins combat / replay / GM under one logical layer.

Closes Wave 7.1 tasks **#2.3**, **#3.1**, **#3.2** — all 10 tasks in `add-tactical-command-shell/tasks.md` are now done.

## What

### Extended context surface

`ITacticalShellContext` now exposes mutable state + a partial-update mutator:

| Field | Kind | Notes |
|------|------|-------|
| `registry` | static | from PR-A |
| `viewerPlayerId` | static | from PR-B |
| `shellMode` | static | wired through GameplayLayout + SpectatorView in this PR |
| `sessionId` | static (new) | drives `sessionStorage` persistence key; `null` = no persistence |
| `state` | mutable (new) | full `ITacticalShellState` from PR-A; single source of truth for slot UI |
| `updateState(partial)` | mutator (new) | merges partial into state; persisted slice writes through to `sessionStorage` |

### Mode-aware ShellSlot filtering (task 3.1)

`<ShellSlot modes={['combat']}>` does **not** register AND does **not** render its children when current `shellMode` is not `'combat'`. Empty or omitted `modes` = "all modes" (backward-compat with PR-B).

Closes the spec scenario *Spectator mode disables private commands*: a future action-dock `ShellSlot` with `modes={['combat']}` renders absent in spectator mode rather than disabled-in-DOM — the stronger guarantee.

### Per-match `sessionStorage` persistence (task 2.3)

- Storage key: `tactical-shell:${sessionId}`
- Persists only the **tray slice** (`leftTrayCollapsed`, `rightTrayPinned`, `bottomDockActiveTab`) — NOT the unit-reference triple
- Hydrates on mount via `useState` lazy initializer
- Write-through `useEffect` dedup'd against `lastPersistedRef` so unit-reference triple mutations (high-frequency) don't churn storage writes
- Tolerates SSR (no window), private mode (`sessionStorage.setItem` throws), malformed JSON (falls back to defaults)
- Scoped per-session-id; match-A state does NOT leak into match-B

**Why the unit-reference triple is not persisted:** `selected`/`active`/`inspectedUnit` re-derive from the interactive session on mount. Persisting them would stale-bind to destroyed/withdrawn/replaced units (campaign roster change between matches, etc.).

### `GameplayLayout` (task 3.1)

- New optional `shellMode` prop on `GameplayLayoutProps` (default `'combat'`)
- Forwarded to `TacticalCommandShell` along with `session.id` for persistence

### `SpectatorView` (tasks 3.1 + 3.2)

- Wrapped in `<TacticalCommandShell shellMode="spectator" sessionId={session.id}>`
- 3 inline regions wrapped in `ShellSlot`: `top-band` (`SpectatorHeader`), `map-center` (`SpectatorHexMap`), `right-tray` (`SpectatorUnitRoster`)
- **No action-dock slot owner registered** — spectator gets zero private commands by construction (task 3.2)
- `PlaybackControls` remain in `top-band` (public observer control, not private combat-actor command)
- Existing `data-testid="spectator-view"` / `data-testid="spectator-map"` preserved unchanged

## Tests (24 new + existing = 58/58 pass)

**PR-C: mode filtering** (4)
- Mode-mismatch slot does NOT register
- Mode-mismatch slot does NOT render children
- Mode-match slot DOES register and render
- Empty/omitted modes = all modes (backward-compat)

**PR-C: state + updateState** (3)
- Default-shape values exposed via context
- Partial-update merge
- Unit-reference triple stays independent across separate updates (Gate 4 invariant re-confirmed at mutator level)

**PR-C: `sessionStorage` persistence** (6)
- Tray slice writes through on updateState
- Hydrates on mount from existing storage
- Does NOT persist unit-reference triple (runtime-only)
- No storage touched when `sessionId` is null
- Per-session scoping: match-A doesn't leak to match-B
- Malformed payload tolerated (falls back to defaults)

**Regression coverage**
- 14/14 GameplayLayout-adjacent smoke tests still pass (`addInteractiveCombatCoreUI.smoke` + `addMovementPhaseUI.smoke`)
- Wave 7.0 e2e slot-identity gate (`e2e/gameplay-layout-slots.spec.ts`) preserved: GameplayLayout DOM structure unchanged
- One pre-existing PR-B test updated to use `shellMode='replay'` so the `modes={['replay']}` slot can register under new mode-filter semantics (was a latent test bug — passed PR-B because no filtering existed)

## Verification

- `npx tsc --noEmit` → clean
- `npx oxlint` → 1 warning (`max-lines: 416/400` on `GameplayLayout.tsx`) consistent with project baseline (`MoveAI.ts:446` already exceeds same cap); 0 errors
- `npx oxfmt --check` → clean
- `npx jest --runTestsByPath` (shell + smoke) → 58/58 passed

## Tasks closed

`openspec/changes/add-tactical-command-shell/tasks.md`:
- [x] 2.3 Pinned/collapsed tray behavior with per-match persistence
- [x] 3.1 Render combat, replay, spectator, GM modes from the same slot contract
- [x] 3.2 Disable private commands in spectator mode

**Wave 7.1 done** (all 10 tasks closed across PR-A / PR-B / PR-C).

## Next

**Phase 7.2** opens with 3-agent parallel fan-out for the next 3 OpenSpec changes:
- `add-tactical-action-menu-system` (PR-D)
- `add-tactical-turn-order-and-phase-rail` (PR-E)
- `add-tactical-unit-inspector-drawers` (PR-F)

All three plug into the slot contract this PR + PR-A/B established; downstream specs author their own `ShellSlot` registrations with the appropriate `modes` filter.
