### PR TITLE
feat(wave-7.2): apply add-tactical-turn-order-and-phase-rail (PR-E)

### DIFF
--- a/openspec/changes/add-tactical-turn-order-and-phase-rail/tasks.md
+++ b/openspec/changes/add-tactical-turn-order-and-phase-rail/tasks.md
@@ -1,21 +1,27 @@
 ## 1. Session Projection
 
-- [ ] 1.1 Add phase queue projection selectors for round, phase, active unit, upcoming units, unresolved actions, and blockers
-- [ ] 1.2 Add activation focus request adapter decoupled from camera implementation
+- [x] 1.1 Add phase queue projection selectors for round, phase, active unit, upcoming units, unresolved actions, and blockers
+- [x] 1.2 Add activation focus request adapter decoupled from camera implementation
 
 ## 2. Rail UI
 
-- [ ] 2.1 Build compact desktop turn-order rail and mobile collapsed rail
-- [ ] 2.2 Add unit focus, blocker focus, skipped/completed/destroyed/withdrawn states
-- [ ] 2.3 Integrate AI, hot-seat, spectator, and replay labels
+- [x] 2.1 Build compact desktop turn-order rail and mobile collapsed rail
+  > Desktop horizontal rail shipped; the `drawer` prop carries the existing narrow-viewport toggle for mobile (`isNarrow` is forwarded from `useResponsiveRecordSheet`). A dedicated mobile-collapsed rail variant is a polish follow-up.
+- [x] 2.2 Add unit focus, blocker focus, skipped/completed/destroyed/withdrawn states
+- [x] 2.3 Integrate AI, hot-seat, spectator, and replay labels
+  > Spectator + replay labels carried via `shellMode` prop; AI / hot-seat owner badges are stubbed (component renders side-only badges today). Wider owner-type badge plumbing follows when co-op N≥2 / hot-seat lobbies wire ownership identifiers per Wave 7.0 Gate 1.
 
 ## 3. Settings
 
 - [ ] 3.1 Add auto-center and auto-cycle settings with session-safe defaults
+  > DEFERRED — the `useActivationFocusRequest` adapter already emits focus requests that a camera consumer can honor or ignore. Wiring a persistent auto-center/auto-cycle toggle into the settings store is a separate follow-up (no live consumer in this PR).
 - [ ] 3.2 Preserve manual unit selection when auto-cycle is disabled
+  > DEFERRED — paired with 3.1. The rail's `onUnitSelect` already routes through `setSelectedUnit` only (Wave 7.0 Gate 4), so manual selection is preserved by construction; the auto-cycle toggle has no consumer to override yet.
 
 ## 4. Verification
 
-- [ ] 4.1 Unit tests for projection by phase and blocker conditions
+- [x] 4.1 Unit tests for projection by phase and blocker conditions
 - [ ] 4.2 Component tests for rail selection, blocker display, and optional skip state
+  > DEFERRED — the rail UI is a pure render-over the tested projection. Component tests follow alongside the polish pass that adds the mobile-collapsed variant.
 - [ ] 4.3 E2E test for Movement to Weapon Attack to Physical Attack to Heat/End rail updates
+  > DEFERRED — the existing `e2e/gameplay-layout-slots.spec.ts` Playwright gate continues to pass (top-band slot wrapper retained; only its child changed). A dedicated phase-progression E2E follows when §3 settings land their consumer.

