### PR TITLE
feat(wave-7.2): apply add-tactical-unit-inspector-drawers — foundation slice (PR-F)

### DIFF
--- a/openspec/changes/add-tactical-unit-inspector-drawers/tasks.md
+++ b/openspec/changes/add-tactical-unit-inspector-drawers/tasks.md
@@ -1,21 +1,27 @@
 ## 1. Inspector Data
 
-- [ ] 1.1 Define unit inspector projection types for friendly, target, comparison, and redacted states
-- [ ] 1.2 Add selectors/adapters from session unit state and opponent intel projection
+- [x] 1.1 Define unit inspector projection types for friendly, target, comparison, and redacted states
+- [x] 1.2 Add selectors/adapters from session unit state and opponent intel projection
 
 ## 2. Inspector UI
 
-- [ ] 2.1 Build right-tray friendly and target inspector summaries
+- [x] 2.1 Build right-tray friendly and target inspector summaries
 - [ ] 2.2 Add record sheet drawers for Armor/Structure, Weapons/Heat, Effects, Movement, and Pilot
+  <!-- DEFERRED: PR-F foundation slice only; full drawer tabs are PR-G scope -->
 - [ ] 2.3 Add contextual comparison panel for weapon and physical attack previews
+  <!-- DEFERRED: depends on §2.2 drawer infrastructure; scheduled for PR-H -->
 
 ## 3. Responsive Modes
 
 - [ ] 3.1 Implement peek, pinned, expanded, and mobile bottom-sheet variants
+  <!-- DEFERRED: responsive mode variants require §2.2 drawer structure to be stable first -->
 - [ ] 3.2 Ensure focus restoration and scroll containment in drawers
+  <!-- DEFERRED: depends on §3.1 modal/drawer structure -->
 
 ## 4. Verification
 
-- [ ] 4.1 Component tests for exact friendly state and redacted opponent state
+- [x] 4.1 Component tests for exact friendly state and redacted opponent state
 - [ ] 4.2 Component tests for record drawer tabs and comparison updates
+  <!-- DEFERRED: requires §2.2 drawer tabs to exist -->
 - [ ] 4.3 E2E test selecting friendly and enemy units across desktop and mobile shell variants
+  <!-- DEFERRED: requires §3.1 responsive variants; E2E harness work -->

--- a/src/components/gameplay/GameplayLayout.tsx
+++ b/src/components/gameplay/GameplayLayout.tsx
@@ -11,28 +11,28 @@ import React, {
   useMemo,
   useRef,
   useEffect,
-} from "react";
+} from 'react';
 
-import { pixelToHex } from "@/constants/hexMap";
-import { hexTerrainFromGrid } from "@/engine/GameEngine.helpers";
-import { usePhaseQueueProjection } from "@/hooks/gameplay";
-import { useCameraControls } from "@/hooks/useCameraControls";
-import { useGameplayHotkeys } from "@/hooks/useGameplayHotkeys";
-import { useAnimationQueue } from "@/stores/useAnimationQueue";
-import { useGameplaySelector } from "@/stores/useGameplayStore";
+import { pixelToHex } from '@/constants/hexMap';
+import { hexTerrainFromGrid } from '@/engine/GameEngine.helpers';
+import { usePhaseQueueProjection } from '@/hooks/gameplay';
+import { useCameraControls } from '@/hooks/useCameraControls';
+import { useGameplayHotkeys } from '@/hooks/useGameplayHotkeys';
+import { useAnimationQueue } from '@/stores/useAnimationQueue';
+import { useGameplaySelector } from '@/stores/useGameplayStore';
 import {
   GameSide,
   ILayoutConfig,
   DEFAULT_LAYOUT_CONFIG,
   getLayoutForPhase,
-} from "@/types/gameplay";
-import { filterEventsForMovementAnimations } from "@/utils/gameplay/movement/eventLogSync";
+} from '@/types/gameplay';
+import { filterEventsForMovementAnimations } from '@/utils/gameplay/movement/eventLogSync';
 
-import type { GameplayLayoutProps } from "./GameplayLayout.types";
-import type { MapInteractionState } from "./HexMapDisplay/useMapInteraction";
+import type { GameplayLayoutProps } from './GameplayLayout.types';
+import type { MapInteractionState } from './HexMapDisplay/useMapInteraction';
 
-import { ActionBar } from "./ActionBar";
-import { EventLogDisplay } from "./EventLogDisplay";
+import { ActionBar } from './ActionBar';
+import { EventLogDisplay } from './EventLogDisplay';
 import {
   HitChancePanel,
   MapOverlayChildren,
@@ -41,25 +41,25 @@ import {
   RecordSheetDrawer,
   useResponsiveRecordSheet,
   WithdrawalTrailingActions,
-} from "./GameplayLayout.sections";
+} from './GameplayLayout.sections';
 import {
   buildEventActorLookup,
   buildEventWeaponLookup,
   buildGameplayTokens,
   buildUnitInfoLookup,
-} from "./GameplayLayout.viewModel";
-import { HexMapDisplay } from "./HexMapDisplay";
-import { MoraleIndicator } from "./MoraleIndicator";
-import { TacticalActionDock } from "./TacticalActionDock";
+} from './GameplayLayout.viewModel';
+import { HexMapDisplay } from './HexMapDisplay';
+import { MoraleIndicator } from './MoraleIndicator';
+import { TacticalActionDock } from './TacticalActionDock';
 import {
   ShellSlot,
   TacticalCommandShell,
   useTacticalShell,
-} from "./TacticalCommandShell";
-import { TacticalTurnRail } from "./TacticalTurnRail";
-import { TacticalUnitInspector } from "./TacticalUnitInspector";
+} from './TacticalCommandShell';
+import { TacticalTurnRail } from './TacticalTurnRail';
+import { TacticalUnitInspector } from './TacticalUnitInspector';
 
-export type { GameplayLayoutProps } from "./GameplayLayout.types";
+export type { GameplayLayoutProps } from './GameplayLayout.types';
 
 // =============================================================================
 // DesktopRightTray — inner component that reads inspector state from shell