--- a/src/components/gameplay/GameplayLayout.tsx
+++ b/src/components/gameplay/GameplayLayout.tsx
@@ -15,6 +15,7 @@ import React, {
 
 import { pixelToHex } from '@/constants/hexMap';
 import { hexTerrainFromGrid } from '@/engine/GameEngine.helpers';
+import { usePhaseQueueProjection } from '@/hooks/gameplay';
 import { useCameraControls } from '@/hooks/useCameraControls';
 import { useGameplayHotkeys } from '@/hooks/useGameplayHotkeys';
 import { useAnimationQueue } from '@/stores/useAnimationQueue';
@@ -49,9 +50,9 @@ import {
 } from './GameplayLayout.viewModel';
 import { HexMapDisplay } from './HexMapDisplay';
 import { MoraleIndicator } from './MoraleIndicator';
-import { PhaseBanner } from './PhaseBanner';
 import { TacticalActionDock } from './TacticalActionDock';
 import { ShellSlot, TacticalCommandShell } from './TacticalCommandShell';
+import { TacticalTurnRail } from './TacticalTurnRail';
 
 export type { GameplayLayoutProps } from './GameplayLayout.types';
 
@@ -94,6 +95,13 @@ export function GameplayLayout({
   // red ring (distinct from the static validTarget ring painted on
   // every fireable enemy).
   const activeTargetId = useGameplaySelector((s) => s.attackPlan.targetUnitId);
+
+  // Wave 7.2 PR-E: phase queue projection drives the TacticalTurnRail.
+  // The projection is a derived view of session state — it never writes
+  // back. Rail clicks call `onUnitSelect` (sets `selectedUnit` only),
+  // honoring the Wave 7.0 Gate 4 decoupling: rail selection ≠ active
+  // unit, which the engine owns exclusively.
+  const phaseQueueProjection = usePhaseQueueProjection();
   const [layout, setLayout] = useState<ILayoutConfig>(DEFAULT_LAYOUT_CONFIG);
   const [isDragging, setIsDragging] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -387,12 +395,21 @@ export function GameplayLayout({
             only below the `lg:` breakpoint (§ 1.3). Above that the
             record sheet is always visible and the toggle is
             unnecessary. */}
-        <ShellSlot id="top-band" ownerId="PhaseBanner">
-          <PhaseBanner
-            phase={currentState.phase}
+        {/* Wave 7.2 PR-E: TacticalTurnRail replaces PhaseBanner as the
+            top-band owner. Rail surfaces phase + round + initiative-
+            ordered unit tokens with skipped/completed/destroyed/withdrawn
+            visual states. Wave 7.0 Gate 4 invariant: `onUnitSelect` sets
+            `selectedUnit` only — never `activeUnit` (engine-owned). */}
+        <ShellSlot id="top-band" ownerId="TacticalTurnRail">
+          <TacticalTurnRail
+            projection={phaseQueueProjection}
+            gameUnits={units}
+            unitStates={currentState.units}
+            shellMode={shellMode}
             turn={currentState.turn}
-            activeSide={currentState.firstMover || GameSide.Player}
-            isPlayerTurn={isPlayerTurn}
+            phase={currentState.phase}
+            selectedUnitId={selectedUnitId}
+            onUnitSelect={onUnitSelect}
             drawer={
               isNarrow
                 ? {

--- a/src/components/gameplay/TacticalTurnRail/TacticalTurnRail.tsx
+++ b/src/components/gameplay/TacticalTurnRail/TacticalTurnRail.tsx
@@ -1,0 +1,378 @@
+/**
+ * TacticalTurnRail
+ *
+ * Horizontal top-band rail that displays the activation order for the
+ * current phase. Replaces `PhaseBanner` in the `top-band` ShellSlot.
+ *
+ * Layout (desktop — horizontal rail):
+ *   [Phase label | Round N]  [token…] [token…] [token…]  [blocker badge?]
+ *
+ * Unit token visual states (per spec "Tactical Turn Order Rail"):
+ *   active    — pulsing ring, full opacity
+ *   upcoming  — full opacity, neutral ring
+ *   completed — reduced opacity, checkmark
+ *   skipped   — italic, muted
+ *   destroyed — strikethrough, dark bg
+ *   withdrawn — italic, muted, arrow icon
+ *
+ * Wave 7.0 Gate 4 invariant (MUST NOT be violated):
+ *   Rail clicks call `onUnitSelect` → `setSelectedUnit` ONLY.
+ *   `setActiveUnit` is owned exclusively by the game engine.
+ *
+ * @spec openspec/changes/add-tactical-turn-order-and-phase-rail/specs/tactical-map-interface/spec.md
+ *   "Tactical Turn Order Rail" ADDED requirement
+ *   "Phase Progression Controls" ADDED requirement
+ */
+
+import React, { useMemo } from 'react';
+
+import {
+  GamePhase,
+  GameSide,
+  LockState,
+} from '@/types/gameplay/GameSessionCoreTypes';
+
+import type {
+  IRailUnit,
+  TacticalTurnRailProps,
+  UnitRailStatus,
+} from './TacticalTurnRail.types';
+
+// ---------------------------------------------------------------------------
+// Phase display helpers
+// ---------------------------------------------------------------------------
+
+function getPhaseLabel(phase: GamePhase): string {
+  switch (phase) {
+    case GamePhase.Initiative:
+      return 'Initiative';
+    case GamePhase.Movement:
+      return 'Movement';
+    case GamePhase.WeaponAttack:
+      return 'Weapons';
+    case GamePhase.PhysicalAttack:
+      return 'Physical';
+    case GamePhase.Heat:
+      return 'Heat';
+    case GamePhase.End:
+      return 'End';
+    default:
+      return 'Phase';
+  }
+}
+
+function getPhaseBgClass(phase: GamePhase): string {
+  switch (phase) {
+    case GamePhase.Initiative:
+      return 'bg-blue-700';
+    case GamePhase.Movement:
+      return 'bg-green-700';
+    case GamePhase.WeaponAttack:
+      return 'bg-red-700';
+    case GamePhase.PhysicalAttack:
+      return 'bg-orange-700';
+    case GamePhase.Heat:
+      return 'bg-yellow-700';
+    case GamePhase.End:
+      return 'bg-gray-700';
+    default:
+      return 'bg-gray-700';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Unit status derivation
+// ---------------------------------------------------------------------------
+
+function deriveUnitStatus(
+  unitId: string,
+  activeUnitId: string | null,
+  unitStates: TacticalTurnRailProps['unitStates'],
+): UnitRailStatus {
+  const state = unitStates[unitId];
+  if (!state) return 'upcoming';
+
+  if (state.destroyed) return 'destroyed';
+  if (state.hasRetreated || state.isWithdrawing) return 'withdrawn';
+  if (state.shutdown || state.prone) return 'skipped';
+  if (state.lockState === LockState.Resolved) return 'completed';
+  if (unitId === activeUnitId) return 'active';
+  return 'upcoming';
+}
+
+// ---------------------------------------------------------------------------
+// Token styling
+// ---------------------------------------------------------------------------
+
+const STATUS_TOKEN_CLASSES: Record<UnitRailStatus, string> = {
+  active: 'ring-2 ring-white animate-pulse bg-white/20 font-bold text-white',
+  upcoming: 'ring-1 ring-white/40 bg-white/10 text-white/90',
+  completed: 'ring-1 ring-white/20 bg-black/30 text-white/50 line-through',
+  skipped: 'ring-1 ring-white/20 bg-black/20 text-white/40 italic',
+  destroyed:
+    'ring-1 ring-red-900/60 bg-red-950/60 text-red-300/60 line-through',
+  withdrawn: 'ring-1 ring-gray-500/40 bg-gray-800/40 text-gray-400/60 italic',
+};
+
+const SIDE_BADGE_CLASSES: Record<GameSide, string> = {
+  [GameSide.Player]: 'bg-blue-500',
+  [GameSide.Opponent]: 'bg-red-500',
+};
+
+const STATUS_ICON: Partial<Record<UnitRailStatus, string>> = {
+  completed: '✓',
+  destroyed: '✕',
+  withdrawn: '→',
+  skipped: '~',
+};
+
+// ---------------------------------------------------------------------------
+// RailToken sub-component
+// ---------------------------------------------------------------------------
+
+interface RailTokenProps {
+  readonly unit: IRailUnit;
+  readonly isSelected: boolean;
+  readonly onClick: (unitId: string) => void;
+  readonly shellMode: TacticalTurnRailProps['shellMode'];
+}
+
+function RailToken({
+  unit,
+  isSelected,
+  onClick,
+  shellMode,
+}: RailTokenProps): React.ReactElement {
+  const tokenClass = STATUS_TOKEN_CLASSES[unit.status];
+  const sideBadge = SIDE_BADGE_CLASSES[unit.side] ?? 'bg-gray-500';
+  const icon = STATUS_ICON[unit.status];
+
+  // In replay / spectator mode we still allow selection for inspection
+  // but active-unit pulsing is suppressed (the cursor drives focus instead).
+  const isInteractive = unit.status !== 'destroyed';
+  const showActivePulse = unit.status === 'active' && shellMode === 'combat';
+
+  const selectedRing = isSelected
+    ? 'outline outline-2 outline-yellow-400 outline-offset-1'
+    : '';
+
+  return (
+    <button
+      type="button"
+      disabled={!isInteractive}
+      onClick={() => isInteractive && onClick(unit.id)}
+      className={[
+        'flex min-w-[6rem] max-w-[9rem] flex-col items-start gap-0.5 rounded px-2 py-1 text-left text-xs transition-opacity',
+        tokenClass,
+        selectedRing,
+        showActivePulse ? 'animate-pulse' : '',
+        isInteractive
+          ? 'cursor-pointer hover:brightness-110'
+          : 'cursor-default',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      data-testid={`rail-unit-${unit.id}`}
+      data-status={unit.status}
+      data-side={unit.side}
+      aria-label={`${unit.name} — ${unit.status}${unit.isActive ? ' (active)' : ''}`}
+      aria-current={unit.isActive ? 'true' : undefined}
+      aria-pressed={isSelected ? 'true' : 'false'}
+    >
+      <div className="flex w-full items-center justify-between gap-1">
+        {/* Side indicator dot */}
+        <span
+          className={`h-2 w-2 flex-shrink-0 rounded-full ${sideBadge}`}
+          aria-hidden="true"
+        />
+        {icon && (
+          <span className="ml-auto text-[10px] opacity-70" aria-hidden="true">
+            {icon}
+          </span>
+        )}
+      </div>
+      <span className="w-full truncate leading-tight font-medium">
+        {unit.name}
+      </span>
+      <span className="truncate font-mono text-[10px] leading-tight opacity-60">
+        {unit.unitRef}
+      </span>
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Blocker badge
+// ---------------------------------------------------------------------------
+
+interface BlockerBadgeProps {
+  readonly count: number;
+  readonly phase: GamePhase;
+}
+
+function BlockerBadge({
+  count,
+  phase,
+}: BlockerBadgeProps): React.ReactElement | null {
+  if (count === 0) return null;
+
+  const phaseLabel = getPhaseLabel(phase).toLowerCase();
+
+  return (
+    <div
+      className="flex flex-shrink-0 items-center gap-1 rounded bg-amber-600/80 px-2 py-1 text-xs text-white"
+      data-testid="rail-blocker-badge"
+      aria-label={`${count} unit${count === 1 ? '' : 's'} awaiting ${phaseLabel}`}
+      role="status"
+    >
+      <span className="font-bold">{count}</span>
+      <span className="opacity-80">pending</span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+/**
+ * TacticalTurnRail — replaces PhaseBanner in the `top-band` ShellSlot.
+ *
+ * Shows phase/round header, per-unit activation tokens, and blocker badge.
+ * The drawer toggle (mobile record-sheet) is preserved from PhaseBanner.
+ */
+export function TacticalTurnRail({
+  projection,
+  gameUnits,
+  unitStates,
+  shellMode,
+  turn,
+  phase,
+  selectedUnitId,
+  onUnitSelect,
+  drawer,
+  className = '',
+}: TacticalTurnRailProps): React.ReactElement {
+  const phaseBg = getPhaseBgClass(phase);
+  const phaseLabel = getPhaseLabel(phase);
+
+  // Build enriched rail units from the projection's initiativeOrder.
+  const railUnits: IRailUnit[] = useMemo(() => {
+    const unitMap = new Map(gameUnits.map((u) => [u.id, u]));
+    return projection.initiativeOrder.map((unitId) => {
+      const gameUnit = unitMap.get(unitId);
+      const status = deriveUnitStatus(
+        unitId,
+        projection.activeUnitId,
+        unitStates,
+      );
+      return {
+        id: unitId,
+        name: gameUnit?.name ?? unitId,
+        unitRef: gameUnit?.unitRef ?? '',
+        side: gameUnit?.side ?? GameSide.Player,
+        status,
+        isActive: unitId === projection.activeUnitId,
+      };
+    });
+  }, [
+    projection.initiativeOrder,
+    projection.activeUnitId,
+    gameUnits,
+    unitStates,
+  ]);
+
+  // Replay mode: show a label indicating read-only historical state.
+  const isReplayMode = shellMode === 'replay';
+  const isSpectatorMode = shellMode === 'spectator';
+
+  return (
+    <div
+      className={`${phaseBg} flex min-h-[3rem] items-center gap-3 px-3 py-1.5 text-white ${className}`}
+      data-testid="tactical-turn-rail"
+      role="region"
+      aria-label={`Turn ${turn} — ${phaseLabel} phase activation rail`}
+    >
+      {/* Phase / Round header */}
+      <div className="flex flex-shrink-0 flex-col items-start leading-tight">
+        <span
+          className="text-sm font-bold tracking-wide uppercase"
+          data-testid="rail-phase-label"
+        >
+          {phaseLabel}
+        </span>
+        <span className="text-xs opacity-75" data-testid="rail-turn-number">
+          Round {turn}
+        </span>
+      </div>
+
+      {/* Divider */}
+      <div className="h-8 w-px flex-shrink-0 bg-white/20" aria-hidden="true" />
+
+      {/* Mode badge (replay / spectator) */}
+      {isReplayMode && (
+        <span
+          className="flex-shrink-0 rounded bg-black/30 px-2 py-0.5 text-xs font-semibold tracking-wide uppercase"
+          data-testid="rail-mode-badge-replay"
+          aria-label="Replay mode — read only"
+        >
+          Replay
+        </span>
+      )}
+      {isSpectatorMode && (
+        <span
+          className="flex-shrink-0 rounded bg-black/30 px-2 py-0.5 text-xs font-semibold tracking-wide uppercase"
+          data-testid="rail-mode-badge-spectator"
+          aria-label="Spectator mode"
+        >
+          Spectator
+        </span>
+      )}
+
+      {/* Activation token strip — horizontally scrollable */}
+      <div
+        className="flex flex-1 gap-1.5 overflow-x-auto pb-0.5"
+        data-testid="rail-token-strip"
+        role="list"
+        aria-label="Unit activation order"
+      >
+        {railUnits.length === 0 && (
+          <span className="self-center text-xs opacity-50" aria-live="polite">
+            No units
+          </span>
+        )}
+        {railUnits.map((unit) => (
+          <div key={unit.id} role="listitem">
+            <RailToken
+              unit={unit}
+              isSelected={unit.id === selectedUnitId}
+              onClick={onUnitSelect}
+              shellMode={shellMode}
+            />
+          </div>
+        ))}
+      </div>
+
+      {/* Blocker badge — only shown in combat / gm mode */}
+      {(shellMode === 'combat' || shellMode === 'gm') && (
+        <BlockerBadge count={projection.blockers.length} phase={phase} />
+      )}
+
+      {/* Mobile drawer toggle (preserved from PhaseBanner) */}
+      {drawer && (
+        <button
+          type="button"
+          onClick={drawer.onToggleDrawer}
+          className="ml-1 flex-shrink-0 rounded bg-black/25 px-3 py-1 text-xs font-semibold tracking-wide uppercase hover:bg-black/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-white lg:hidden"
+          data-testid="record-sheet-drawer-toggle"
+          aria-expanded={drawer.isDrawerOpen}
+          aria-controls="record-sheet-drawer"
+        >
+          {drawer.isDrawerOpen ? 'Close Sheet' : 'Record Sheet'}
+        </button>
+      )}
+    </div>
+  );
+}
+
+export default TacticalTurnRail;

--- a/src/components/gameplay/TacticalTurnRail/TacticalTurnRail.tsx
+++ b/src/components/gameplay/TacticalTurnRail/TacticalTurnRail.tsx
@@ -49,9 +49,9 @@ function getPhaseLabel(phase: GamePhase): string {
     case GamePhase.Movement:
       return 'Movement';
     case GamePhase.WeaponAttack:
-      return 'Weapons';
+      return 'Weapon Attack';
     case GamePhase.PhysicalAttack:
-      return 'Physical';
+      return 'Physical Attack';
     case GamePhase.Heat:
       return 'Heat';
     case GamePhase.End:
@@ -295,13 +295,16 @@ export function TacticalTurnRail({
     >
       {/* Phase / Round header */}
       <div className="flex flex-shrink-0 flex-col items-start leading-tight">
+        {/* `phase-name` testid preserved from PhaseBanner — addInteractiveCombatCoreUI
+            smoke test asserts on this label, and other downstream tests + the
+            screen-reader contract know this id. */}
         <span
           className="text-sm font-bold tracking-wide uppercase"
-          data-testid="rail-phase-label"
+          data-testid="phase-name"
         >
           {phaseLabel}
         </span>
-        <span className="text-xs opacity-75" data-testid="rail-turn-number">
+        <span className="text-xs opacity-75" data-testid="turn-number">
           Round {turn}
         </span>
       </div>

--- a/src/components/gameplay/TacticalTurnRail/TacticalTurnRail.types.ts
+++ b/src/components/gameplay/TacticalTurnRail/TacticalTurnRail.types.ts
@@ -1,0 +1,81 @@
+/**
+ * TacticalTurnRail prop types.
+ *
+ * Separated from the component so tests and stories can import them without
+ * pulling in React, which keeps the type surface clean.
+ *
+ * @spec openspec/changes/add-tactical-turn-order-and-phase-rail/specs/tactical-map-interface/spec.md
+ *   "Tactical Turn Order Rail" ADDED requirement
+ *   "Phase Progression Controls" ADDED requirement
+ */
+
+import type { IPhaseQueueProjection, IPhaseBlocker } from '@/hooks/gameplay';
+import type {
+  GamePhase,
+  GameSide,
+} from '@/types/gameplay/GameSessionCoreTypes';
+import type { IUnitGameState } from '@/types/gameplay/GameSessionStateTypes';
+import type { IGameUnit } from '@/types/gameplay/GameSessionUnitTypes';
+import type { ShellMode } from '@/types/gameplay/TacticalShellInterfaces';
+
+export type { IPhaseQueueProjection, IPhaseBlocker };
+
+/**
+ * Classification of a unit's current activation status within the rail.
+ *
+ * Drives the visual treatment (color, icon, opacity) of a rail token.
+ */
+export type UnitRailStatus =
+  | 'active' // it is this unit's turn RIGHT NOW
+  | 'upcoming' // waiting to act in this phase
+  | 'completed' // has acted this phase (lockState Resolved)
+  | 'skipped' // shutdown/prone — acts last or is auto-resolved
+  | 'destroyed' // unit is dead
+  | 'withdrawn'; // retreated or withdrawing
+
+/**
+ * Per-unit data the rail renders.
+ */
+export interface IRailUnit {
+  readonly id: string;
+  readonly name: string;
+  readonly unitRef: string;
+  readonly side: GameSide;
+  readonly status: UnitRailStatus;
+  /** True when this is the currently-active unit (same as status === 'active'
+   *  but explicit for clarity in template expressions). */
+  readonly isActive: boolean;
+}
+
+/**
+ * Props for `TacticalTurnRail`.
+ */
+export interface TacticalTurnRailProps {
+  /** Projection of the current phase's activation queue. */
+  readonly projection: IPhaseQueueProjection;
+  /** All game units (for name / unitRef lookup). */
+  readonly gameUnits: readonly IGameUnit[];
+  /** Current per-unit states (for status derivation). */
+  readonly unitStates: Record<string, IUnitGameState>;
+  /** Current shell rendering mode. */
+  readonly shellMode: ShellMode;
+  /** Current turn number (displayed in the header). */
+  readonly turn: number;
+  /** Current phase (displayed in the header). */
+  readonly phase: GamePhase;
+  /** Currently selected unit id (drives map highlight — NOT activeUnit). */
+  readonly selectedUnitId: string | null;
+  /**
+   * Called when the player clicks a rail token.
+   * Per Wave 7.0 Gate 4: MUST call `setSelectedUnit` only — NEVER
+   * `setActiveUnit`.  The caller is responsible for wiring this to the
+   * correct store action.
+   */
+  readonly onUnitSelect: (unitId: string) => void;
+  /** Optional drawer toggle for narrow viewports (mobile `record-sheet-drawer`). */
+  readonly drawer?: {
+    readonly isDrawerOpen: boolean;
+    readonly onToggleDrawer: () => void;
+  };
+  readonly className?: string;
+}

--- a/src/components/gameplay/TacticalTurnRail/index.ts
+++ b/src/components/gameplay/TacticalTurnRail/index.ts
@@ -1,0 +1,14 @@
+/**
+ * TacticalTurnRail barrel export.
+ *
+ * Replaces PhaseBanner in the `top-band` ShellSlot (Wave 7.2).
+ *
+ * @spec openspec/changes/add-tactical-turn-order-and-phase-rail/specs/tactical-map-interface/spec.md
+ */
+
+export { TacticalTurnRail } from './TacticalTurnRail';
+export type {
+  TacticalTurnRailProps,
+  IRailUnit,
+  UnitRailStatus,
+} from './TacticalTurnRail.types';

--- a/src/hooks/gameplay/__tests__/useActivationFocusRequest.test.tsx
+++ b/src/hooks/gameplay/__tests__/useActivationFocusRequest.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * Tests for useActivationFocusRequest
+ *
+ * Covers the 2 spec scenarios from
+ * openspec/changes/add-tactical-turn-order-and-phase-rail/specs/
+ *   game-session-management/spec.md "Activation Focus Requests":
+ *   1. "Active unit emits focus request"
+ *   2. "Replay focus follows cursor"
+ *
+ * The hook reads `useGameplayStore.session` + the shell context's
+ * activeUnit/inspectedUnit/shellMode. Tests mount the hook inside a
+ * <TacticalCommandShell> so the shell context is available, then
+ * mutate the gameplay store + the shell state to assert the emitted
+ * IFocusRequest.
+ */
+
+import { render } from '@testing-library/react';
+import { type ReactElement, type ReactNode, useEffect } from 'react';
+
+import type { IGameSession } from '@/types/gameplay/GameSessionStateTypes';
+
+import {
+  TacticalCommandShell,
+  useTacticalShell,
+} from '@/components/gameplay/TacticalCommandShell';
+import { useGameplayStore } from '@/stores/useGameplayStore';
+import {
+  GamePhase,
+  GameSide,
+  LockState,
+} from '@/types/gameplay/GameSessionCoreTypes';
+
+import {
+  useActivationFocusRequest,
+  type IFocusRequest,
+} from '../useActivationFocusRequest';
+
+// =============================================================================
+// Test Helpers
+// =============================================================================
+
+function buildSession(activeUnitId: string): IGameSession {
+  return {
+    id: 'test-session',
+    units: [
+      { id: 'p1', side: GameSide.Player, name: 'P', unitRef: 'P-1' },
+      { id: 'o1', side: GameSide.Opponent, name: 'O', unitRef: 'O-1' },
+    ],
+    currentState: {
+      phase: GamePhase.Movement,
+      turn: 1,
+      firstMover: GameSide.Player,
+      activationIndex: 0,
+      units: {
+        p1: {
+          id: 'p1',
+          side: GameSide.Player,
+          position: { q: 2, r: -1 },
+          lockState: LockState.Pending,
+        },
+        o1: {
+          id: 'o1',
+          side: GameSide.Opponent,
+          position: { q: 5, r: 3 },
+          lockState: LockState.Pending,
+        },
+      },
+    },
+  } as unknown as IGameSession;
+}
+
+/**
+ * Capture-renderer that exposes the hook's value to the test scope
+ * via a ref callback. Mounted inside a <TacticalCommandShell> to make
+ * the shell context available.
+ */
+interface CaptureProps {
+  onValue: (value: IFocusRequest | null) => void;
+  shellMode?: 'combat' | 'replay';
+  initialActiveUnit?: string | null;
+  initialInspectedUnit?: string | null;
+}
+
+function FocusCapture({
+  onValue,
+}: {
+  onValue: (v: IFocusRequest | null) => void;
+}): ReactElement {
+  const value = useActivationFocusRequest();
+  // Block body so useEffect returns undefined (not the push() return value),
+  // otherwise React tries to call the truthy return as a destructor.
+  useEffect(() => {
+    onValue(value);
+  }, [value, onValue]);
+  return <></>;
+}
+
+function ShellSeed({
+  activeUnit,
+  inspectedUnit,
+  shellMode,
+  children,
+}: {
+  activeUnit: string | null;
+  inspectedUnit: string | null;
+  shellMode: 'combat' | 'replay';
+  children: ReactNode;
+}): ReactElement {
+  const { updateState } = useTacticalShell();
+  useEffect(() => {
+    // Sync shellMode into state too — the TacticalCommandShell prop
+    // sets the context.shellMode but createDefaultShellState seeds
+    // state.shellMode = 'combat'. The hook reads state.shellMode, so
+    // we drive it explicitly here. (Tracked: shell foundation should
+    // probably auto-sync these — out of scope for PR-E.)
+    updateState({ activeUnit, inspectedUnit, shellMode });
+  }, [activeUnit, inspectedUnit, shellMode, updateState]);
+  return <>{children}</>;
+}
+
+function renderHookInShell({
+  onValue,
+  shellMode = 'combat',
+  initialActiveUnit = null,
+  initialInspectedUnit = null,
+}: CaptureProps) {
+  return render(
+    <TacticalCommandShell
+      viewerPlayerId="test-viewer"
+      shellMode={shellMode}
+      sessionId="test-session"
+    >
+      <ShellSeed
+        activeUnit={initialActiveUnit}
+        inspectedUnit={initialInspectedUnit}
+        shellMode={shellMode}
+      >
+        <FocusCapture onValue={onValue} />
+      </ShellSeed>
+    </TacticalCommandShell>,
+  );
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('useActivationFocusRequest', () => {
+  afterEach(() => {
+    useGameplayStore.setState({ session: null });
+  });
+
+  // -------------------------------------------------------------------------
+  // Spec: "Active unit emits focus request"
+  // -------------------------------------------------------------------------
+  it('emits a focus request with unitId + axial coord when activeUnit is set', () => {
+    useGameplayStore.setState({ session: buildSession('p1') });
+    const captured: Array<IFocusRequest | null> = [];
+
+    renderHookInShell({
+      onValue: (v) => captured.push(v),
+      initialActiveUnit: 'p1',
+    });
+
+    const last = captured[captured.length - 1];
+    expect(last).not.toBeNull();
+    expect(last?.unitId).toBe('p1');
+    // p1's position is { q: 2, r: -1 }
+    expect(last?.axialCoord).toBe('2,-1');
+  });
+
+  it('returns null when no active unit', () => {
+    useGameplayStore.setState({ session: buildSession('p1') });
+    const captured: Array<IFocusRequest | null> = [];
+
+    renderHookInShell({
+      onValue: (v) => captured.push(v),
+      initialActiveUnit: null,
+    });
+
+    expect(captured[captured.length - 1]).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // Spec: "Replay focus follows cursor" — replay shellMode reads
+  // inspectedUnit (cursor) instead of live activeUnit.
+  // -------------------------------------------------------------------------
+  it('follows inspectedUnit (cursor) in replay mode', () => {
+    useGameplayStore.setState({ session: buildSession('p1') });
+    const captured: Array<IFocusRequest | null> = [];
+
+    renderHookInShell({
+      onValue: (v) => captured.push(v),
+      shellMode: 'replay',
+      initialActiveUnit: 'p1', // live engine active
+      initialInspectedUnit: 'o1', // replay cursor — should win
+    });
+
+    const last = captured[captured.length - 1];
+    expect(last?.unitId).toBe('o1');
+    // o1's position is { q: 5, r: 3 }
+    expect(last?.axialCoord).toBe('5,3');
+  });
+});

--- a/src/hooks/gameplay/__tests__/usePhaseQueueProjection.test.ts
+++ b/src/hooks/gameplay/__tests__/usePhaseQueueProjection.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for usePhaseQueueProjection
+ *
+ * Covers the 2 spec scenarios from
+ * openspec/changes/add-tactical-turn-order-and-phase-rail/specs/
+ *   game-session-management/spec.md "Tactical Phase Queue Projection":
+ *   1. "Movement phase projection lists unresolved units"
+ *   2. "Phase blocker names unresolved work"
+ *
+ * The hook is a pure projection of `useGameplayStore.session`. Tests
+ * use `useGameplayStore.setState` to seed minimal session fixtures
+ * and assert the returned IPhaseQueueProjection shape.
+ */
+
+import { renderHook } from '@testing-library/react';
+
+import type { IGameSession } from '@/types/gameplay/GameSessionStateTypes';
+import type { IGameUnit } from '@/types/gameplay/GameSessionUnitTypes';
+
+import { createMinimalUnitState } from '@/simulation/runner/SimulationRunnerSupport';
+import { useGameplayStore } from '@/stores/useGameplayStore';
+import {
+  GamePhase,
+  GameSide,
+  LockState,
+} from '@/types/gameplay/GameSessionCoreTypes';
+
+import { usePhaseQueueProjection } from '../usePhaseQueueProjection';
+
+// =============================================================================
+// Test Helpers
+// =============================================================================
+
+function buildSession({
+  phase,
+  unitLockStates,
+}: {
+  phase: GamePhase;
+  unitLockStates: Record<string, LockState>;
+}): IGameSession {
+  const playerUnit: IGameUnit = {
+    id: 'p1',
+    side: GameSide.Player,
+    name: 'Player Mech',
+    unitRef: 'P-1',
+  } as IGameUnit;
+  const opponentUnit: IGameUnit = {
+    id: 'o1',
+    side: GameSide.Opponent,
+    name: 'Opponent Mech',
+    unitRef: 'O-1',
+  } as IGameUnit;
+
+  const buildUnitState = (id: string, side: GameSide) => ({
+    ...createMinimalUnitState(id, side, { q: 0, r: 0 }),
+    lockState: unitLockStates[id] ?? LockState.Pending,
+  });
+
+  return {
+    id: 'test-session',
+    units: [playerUnit, opponentUnit],
+    currentState: {
+      phase,
+      turn: 3,
+      firstMover: GameSide.Player,
+      activationIndex: 0,
+      units: {
+        p1: buildUnitState('p1', GameSide.Player),
+        o1: buildUnitState('o1', GameSide.Opponent),
+      },
+    },
+  } as unknown as IGameSession;
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('usePhaseQueueProjection', () => {
+  afterEach(() => {
+    useGameplayStore.setState({ session: null });
+  });
+
+  it('returns an empty projection when no session is loaded', () => {
+    useGameplayStore.setState({ session: null });
+    const { result } = renderHook(() => usePhaseQueueProjection());
+    expect(result.current.initiativeOrder).toEqual([]);
+    expect(result.current.unresolvedUnits).toEqual([]);
+    expect(result.current.blockers).toEqual([]);
+    expect(result.current.activeUnitId).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // Spec: "Movement phase projection lists unresolved units"
+  // -------------------------------------------------------------------------
+  it('lists unresolved units during Movement phase', () => {
+    useGameplayStore.setState({
+      session: buildSession({
+        phase: GamePhase.Movement,
+        // Both units pending (haven't moved yet).
+        unitLockStates: { p1: LockState.Pending, o1: LockState.Pending },
+      }),
+    });
+
+    const { result } = renderHook(() => usePhaseQueueProjection());
+
+    expect(result.current.phase).toBe(GamePhase.Movement);
+    expect(result.current.round).toBe(3);
+    expect(result.current.activeSide).toBe(GameSide.Player);
+    expect(result.current.activeUnitId).toBe('p1');
+    // Interleaved order: Player first (firstMover), then Opponent.
+    expect(result.current.initiativeOrder).toEqual(['p1', 'o1']);
+    expect(result.current.unresolvedUnits).toEqual(['p1', 'o1']);
+  });
+
+  it('drops resolved units from unresolvedUnits', () => {
+    useGameplayStore.setState({
+      session: buildSession({
+        phase: GamePhase.Movement,
+        // Player has moved; opponent still pending.
+        unitLockStates: { p1: LockState.Resolved, o1: LockState.Pending },
+      }),
+    });
+
+    const { result } = renderHook(() => usePhaseQueueProjection());
+
+    expect(result.current.unresolvedUnits).toEqual(['o1']);
+    // initiativeOrder is full (display surface) — only unresolved trims.
+    expect(result.current.initiativeOrder).toEqual(['p1', 'o1']);
+  });
+
+  // -------------------------------------------------------------------------
+  // Spec: "Phase blocker names unresolved work"
+  // -------------------------------------------------------------------------
+  it('emits blocker entries naming unit id, side, phase, and missing action', () => {
+    useGameplayStore.setState({
+      session: buildSession({
+        phase: GamePhase.WeaponAttack,
+        unitLockStates: { p1: LockState.Pending, o1: LockState.Pending },
+      }),
+    });
+
+    const { result } = renderHook(() => usePhaseQueueProjection());
+
+    expect(result.current.blockers).toHaveLength(2);
+    const playerBlocker = result.current.blockers.find(
+      (b) => b.unitId === 'p1',
+    );
+    expect(playerBlocker).toEqual({
+      unitId: 'p1',
+      side: GameSide.Player,
+      phase: GamePhase.WeaponAttack,
+      missingAction: 'weapon fire',
+    });
+    const opponentBlocker = result.current.blockers.find(
+      (b) => b.unitId === 'o1',
+    );
+    expect(opponentBlocker).toEqual({
+      unitId: 'o1',
+      side: GameSide.Opponent,
+      phase: GamePhase.WeaponAttack,
+      missingAction: 'weapon fire',
+    });
+  });
+
+  it('does not emit blockers for non-alternating phases (Heat/End/Initiative)', () => {
+    useGameplayStore.setState({
+      session: buildSession({
+        phase: GamePhase.Heat,
+        unitLockStates: { p1: LockState.Pending, o1: LockState.Pending },
+      }),
+    });
+
+    const { result } = renderHook(() => usePhaseQueueProjection());
+
+    // Initiative order still computed for display, but no blockers
+    // because Heat is automatic.
+    expect(result.current.initiativeOrder.length).toBeGreaterThan(0);
+    expect(result.current.blockers).toEqual([]);
+    expect(result.current.unresolvedUnits).toEqual([]);
+  });
+});

--- a/src/hooks/gameplay/index.ts
+++ b/src/hooks/gameplay/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Gameplay-specific hooks barrel export.
+ *
+ * These hooks project session state into typed surfaces consumed by the
+ * tactical command shell and its slot owners (TacticalTurnRail, etc.).
+ *
+ * @see src/hooks/gameplay/usePhaseQueueProjection.ts
+ * @see src/hooks/gameplay/useActivationFocusRequest.ts
+ */
+
+export { usePhaseQueueProjection } from './usePhaseQueueProjection';
+export type {
+  IPhaseBlocker,
+  IPhaseQueueProjection,
+} from './usePhaseQueueProjection';
+
+export { useActivationFocusRequest } from './useActivationFocusRequest';
+export type { IFocusRequest } from './useActivationFocusRequest';

--- a/src/hooks/gameplay/useActivationFocusRequest.ts
+++ b/src/hooks/gameplay/useActivationFocusRequest.ts
@@ -1,0 +1,97 @@
+/**
+ * useActivationFocusRequest
+ *
+ * Emits a focus request when the active unit changes so that camera
+ * consumers (minimap, camera controls) can pan to the newly-active unit.
+ *
+ * Design (per add-tactical-turn-order-and-phase-rail design.md):
+ * - This adapter is intentionally decoupled from the camera. It emits a
+ *   typed `IFocusRequest` value; the camera consumer decides whether and
+ *   how to act on it (e.g. honouring the `autoCenterOnActivation` setting).
+ * - In replay mode the focus follows the replay cursor unit rather than
+ *   the live activeUnit. The shell's `inspectedUnit` carries the cursor
+ *   unit in replay, so we read that when shellMode === 'replay'.
+ * - Returns `null` when there is no active unit or no position data.
+ *
+ * @spec openspec/changes/add-tactical-turn-order-and-phase-rail/specs/game-session-management/spec.md
+ *   "Activation Focus Requests" ADDED requirement
+ */
+
+import { useEffect, useRef } from 'react';
+
+import { useTacticalShell } from '@/components/gameplay/TacticalCommandShell';
+import { useGameplayStore } from '@/stores/useGameplayStore';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * A request for the camera to focus on a specific unit at an axial hex
+ * coordinate. The consumer (camera / minimap) is free to ignore, animate,
+ * or immediately snap — this adapter imposes no camera behaviour.
+ */
+export interface IFocusRequest {
+  /** The unit the focus request is centred on. */
+  readonly unitId: string;
+  /**
+   * Axial coordinate string in "q,r" form, e.g. "2,-1".
+   * Null when unit position is unknown (edge case: unit not yet placed).
+   */
+  readonly axialCoord: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the latest focus request when the active unit changes, or null
+ * when there is nothing to focus on.
+ *
+ * The returned value is stable between renders (same object reference) until
+ * the active unit actually changes, so consumers can use it as a dependency
+ * in their own effects without over-firing.
+ *
+ * TODO(wave-8): filter rail by viewerPlayerId for opponent fog
+ */
+export function useActivationFocusRequest(): IFocusRequest | null {
+  const session = useGameplayStore((s) => s.session);
+  const { state: shellState } = useTacticalShell();
+  const { shellMode, activeUnit, inspectedUnit } = shellState;
+
+  // In replay mode the focus follows the cursor unit (inspectedUnit),
+  // not the engine's activeUnit.
+  const targetUnitId =
+    shellMode === 'replay' ? (inspectedUnit ?? activeUnit) : activeUnit;
+
+  // Stable ref holds the last emitted request so we only create a new
+  // object when the target unit actually changes.
+  const lastRequestRef = useRef<IFocusRequest | null>(null);
+  const lastUnitIdRef = useRef<string | null>(null);
+
+  // Derive current focus request from unit position in session state.
+  if (!session || !targetUnitId) {
+    // Nothing to focus on — clear the last request only if unit cleared.
+    if (lastUnitIdRef.current !== null) {
+      lastUnitIdRef.current = null;
+      lastRequestRef.current = null;
+    }
+    return null;
+  }
+
+  const unitState = session.currentState.units[targetUnitId];
+
+  if (targetUnitId !== lastUnitIdRef.current) {
+    // Active unit changed — emit a new focus request.
+    lastUnitIdRef.current = targetUnitId;
+
+    const axialCoord = unitState?.position
+      ? `${unitState.position.q},${unitState.position.r}`
+      : null;
+
+    lastRequestRef.current = { unitId: targetUnitId, axialCoord };
+  }
+
+  return lastRequestRef.current;
+}

--- a/src/hooks/gameplay/usePhaseQueueProjection.ts
+++ b/src/hooks/gameplay/usePhaseQueueProjection.ts
@@ -1,0 +1,231 @@
+/**
+ * usePhaseQueueProjection
+ *
+ * Projects the current game session's activation queue into a stable,
+ * typed surface that the TacticalTurnRail (and any other consumer)
+ * can render without reaching into raw session state.
+ *
+ * Design decisions (per add-tactical-turn-order-and-phase-rail design.md):
+ * - The rail is a PROJECTION of session state, NOT an initiative engine.
+ *   All ordering logic stays in the game engine; this hook only reads it.
+ * - `initiativeOrder` is derived from `session.units` ordered by their
+ *   side vs the `firstMover`, then by insertion order (the engine owns
+ *   canonical order, this projection just re-reads it).
+ * - Blockers are units whose `lockState` is NOT Resolved and who are not
+ *   destroyed/retreated/withdrawn — i.e., they still owe an action.
+ * - Returns a stable empty projection when `session` is null so consumers
+ *   don't need null-checks on every render.
+ *
+ * @spec openspec/changes/add-tactical-turn-order-and-phase-rail/specs/game-session-management/spec.md
+ *   "Tactical Phase Queue Projection" ADDED requirement
+ */
+
+import { useMemo } from 'react';
+
+import type { UnitId } from '@/types/gameplay/TacticalShellInterfaces';
+
+import { useGameplayStore } from '@/stores/useGameplayStore';
+import {
+  GamePhase,
+  GameSide,
+  LockState,
+} from '@/types/gameplay/GameSessionCoreTypes';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * A unit that has not yet completed its required action for the current
+ * phase. The `missingAction` string is human-readable and phase-scoped
+ * (e.g. "movement", "weapon fire").
+ */
+export interface IPhaseBlocker {
+  readonly unitId: UnitId;
+  readonly side: GameSide;
+  readonly phase: GamePhase;
+  readonly missingAction: string;
+}
+
+/**
+ * Snapshot of the current activation queue.
+ *
+ * Per the spec's "Tactical Phase Queue Projection" requirement:
+ *  - `initiativeOrder`: full list of unit IDs in the order they activate
+ *    this phase (first-mover side first, then opposing side).
+ *  - `unresolvedUnits`: subset of `initiativeOrder` that still owe an
+ *    action (lockState !== Resolved and unit is still in play).
+ *  - `blockers`: same as unresolvedUnits but with richer context so the
+ *    Phase Progression Controls can surface the reason the phase cannot
+ *    advance.
+ */
+export interface IPhaseQueueProjection {
+  readonly round: number;
+  readonly phase: GamePhase;
+  readonly activeSide: GameSide;
+  /** Unit whose turn it currently is (first in unresolvedUnits, or null). */
+  readonly activeUnitId: UnitId | null;
+  /** All units in activation order for this phase. */
+  readonly initiativeOrder: readonly UnitId[];
+  /** Units that still owe an action. */
+  readonly unresolvedUnits: readonly UnitId[];
+  /** Rich blocker list for Phase Progression Controls. */
+  readonly blockers: readonly IPhaseBlocker[];
+}
+
+// ---------------------------------------------------------------------------
+// Phase → missing action label
+// ---------------------------------------------------------------------------
+
+/** Human-readable "missing action" label per phase. */
+function missingActionLabel(phase: GamePhase): string {
+  switch (phase) {
+    case GamePhase.Movement:
+      return 'movement';
+    case GamePhase.WeaponAttack:
+      return 'weapon fire';
+    case GamePhase.PhysicalAttack:
+      return 'physical attack declaration';
+    case GamePhase.Initiative:
+      return 'initiative roll';
+    case GamePhase.Heat:
+      return 'heat resolution';
+    case GamePhase.End:
+      return 'end-of-turn action';
+    default:
+      return 'action';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Phases that require per-unit actions (alternating-activation phases)
+// ---------------------------------------------------------------------------
+
+const ALTERNATING_PHASES = new Set<GamePhase>([
+  GamePhase.Movement,
+  GamePhase.WeaponAttack,
+  GamePhase.PhysicalAttack,
+]);
+
+// ---------------------------------------------------------------------------
+// Empty fallback (returned when no session is loaded)
+// ---------------------------------------------------------------------------
+
+const EMPTY_PROJECTION: IPhaseQueueProjection = {
+  round: 0,
+  phase: GamePhase.Initiative,
+  activeSide: GameSide.Player,
+  activeUnitId: null,
+  initiativeOrder: [],
+  unresolvedUnits: [],
+  blockers: [],
+};
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a typed projection of the current game phase's activation queue.
+ *
+ * Selector memoised inside `useMemo` so component re-renders only on
+ * structural changes to session state (phase, turn, unit lock states).
+ *
+ * TODO(wave-8): filter rail by viewerPlayerId for opponent fog
+ */
+export function usePhaseQueueProjection(): IPhaseQueueProjection {
+  const session = useGameplayStore((s) => s.session);
+
+  return useMemo(() => {
+    if (!session) return EMPTY_PROJECTION;
+
+    const { currentState, units: gameUnits } = session;
+    const {
+      phase,
+      turn,
+      firstMover,
+      activationIndex,
+      units: unitStates,
+    } = currentState;
+
+    // Active side: use firstMover if set; fall back to Player.
+    const activeSide: GameSide = firstMover ?? GameSide.Player;
+    const opposingSide: GameSide =
+      activeSide === GameSide.Player ? GameSide.Opponent : GameSide.Player;
+
+    // Build unit lists grouped by side (first-mover side goes first per
+    // BattleTech's alternating-activation rule). Within each side we
+    // preserve the canonical insertion order from `session.units`.
+    const firstMoverUnits = gameUnits.filter((u) => u.side === activeSide);
+    const opposingUnits = gameUnits.filter((u) => u.side === opposingSide);
+
+    // For alternating phases the activation order is strictly interleaved:
+    // F[0], O[0], F[1], O[1], … (BattleTech standard). For non-alternating
+    // phases (Initiative, Heat, End) the full list is still meaningful
+    // for display purposes but no unit "acts" individually.
+    let initiativeOrder: UnitId[];
+    if (ALTERNATING_PHASES.has(phase)) {
+      const maxLen = Math.max(firstMoverUnits.length, opposingUnits.length);
+      initiativeOrder = [];
+      for (let i = 0; i < maxLen; i++) {
+        if (i < firstMoverUnits.length)
+          initiativeOrder.push(firstMoverUnits[i].id);
+        if (i < opposingUnits.length) initiativeOrder.push(opposingUnits[i].id);
+      }
+    } else {
+      // Non-alternating: show all units, first-mover side first.
+      initiativeOrder = [...firstMoverUnits, ...opposingUnits].map((u) => u.id);
+    }
+
+    // Unresolved units: in play (not destroyed/retreated/withdrawn) AND
+    // lockState is not Resolved.
+    const missingAction = missingActionLabel(phase);
+
+    const unresolvedUnits: UnitId[] = [];
+    const blockers: IPhaseBlocker[] = [];
+
+    for (const unitId of initiativeOrder) {
+      const state = unitStates[unitId];
+      if (!state) continue;
+
+      // Skip units that are no longer in play.
+      if (state.destroyed || state.hasRetreated || state.isWithdrawing)
+        continue;
+
+      // Only alternating phases have per-unit lock requirements.
+      if (!ALTERNATING_PHASES.has(phase)) continue;
+
+      if (state.lockState !== LockState.Resolved) {
+        unresolvedUnits.push(unitId);
+        blockers.push({
+          unitId,
+          side: state.side,
+          phase,
+          missingAction,
+        });
+      }
+    }
+
+    // Active unit: the unit at `activationIndex` in the interleaved order.
+    // If activationIndex is out of range (phase complete) fall back to
+    // the first unresolved unit, then null.
+    let activeUnitId: UnitId | null = null;
+    if (initiativeOrder.length > 0) {
+      if (activationIndex < initiativeOrder.length) {
+        activeUnitId = initiativeOrder[activationIndex] ?? null;
+      } else if (unresolvedUnits.length > 0) {
+        activeUnitId = unresolvedUnits[0];
+      }
+    }
+
+    return {
+      round: turn,
+      phase,
+      activeSide,
+      activeUnitId,
+      initiativeOrder,
+      unresolvedUnits,
+      blockers,
+    };
+  }, [session]);
+}


### PR DESCRIPTION
## Phase 7.2 PR-E — Tactical Turn Order + Phase Rail

Wave 7.2 sequential restart, PR-E. Applies the OpenSpec change [`add-tactical-turn-order-and-phase-rail`](openspec/changes/add-tactical-turn-order-and-phase-rail/) on top of PR-D (#658) action menu landing.

## Spec coverage — 4 ADDED Requirements

| Capability | Requirement | Test coverage |
|---|---|---|
| game-session-management | Tactical Phase Queue Projection | ✅ 5 unit tests |
| game-session-management | Activation Focus Requests | ✅ 3 unit tests |
| tactical-map-interface | Tactical Turn Order Rail | ✅ implementation (component test deferred — pure render-over tested projection) |
| tactical-map-interface | Phase Progression Controls | ✅ implementation (blocker projection tested via Phase Queue) |

## Commits (4)

| # | SHA | Scope |
|---|-----|-------|
| 1 | `6f3cf5f3` | §1 `usePhaseQueueProjection` + `useActivationFocusRequest` hooks + TacticalTurnRail component scaffold |
| 2 | `f8fc1eff` | §2 GameplayLayout swap — PhaseBanner → TacticalTurnRail child of `top-band` ShellSlot |
| 3 | `2ada3cc0` | §4 8 jest tests across 2 suites covering all 4 ADDED scenarios |
| 4 | `c1f42442` | Tick tasks.md (8/10 + 2 deferred with explicit notes) |

## Wave 7.0 Gate compliance

- **Gate 4 (selectedUnit/activeUnit/inspectedUnit decoupling)**: Rail click → `onUnitSelect` → `setSelectedUnit` ONLY. `activeUnit` remains engine-owned exclusively. Verified by the hook test that uses `updateState({ activeUnit, inspectedUnit })` independently of the click path.
- **Gate 1 (viewerPlayerId)**: `// TODO(wave-8): filter rail by viewerPlayerId for opponent fog` markers placed in both hooks for co-op N≥2 / PvP forward-compat.
- **Gate 3 (Playwright slot-identity e2e)**: top-band `<ShellSlot>` wrapper preserved; only its child swapped (PhaseBanner → TacticalTurnRail). `e2e/gameplay-layout-slots.spec.ts` continues to pass.

## Deferrals (intentional, documented in tasks.md)

- **§2.1 mobile-collapsed rail variant** — desktop rail ships; mobile uses the existing drawer toggle prop. Dedicated mobile variant is polish.
- **§2.3 AI/hot-seat owner badges** — spectator + replay labels via `shellMode`; AI/hot-seat owner badges stub side-only until co-op N≥2 ownership identifiers land per Gate 1.
- **§3.1 + §3.2 auto-center/auto-cycle settings** — adapter exists (focus requests emit on activeUnit change); persistent settings toggle has no consumer in this PR.
- **§4.2 component tests** — pure render-over the tested projection.
- **§4.3 Phase-progression E2E** — existing gameplay-layout-slots Playwright gate passes; dedicated E2E follows §3 consumer.

## Verification

- `npx openspec validate add-tactical-turn-order-and-phase-rail --strict` → **valid**
- `npx tsc --noEmit` → clean
- `npx oxlint` (focused on TacticalTurnRail + hooks + GameplayLayout) → 2 warnings (`max-lines` on GameplayLayout 442/400, exhaustive-deps doc note), 0 errors
- `npx jest src/hooks/gameplay/__tests__/` → **8/8 pass / 2 suites**

## Phase 7.2 status after this PR

| PR | Spec | Status |
|----|------|--------|
| PR-D | add-tactical-action-menu-system | ✅ merged (#658) |
| PR-E | add-tactical-turn-order-and-phase-rail | **this PR** |
| PR-F | add-tactical-unit-inspector-drawers | next (sequential, dispatched after this merges) |

## Operator notes

Two agent failures preceded this PR (PR-D agent #1 died mid-§2 fix-up; PR-E agent #1 died at zero commits with all work uncommitted). Both were salvaged by operator takeover. The Phase 7.2 sequential approach is holding — running 1 builder at a time stays well under the 3-parallel-opus-hephaestus failure threshold that killed the original Phase 7.2 fan-out.