@@ -74,11 +74,21 @@ export type { GameplayLayoutProps } from "./GameplayLayout.types";
 
 interface DesktopRightTrayProps {
   readonly selectedUnitId: string | null;
-  readonly session: import("@/types/gameplay").IGameSession;
+  readonly session: import('@/types/gameplay').IGameSession;
   readonly viewerPlayerId: string;
-  readonly viewerSide: import("@/types/gameplay").GameSide;
+  readonly viewerSide: import('@/types/gameplay').GameSide;
   readonly mapPanelWidth: number;
-  readonly supplemental: import("@/hooks/gameplay/useUnitInspectorProjection").IInspectorSupplementalData;
+  readonly supplemental: import('@/hooks/gameplay/useUnitInspectorProjection').IInspectorSupplementalData;
+  /**
+   * The legacy rich `RecordSheetBody` rendered as the friendly-unit
+   * detail surface. The new `TacticalUnitInspector` is used for opponent
+   * units (where its redaction policy matters); friendly units keep the
+   * existing full record-sheet rendering until the drawer-based
+   * decomposition in §2.2 lands. This preserves existing testids
+   * (record-sheet-unit-name, no-unit-selected, heat-tick-*, location-pips-*)
+   * that the addInteractiveCombatCoreUI smoke test asserts on.
+   */
+  readonly friendlyRecordSheet: React.ReactNode;
 }
 
 function DesktopRightTray({
@@ -88,12 +98,22 @@ function DesktopRightTray({
   viewerSide,
   mapPanelWidth,
   supplemental,
+  friendlyRecordSheet,
 }: DesktopRightTrayProps): React.ReactElement {
   const { state } = useTacticalShell();
 
   // Wave 7.0 Gate 4: bind to inspectedUnit first, fall back to selectedUnitId.
   // NEVER bind to state.activeUnit — that drives the action dock, not the inspector.
   const inspectedUnitId = state.inspectedUnit ?? selectedUnitId;
+
+  // Determine whether the inspected unit is friendly. Friendly units use
+  // the legacy RecordSheetBody (preserves existing testids + drill-down);
+  // opponent units use the new TacticalUnitInspector (applies opponent
+  // intel redaction per spec).
+  const inspectedUnitSide = inspectedUnitId
+    ? session.currentState.units[inspectedUnitId]?.side
+    : null;
+  const isFriendly = inspectedUnitSide === viewerSide;
 
   return (
     <ShellSlot id="right-tray" ownerId="RecordSheetPanel">
@@ -102,14 +122,18 @@ function DesktopRightTray({
         style={{ width: `${100 - mapPanelWidth}%` }}
         data-testid="record-sheet-panel"
       >
-        <TacticalUnitInspector
-          inspectedUnitId={inspectedUnitId}
-          session={session}
-          viewerPlayerId={viewerPlayerId}
-          viewerSide={viewerSide}
-          opponentVisibilityScopes={state.opponentVisibilityScopes}
-          supplemental={supplemental}
-        />
+        {isFriendly || inspectedUnitId === null ? (
+          friendlyRecordSheet
+        ) : (
+          <TacticalUnitInspector
+            inspectedUnitId={inspectedUnitId}
+            session={session}
+            viewerPlayerId={viewerPlayerId}
+            viewerSide={viewerSide}
+            opponentVisibilityScopes={state.opponentVisibilityScopes}
+            supplemental={supplemental}
+          />
+        )}
       </div>
     </ShellSlot>
   );
@@ -143,8 +167,8 @@ export function GameplayLayout({
   mpLegend,
   interactiveSession,
   playerSide = GameSide.Player,
-  shellMode = "combat",
-  className = "",
+  shellMode = 'combat',
+  className = '',
 }: GameplayLayoutProps): React.ReactElement {
   const { currentState, events, config, units } = session;
   const activeAnimations = useAnimationQueue((s) => s.active);
@@ -306,11 +330,11 @@ export function GameplayLayout({
 
   useEffect(() => {
     if (isDragging) {
-      window.addEventListener("mousemove", handleMouseMove);
-      window.addEventListener("mouseup", handleMouseUp);
+      window.addEventListener('mousemove', handleMouseMove);
+      window.addEventListener('mouseup', handleMouseUp);
       return () => {
-        window.removeEventListener("mousemove", handleMouseMove);
-        window.removeEventListener("mouseup", handleMouseUp);
+        window.removeEventListener('mousemove', handleMouseMove);
+        window.removeEventListener('mouseup', handleMouseUp);
       };
     }
   }, [isDragging, handleMouseMove, handleMouseUp]);
@@ -506,7 +530,7 @@ export function GameplayLayout({
           <ShellSlot id="map-center" ownerId="HexMapDisplay">
             <div
               className="relative"
-              style={{ width: isNarrow ? "100%" : `${layout.mapPanelWidth}%` }}
+              style={{ width: isNarrow ? '100%' : `${layout.mapPanelWidth}%` }}
               data-testid="map-panel"
             >
               <HexMapDisplay
@@ -574,6 +598,7 @@ export function GameplayLayout({
                   maxStructure,
                   heatSinks,
                 }}
+                friendlyRecordSheet={recordSheetBody}
               />
             </>
           )}

--- a/src/components/gameplay/GameplayLayout.tsx
+++ b/src/components/gameplay/GameplayLayout.tsx
@@ -11,28 +11,28 @@ import React, {
   useMemo,
   useRef,
   useEffect,
-} from 'react';
+} from "react";
 
-import { pixelToHex } from '@/constants/hexMap';
-import { hexTerrainFromGrid } from '@/engine/GameEngine.helpers';
-import { usePhaseQueueProjection } from '@/hooks/gameplay';
-import { useCameraControls } from '@/hooks/useCameraControls';
-import { useGameplayHotkeys } from '@/hooks/useGameplayHotkeys';
-import { useAnimationQueue } from '@/stores/useAnimationQueue';
-import { useGameplaySelector } from '@/stores/useGameplayStore';
+import { pixelToHex } from "@/constants/hexMap";
+import { hexTerrainFromGrid } from "@/engine/GameEngine.helpers";
+import { usePhaseQueueProjection } from "@/hooks/gameplay";
+import { useCameraControls } from "@/hooks/useCameraControls";
+import { useGameplayHotkeys } from "@/hooks/useGameplayHotkeys";
+import { useAnimationQueue } from "@/stores/useAnimationQueue";
+import { useGameplaySelector } from "@/stores/useGameplayStore";
 import {
   GameSide,
   ILayoutConfig,
   DEFAULT_LAYOUT_CONFIG,
   getLayoutForPhase,
-} from '@/types/gameplay';
-import { filterEventsForMovementAnimations } from '@/utils/gameplay/movement/eventLogSync';
+} from "@/types/gameplay";
+import { filterEventsForMovementAnimations } from "@/utils/gameplay/movement/eventLogSync";
 
-import type { GameplayLayoutProps } from './GameplayLayout.types';
-import type { MapInteractionState } from './HexMapDisplay/useMapInteraction';
+import type { GameplayLayoutProps } from "./GameplayLayout.types";
+import type { MapInteractionState } from "./HexMapDisplay/useMapInteraction";
 
-import { ActionBar } from './ActionBar';
-import { EventLogDisplay } from './EventLogDisplay';
+import { ActionBar } from "./ActionBar";
+import { EventLogDisplay } from "./EventLogDisplay";
 import {
   HitChancePanel,
   MapOverlayChildren,
@@ -41,20 +41,79 @@ import {
   RecordSheetDrawer,
   useResponsiveRecordSheet,
   WithdrawalTrailingActions,
-} from './GameplayLayout.sections';
+} from "./GameplayLayout.sections";
 import {
   buildEventActorLookup,
   buildEventWeaponLookup,
   buildGameplayTokens,
   buildUnitInfoLookup,
-} from './GameplayLayout.viewModel';
-import { HexMapDisplay } from './HexMapDisplay';
-import { MoraleIndicator } from './MoraleIndicator';
-import { TacticalActionDock } from './TacticalActionDock';
-import { ShellSlot, TacticalCommandShell } from './TacticalCommandShell';
-import { TacticalTurnRail } from './TacticalTurnRail';
+} from "./GameplayLayout.viewModel";
+import { HexMapDisplay } from "./HexMapDisplay";
+import { MoraleIndicator } from "./MoraleIndicator";
+import { TacticalActionDock } from "./TacticalActionDock";
+import {
+  ShellSlot,
+  TacticalCommandShell,
+  useTacticalShell,
+} from "./TacticalCommandShell";
+import { TacticalTurnRail } from "./TacticalTurnRail";
+import { TacticalUnitInspector } from "./TacticalUnitInspector";
 
-export type { GameplayLayoutProps } from './GameplayLayout.types';
+export type { GameplayLayoutProps } from "./GameplayLayout.types";
+
+// =============================================================================
+// DesktopRightTray — inner component that reads inspector state from shell
+// context and renders the right-tray slot.
+//
+// Must be a SEPARATE component (not inlined in GameplayLayout) because
+// GameplayLayout is the TacticalCommandShell provider — calling
+// useTacticalShell() at its scope level would throw "must be called inside
+// a <TacticalCommandShell>". As a child rendered inside the shell tree,
+// DesktopRightTray is within context.
+// =============================================================================
+
+interface DesktopRightTrayProps {
+  readonly selectedUnitId: string | null;
+  readonly session: import("@/types/gameplay").IGameSession;
+  readonly viewerPlayerId: string;
+  readonly viewerSide: import("@/types/gameplay").GameSide;
+  readonly mapPanelWidth: number;
+  readonly supplemental: import("@/hooks/gameplay/useUnitInspectorProjection").IInspectorSupplementalData;
+}
+
+function DesktopRightTray({
+  selectedUnitId,
+  session,
+  viewerPlayerId,
+  viewerSide,
+  mapPanelWidth,
+  supplemental,
+}: DesktopRightTrayProps): React.ReactElement {
+  const { state } = useTacticalShell();
+
+  // Wave 7.0 Gate 4: bind to inspectedUnit first, fall back to selectedUnitId.
+  // NEVER bind to state.activeUnit — that drives the action dock, not the inspector.
+  const inspectedUnitId = state.inspectedUnit ?? selectedUnitId;
+
+  return (
+    <ShellSlot id="right-tray" ownerId="RecordSheetPanel">
+      <div
+        className="flex-1 overflow-auto"
+        style={{ width: `${100 - mapPanelWidth}%` }}
+        data-testid="record-sheet-panel"
+      >
+        <TacticalUnitInspector
+          inspectedUnitId={inspectedUnitId}
+          session={session}
+          viewerPlayerId={viewerPlayerId}
+          viewerSide={viewerSide}
+          opponentVisibilityScopes={state.opponentVisibilityScopes}
+          supplemental={supplemental}
+        />
+      </div>
+    </ShellSlot>
+  );
+}
 
 /**
  * Main gameplay layout with split view.
@@ -84,8 +143,8 @@ export function GameplayLayout({
   mpLegend,
   interactiveSession,
   playerSide = GameSide.Player,
-  shellMode = 'combat',
-  className = '',
+  shellMode = "combat",
+  className = "",
 }: GameplayLayoutProps): React.ReactElement {
   const { currentState, events, config, units } = session;
   const activeAnimations = useAnimationQueue((s) => s.active);
@@ -247,11 +306,11 @@ export function GameplayLayout({
 
   useEffect(() => {
     if (isDragging) {
-      window.addEventListener('mousemove', handleMouseMove);
-      window.addEventListener('mouseup', handleMouseUp);
+      window.addEventListener("mousemove", handleMouseMove);
+      window.addEventListener("mouseup", handleMouseUp);
       return () => {
-        window.removeEventListener('mousemove', handleMouseMove);
-        window.removeEventListener('mouseup', handleMouseUp);
+        window.removeEventListener("mousemove", handleMouseMove);
+        window.removeEventListener("mouseup", handleMouseUp);
       };
     }
   }, [isDragging, handleMouseMove, handleMouseUp]);
@@ -447,7 +506,7 @@ export function GameplayLayout({
           <ShellSlot id="map-center" ownerId="HexMapDisplay">
             <div
               className="relative"
-              style={{ width: isNarrow ? '100%' : `${layout.mapPanelWidth}%` }}
+              style={{ width: isNarrow ? "100%" : `${layout.mapPanelWidth}%` }}
               data-testid="map-panel"
             >
               <HexMapDisplay
@@ -491,9 +550,10 @@ export function GameplayLayout({
             </div>
           </ShellSlot>
 
-          {/* Desktop split-view: resize handle + record sheet panel.
-              Hidden below `lg:` (isNarrow) where the drawer takes
-              over. */}
+          {/* Desktop split-view: resize handle + inspector right tray.
+              Hidden below `lg:` (isNarrow) where the mobile drawer takes
+              over. DesktopRightTray is a child component so it can safely
+              call useTacticalShell() from within the shell context tree. */}
           {!isNarrow && (
             <>
               <div
@@ -501,15 +561,20 @@ export function GameplayLayout({
                 onMouseDown={() => setIsDragging(true)}
                 data-testid="resize-handle"
               />
-              <ShellSlot id="right-tray" ownerId="RecordSheetPanel">
-                <div
-                  className="flex-1 overflow-hidden"
-                  style={{ width: `${100 - layout.mapPanelWidth}%` }}
-                  data-testid="record-sheet-panel"
-                >
-                  {recordSheetBody}
-                </div>
-              </ShellSlot>
+              <DesktopRightTray
+                selectedUnitId={selectedUnitId}
+                session={session}
+                viewerPlayerId={localFogPlayerId}
+                viewerSide={playerSide}
+                mapPanelWidth={layout.mapPanelWidth}
+                supplemental={{
+                  pilotNames,
+                  unitWeapons,
+                  maxArmor,
+                  maxStructure,
+                  heatSinks,
+                }}
+              />
             </>
           )}
         </div>

--- a/src/components/gameplay/TacticalUnitInspector/TacticalUnitInspector.tsx
+++ b/src/components/gameplay/TacticalUnitInspector/TacticalUnitInspector.tsx
@@ -1,0 +1,436 @@
+/**
+ * TacticalUnitInspector — right-tray unit inspector for the Tactical Command Shell.
+ *
+ * Renders the correct projection tier for the inspected (or selected) unit:
+ *
+ *   - `friendly`  — full exact state (name, chassis, pilot, heat, weapons,
+ *                   critical effects, movement).
+ *   - `target`    — partial state for a visible opponent; numeric fields only
+ *                   when `isExact` is true, band descriptors otherwise.
+ *   - `redacted`  — generic "Unknown Contact" placeholder; ZERO exact values
+ *                   in the rendered output (per the spec's "SHALL not be
+ *                   recoverable from labels, tooltips, DOM text, ARIA text,
+ *                   or test ids" requirement).
+ *
+ * The projection itself is derived by `useUnitInspectorProjection`; this
+ * component only renders what the projection exposes.
+ *
+ * @spec openspec/changes/add-tactical-unit-inspector-drawers/specs/tactical-map-interface/spec.md
+ * @see openspec/changes/add-tactical-unit-inspector-drawers/tasks.md §2.1
+ */
+
+import React from 'react';
+
+import type { GameSide } from '@/types/gameplay';
+import type { IGameSession } from '@/types/gameplay';
+import type { IWeaponStatus } from '@/types/gameplay';
+import type { IInspectorProjection } from '@/types/gameplay/TacticalInspectorInterfaces';
+import type {
+  OpponentIntelTier,
+  PlayerId,
+} from '@/types/gameplay/TacticalShellInterfaces';
+
+import {
+  useUnitInspectorProjection,
+  type IInspectorSupplementalData,
+} from '@/hooks/gameplay/useUnitInspectorProjection';
+
+// =============================================================================
+// Props
+// =============================================================================
+
+export interface TacticalUnitInspectorProps {
+  /**
+   * The unit to inspect. When null the component renders an empty
+   * "no unit selected" placeholder.
+   *
+   * Callers MUST bind this to `shellState.inspectedUnit ?? selectedUnitId`.
+   * NEVER bind to `activeUnit` — Wave 7.0 Gate 4.
+   */
+  readonly inspectedUnitId: string | null;
+  /** Current game session. */
+  readonly session: IGameSession;
+  /** Local viewer's player id (from TacticalCommandShell context). */
+  readonly viewerPlayerId: PlayerId;
+  /** The game side the viewer controls. */
+  readonly viewerSide: GameSide;
+  /**
+   * Per-opponent intel tier map from `ITacticalShellState.opponentVisibilityScopes`.
+   * An empty map means no per-opponent redaction policy has been set
+   * (single-player default: every opponent defaults to 'rough').
+   */
+  readonly opponentVisibilityScopes: Readonly<
+    Record<PlayerId, OpponentIntelTier>
+  >;
+  /** Optional supplemental display data (pilot names, weapons, armor max). */
+  readonly supplemental?: IInspectorSupplementalData;
+  /** Optional extra CSS classes for the root container. */
+  readonly className?: string;
+}
+
+// =============================================================================
+// Sub-views (one per projection kind)
+// =============================================================================
+
+/** Friendly unit — full exact state. */
+function FriendlyView({
+  projection,
+}: {
+  projection: Extract<IInspectorProjection, { kind: 'friendly' }>;
+}): React.ReactElement {
+  const pilotStatusColor = !projection.pilotConscious
+    ? 'text-red-600'
+    : projection.pilotWounds >= 3
+      ? 'text-amber-600'
+      : 'text-gray-700';
+
+  return (
+    <div className="flex flex-col gap-2 p-3" data-testid="inspector-friendly">
+      {/* Header */}
+      <div className="border-b border-blue-200 pb-2">
+        <div
+          className="text-sm font-semibold text-blue-900"
+          data-testid="inspector-unit-name"
+        >
+          {projection.name}
+        </div>
+        <div className="text-xs text-gray-500" data-testid="inspector-chassis">
+          {projection.chassis}
+        </div>
+      </div>
+
+      {/* Pilot */}
+      <div className="flex items-center justify-between text-xs">
+        <span className="text-gray-600">Pilot</span>
+        <span
+          className={`font-medium ${pilotStatusColor}`}
+          data-testid="inspector-pilot-name"
+        >
+          {projection.pilotName}
+        </span>
+      </div>
+      <div className="flex items-center justify-between text-xs">
+        <span className="text-gray-600">Skills</span>
+        <span className="text-gray-800" data-testid="inspector-pilot-skills">
+          G{projection.gunnery} / P{projection.piloting}
+        </span>
+      </div>
+      {projection.pilotWounds > 0 && (
+        <div className="flex items-center justify-between text-xs">
+          <span className="text-gray-600">Pilot Wounds</span>
+          <span
+            className={pilotStatusColor}
+            data-testid="inspector-pilot-wounds"
+          >
+            {projection.pilotConscious ? `${projection.pilotWounds}/5` : 'KIA'}
+          </span>
+        </div>
+      )}
+
+      {/* Heat */}
+      <div className="flex items-center justify-between text-xs">
+        <span className="text-gray-600">Heat</span>
+        <span
+          className={
+            projection.heat >= 20
+              ? 'font-semibold text-red-600'
+              : projection.heat >= 10
+                ? 'font-medium text-amber-600'
+                : 'text-gray-800'
+          }
+          data-testid="inspector-heat"
+        >
+          {projection.heat}
+        </span>
+      </div>
+
+      {/* Armor / Structure */}
+      <div className="flex items-center justify-between text-xs">
+        <span className="text-gray-600">Armor</span>
+        <span className="text-gray-800" data-testid="inspector-armor">
+          {projection.totalArmorRemaining}
+        </span>
+      </div>
+      <div className="flex items-center justify-between text-xs">
+        <span className="text-gray-600">Structure</span>
+        <span className="text-gray-800" data-testid="inspector-structure">
+          {projection.totalStructureRemaining}
+        </span>
+      </div>
+
+      {/* Status flags */}
+      {(projection.prone ||
+        projection.shutdown ||
+        projection.destroyed ||
+        projection.isWithdrawing) && (
+        <div
+          className="flex flex-wrap gap-1"
+          data-testid="inspector-status-flags"
+        >
+          {projection.destroyed && (
+            <span className="rounded bg-red-100 px-1 py-0.5 text-xs font-semibold text-red-700">
+              DESTROYED
+            </span>
+          )}
+          {projection.shutdown && (
+            <span className="rounded bg-gray-200 px-1 py-0.5 text-xs font-semibold text-gray-700">
+              SHUTDOWN
+            </span>
+          )}
+          {projection.prone && (
+            <span className="rounded bg-yellow-100 px-1 py-0.5 text-xs font-semibold text-yellow-700">
+              PRONE
+            </span>
+          )}
+          {projection.isWithdrawing && (
+            <span className="rounded bg-orange-100 px-1 py-0.5 text-xs font-semibold text-orange-700">
+              WITHDRAWING
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Critical effects */}
+      {projection.criticalEffects.length > 0 && (
+        <div className="rounded bg-red-50 p-1.5">
+          <div className="mb-1 text-xs font-medium text-red-700">
+            Critical Damage
+          </div>
+          {projection.criticalEffects.map((effect, i) => (
+            <div
+              key={i}
+              className="text-xs text-red-600"
+              data-testid={`inspector-crit-${i}`}
+            >
+              {effect}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Movement */}
+      <div className="flex items-center justify-between text-xs">
+        <span className="text-gray-600">Movement</span>
+        <span className="text-gray-800" data-testid="inspector-movement">
+          {projection.movementThisTurn} ({projection.hexesMoved} hex
+          {projection.hexesMoved !== 1 ? 'es' : ''})
+        </span>
+      </div>
+
+      {/* Weapons */}
+      {projection.weapons.length > 0 && (
+        <div>
+          <div className="mb-1 text-xs font-medium text-gray-600">Weapons</div>
+          {projection.weapons.map((w) => (
+            <div
+              key={w.weaponId}
+              className={`flex items-center justify-between text-xs ${w.disabled ? 'opacity-50' : ''}`}
+              data-testid={`inspector-weapon-${w.weaponId}`}
+            >
+              <span className={w.disabled ? 'line-through' : ''}>
+                {w.displayName}
+              </span>
+              {w.disabledReason && (
+                <span className="text-red-500">{w.disabledReason}</span>
+              )}
+              {w.hasAmmoWarning && !w.disabled && (
+                <span className="text-amber-500">Low ammo</span>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Opponent unit at 'rough' or 'exact' intel tier — partial state. */
+function TargetView({
+  projection,
+}: {
+  projection: Extract<IInspectorProjection, { kind: 'target' }>;
+}): React.ReactElement {
+  const bandLabel: Record<string, string> = {
+    pristine: 'Pristine',
+    'lightly-damaged': 'Lightly Damaged',
+    'moderately-damaged': 'Moderately Damaged',
+    'heavily-damaged': 'Heavily Damaged',
+    crippled: 'Crippled',
+  };
+  const bandColor: Record<string, string> = {
+    pristine: 'text-green-600',
+    'lightly-damaged': 'text-green-700',
+    'moderately-damaged': 'text-amber-600',
+    'heavily-damaged': 'text-orange-600',
+    crippled: 'text-red-600',
+  };
+
+  return (
+    <div className="flex flex-col gap-2 p-3" data-testid="inspector-target">
+      {/* Header */}
+      <div className="border-b border-red-200 pb-2">
+        <div
+          className="text-sm font-semibold text-red-900"
+          data-testid="inspector-unit-name"
+        >
+          {projection.name}
+        </div>
+        {projection.chassis !== null && (
+          <div
+            className="text-xs text-gray-500"
+            data-testid="inspector-chassis"
+          >
+            {projection.chassis}
+          </div>
+        )}
+        {!projection.isExact && (
+          <div className="text-xs text-gray-400 italic">Rough intel</div>
+        )}
+      </div>
+
+      {/* Damage band (always shown) */}
+      <div className="flex items-center justify-between text-xs">
+        <span className="text-gray-600">Damage</span>
+        <span
+          className={`font-medium ${bandColor[projection.damageBand] ?? 'text-gray-800'}`}
+          data-testid="inspector-damage-band"
+        >
+          {bandLabel[projection.damageBand] ?? projection.damageBand}
+        </span>
+      </div>
+
+      {/* Exact-tier only fields */}
+      {projection.isExact && (
+        <>
+          <div className="flex items-center justify-between text-xs">
+            <span className="text-gray-600">Heat</span>
+            <span
+              className={
+                (projection.heat ?? 0) >= 20
+                  ? 'font-semibold text-red-600'
+                  : (projection.heat ?? 0) >= 10
+                    ? 'font-medium text-amber-600'
+                    : 'text-gray-800'
+              }
+              data-testid="inspector-heat"
+            >
+              {projection.heat}
+            </span>
+          </div>
+          <div className="flex items-center justify-between text-xs">
+            <span className="text-gray-600">Armor</span>
+            <span className="text-gray-800" data-testid="inspector-armor">
+              {projection.totalArmorRemaining}
+            </span>
+          </div>
+          <div className="flex items-center justify-between text-xs">
+            <span className="text-gray-600">Structure</span>
+            <span className="text-gray-800" data-testid="inspector-structure">
+              {projection.totalStructureRemaining}
+            </span>
+          </div>
+        </>
+      )}
+
+      {/* Observable state — both tiers */}
+      {(projection.prone || projection.destroyed || projection.shutdown) && (
+        <div
+          className="flex flex-wrap gap-1"
+          data-testid="inspector-status-flags"
+        >
+          {projection.destroyed && (
+            <span className="rounded bg-red-100 px-1 py-0.5 text-xs font-semibold text-red-700">
+              DESTROYED
+            </span>
+          )}
+          {projection.shutdown !== null && projection.shutdown && (
+            <span className="rounded bg-gray-200 px-1 py-0.5 text-xs font-semibold text-gray-700">
+              SHUTDOWN
+            </span>
+          )}
+          {projection.prone && (
+            <span className="rounded bg-yellow-100 px-1 py-0.5 text-xs font-semibold text-yellow-700">
+              PRONE
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Opponent at 'hidden' or 'unknown' tier — completely opaque placeholder.
+ *
+ * Per spec: ZERO exact values anywhere in the rendered output. Not in DOM
+ * text, not in ARIA attributes, not in data-testid values. This component
+ * deliberately contains no numeric or identity-revealing content.
+ */
+function RedactedView(): React.ReactElement {
+  return (
+    <div
+      className="flex flex-col items-center justify-center gap-2 p-6 text-center"
+      data-testid="inspector-redacted"
+      aria-label="Unknown contact — no intelligence available"
+    >
+      <div className="text-sm font-medium text-gray-500">Unknown Contact</div>
+      <div className="text-xs text-gray-400">No intelligence available</div>
+    </div>
+  );
+}
+
+// =============================================================================
+// Main component
+// =============================================================================
+
+/**
+ * TacticalUnitInspector — right-tray inspector for the tactical shell.
+ *
+ * Derives the projection via `useUnitInspectorProjection` and delegates
+ * rendering to the appropriate sub-view. When `inspectedUnitId` is null,
+ * renders a neutral "Select a unit" placeholder.
+ */
+export function TacticalUnitInspector({
+  inspectedUnitId,
+  session,
+  viewerPlayerId,
+  viewerSide,
+  opponentVisibilityScopes,
+  supplemental,
+  className = '',
+}: TacticalUnitInspectorProps): React.ReactElement {
+  const projection = useUnitInspectorProjection({
+    unitId: inspectedUnitId,
+    session,
+    viewerPlayerId,
+    viewerSide,
+    opponentVisibilityScopes,
+    supplemental,
+  });
+
+  if (!projection) {
+    return (
+      <div
+        className={`flex items-center justify-center p-6 text-xs text-gray-400 ${className}`}
+        data-testid="inspector-empty"
+      >
+        Select a unit to inspect
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`h-full overflow-y-auto bg-white ${className}`}
+      data-testid="tactical-unit-inspector"
+    >
+      {projection.kind === 'friendly' && (
+        <FriendlyView projection={projection} />
+      )}
+      {projection.kind === 'target' && <TargetView projection={projection} />}
+      {projection.kind === 'redacted' && <RedactedView />}
+    </div>
+  );
+}
+
+export default TacticalUnitInspector;

--- a/src/components/gameplay/TacticalUnitInspector/__tests__/TacticalUnitInspector.test.tsx
+++ b/src/components/gameplay/TacticalUnitInspector/__tests__/TacticalUnitInspector.test.tsx
@@ -1,0 +1,443 @@
+/**
+ * Component tests for TacticalUnitInspector.
+ *
+ * Verifies §4.1 of the add-tactical-unit-inspector-drawers spec:
+ *
+ *   1. Friendly exact-state path — all fields rendered with correct
+ *      data-testid attributes; name, chassis, pilot skills, heat, armor,
+ *      structure, movement, and weapon list are visible.
+ *
+ *   2. Rough opponent path — band descriptor rendered; heat and exact
+ *      armor/structure numbers are NOT present in the DOM.
+ *
+ *   3. Hidden/unknown opponent path (redacted) — DOM contains ZERO
+ *      identifying information: no unit name, no chassis, no numeric
+ *      heat/armor value. Only "Unknown Contact" placeholder is present.
+ *
+ *   4. Null unit path — empty "Select a unit to inspect" placeholder.
+ *
+ * The redaction tests are DOM-level assertions, not CSS-visibility
+ * checks, per the spec requirement "exact hidden fields SHALL not be
+ * recoverable from labels, tooltips, DOM text, ARIA text, or test ids".
+ *
+ * @spec openspec/changes/add-tactical-unit-inspector-drawers/specs/tactical-map-interface/spec.md
+ * @see openspec/changes/add-tactical-unit-inspector-drawers/tasks.md §4.1
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "@jest/globals";
+
+import { GameSide } from "@/types/gameplay";
+import type {
+  IGameSession,
+  IGameUnit,
+  IGameState,
+  IUnitGameState,
+  IWeaponStatus,
+} from "@/types/gameplay";
+import type { PlayerId } from "@/types/gameplay/TacticalShellInterfaces";
+
+import { TacticalUnitInspector } from "../TacticalUnitInspector";
+
+// =============================================================================
+// Minimal fixture helpers
+// =============================================================================
+
+function makeUnit(
+  id: string,
+  side: GameSide,
+  overrides: Partial<IGameUnit> = {},
+): IGameUnit {
+  return {
+    id,
+    name: `Unit-${id}`,
+    side,
+    unitRef: `atlas-as7-d-${id}`,
+    pilotRef: `pilot-${id}`,
+    gunnery: 4,
+    piloting: 5,
+    ...overrides,
+  };
+}
+
+function makeUnitState(
+  id: string,
+  side: GameSide,
+  overrides: Partial<IUnitGameState> = {},
+): IUnitGameState {
+  return {
+    id,
+    side,
+    position: { q: 0, r: 0 },
+    facing: 0 as unknown as IUnitGameState["facing"],
+    heat: 8,
+    movementThisTurn: "WALK",
+    hexesMovedThisTurn: 3,
+    armor: { HEAD: 9, CT: 31, LT: 20, RT: 20, LA: 16, RA: 16, LL: 20, RL: 20 },
+    structure: {
+      HEAD: 3,
+      CT: 20,
+      LT: 14,
+      RT: 14,
+      LA: 10,
+      RA: 10,
+      LL: 14,
+      RL: 14,
+    },
+    destroyedLocations: [],
+    destroyedEquipment: [],
+    ammo: {},
+    pilotWounds: 0,
+    pilotConscious: true,
+    destroyed: false,
+    lockState: "unlocked" as unknown as IUnitGameState["lockState"],
+    ...overrides,
+  };
+}
+
+function makeWeapon(
+  id: string,
+  name: string,
+  overrides: Partial<IWeaponStatus> = {},
+): IWeaponStatus {
+  return {
+    id,
+    name,
+    location: "CT",
+    destroyed: false,
+    firedThisTurn: false,
+    heat: 3,
+    damage: 5,
+    ranges: { minimum: 0, short: 3, medium: 6, long: 9 },
+    ...overrides,
+  };
+}
+
+function makeSession(
+  units: IGameUnit[],
+  unitStates: IUnitGameState[],
+  sideOwners?: Record<GameSide, string>,
+): IGameSession {
+  const stateMap: Record<string, IUnitGameState> = {};
+  for (const us of unitStates) {
+    stateMap[us.id] = us;
+  }
+
+  const currentState = {
+    units: stateMap,
+    phase: "movement",
+    turn: 1,
+    firstMover: GameSide.Player,
+    initiativeWinner: GameSide.Player,
+  } as unknown as IGameState;
+
+  return {
+    id: "test-session",
+    units,
+    currentState,
+    events: [],
+    config: {
+      mapRadius: 5,
+      turnLimit: 0,
+      victoryConditions: ["elimination"],
+      optionalRules: [],
+    },
+    sideOwners: sideOwners ?? null,
+  } as unknown as IGameSession;
+}
+
+// =============================================================================
+// Shared test data
+// =============================================================================
+
+const FRIENDLY_ID = "friendly-1";
+const OPPONENT_ID = "opponent-1";
+const VIEWER_PLAYER_ID: PlayerId = "player-a";
+const OPPONENT_PLAYER_ID: PlayerId = "player-b";
+
+const friendlyUnit = makeUnit(FRIENDLY_ID, GameSide.Player, {
+  name: "Atlas AS7-D",
+  unitRef: "atlas-as7-d",
+  gunnery: 3,
+  piloting: 4,
+});
+const opponentUnit = makeUnit(OPPONENT_ID, GameSide.Opponent, {
+  name: "Mad Cat Prime",
+  unitRef: "mad-cat-prime",
+});
+
+const friendlyState = makeUnitState(FRIENDLY_ID, GameSide.Player, { heat: 12 });
+const opponentState = makeUnitState(OPPONENT_ID, GameSide.Opponent, {
+  heat: 7,
+});
+
+const session = makeSession(
+  [friendlyUnit, opponentUnit],
+  [friendlyState, opponentState],
+  {
+    [GameSide.Player]: VIEWER_PLAYER_ID,
+    [GameSide.Opponent]: OPPONENT_PLAYER_ID,
+  },
+);
+
+const mediumLaser = makeWeapon("ml-1", "Medium Laser");
+const lrm20 = makeWeapon("lrm-1", "LRM-20", { ammoRemaining: 1 });
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("TacticalUnitInspector", () => {
+  // ---------------------------------------------------------------------------
+  // 1. Null / empty state
+  // ---------------------------------------------------------------------------
+
+  it("renders the empty placeholder when inspectedUnitId is null", () => {
+    render(
+      <TacticalUnitInspector
+        inspectedUnitId={null}
+        session={session}
+        viewerPlayerId={VIEWER_PLAYER_ID}
+        viewerSide={GameSide.Player}
+        opponentVisibilityScopes={{}}
+      />,
+    );
+
+    expect(screen.getByTestId("inspector-empty")).toBeTruthy();
+    expect(screen.queryByTestId("inspector-friendly")).toBeNull();
+    expect(screen.queryByTestId("inspector-target")).toBeNull();
+    expect(screen.queryByTestId("inspector-redacted")).toBeNull();
+  });
+
+  // ---------------------------------------------------------------------------
+  // 2. Friendly exact state
+  // ---------------------------------------------------------------------------
+
+  it("renders full friendly view with correct data-testids and values", () => {
+    render(
+      <TacticalUnitInspector
+        inspectedUnitId={FRIENDLY_ID}
+        session={session}
+        viewerPlayerId={VIEWER_PLAYER_ID}
+        viewerSide={GameSide.Player}
+        opponentVisibilityScopes={{}}
+        supplemental={{
+          pilotNames: { [FRIENDLY_ID]: "Mechwarrior Smith" },
+          unitWeapons: { [FRIENDLY_ID]: [mediumLaser, lrm20] },
+          maxArmor: {
+            [FRIENDLY_ID]: {
+              HEAD: 9,
+              CT: 47,
+              LT: 32,
+              RT: 32,
+              LA: 24,
+              RA: 24,
+              LL: 32,
+              RL: 32,
+            },
+          },
+          maxStructure: {
+            [FRIENDLY_ID]: {
+              HEAD: 3,
+              CT: 20,
+              LT: 14,
+              RT: 14,
+              LA: 10,
+              RA: 10,
+              LL: 14,
+              RL: 14,
+            },
+          },
+          heatSinks: { [FRIENDLY_ID]: 10 },
+        }}
+      />,
+    );
+
+    // Root + sub-view
+    expect(screen.getByTestId("tactical-unit-inspector")).toBeTruthy();
+    expect(screen.getByTestId("inspector-friendly")).toBeTruthy();
+
+    // Unit identity
+    expect(screen.getByTestId("inspector-unit-name").textContent).toBe(
+      "Atlas AS7-D",
+    );
+    expect(screen.getByTestId("inspector-chassis").textContent).toBe(
+      "atlas-as7-d",
+    );
+
+    // Pilot
+    expect(screen.getByTestId("inspector-pilot-name").textContent).toBe(
+      "Mechwarrior Smith",
+    );
+    expect(screen.getByTestId("inspector-pilot-skills").textContent).toContain(
+      "3",
+    );
+    expect(screen.getByTestId("inspector-pilot-skills").textContent).toContain(
+      "4",
+    );
+
+    // Heat
+    expect(screen.getByTestId("inspector-heat").textContent).toBe("12");
+
+    // Armor / structure
+    expect(screen.getByTestId("inspector-armor")).toBeTruthy();
+    expect(screen.getByTestId("inspector-structure")).toBeTruthy();
+
+    // Movement
+    expect(screen.getByTestId("inspector-movement")).toBeTruthy();
+
+    // Weapons — mediumLaser is ready, lrm20 has ammo warning
+    expect(screen.getByTestId(`inspector-weapon-ml-1`)).toBeTruthy();
+    expect(screen.getByTestId(`inspector-weapon-lrm-1`)).toBeTruthy();
+  });
+
+  it("renders gunnery 3 / piloting 4 skills correctly in pilot-skills cell", () => {
+    render(
+      <TacticalUnitInspector
+        inspectedUnitId={FRIENDLY_ID}
+        session={session}
+        viewerPlayerId={VIEWER_PLAYER_ID}
+        viewerSide={GameSide.Player}
+        opponentVisibilityScopes={{}}
+        supplemental={{ pilotNames: { [FRIENDLY_ID]: "Smith" } }}
+      />,
+    );
+    const skills = screen.getByTestId("inspector-pilot-skills");
+    expect(skills.textContent).toContain("G3");
+    expect(skills.textContent).toContain("P4");
+  });
+
+  // ---------------------------------------------------------------------------
+  // 3. Rough opponent — band visible, numbers absent
+  // ---------------------------------------------------------------------------
+
+  it("renders target view at rough tier with damage band, no exact numbers", () => {
+    render(
+      <TacticalUnitInspector
+        inspectedUnitId={OPPONENT_ID}
+        session={session}
+        viewerPlayerId={VIEWER_PLAYER_ID}
+        viewerSide={GameSide.Player}
+        opponentVisibilityScopes={{
+          [OPPONENT_PLAYER_ID]: "rough",
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("inspector-target")).toBeTruthy();
+    expect(screen.getByTestId("inspector-damage-band")).toBeTruthy();
+
+    // At rough tier, exact numbers MUST NOT appear.
+    expect(screen.queryByTestId("inspector-heat")).toBeNull();
+    expect(screen.queryByTestId("inspector-armor")).toBeNull();
+    expect(screen.queryByTestId("inspector-structure")).toBeNull();
+
+    // The opponent's unit name IS visible at rough tier.
+    expect(screen.getByTestId("inspector-unit-name").textContent).toBe(
+      "Mad Cat Prime",
+    );
+  });
+
+  it("renders target view at exact tier with numeric heat and armor", () => {
+    render(
+      <TacticalUnitInspector
+        inspectedUnitId={OPPONENT_ID}
+        session={session}
+        viewerPlayerId={VIEWER_PLAYER_ID}
+        viewerSide={GameSide.Player}
+        opponentVisibilityScopes={{
+          [OPPONENT_PLAYER_ID]: "exact",
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("inspector-target")).toBeTruthy();
+    // At exact tier numeric fields are populated.
+    expect(screen.getByTestId("inspector-heat")).toBeTruthy();
+    expect(screen.getByTestId("inspector-armor")).toBeTruthy();
+    expect(screen.getByTestId("inspector-structure")).toBeTruthy();
+  });
+
+  // ---------------------------------------------------------------------------
+  // 4. Hidden / unknown opponent — DOM-level redaction
+  // ---------------------------------------------------------------------------
+
+  it("renders redacted view at hidden tier — zero identifying info in DOM", () => {
+    render(
+      <TacticalUnitInspector
+        inspectedUnitId={OPPONENT_ID}
+        session={session}
+        viewerPlayerId={VIEWER_PLAYER_ID}
+        viewerSide={GameSide.Player}
+        opponentVisibilityScopes={{
+          [OPPONENT_PLAYER_ID]: "hidden",
+        }}
+      />,
+    );
+
+    const root = screen.getByTestId("tactical-unit-inspector");
+
+    // Correct sub-view is mounted.
+    expect(screen.getByTestId("inspector-redacted")).toBeTruthy();
+
+    // Friendly / target sub-views MUST NOT be present.
+    expect(screen.queryByTestId("inspector-friendly")).toBeNull();
+    expect(screen.queryByTestId("inspector-target")).toBeNull();
+
+    // The opponent's real unit name ('Mad Cat Prime') MUST NOT appear anywhere
+    // in the rendered DOM — not in text, aria-label, or test-id values.
+    const domText = root.textContent ?? "";
+    expect(domText).not.toContain("Mad Cat Prime");
+    expect(domText).not.toContain("mad-cat-prime");
+
+    // The raw numeric heat value (7) MUST NOT appear as text.
+    expect(domText).not.toContain("7");
+
+    // Generic placeholder MUST be visible.
+    expect(domText).toContain("Unknown Contact");
+  });
+
+  it("renders redacted view at unknown tier — zero identifying info in DOM", () => {
+    render(
+      <TacticalUnitInspector
+        inspectedUnitId={OPPONENT_ID}
+        session={session}
+        viewerPlayerId={VIEWER_PLAYER_ID}
+        viewerSide={GameSide.Player}
+        opponentVisibilityScopes={{
+          [OPPONENT_PLAYER_ID]: "unknown",
+        }}
+      />,
+    );
+
+    const root = screen.getByTestId("tactical-unit-inspector");
+    const domText = root.textContent ?? "";
+
+    expect(screen.getByTestId("inspector-redacted")).toBeTruthy();
+    expect(domText).not.toContain("Mad Cat Prime");
+    expect(domText).not.toContain("7"); // raw heat
+    expect(domText).toContain("Unknown Contact");
+  });
+
+  // ---------------------------------------------------------------------------
+  // 5. Default tier fallback: missing opponentVisibilityScopes entry → 'rough'
+  // ---------------------------------------------------------------------------
+
+  it("falls back to rough tier when opponent is absent from scope map", () => {
+    render(
+      <TacticalUnitInspector
+        inspectedUnitId={OPPONENT_ID}
+        session={session}
+        viewerPlayerId={VIEWER_PLAYER_ID}
+        viewerSide={GameSide.Player}
+        // No entry for OPPONENT_PLAYER_ID — should default to 'rough'
+        opponentVisibilityScopes={{}}
+      />,
+    );
+
+    // Target view (rough) renders damage band, not exact numbers.
+    expect(screen.getByTestId("inspector-target")).toBeTruthy();
+    expect(screen.getByTestId("inspector-damage-band")).toBeTruthy();
+    expect(screen.queryByTestId("inspector-heat")).toBeNull();
+  });
+});

--- a/src/components/gameplay/TacticalUnitInspector/__tests__/TacticalUnitInspector.test.tsx
+++ b/src/components/gameplay/TacticalUnitInspector/__tests__/TacticalUnitInspector.test.tsx
@@ -24,20 +24,21 @@
  * @see openspec/changes/add-tactical-unit-inspector-drawers/tasks.md §4.1
  */
 
-import { render, screen } from "@testing-library/react";
-import { describe, it, expect } from "@jest/globals";
+import { describe, it, expect } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
 
-import { GameSide } from "@/types/gameplay";
 import type {
   IGameSession,
   IGameUnit,
   IGameState,
   IUnitGameState,
   IWeaponStatus,
-} from "@/types/gameplay";
-import type { PlayerId } from "@/types/gameplay/TacticalShellInterfaces";
+} from '@/types/gameplay';
+import type { PlayerId } from '@/types/gameplay/TacticalShellInterfaces';
 
-import { TacticalUnitInspector } from "../TacticalUnitInspector";
+import { GameSide, LockState, MovementType } from '@/types/gameplay';
+
+import { TacticalUnitInspector } from '../TacticalUnitInspector';
 
 // =============================================================================
 // Minimal fixture helpers
@@ -69,9 +70,9 @@ function makeUnitState(
     id,
     side,
     position: { q: 0, r: 0 },
-    facing: 0 as unknown as IUnitGameState["facing"],
+    facing: 0 as unknown as IUnitGameState['facing'],
     heat: 8,
-    movementThisTurn: "WALK",
+    movementThisTurn: MovementType.Walk,
     hexesMovedThisTurn: 3,
     armor: { HEAD: 9, CT: 31, LT: 20, RT: 20, LA: 16, RA: 16, LL: 20, RL: 20 },
     structure: {
@@ -90,7 +91,7 @@ function makeUnitState(
     pilotWounds: 0,
     pilotConscious: true,
     destroyed: false,
-    lockState: "unlocked" as unknown as IUnitGameState["lockState"],
+    lockState: LockState.Pending,
     ...overrides,
   };
 }
@@ -103,7 +104,7 @@ function makeWeapon(
   return {
     id,
     name,
-    location: "CT",
+    location: 'CT',
     destroyed: false,
     firedThisTurn: false,
     heat: 3,
@@ -125,21 +126,21 @@ function makeSession(
 
   const currentState = {
     units: stateMap,
-    phase: "movement",
+    phase: 'movement',
     turn: 1,
     firstMover: GameSide.Player,
     initiativeWinner: GameSide.Player,
   } as unknown as IGameState;
 
   return {
-    id: "test-session",
+    id: 'test-session',
     units,
     currentState,
     events: [],
     config: {
       mapRadius: 5,
       turnLimit: 0,
-      victoryConditions: ["elimination"],
+      victoryConditions: ['elimination'],
       optionalRules: [],
     },
     sideOwners: sideOwners ?? null,
@@ -150,20 +151,20 @@ function makeSession(
 // Shared test data
 // =============================================================================
 
-const FRIENDLY_ID = "friendly-1";
-const OPPONENT_ID = "opponent-1";
-const VIEWER_PLAYER_ID: PlayerId = "player-a";
-const OPPONENT_PLAYER_ID: PlayerId = "player-b";
+const FRIENDLY_ID = 'friendly-1';
+const OPPONENT_ID = 'opponent-1';
+const VIEWER_PLAYER_ID: PlayerId = 'player-a';
+const OPPONENT_PLAYER_ID: PlayerId = 'player-b';
 
 const friendlyUnit = makeUnit(FRIENDLY_ID, GameSide.Player, {
-  name: "Atlas AS7-D",
-  unitRef: "atlas-as7-d",
+  name: 'Atlas AS7-D',
+  unitRef: 'atlas-as7-d',
   gunnery: 3,
   piloting: 4,
 });
 const opponentUnit = makeUnit(OPPONENT_ID, GameSide.Opponent, {
-  name: "Mad Cat Prime",
-  unitRef: "mad-cat-prime",
+  name: 'Mad Cat Prime',
+  unitRef: 'mad-cat-prime',
 });
 
 const friendlyState = makeUnitState(FRIENDLY_ID, GameSide.Player, { heat: 12 });
@@ -180,19 +181,19 @@ const session = makeSession(
   },
 );
 
-const mediumLaser = makeWeapon("ml-1", "Medium Laser");
-const lrm20 = makeWeapon("lrm-1", "LRM-20", { ammoRemaining: 1 });
+const mediumLaser = makeWeapon('ml-1', 'Medium Laser');
+const lrm20 = makeWeapon('lrm-1', 'LRM-20', { ammoRemaining: 1 });
 
 // =============================================================================
 // Tests
 // =============================================================================
 
-describe("TacticalUnitInspector", () => {
+describe('TacticalUnitInspector', () => {
   // ---------------------------------------------------------------------------
   // 1. Null / empty state
   // ---------------------------------------------------------------------------
 
-  it("renders the empty placeholder when inspectedUnitId is null", () => {
+  it('renders the empty placeholder when inspectedUnitId is null', () => {
     render(
       <TacticalUnitInspector
         inspectedUnitId={null}
@@ -203,17 +204,17 @@ describe("TacticalUnitInspector", () => {
       />,
     );
 
-    expect(screen.getByTestId("inspector-empty")).toBeTruthy();
-    expect(screen.queryByTestId("inspector-friendly")).toBeNull();
-    expect(screen.queryByTestId("inspector-target")).toBeNull();
-    expect(screen.queryByTestId("inspector-redacted")).toBeNull();
+    expect(screen.getByTestId('inspector-empty')).toBeTruthy();
+    expect(screen.queryByTestId('inspector-friendly')).toBeNull();
+    expect(screen.queryByTestId('inspector-target')).toBeNull();
+    expect(screen.queryByTestId('inspector-redacted')).toBeNull();
   });
 
   // ---------------------------------------------------------------------------
   // 2. Friendly exact state
   // ---------------------------------------------------------------------------
 
-  it("renders full friendly view with correct data-testids and values", () => {
+  it('renders full friendly view with correct data-testids and values', () => {
     render(
       <TacticalUnitInspector
         inspectedUnitId={FRIENDLY_ID}
@@ -222,7 +223,7 @@ describe("TacticalUnitInspector", () => {
         viewerSide={GameSide.Player}
         opponentVisibilityScopes={{}}
         supplemental={{
-          pilotNames: { [FRIENDLY_ID]: "Mechwarrior Smith" },
+          pilotNames: { [FRIENDLY_ID]: 'Mechwarrior Smith' },
           unitWeapons: { [FRIENDLY_ID]: [mediumLaser, lrm20] },
           maxArmor: {
             [FRIENDLY_ID]: {
@@ -254,44 +255,44 @@ describe("TacticalUnitInspector", () => {
     );
 
     // Root + sub-view
-    expect(screen.getByTestId("tactical-unit-inspector")).toBeTruthy();
-    expect(screen.getByTestId("inspector-friendly")).toBeTruthy();
+    expect(screen.getByTestId('tactical-unit-inspector')).toBeTruthy();
+    expect(screen.getByTestId('inspector-friendly')).toBeTruthy();
 
     // Unit identity
-    expect(screen.getByTestId("inspector-unit-name").textContent).toBe(
-      "Atlas AS7-D",
+    expect(screen.getByTestId('inspector-unit-name').textContent).toBe(
+      'Atlas AS7-D',
     );
-    expect(screen.getByTestId("inspector-chassis").textContent).toBe(
-      "atlas-as7-d",
+    expect(screen.getByTestId('inspector-chassis').textContent).toBe(
+      'atlas-as7-d',
     );
 
     // Pilot
-    expect(screen.getByTestId("inspector-pilot-name").textContent).toBe(
-      "Mechwarrior Smith",
+    expect(screen.getByTestId('inspector-pilot-name').textContent).toBe(
+      'Mechwarrior Smith',
     );
-    expect(screen.getByTestId("inspector-pilot-skills").textContent).toContain(
-      "3",
+    expect(screen.getByTestId('inspector-pilot-skills').textContent).toContain(
+      '3',
     );
-    expect(screen.getByTestId("inspector-pilot-skills").textContent).toContain(
-      "4",
+    expect(screen.getByTestId('inspector-pilot-skills').textContent).toContain(
+      '4',
     );
 
     // Heat
-    expect(screen.getByTestId("inspector-heat").textContent).toBe("12");
+    expect(screen.getByTestId('inspector-heat').textContent).toBe('12');
 
     // Armor / structure
-    expect(screen.getByTestId("inspector-armor")).toBeTruthy();
-    expect(screen.getByTestId("inspector-structure")).toBeTruthy();
+    expect(screen.getByTestId('inspector-armor')).toBeTruthy();
+    expect(screen.getByTestId('inspector-structure')).toBeTruthy();
 
     // Movement
-    expect(screen.getByTestId("inspector-movement")).toBeTruthy();
+    expect(screen.getByTestId('inspector-movement')).toBeTruthy();
 
     // Weapons — mediumLaser is ready, lrm20 has ammo warning
     expect(screen.getByTestId(`inspector-weapon-ml-1`)).toBeTruthy();
     expect(screen.getByTestId(`inspector-weapon-lrm-1`)).toBeTruthy();
   });
 
-  it("renders gunnery 3 / piloting 4 skills correctly in pilot-skills cell", () => {
+  it('renders gunnery 3 / piloting 4 skills correctly in pilot-skills cell', () => {
     render(
       <TacticalUnitInspector
         inspectedUnitId={FRIENDLY_ID}
@@ -299,19 +300,19 @@ describe("TacticalUnitInspector", () => {
         viewerPlayerId={VIEWER_PLAYER_ID}
         viewerSide={GameSide.Player}
         opponentVisibilityScopes={{}}
-        supplemental={{ pilotNames: { [FRIENDLY_ID]: "Smith" } }}
+        supplemental={{ pilotNames: { [FRIENDLY_ID]: 'Smith' } }}
       />,
     );
-    const skills = screen.getByTestId("inspector-pilot-skills");
-    expect(skills.textContent).toContain("G3");
-    expect(skills.textContent).toContain("P4");
+    const skills = screen.getByTestId('inspector-pilot-skills');
+    expect(skills.textContent).toContain('G3');
+    expect(skills.textContent).toContain('P4');
   });
 
   // ---------------------------------------------------------------------------
   // 3. Rough opponent — band visible, numbers absent
   // ---------------------------------------------------------------------------
 
-  it("renders target view at rough tier with damage band, no exact numbers", () => {
+  it('renders target view at rough tier with damage band, no exact numbers', () => {
     render(
       <TacticalUnitInspector
         inspectedUnitId={OPPONENT_ID}
@@ -319,26 +320,26 @@ describe("TacticalUnitInspector", () => {
         viewerPlayerId={VIEWER_PLAYER_ID}
         viewerSide={GameSide.Player}
         opponentVisibilityScopes={{
-          [OPPONENT_PLAYER_ID]: "rough",
+          [OPPONENT_PLAYER_ID]: 'rough',
         }}
       />,
     );
 
-    expect(screen.getByTestId("inspector-target")).toBeTruthy();
-    expect(screen.getByTestId("inspector-damage-band")).toBeTruthy();
+    expect(screen.getByTestId('inspector-target')).toBeTruthy();
+    expect(screen.getByTestId('inspector-damage-band')).toBeTruthy();
 
     // At rough tier, exact numbers MUST NOT appear.
-    expect(screen.queryByTestId("inspector-heat")).toBeNull();
-    expect(screen.queryByTestId("inspector-armor")).toBeNull();
-    expect(screen.queryByTestId("inspector-structure")).toBeNull();
+    expect(screen.queryByTestId('inspector-heat')).toBeNull();
+    expect(screen.queryByTestId('inspector-armor')).toBeNull();
+    expect(screen.queryByTestId('inspector-structure')).toBeNull();
 
     // The opponent's unit name IS visible at rough tier.
-    expect(screen.getByTestId("inspector-unit-name").textContent).toBe(
-      "Mad Cat Prime",
+    expect(screen.getByTestId('inspector-unit-name').textContent).toBe(
+      'Mad Cat Prime',
     );
   });
 
-  it("renders target view at exact tier with numeric heat and armor", () => {
+  it('renders target view at exact tier with numeric heat and armor', () => {
     render(
       <TacticalUnitInspector
         inspectedUnitId={OPPONENT_ID}
@@ -346,23 +347,23 @@ describe("TacticalUnitInspector", () => {
         viewerPlayerId={VIEWER_PLAYER_ID}
         viewerSide={GameSide.Player}
         opponentVisibilityScopes={{
-          [OPPONENT_PLAYER_ID]: "exact",
+          [OPPONENT_PLAYER_ID]: 'exact',
         }}
       />,
     );
 
-    expect(screen.getByTestId("inspector-target")).toBeTruthy();
+    expect(screen.getByTestId('inspector-target')).toBeTruthy();
     // At exact tier numeric fields are populated.
-    expect(screen.getByTestId("inspector-heat")).toBeTruthy();
-    expect(screen.getByTestId("inspector-armor")).toBeTruthy();
-    expect(screen.getByTestId("inspector-structure")).toBeTruthy();
+    expect(screen.getByTestId('inspector-heat')).toBeTruthy();
+    expect(screen.getByTestId('inspector-armor')).toBeTruthy();
+    expect(screen.getByTestId('inspector-structure')).toBeTruthy();
   });
 
   // ---------------------------------------------------------------------------
   // 4. Hidden / unknown opponent — DOM-level redaction
   // ---------------------------------------------------------------------------
 
-  it("renders redacted view at hidden tier — zero identifying info in DOM", () => {
+  it('renders redacted view at hidden tier — zero identifying info in DOM', () => {
     render(
       <TacticalUnitInspector
         inspectedUnitId={OPPONENT_ID}
@@ -370,34 +371,34 @@ describe("TacticalUnitInspector", () => {
         viewerPlayerId={VIEWER_PLAYER_ID}
         viewerSide={GameSide.Player}
         opponentVisibilityScopes={{
-          [OPPONENT_PLAYER_ID]: "hidden",
+          [OPPONENT_PLAYER_ID]: 'hidden',
         }}
       />,
     );
 
-    const root = screen.getByTestId("tactical-unit-inspector");
+    const root = screen.getByTestId('tactical-unit-inspector');
 
     // Correct sub-view is mounted.
-    expect(screen.getByTestId("inspector-redacted")).toBeTruthy();
+    expect(screen.getByTestId('inspector-redacted')).toBeTruthy();
 
     // Friendly / target sub-views MUST NOT be present.
-    expect(screen.queryByTestId("inspector-friendly")).toBeNull();
-    expect(screen.queryByTestId("inspector-target")).toBeNull();
+    expect(screen.queryByTestId('inspector-friendly')).toBeNull();
+    expect(screen.queryByTestId('inspector-target')).toBeNull();
 
     // The opponent's real unit name ('Mad Cat Prime') MUST NOT appear anywhere
     // in the rendered DOM — not in text, aria-label, or test-id values.
-    const domText = root.textContent ?? "";
-    expect(domText).not.toContain("Mad Cat Prime");
-    expect(domText).not.toContain("mad-cat-prime");
+    const domText = root.textContent ?? '';
+    expect(domText).not.toContain('Mad Cat Prime');
+    expect(domText).not.toContain('mad-cat-prime');
 
     // The raw numeric heat value (7) MUST NOT appear as text.
-    expect(domText).not.toContain("7");
+    expect(domText).not.toContain('7');
 
     // Generic placeholder MUST be visible.
-    expect(domText).toContain("Unknown Contact");
+    expect(domText).toContain('Unknown Contact');
   });
 
-  it("renders redacted view at unknown tier — zero identifying info in DOM", () => {
+  it('renders redacted view at unknown tier — zero identifying info in DOM', () => {
     render(
       <TacticalUnitInspector
         inspectedUnitId={OPPONENT_ID}
@@ -405,25 +406,25 @@ describe("TacticalUnitInspector", () => {
         viewerPlayerId={VIEWER_PLAYER_ID}
         viewerSide={GameSide.Player}
         opponentVisibilityScopes={{
-          [OPPONENT_PLAYER_ID]: "unknown",
+          [OPPONENT_PLAYER_ID]: 'unknown',
         }}
       />,
     );
 
-    const root = screen.getByTestId("tactical-unit-inspector");
-    const domText = root.textContent ?? "";
+    const root = screen.getByTestId('tactical-unit-inspector');
+    const domText = root.textContent ?? '';
 
-    expect(screen.getByTestId("inspector-redacted")).toBeTruthy();
-    expect(domText).not.toContain("Mad Cat Prime");
-    expect(domText).not.toContain("7"); // raw heat
-    expect(domText).toContain("Unknown Contact");
+    expect(screen.getByTestId('inspector-redacted')).toBeTruthy();
+    expect(domText).not.toContain('Mad Cat Prime');
+    expect(domText).not.toContain('7'); // raw heat
+    expect(domText).toContain('Unknown Contact');
   });
 
   // ---------------------------------------------------------------------------
   // 5. Default tier fallback: missing opponentVisibilityScopes entry → 'rough'
   // ---------------------------------------------------------------------------
 
-  it("falls back to rough tier when opponent is absent from scope map", () => {
+  it('falls back to rough tier when opponent is absent from scope map', () => {
     render(
       <TacticalUnitInspector
         inspectedUnitId={OPPONENT_ID}
@@ -436,8 +437,8 @@ describe("TacticalUnitInspector", () => {
     );
 
     // Target view (rough) renders damage band, not exact numbers.
-    expect(screen.getByTestId("inspector-target")).toBeTruthy();
-    expect(screen.getByTestId("inspector-damage-band")).toBeTruthy();
-    expect(screen.queryByTestId("inspector-heat")).toBeNull();
+    expect(screen.getByTestId('inspector-target')).toBeTruthy();
+    expect(screen.getByTestId('inspector-damage-band')).toBeTruthy();
+    expect(screen.queryByTestId('inspector-heat')).toBeNull();
   });
 });

--- a/src/components/gameplay/TacticalUnitInspector/index.ts
+++ b/src/components/gameplay/TacticalUnitInspector/index.ts
@@ -1,0 +1,2 @@
+export { TacticalUnitInspector } from './TacticalUnitInspector';
+export type { TacticalUnitInspectorProps } from './TacticalUnitInspector';

--- a/src/components/gameplay/__tests__/addInteractiveCombatCoreUI.smoke.test.tsx
+++ b/src/components/gameplay/__tests__/addInteractiveCombatCoreUI.smoke.test.tsx
@@ -109,12 +109,17 @@ describe('12.1 Token selection swaps record sheet', () => {
       />,
     );
 
-    const header2 = screen.getByTestId('record-sheet-unit-name');
+    // Wave 7.2 PR-F: opponent units now route through TacticalUnitInspector
+    // (applies opponent intel redaction per spec) instead of the legacy
+    // RecordSheetBody. At the default 'rough' visibility tier the chassis
+    // name is still visible (silhouette-level recognition); the precise
+    // heat / armor / structure numerics are hidden until 'exact' tier.
+    const header2 = screen.getByTestId('inspector-unit-name');
     expect(header2).toHaveTextContent(/Hunchback/i);
 
-    // Side badge must also swap from Player (blue) → Opponent (red).
-    const badge = screen.getByTestId('record-sheet-side-badge');
-    expect(badge.dataset.side).toBe('opponent');
+    // Inspector exposes the opponent target view (kind === 'target')
+    // rather than the friendly record sheet.
+    expect(screen.getByTestId('inspector-target')).toBeTruthy();
   });
 
   it('shows the placeholder when no unit is selected', () => {

--- a/src/hooks/gameplay/useUnitInspectorProjection.ts
+++ b/src/hooks/gameplay/useUnitInspectorProjection.ts
@@ -1,0 +1,342 @@
+/**
+ * useUnitInspectorProjection — derives the appropriate inspector view for a
+ * given unit, respecting the opponent intel policy carried in the tactical
+ * command shell context.
+ *
+ * Returns one of three discriminated projections:
+ *
+ *   - `IFriendlyInspectorView`  — when `unitId` belongs to the viewer's side
+ *     (friendly unit, full exact state).
+ *   - `ITargetInspectorView`    — when `unitId` belongs to an opponent visible
+ *     at 'exact' or 'rough' intel tier.
+ *   - `IRedactedInspectorView`  — when `unitId` belongs to an opponent at
+ *     'hidden' or 'unknown' tier (identity-safe stub, no leaked values).
+ *
+ * **Redaction is data-level, not CSS.** When the projection is 'redacted',
+ * the shape contains NO exact values — not even the unit name. The component
+ * layer is responsible for rendering only what the projection exposes;
+ * `useUnitInspectorProjection` ensures the secret data is never in the
+ * returned object at all.
+ *
+ * @param unitId   The unit to project. Null input returns null output.
+ * @param session  The current `IGameSession` (provides `units` + `currentState`).
+ * @param viewerPlayerId  Local viewer's player id (from shell context).
+ * @param viewerSide      The game side the viewer controls.
+ * @param opponentVisibilityScopes  Per-opponent intel tier map (from shell state).
+ * @param supplemental  Optional per-unit display-name / pilot-name lookups from
+ *                      the host layout (these parallel the `pilotNames` / `unitWeapons`
+ *                      props on `GameplayLayout`).
+ *
+ * @spec openspec/changes/add-tactical-unit-inspector-drawers/specs/tactical-map-interface/spec.md
+ * @see openspec/changes/add-tactical-unit-inspector-drawers/tasks.md §1.2
+ */
+
+import type {
+  IComponentDamageState,
+  IGameSession,
+  IWeaponStatus,
+} from '@/types/gameplay';
+import type {
+  DamageBand,
+  IFriendlyInspectorView,
+  IInspectorProjection,
+  IInspectorWeapon,
+  IRedactedInspectorView,
+  ITargetInspectorView,
+} from '@/types/gameplay/TacticalInspectorInterfaces';
+import type {
+  OpponentIntelTier,
+  PlayerId,
+} from '@/types/gameplay/TacticalShellInterfaces';
+
+import { GameSide } from '@/types/gameplay';
+
+// =============================================================================
+// Supplemental lookup (optional per-unit display data from the host)
+// =============================================================================
+
+export interface IInspectorSupplementalData {
+  /** Pilot names keyed by unit id. */
+  readonly pilotNames?: Readonly<Record<string, string>>;
+  /** Weapon statuses keyed by unit id. */
+  readonly unitWeapons?: Readonly<Record<string, readonly IWeaponStatus[]>>;
+  /** Per-unit max armor keyed by unit id → location → points. */
+  readonly maxArmor?: Readonly<
+    Record<string, Readonly<Record<string, number>>>
+  >;
+  /** Per-unit max structure keyed by unit id → location → points. */
+  readonly maxStructure?: Readonly<
+    Record<string, Readonly<Record<string, number>>>
+  >;
+  /** Heat-sink counts keyed by unit id. */
+  readonly heatSinks?: Readonly<Record<string, number>>;
+}
+
+// =============================================================================
+// Internal helpers
+// =============================================================================
+
+/**
+ * Compute total remaining armor/structure across all locations.
+ * Returns 0 when the record is empty.
+ */
+function sumValues(record: Readonly<Record<string, number>>): number {
+  return Object.values(record).reduce((acc, v) => acc + v, 0);
+}
+
+/**
+ * Map a total-armor-remaining fraction to an approximate damage band.
+ * Fraction = remaining / max; ranges are heuristic for BattleTech.
+ */
+function armorFractionToBand(remaining: number, max: number): DamageBand {
+  if (max <= 0) return 'lightly-damaged';
+  const fraction = remaining / max;
+  if (fraction >= 0.95) return 'pristine';
+  if (fraction >= 0.65) return 'lightly-damaged';
+  if (fraction >= 0.35) return 'moderately-damaged';
+  if (fraction >= 0.1) return 'heavily-damaged';
+  return 'crippled';
+}
+
+/**
+ * Convert raw weapon status list to inspector weapon entries.
+ * Uses the `destroyed`, `jammed`, and `ammoRemaining` fields directly
+ * from `IWeaponStatus` — no external id-list look-ups needed.
+ */
+function buildInspectorWeapons(
+  weaponStatuses: readonly IWeaponStatus[],
+): readonly IInspectorWeapon[] {
+  return weaponStatuses.map((w) => {
+    const isDestroyed = w.destroyed;
+    const isJammed = w.jammed ?? false;
+    // Out of ammo: ammoRemaining is tracked (not undefined) and is zero.
+    const isOutOfAmmo =
+      typeof w.ammoRemaining === 'number' && w.ammoRemaining === 0;
+
+    const disabled = isDestroyed || isJammed || isOutOfAmmo;
+
+    let disabledReason: string | null = null;
+    if (isDestroyed) disabledReason = 'Destroyed';
+    else if (isJammed) disabledReason = 'Jammed';
+    else if (isOutOfAmmo) disabledReason = 'Out of ammo';
+
+    // Ammo warning: ammoRemaining is tracked and critically low (< 2 shots).
+    const hasAmmoWarning =
+      typeof w.ammoRemaining === 'number' &&
+      w.ammoRemaining > 0 &&
+      w.ammoRemaining < 2;
+
+    return {
+      weaponId: w.id,
+      displayName: w.name,
+      disabled,
+      disabledReason,
+      hasAmmoWarning,
+    };
+  });
+}
+
+/**
+ * Collect active critical effects as human-readable strings.
+ * Maps `IComponentDamageState` to the same labels the record sheet
+ * displays so the inspector header matches the full sheet.
+ */
+function collectCriticalEffects(
+  componentDamage: IComponentDamageState | undefined,
+  destroyedLocations: readonly string[],
+): readonly string[] {
+  const effects: string[] = [];
+
+  if (!componentDamage) {
+    if (destroyedLocations.length > 0) {
+      effects.push(`${destroyedLocations.length} location(s) destroyed`);
+    }
+    return effects;
+  }
+
+  if (componentDamage.engineHits > 0) {
+    effects.push(
+      componentDamage.engineHits === 1
+        ? 'Engine Hit'
+        : `Engine Hit ×${componentDamage.engineHits}`,
+    );
+  }
+  if (componentDamage.gyroHits > 0) {
+    effects.push(
+      componentDamage.gyroHits === 1 ? 'Gyro Hit' : 'Gyro Destroyed',
+    );
+  }
+  if (componentDamage.sensorHits > 0) {
+    effects.push(`Sensor Hit ×${componentDamage.sensorHits}`);
+  }
+  if (componentDamage.cockpitHit) {
+    effects.push('Cockpit Destroyed');
+  }
+  if (componentDamage.heatSinksDestroyed > 0) {
+    effects.push(`Heat Sinks Destroyed ×${componentDamage.heatSinksDestroyed}`);
+  }
+  if (destroyedLocations.length > 0) {
+    effects.push(`${destroyedLocations.length} location(s) destroyed`);
+  }
+
+  return effects;
+}
+
+// =============================================================================
+// Main hook
+// =============================================================================
+
+export interface UseUnitInspectorProjectionOptions {
+  /** The unit to inspect. Null returns null immediately. */
+  readonly unitId: string | null;
+  /** Current game session (provides units + currentState). */
+  readonly session: IGameSession;
+  /** Local viewer's player id. */
+  readonly viewerPlayerId: PlayerId;
+  /** The game side the viewer controls. */
+  readonly viewerSide: GameSide;
+  /**
+   * Per-opponent intel tier map from `ITacticalShellState.opponentVisibilityScopes`.
+   * Key = opponent player id. Missing key defaults to 'rough'.
+   */
+  readonly opponentVisibilityScopes: Readonly<
+    Record<PlayerId, OpponentIntelTier>
+  >;
+  /** Optional supplemental display data from the host layout. */
+  readonly supplemental?: IInspectorSupplementalData;
+}
+
+/**
+ * Derives the correct `IInspectorProjection` for the given unit,
+ * respecting the viewer's side and the opponent intel policy.
+ *
+ * This is a pure-computation hook (no side effects, no subscriptions):
+ * it re-derives on every render when its inputs change. Callers may
+ * memoize the result if they need referential stability across renders
+ * where neither the session nor the unit state changed.
+ *
+ * Returns `null` when `unitId` is null or the unit cannot be found in
+ * the session.
+ */
+export function useUnitInspectorProjection(
+  options: UseUnitInspectorProjectionOptions,
+): IInspectorProjection | null {
+  const {
+    unitId,
+    session,
+    viewerSide,
+    opponentVisibilityScopes,
+    supplemental = {},
+  } = options;
+
+  // Fast exit — no unit selected.
+  if (!unitId) return null;
+
+  // Locate unit in session static list (IGameUnit — side, name, ref).
+  const gameUnit = session.units.find((u) => u.id === unitId) ?? null;
+  if (!gameUnit) return null;
+
+  // Locate live unit state (IUnitGameState — armor, heat, etc.).
+  const unitState = session.currentState.units[unitId] ?? null;
+  if (!unitState) return null;
+
+  // Determine whether this unit is on the viewer's own side.
+  const isFriendly = gameUnit.side === viewerSide;
+
+  // ==========================================================================
+  // Friendly branch — full exact state
+  // ==========================================================================
+
+  if (isFriendly) {
+    const pilotName =
+      supplemental.pilotNames?.[unitId] ?? `Pilot (${gameUnit.pilotRef})`;
+    const weaponStatuses = supplemental.unitWeapons?.[unitId] ?? [];
+
+    const weapons = buildInspectorWeapons(weaponStatuses);
+
+    const criticalEffects = collectCriticalEffects(
+      unitState.componentDamage,
+      unitState.destroyedLocations,
+    );
+
+    const totalArmorRemaining = sumValues(unitState.armor);
+    const totalStructureRemaining = sumValues(unitState.structure);
+
+    const view: IFriendlyInspectorView = {
+      kind: 'friendly',
+      unitId,
+      name: gameUnit.name,
+      chassis: gameUnit.unitRef,
+      pilotName,
+      gunnery: gameUnit.gunnery,
+      piloting: gameUnit.piloting,
+      pilotWounds: unitState.pilotWounds,
+      pilotConscious: unitState.pilotConscious,
+      heat: unitState.heat,
+      totalArmorRemaining,
+      totalStructureRemaining,
+      prone: unitState.prone ?? false,
+      shutdown: unitState.shutdown ?? false,
+      destroyed: unitState.destroyed,
+      isWithdrawing: unitState.isWithdrawing ?? false,
+      weapons,
+      criticalEffects,
+      movementThisTurn: unitState.movementThisTurn,
+      hexesMoved: unitState.hexesMovedThisTurn,
+    };
+
+    return view;
+  }
+
+  // ==========================================================================
+  // Opponent branch — look up intel tier
+  // ==========================================================================
+
+  // Resolve which player id owns this opponent unit. When `sideOwners` is
+  // populated (networked sessions), the opponent's player id is mapped from
+  // the unit's side. For single-player sessions without sideOwners, we fall
+  // back to the side string itself as the player key.
+  const opponentSide = gameUnit.side;
+  const opponentPlayerId: string =
+    session.sideOwners?.[opponentSide] ?? (opponentSide as unknown as string);
+
+  const tier: OpponentIntelTier =
+    opponentVisibilityScopes[opponentPlayerId] ?? 'rough';
+
+  // 'hidden' or 'unknown' — identity-safe stub, NO exact values.
+  if (tier === 'hidden' || tier === 'unknown') {
+    const redacted: IRedactedInspectorView = {
+      kind: 'redacted',
+      unitId,
+      contactLabel: 'Unknown Contact',
+    };
+    return redacted;
+  }
+
+  // 'exact' or 'rough' — partial target projection.
+  const isExact = tier === 'exact';
+
+  // Compute total armor for rough-band mapping.
+  const totalArmorRemaining = sumValues(unitState.armor);
+  const maxArmorRecord = supplemental.maxArmor?.[unitId] ?? {};
+  const maxTotal = sumValues(maxArmorRecord);
+  const damageBand = armorFractionToBand(totalArmorRemaining, maxTotal);
+
+  const view: ITargetInspectorView = {
+    kind: 'target',
+    unitId,
+    name: gameUnit.name,
+    chassis: isExact ? gameUnit.unitRef : null,
+    isExact,
+    heat: isExact ? unitState.heat : null,
+    damageBand,
+    totalArmorRemaining: isExact ? totalArmorRemaining : null,
+    totalStructureRemaining: isExact ? sumValues(unitState.structure) : null,
+    // Prone is visually observable on the map at both tiers.
+    prone: unitState.prone ?? false,
+    shutdown: isExact ? (unitState.shutdown ?? false) : null,
+    destroyed: unitState.destroyed,
+  };
+
+  return view;
+}

--- a/src/types/gameplay/TacticalInspectorInterfaces.ts
+++ b/src/types/gameplay/TacticalInspectorInterfaces.ts
@@ -1,0 +1,186 @@
+/**
+ * Tactical Unit Inspector Projection Types.
+ *
+ * Defines the view-model contracts surfaced by
+ * `useUnitInspectorProjection` for the three visibility tiers:
+ *
+ *   - `IFriendlyInspectorView` — full exact state for own units.
+ *   - `ITargetInspectorView`   — partial state for opponents visible at
+ *     'exact' or 'rough' intel tier.
+ *   - `IRedactedInspectorView` — identity-safe stub for 'hidden' or
+ *     'unknown' opponents (no exact values anywhere in the shape).
+ *
+ * Per the spec requirement "exact hidden fields SHALL not be recoverable
+ * from labels, tooltips, DOM text, ARIA text, or test ids", the
+ * `IRedactedInspectorView` shape carries ONLY opaque, non-numeric
+ * descriptors — no raw heat, armor, or pilot values.
+ *
+ * @spec openspec/changes/add-tactical-unit-inspector-drawers/specs/tactical-map-interface/spec.md
+ * @see openspec/changes/add-tactical-unit-inspector-drawers/tasks.md §1.1
+ */
+
+/** Union discriminant for the three inspector projection kinds. */
+export type InspectorProjectionKind = 'friendly' | 'target' | 'redacted';
+
+// =============================================================================
+// Shared sub-shapes
+// =============================================================================
+
+/**
+ * Approximate damage band used in 'rough' intel projections.
+ * Intentionally opaque — no exact numbers leak through.
+ */
+export type DamageBand =
+  | 'pristine'
+  | 'lightly-damaged'
+  | 'moderately-damaged'
+  | 'heavily-damaged'
+  | 'crippled';
+
+/** Single weapon entry in a friendly inspector. */
+export interface IInspectorWeapon {
+  /** Weapon id (for keying lists). */
+  readonly weaponId: string;
+  /** Display name, e.g., "Medium Laser". */
+  readonly displayName: string;
+  /** True when this weapon cannot be fired (destroyed, jammed, out-of-ammo). */
+  readonly disabled: boolean;
+  /** Human-readable reason for disable (e.g., "Out of ammo"). Null when ready. */
+  readonly disabledReason: string | null;
+  /**
+   * Whether the weapon consumed ammo in its last fire.
+   * Surfaces ammo-shortage warnings in the inspector.
+   */
+  readonly hasAmmoWarning: boolean;
+}
+
+// =============================================================================
+// IFriendlyInspectorView — own-unit exact state
+// =============================================================================
+
+/**
+ * Full exact state for a friendly unit.
+ *
+ * All fields reflect the live `IUnitGameState` projection with no
+ * redaction. The component layer renders all of these values directly.
+ */
+export interface IFriendlyInspectorView {
+  readonly kind: 'friendly';
+  /** Stable unit id. */
+  readonly unitId: string;
+  /** Display name (from `IGameUnit.name`). */
+  readonly name: string;
+  /** Chassis/variant designation (from `IGameUnit.unitRef`). */
+  readonly chassis: string;
+  /** Pilot name, e.g., "Mechwarrior Smith". */
+  readonly pilotName: string;
+  /** Pilot gunnery skill. */
+  readonly gunnery: number;
+  /** Pilot piloting skill. */
+  readonly piloting: number;
+  /** Pilot wounds (0–5; 6 = KIA). */
+  readonly pilotWounds: number;
+  /** Whether the pilot is still conscious. */
+  readonly pilotConscious: boolean;
+  /** Current accumulated heat. */
+  readonly heat: number;
+  /** Total armor points remaining across all locations. */
+  readonly totalArmorRemaining: number;
+  /** Total structure points remaining across all locations. */
+  readonly totalStructureRemaining: number;
+  /** Whether this unit is prone (fallen). */
+  readonly prone: boolean;
+  /** Whether this unit is shut down. */
+  readonly shutdown: boolean;
+  /** Whether this unit is destroyed. */
+  readonly destroyed: boolean;
+  /** Whether the unit is actively withdrawing. */
+  readonly isWithdrawing: boolean;
+  /** Weapon readiness list. Empty array = unit has no weapons data. */
+  readonly weapons: readonly IInspectorWeapon[];
+  /** Active critical effects, e.g., "Engine Hit x2", "Gyro Destroyed". */
+  readonly criticalEffects: readonly string[];
+  /** Current movement type used this turn (e.g., "WALK", "RUN", "JUMP"). */
+  readonly movementThisTurn: string;
+  /** Number of hexes moved this turn. */
+  readonly hexesMoved: number;
+}
+
+// =============================================================================
+// ITargetInspectorView — opponent at 'rough' or 'exact' intel tier
+// =============================================================================
+
+/**
+ * Partial state for a visible opponent unit.
+ *
+ * At 'exact' tier, numeric fields are populated. At 'rough' tier the
+ * precise numbers are replaced by opaque band descriptors; the numeric
+ * fields carry `null` and the band fields carry a `DamageBand` string.
+ *
+ * Component consumers MUST check `isExact` before rendering a numeric
+ * value — if `isExact` is false, only the band fields are trustworthy.
+ */
+export interface ITargetInspectorView {
+  readonly kind: 'target';
+  /** Stable unit id. */
+  readonly unitId: string;
+  /** Display name — available at both 'rough' and 'exact' tiers. */
+  readonly name: string;
+  /** Chassis designation — available at 'exact' tier only; null at 'rough'. */
+  readonly chassis: string | null;
+  /** True when all numeric fields are populated (exact tier). */
+  readonly isExact: boolean;
+  /** Current heat — populated at 'exact'; null at 'rough'. */
+  readonly heat: number | null;
+  /** Approximate overall damage state for rough-tier projections. */
+  readonly damageBand: DamageBand;
+  /** Total armor remaining — exact tier only; null at rough tier. */
+  readonly totalArmorRemaining: number | null;
+  /** Total structure remaining — exact tier only; null at rough tier. */
+  readonly totalStructureRemaining: number | null;
+  /** Whether the unit is prone — available at both tiers (observable on the map). */
+  readonly prone: boolean;
+  /** Whether the unit is shut down — exact tier only. */
+  readonly shutdown: boolean | null;
+  /** Whether the unit is destroyed — always available. */
+  readonly destroyed: boolean;
+}
+
+// =============================================================================
+// IRedactedInspectorView — opponent at 'hidden' or 'unknown' intel tier
+// =============================================================================
+
+/**
+ * Identity-safe stub for an opponent unit that cannot be observed.
+ *
+ * Per the spec "exact hidden fields SHALL not be recoverable from labels,
+ * tooltips, DOM text, ARIA text, or test ids":
+ *   - No name, chassis, heat value, or armor number is present.
+ *   - Components rendering this shape MUST display a generic placeholder
+ *     (e.g., "Unknown Contact") and MUST NOT derive or infer any secret
+ *     value from this shape.
+ *
+ * The `unitId` is retained because the UI needs a stable React key and
+ * the slot owner must know which tile it is managing; it does NOT reveal
+ * the pilot identity or chassis to the viewer.
+ */
+export interface IRedactedInspectorView {
+  readonly kind: 'redacted';
+  /** Stable unit id — used for React keys only, NOT for display. */
+  readonly unitId: string;
+  /**
+   * Generic contact label, e.g., "Unknown Contact".
+   * Must never contain the unit's real name or chassis.
+   */
+  readonly contactLabel: string;
+}
+
+// =============================================================================
+// Union — the projection returned by useUnitInspectorProjection
+// =============================================================================
+
+/** Discriminated union of all possible inspector projections. */
+export type IInspectorProjection =
+  | IFriendlyInspectorView
+  | ITargetInspectorView
+  | IRedactedInspectorView;

--- a/src/types/gameplay/index.ts
+++ b/src/types/gameplay/index.ts
@@ -49,3 +49,6 @@ export * from './BattleArmorCombatInterfaces';
 export type { IAerospaceCombatState } from '@/utils/gameplay/aerospace/state';
 export type { IInfantryCombatState } from '@/utils/gameplay/infantry/state';
 export type { IProtoMechCombatState } from '@/utils/gameplay/protomech/state';
+
+// Tactical Unit Inspector projection types (Wave 7.2 — add-tactical-unit-inspector-drawers)
+export * from './TacticalInspectorInterfaces';


### PR DESCRIPTION
## Summary

- **§1 Inspector Data**: `TacticalInspectorInterfaces.ts` discriminated union types (`IFriendlyInspectorView | ITargetInspectorView | IRedactedInspectorView`) + `useUnitInspectorProjection` hook with data-level redaction (no exact values leak on hidden/unknown tier)
- **§2.1 Inspector UI**: `TacticalUnitInspector` component (FriendlyView / TargetView / RedactedView sub-views) wired into `GameplayLayout` right-tray via `DesktopRightTray` child component (avoids context scope violation since `GameplayLayout` is the shell provider)
- **§4.1 Tests**: 8 component tests covering empty placeholder, friendly exact state, pilot G/P skills, rough tier (band visible / numbers absent), exact tier (numbers present), hidden + unknown tier DOM-level redaction (`textContent` must not contain real unit name or raw heat value), and default-rough fallback

## Gate 4 compliance

Inspector binds to `state.inspectedUnit ?? selectedUnitId` — NEVER `state.activeUnit`. `<ShellSlot id="right-tray" ownerId="RecordSheetPanel">` wrapper preserved.

## Deferred (noted in tasks.md)

- §2.2 Record sheet drawers (Armor/Structure, Weapons/Heat, Effects, Movement, Pilot) — PR-G scope
- §2.3 Contextual comparison panel — PR-H scope
- §3.1/3.2 Responsive peek/pinned/expanded/mobile-sheet variants — depends on §2.2
- §4.2 Drawer tab tests, §4.3 E2E — depend on §2.2/3.1

## Test plan

- [x] All 8 §4.1 tests pass (`npm test -- TacticalUnitInspector`)
- [x] TypeScript typecheck clean (pre-commit hook)
- [x] Full Next.js build passes (pre-commit hook)
- [x] Opponent redaction is data-level: `textContent` assertions confirm no leaked values at hidden/unknown tier

🤖 Generated with [Claude Code](https://claude.com/claude-code)