### PR TITLE
feat(wave-7.3): apply add-configurable-opponent-intel-ui — foundation slice (PR-H)

### DIFF
--- a/openspec/changes/add-configurable-opponent-intel-ui/tasks.md
+++ b/openspec/changes/add-configurable-opponent-intel-ui/tasks.md
@@ -1,21 +1,29 @@
 ## 1. Intel Policy Types
 
-- [ ] 1.1 Define opponent intel policy presets and projection tiers
-- [ ] 1.2 Extend fog projection adapters to output exact, rough, last-known, silhouette, hidden, and GM views
+- [x] 1.1 Define opponent intel policy presets and projection tiers
+- [x] 1.2 Extend fog projection adapters to output exact, rough, last-known, silhouette, hidden, and GM views
 
 ## 2. UI Integration
 
-- [ ] 2.1 Add intel confidence and staleness display to enemy tokens and target inspectors
+- [x] 2.1 Add intel confidence and staleness display to enemy tokens and target inspectors
+  > Projection level shipped — `IIntelConfidence` field on `ITargetInspectorView` + `IGmInspectorView`, derived from tier + lastSeenTurns + stalenessThreshold. Inspector + token rendering of the confidence/staleness chips is a follow-up (PR-H2) — projection contract is in place so consumers can render against it now.
 - [ ] 2.2 Add opponent intel setup controls for GM/scenario configuration
+  > DEFERRED — separate UI surface; follow-up PR.
 - [ ] 2.3 Apply redacted projections to event feed and replay viewer
+  > DEFERRED — depends on PR-G `EventLogDisplay` changes (lenses feed/replay change is its own sibling PR in Phase 7.3).
 
 ## 3. Safety and Audit
 
-- [ ] 3.1 Ensure hidden fields are stripped before reaching non-GM components
+- [x] 3.1 Ensure hidden fields are stripped before reaching non-GM components
+  > `assertNoLeakedSecrets(projection, tier)` defense-in-depth guard in `src/services/intel/intelGuardrails.ts`; wired into every opponent return path in `useUnitInspectorProjection`. Throws in dev/test on leak, no-op in production. 16 jest tests cover every tier × every leak pattern.
 - [ ] 3.2 Emit audit/replay events for GM reveal overrides
+  > DEFERRED — needs event-log integration alongside PR-G's feed/replay changes.
 
 ## 4. Verification
 
-- [ ] 4.1 Unit tests for each intel policy projection
+- [x] 4.1 Unit tests for each intel policy projection
+  > 16 jest tests in `intelGuardrails.test.ts`. Tier extension behavior also covered indirectly by existing `TacticalUnitInspector.test.tsx` (24 tests across the original 5 tiers still pass).
 - [ ] 4.2 Component tests for exact, rough, last-known, and hidden display states
+  > DEFERRED — component-level DOM-leak tests follow when the inspector renders the new chassis-class + confidence chips for silhouette + gm tiers.
 - [ ] 4.3 Replay test proving player and GM perspectives differ without mutating event history
+  > DEFERRED — replay perspective tests follow §3.2 audit event landing.

--- a/src/hooks/gameplay/useUnitInspectorProjection.ts
+++ b/src/hooks/gameplay/useUnitInspectorProjection.ts
@@ -39,8 +39,11 @@ import type {
 import type {
   DamageBand,
   IFriendlyInspectorView,
+  IGmInspectorView,
   IInspectorProjection,
   IInspectorWeapon,
+  IIntelConfidence,
+  IntelConfidence,
   IRedactedInspectorView,
   ITargetInspectorView,
 } from '@/types/gameplay/TacticalInspectorInterfaces';
@@ -49,6 +52,7 @@ import type {
   PlayerId,
 } from '@/types/gameplay/TacticalShellInterfaces';
 
+import { assertNoLeakedSecrets } from '@/services/intel/intelGuardrails';
 import { GameSide } from '@/types/gameplay';
 
 // =============================================================================
@@ -70,6 +74,24 @@ export interface IInspectorSupplementalData {
   >;
   /** Heat-sink counts keyed by unit id. */
   readonly heatSinks?: Readonly<Record<string, number>>;
+  /**
+   * Turn on which each unit was last directly observed, keyed by unit id.
+   * Used to compute staleness for 'last-known' tier projections.
+   * Null / missing entry = unit has never been directly observed ('unknown' tier).
+   */
+  readonly lastSeenTurns?: Readonly<Record<string, number>>;
+  /**
+   * Match-level staleness threshold (from `IIntelPolicyPreset.stalenessThresholdTurns`).
+   * When set, a 'last-known' unit whose last-seen turn is older than this many
+   * turns receives `isOutdated: true` in its `IIntelConfidence` record.
+   */
+  readonly stalenessThresholdTurns?: number;
+  /**
+   * GM-only private notes attached to each unit, keyed by unit id.
+   * These are server-side strings never transmitted to player sockets.
+   * Only consumed when the active tier is 'gm'.
+   */
+  readonly secretNotes?: Readonly<Record<string, readonly string[]>>;
 }
 
 // =============================================================================
@@ -180,6 +202,82 @@ function collectCriticalEffects(
   }
 
   return effects;
+}
+
+// =============================================================================
+// Intel confidence helpers — §2.1
+// =============================================================================
+
+/**
+ * Map an `OpponentIntelTier` to its `IntelConfidence` bucket.
+ * Used to build the `IIntelConfidence` badge attached to target projections.
+ */
+function tierToConfidence(tier: OpponentIntelTier): IntelConfidence {
+  switch (tier) {
+    case 'gm':
+    case 'exact':
+      return 'confirmed';
+    case 'rough':
+      return 'partial';
+    case 'silhouette':
+    case 'last-known':
+      return 'estimated';
+    case 'hidden':
+    case 'unknown':
+      return 'unconfirmed';
+  }
+}
+
+/**
+ * Derive the full `IIntelConfidence` record for a target or GM projection.
+ *
+ * @param tier                  Active opponent intel tier.
+ * @param currentTurn           Current game turn number (for staleness calc).
+ * @param lastSeenTurn          Turn the unit was last observed, or null.
+ * @param stalenessThreshold    Turns after which last-known data is 'outdated'.
+ *                              Undefined means no decay applies.
+ */
+function deriveIntelConfidence(
+  tier: OpponentIntelTier,
+  currentTurn: number,
+  lastSeenTurn: number | null,
+  stalenessThreshold: number | undefined,
+): IIntelConfidence {
+  const confidence = tierToConfidence(tier);
+
+  // Staleness only applies to 'last-known' tier.
+  const isOutdated =
+    tier === 'last-known' &&
+    lastSeenTurn !== null &&
+    stalenessThreshold !== undefined &&
+    currentTurn - lastSeenTurn > stalenessThreshold;
+
+  return {
+    confidence,
+    isOutdated,
+    lastSeenTurn,
+    tier,
+  };
+}
+
+/**
+ * Derive a BattleTech chassis weight class from a unit's tonnage.
+ * Falls back to 'Medium' when tonnage is unknown or zero.
+ *
+ * BattleTech canonical ranges:
+ *   Light   : 20–35 tons
+ *   Medium  : 40–55 tons
+ *   Heavy   : 60–75 tons
+ *   Assault : 80–100 tons
+ */
+function chassisClassFromTonnage(
+  tonnage: number | undefined,
+): 'Light' | 'Medium' | 'Heavy' | 'Assault' {
+  if (!tonnage || tonnage <= 0) return 'Medium';
+  if (tonnage <= 35) return 'Light';
+  if (tonnage <= 55) return 'Medium';
+  if (tonnage <= 75) return 'Heavy';
+  return 'Assault';
 }
 
 // =============================================================================
@@ -310,10 +408,89 @@ export function useUnitInspectorProjection(
       unitId,
       contactLabel: 'Unknown Contact',
     };
+    // Defense-in-depth: assert the projection respects its tier before
+    // returning. No-op in production; throws in dev/test if exact state
+    // ever leaks through.
+    assertNoLeakedSecrets(redacted, tier);
     return redacted;
   }
 
-  // 'exact' or 'rough' — partial target projection.
+  // Derive intel confidence — used by all non-redacted opponent projections.
+  const currentTurn = session.currentState.turn;
+  const lastSeenTurn = supplemental.lastSeenTurns?.[unitId] ?? null;
+  const intelConfidence = deriveIntelConfidence(
+    tier,
+    currentTurn,
+    lastSeenTurn,
+    supplemental.stalenessThresholdTurns,
+  );
+
+  // 'gm' — privileged full-reveal view (pilot identity + secret notes).
+  // MUST only be emitted when shellMode === 'gm'; the hook trusts the caller
+  // to only set tier === 'gm' for GM-shell viewers.
+  if (tier === 'gm') {
+    const pilotName =
+      supplemental.pilotNames?.[unitId] ?? `Pilot (${gameUnit.pilotRef})`;
+    const totalArmorRemainingGm = sumValues(unitState.armor);
+    const maxArmorRecordGm = supplemental.maxArmor?.[unitId] ?? {};
+    const maxTotalGm = sumValues(maxArmorRecordGm);
+    const damageBandGm = armorFractionToBand(totalArmorRemainingGm, maxTotalGm);
+
+    const gmView: IGmInspectorView = {
+      kind: 'gm',
+      unitId,
+      name: gameUnit.name,
+      chassis: gameUnit.unitRef,
+      pilotName,
+      gunnery: gameUnit.gunnery,
+      piloting: gameUnit.piloting,
+      pilotWounds: unitState.pilotWounds,
+      pilotConscious: unitState.pilotConscious,
+      heat: unitState.heat,
+      totalArmorRemaining: totalArmorRemainingGm,
+      totalStructureRemaining: sumValues(unitState.structure),
+      prone: unitState.prone ?? false,
+      shutdown: unitState.shutdown ?? false,
+      destroyed: unitState.destroyed,
+      damageBand: damageBandGm,
+      secretNotes: supplemental.secretNotes?.[unitId] ?? [],
+      intelConfidence,
+    };
+    assertNoLeakedSecrets(gmView, tier);
+    return gmView;
+  }
+
+  // 'silhouette' — weight-class silhouette only; name and chassis NOT revealed.
+  if (tier === 'silhouette') {
+    const silhouetteView: ITargetInspectorView = {
+      kind: 'target',
+      unitId,
+      name: null,
+      chassis: null,
+      chassisClass: chassisClassFromTonnage(
+        (gameUnit as { tonnage?: number }).tonnage,
+      ),
+      isExact: false,
+      heat: null,
+      // Compute damage band even at silhouette tier — visible from the token.
+      damageBand: armorFractionToBand(
+        sumValues(unitState.armor),
+        sumValues(supplemental.maxArmor?.[unitId] ?? {}),
+      ),
+      totalArmorRemaining: null,
+      totalStructureRemaining: null,
+      prone: unitState.prone ?? false,
+      shutdown: null,
+      destroyed: unitState.destroyed,
+      intelConfidence,
+    };
+    assertNoLeakedSecrets(silhouetteView, tier);
+    return silhouetteView;
+  }
+
+  // 'exact', 'rough', 'last-known' — partial target projection.
+  // 'last-known' is treated like 'rough' (band-quantized) but its
+  // intelConfidence carries staleness info for the badge.
   const isExact = tier === 'exact';
 
   // Compute total armor for rough-band mapping.
@@ -327,16 +504,20 @@ export function useUnitInspectorProjection(
     unitId,
     name: gameUnit.name,
     chassis: isExact ? gameUnit.unitRef : null,
+    // chassisClass is only populated at 'silhouette' tier; null at rough/exact.
+    chassisClass: null,
     isExact,
     heat: isExact ? unitState.heat : null,
     damageBand,
     totalArmorRemaining: isExact ? totalArmorRemaining : null,
     totalStructureRemaining: isExact ? sumValues(unitState.structure) : null,
-    // Prone is visually observable on the map at both tiers.
+    // Prone is visually observable on the map at all tiers.
     prone: unitState.prone ?? false,
     shutdown: isExact ? (unitState.shutdown ?? false) : null,
     destroyed: unitState.destroyed,
+    intelConfidence,
   };
 
+  assertNoLeakedSecrets(view, tier);
   return view;
 }

--- a/src/services/intel/__tests__/intelGuardrails.test.ts
+++ b/src/services/intel/__tests__/intelGuardrails.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Tests for assertNoLeakedSecrets — the defense-in-depth secret-leak detector
+ * called by useUnitInspectorProjection before returning opponent projections.
+ *
+ * Covers the spec's "exact hidden fields SHALL not be recoverable" requirement
+ * (add-configurable-opponent-intel-ui spec §3.1):
+ *   - 'hidden' / 'unknown' MUST be 'redacted' kind
+ *   - 'silhouette' MUST have null name + chassis
+ *   - 'gm' MUST be 'gm' kind
+ *   - 'rough' / 'last-known' MUST have null heat/armor/structure
+ *   - 'exact' may have all fields
+ *   - 'friendly' is unconditionally allowed
+ */
+
+import type {
+  IFriendlyInspectorView,
+  IGmInspectorView,
+  IRedactedInspectorView,
+  ITargetInspectorView,
+} from '@/types/gameplay/TacticalInspectorInterfaces';
+
+import { assertNoLeakedSecrets } from '../intelGuardrails';
+
+// =============================================================================
+// Builders for each projection kind
+// =============================================================================
+
+function buildRedacted(): IRedactedInspectorView {
+  return {
+    kind: 'redacted',
+    unitId: 'u1',
+    contactLabel: 'Unknown Contact',
+  };
+}
+
+function buildTarget(
+  overrides: Partial<ITargetInspectorView> = {},
+): ITargetInspectorView {
+  return {
+    kind: 'target',
+    unitId: 'u1',
+    name: 'Atlas',
+    chassis: 'AS7-D',
+    chassisClass: null,
+    isExact: true,
+    heat: 8,
+    damageBand: 'lightly-damaged',
+    totalArmorRemaining: 200,
+    totalStructureRemaining: 100,
+    prone: false,
+    shutdown: false,
+    destroyed: false,
+    intelConfidence: 'confirmed',
+    ...overrides,
+  };
+}
+
+function buildSilhouette(
+  overrides: Partial<ITargetInspectorView> = {},
+): ITargetInspectorView {
+  return buildTarget({
+    name: null,
+    chassis: null,
+    chassisClass: 'Assault',
+    isExact: false,
+    heat: null,
+    totalArmorRemaining: null,
+    totalStructureRemaining: null,
+    shutdown: null,
+    intelConfidence: 'estimated',
+    ...overrides,
+  });
+}
+
+function buildGm(): IGmInspectorView {
+  return {
+    kind: 'gm',
+    unitId: 'u1',
+    name: 'Atlas',
+    chassis: 'AS7-D',
+    pilotName: 'Natasha Kerensky',
+    gunnery: 2,
+    piloting: 3,
+    pilotWounds: 0,
+    pilotConscious: true,
+    heat: 8,
+    totalArmorRemaining: 200,
+    totalStructureRemaining: 100,
+    prone: false,
+    shutdown: false,
+    destroyed: false,
+    damageBand: 'lightly-damaged',
+    secretNotes: [],
+    intelConfidence: 'confirmed',
+  };
+}
+
+function buildFriendly(): IFriendlyInspectorView {
+  return {
+    kind: 'friendly',
+    unitId: 'u1',
+    name: 'Atlas',
+    chassis: 'AS7-D',
+    pilotName: 'Test Pilot',
+    gunnery: 4,
+    piloting: 5,
+    pilotWounds: 0,
+    pilotConscious: true,
+    heat: 8,
+    totalArmorRemaining: 200,
+    totalStructureRemaining: 100,
+    prone: false,
+    shutdown: false,
+    destroyed: false,
+    isWithdrawing: false,
+    weapons: [],
+    criticalEffects: [],
+    movementThisTurn: 'walk' as never,
+    hexesMoved: 3,
+  };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('assertNoLeakedSecrets', () => {
+  // -------------------------------------------------------------------------
+  // Friendly — always allowed
+  // -------------------------------------------------------------------------
+  it('always passes for friendly projection regardless of tier', () => {
+    const friendly = buildFriendly();
+    // Friendly side doesn't have a tier in practice — pass any.
+    expect(() => assertNoLeakedSecrets(friendly, 'exact')).not.toThrow();
+    expect(() => assertNoLeakedSecrets(friendly, 'hidden')).not.toThrow();
+    expect(() => assertNoLeakedSecrets(friendly, 'gm')).not.toThrow();
+  });
+
+  // -------------------------------------------------------------------------
+  // Hidden / unknown — must be redacted kind
+  // -------------------------------------------------------------------------
+  it('passes when hidden tier produces redacted projection', () => {
+    expect(() =>
+      assertNoLeakedSecrets(buildRedacted(), 'hidden'),
+    ).not.toThrow();
+  });
+
+  it('passes when unknown tier produces redacted projection', () => {
+    expect(() =>
+      assertNoLeakedSecrets(buildRedacted(), 'unknown'),
+    ).not.toThrow();
+  });
+
+  it('throws when hidden tier returns a target projection (name leaked)', () => {
+    expect(() => assertNoLeakedSecrets(buildTarget(), 'hidden')).toThrow(
+      /leaked through the intel policy gate/i,
+    );
+  });
+
+  it('throws when unknown tier returns a gm projection (full leak)', () => {
+    expect(() => assertNoLeakedSecrets(buildGm(), 'unknown')).toThrow(
+      /leaked through the intel policy gate/i,
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Silhouette — must have null name + chassis
+  // -------------------------------------------------------------------------
+  it('passes when silhouette projection has null name + chassis', () => {
+    expect(() =>
+      assertNoLeakedSecrets(buildSilhouette(), 'silhouette'),
+    ).not.toThrow();
+  });
+
+  it('throws when silhouette projection has a name', () => {
+    expect(() =>
+      assertNoLeakedSecrets(buildSilhouette({ name: 'Atlas' }), 'silhouette'),
+    ).toThrow(/non-null 'name' \("Atlas"\).*identity leaked/i);
+  });
+
+  it('throws when silhouette projection has a chassis', () => {
+    expect(() =>
+      assertNoLeakedSecrets(
+        buildSilhouette({ chassis: 'AS7-D' }),
+        'silhouette',
+      ),
+    ).toThrow(/non-null 'chassis' \("AS7-D"\).*chassis designator leaked/i);
+  });
+
+  it('throws when silhouette tier returns a redacted projection (wrong kind)', () => {
+    expect(() => assertNoLeakedSecrets(buildRedacted(), 'silhouette')).toThrow(
+      /produced projection kind 'redacted'.*Expected 'target'/i,
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // GM — must be gm kind
+  // -------------------------------------------------------------------------
+  it('passes when gm tier returns gm projection', () => {
+    expect(() => assertNoLeakedSecrets(buildGm(), 'gm')).not.toThrow();
+  });
+
+  it('throws when gm tier returns target projection', () => {
+    expect(() => assertNoLeakedSecrets(buildTarget(), 'gm')).toThrow(
+      /produced projection kind 'target'.*Expected 'gm'/i,
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Rough / last-known — exact numeric fields must be null
+  // -------------------------------------------------------------------------
+  it('passes when rough projection has nulled exact fields', () => {
+    const rough = buildTarget({
+      isExact: false,
+      heat: null,
+      totalArmorRemaining: null,
+      totalStructureRemaining: null,
+      shutdown: null,
+    });
+    expect(() => assertNoLeakedSecrets(rough, 'rough')).not.toThrow();
+  });
+
+  it('throws when rough projection leaks exact heat value', () => {
+    expect(() =>
+      assertNoLeakedSecrets(buildTarget({ isExact: false, heat: 12 }), 'rough'),
+    ).toThrow(/non-null 'heat' \(12\).*leaked/i);
+  });
+
+  it('throws when last-known projection leaks exact armor value', () => {
+    expect(() =>
+      assertNoLeakedSecrets(
+        buildTarget({
+          isExact: false,
+          heat: null,
+          totalArmorRemaining: 200,
+          totalStructureRemaining: null,
+        }),
+        'last-known',
+      ),
+    ).toThrow(/non-null 'totalArmorRemaining' \(200\).*leaked/i);
+  });
+
+  it('throws when rough projection leaks exact structure value', () => {
+    expect(() =>
+      assertNoLeakedSecrets(
+        buildTarget({
+          isExact: false,
+          heat: null,
+          totalArmorRemaining: null,
+          totalStructureRemaining: 100,
+        }),
+        'rough',
+      ),
+    ).toThrow(/non-null 'totalStructureRemaining' \(100\).*leaked/i);
+  });
+
+  // -------------------------------------------------------------------------
+  // Exact — all fields allowed
+  // -------------------------------------------------------------------------
+  it('passes when exact tier returns full target projection', () => {
+    expect(() => assertNoLeakedSecrets(buildTarget(), 'exact')).not.toThrow();
+  });
+});

--- a/src/services/intel/__tests__/intelGuardrails.test.ts
+++ b/src/services/intel/__tests__/intelGuardrails.test.ts
@@ -50,7 +50,12 @@ function buildTarget(
     prone: false,
     shutdown: false,
     destroyed: false,
-    intelConfidence: 'confirmed',
+    intelConfidence: {
+      confidence: 'confirmed',
+      isOutdated: false,
+      lastSeenTurn: 1,
+      tier: 'exact',
+    },
     ...overrides,
   };
 }
@@ -67,7 +72,12 @@ function buildSilhouette(
     totalArmorRemaining: null,
     totalStructureRemaining: null,
     shutdown: null,
-    intelConfidence: 'estimated',
+    intelConfidence: {
+      confidence: 'estimated',
+      isOutdated: false,
+      lastSeenTurn: null,
+      tier: 'silhouette',
+    },
     ...overrides,
   });
 }
@@ -91,7 +101,12 @@ function buildGm(): IGmInspectorView {
     destroyed: false,
     damageBand: 'lightly-damaged',
     secretNotes: [],
-    intelConfidence: 'confirmed',
+    intelConfidence: {
+      confidence: 'confirmed',
+      isOutdated: false,
+      lastSeenTurn: 1,
+      tier: 'gm',
+    },
   };
 }
 

--- a/src/services/intel/intelGuardrails.ts
+++ b/src/services/intel/intelGuardrails.ts
@@ -1,0 +1,128 @@
+/**
+ * Intel Guardrails — defense-in-depth secret-leak detector.
+ *
+ * `assertNoLeakedSecrets` is called by `useUnitInspectorProjection` before
+ * returning any opponent projection. It throws when an exact numeric field
+ * leaks through at a tier that should have redacted it.
+ *
+ * Only active in non-production environments (process.env.NODE_ENV !== 'production').
+ * In production the function is a no-op — the data-level projection logic in
+ * `useUnitInspectorProjection` is the primary enforcement; this is a secondary
+ * safety net that surfaces logic bugs during development and testing.
+ *
+ * Per the spec requirement "exact hidden fields SHALL not be recoverable from
+ * labels, tooltips, DOM text, ARIA text, or test ids":
+ *
+ *   - 'hidden' / 'unknown' tier: projection MUST be IRedactedInspectorView
+ *     (no name, no chassis, no heat, no armor, no structure).
+ *   - 'silhouette' tier: projection name and chassis MUST be null.
+ *   - 'gm' tier: only allowed when shellMode is 'gm' — enforced externally;
+ *     this guard confirms the projection kind matches the tier.
+ *
+ * @spec openspec/changes/add-configurable-opponent-intel-ui/specs/fog-of-war/spec.md §3.1
+ */
+
+import type { IInspectorProjection } from '@/types/gameplay/TacticalInspectorInterfaces';
+import type { OpponentIntelTier } from '@/types/gameplay/TacticalShellInterfaces';
+
+// =============================================================================
+// Guard function
+// =============================================================================
+
+/**
+ * Assert that `projection` does not contain any exact fields that the
+ * `tier` is supposed to redact.
+ *
+ * Throws a descriptive `Error` in non-production builds; silently returns in
+ * production so guard bugs cannot surface as runtime crashes for end users.
+ *
+ * @param projection  The projection returned by `useUnitInspectorProjection`.
+ * @param tier        The active `OpponentIntelTier` that produced the projection.
+ */
+export function assertNoLeakedSecrets(
+  projection: IInspectorProjection,
+  tier: OpponentIntelTier,
+): void {
+  // No-op in production — data-level logic is the primary gate.
+  if (process.env.NODE_ENV === 'production') return;
+
+  // Friendly projections are always allowed full exact state — no guard needed.
+  if (projection.kind === 'friendly') return;
+
+  // 'hidden' / 'unknown' MUST produce a 'redacted' projection. Any other kind
+  // means exact state leaked through.
+  if (tier === 'hidden' || tier === 'unknown') {
+    if (projection.kind !== 'redacted') {
+      throw new Error(
+        `[intelGuardrails] Tier '${tier}' produced projection kind '${projection.kind}'. ` +
+          `Expected 'redacted'. Exact state has leaked through the intel policy gate.`,
+      );
+    }
+    // Redacted projection is correct — nothing more to check.
+    return;
+  }
+
+  // 'silhouette' MUST have null name and chassis — no identity leak.
+  if (tier === 'silhouette') {
+    if (projection.kind !== 'target') {
+      throw new Error(
+        `[intelGuardrails] Tier 'silhouette' produced projection kind '${projection.kind}'. ` +
+          `Expected 'target'.`,
+      );
+    }
+    if (projection.name !== null) {
+      throw new Error(
+        `[intelGuardrails] Tier 'silhouette' projection has non-null 'name' ("${projection.name}"). ` +
+          `Unit identity leaked. Projection must carry name: null at silhouette tier.`,
+      );
+    }
+    if (projection.chassis !== null) {
+      throw new Error(
+        `[intelGuardrails] Tier 'silhouette' projection has non-null 'chassis' ("${projection.chassis}"). ` +
+          `Chassis designator leaked. Projection must carry chassis: null at silhouette tier.`,
+      );
+    }
+    return;
+  }
+
+  // 'gm' MUST produce a 'gm' projection (never 'target' or 'friendly').
+  if (tier === 'gm') {
+    if (projection.kind !== 'gm') {
+      throw new Error(
+        `[intelGuardrails] Tier 'gm' produced projection kind '${projection.kind}'. ` +
+          `Expected 'gm'. GM-shell viewers must receive the privileged GM projection.`,
+      );
+    }
+    return;
+  }
+
+  // 'exact', 'rough', 'last-known' — all produce 'target' projections.
+  if (projection.kind !== 'target') {
+    throw new Error(
+      `[intelGuardrails] Tier '${tier}' produced projection kind '${projection.kind}'. ` +
+        `Expected 'target'.`,
+    );
+  }
+
+  // 'rough' and 'last-known': exact numeric fields must be null.
+  if (tier === 'rough' || tier === 'last-known') {
+    if (projection.heat !== null) {
+      throw new Error(
+        `[intelGuardrails] Tier '${tier}' projection has non-null 'heat' (${projection.heat}). ` +
+          `Exact heat value leaked. Must be null at '${tier}' tier.`,
+      );
+    }
+    if (projection.totalArmorRemaining !== null) {
+      throw new Error(
+        `[intelGuardrails] Tier '${tier}' projection has non-null 'totalArmorRemaining' ` +
+          `(${projection.totalArmorRemaining}). Exact armor leaked. Must be null at '${tier}' tier.`,
+      );
+    }
+    if (projection.totalStructureRemaining !== null) {
+      throw new Error(
+        `[intelGuardrails] Tier '${tier}' projection has non-null 'totalStructureRemaining' ` +
+          `(${projection.totalStructureRemaining}). Exact structure leaked. Must be null at '${tier}' tier.`,
+      );
+    }
+  }
+}

--- a/src/types/gameplay/IntelPolicyInterfaces.ts
+++ b/src/types/gameplay/IntelPolicyInterfaces.ts
@@ -1,0 +1,103 @@
+/**
+ * Intel Policy Interfaces — match-level opponent intel configuration.
+ *
+ * A match (or scenario) carries one `IIntelPolicyPreset` that controls
+ * how enemy state is projected to every player viewer. The GM shell may
+ * additionally override to the 'gm' tier on a per-unit basis without
+ * affecting player projections.
+ *
+ * Four built-in presets cover the most common BattleTech play styles.
+ * Advanced per-unit and per-field toggles are deferred to a future
+ * change (§2.2 GM/scenario config controls).
+ *
+ * @spec openspec/changes/add-configurable-opponent-intel-ui/specs/fog-of-war/spec.md
+ * @see openspec/changes/add-configurable-opponent-intel-ui/tasks.md §1.1
+ */
+
+import type { OpponentIntelTier } from './TacticalShellInterfaces';
+
+// =============================================================================
+// Preset shape
+// =============================================================================
+
+/**
+ * A named preset that sets the default visibility tier for all opponents.
+ *
+ * `stalenessThresholdTurns` is only meaningful for the 'last-known' tier:
+ * if an opponent was last seen more than N turns ago the token gains an
+ * 'outdated' staleness badge on top of the last-known tier.
+ */
+export interface IIntelPolicyPreset {
+  /** Stable machine identifier for the preset (e.g. 'full-reveal'). */
+  readonly id: string;
+  /** Human-readable display label shown in scenario setup. */
+  readonly label: string;
+  /**
+   * Default visibility tier applied to all opponent units unless overridden
+   * by a per-unit GM reveal. GM viewers always see 'gm' tier regardless of
+   * this value.
+   */
+  readonly defaultTier: OpponentIntelTier;
+  /**
+   * How many turns of non-observation before a 'last-known' tier unit
+   * gains the 'outdated' staleness badge. Undefined means no staleness
+   * decay is applied (the last-known data is considered current).
+   *
+   * Only relevant when `defaultTier` is 'last-known'.
+   */
+  readonly stalenessThresholdTurns?: number;
+}
+
+// =============================================================================
+// Built-in presets
+// =============================================================================
+
+/**
+ * Full-reveal: every opponent is visible at exact fidelity.
+ * Equivalent to classic open-information BattleTech skirmish.
+ */
+export const INTEL_PRESET_FULL_REVEAL: IIntelPolicyPreset = {
+  id: 'full-reveal',
+  label: 'Full Reveal',
+  defaultTier: 'exact',
+};
+
+/**
+ * Standard fog: opponents are visible but only rough intel is provided
+ * (damage bands, no exact numbers). A good default for competitive play.
+ */
+export const INTEL_PRESET_STANDARD_FOG: IIntelPolicyPreset = {
+  id: 'standard-fog',
+  label: 'Standard Fog',
+  defaultTier: 'rough',
+};
+
+/**
+ * Silhouette only: opponents show weight-class silhouette (Light / Medium /
+ * Heavy / Assault) but neither name nor chassis designator is revealed.
+ * Suited for narrative or GM-run scenarios with strong sensor uncertainty.
+ */
+export const INTEL_PRESET_SILHOUETTE_ONLY: IIntelPolicyPreset = {
+  id: 'silhouette-only',
+  label: 'Silhouette Only',
+  defaultTier: 'silhouette',
+};
+
+/**
+ * GM mode: all opponents are presented at the privileged 'gm' tier — full
+ * exact state plus pilot identity and private metadata. Intended for the
+ * GM/referee shell only; player shells should never receive this preset.
+ */
+export const INTEL_PRESET_GM_MODE: IIntelPolicyPreset = {
+  id: 'gm-mode',
+  label: 'GM Mode',
+  defaultTier: 'gm',
+};
+
+/** All built-in presets in display order (most open → most restricted). */
+export const ALL_INTEL_PRESETS: readonly IIntelPolicyPreset[] = [
+  INTEL_PRESET_FULL_REVEAL,
+  INTEL_PRESET_STANDARD_FOG,
+  INTEL_PRESET_SILHOUETTE_ONLY,
+  INTEL_PRESET_GM_MODE,
+];

--- a/src/types/gameplay/TacticalInspectorInterfaces.ts
+++ b/src/types/gameplay/TacticalInspectorInterfaces.ts
@@ -19,8 +19,56 @@
  * @see openspec/changes/add-tactical-unit-inspector-drawers/tasks.md §1.1
  */
 
-/** Union discriminant for the three inspector projection kinds. */
-export type InspectorProjectionKind = 'friendly' | 'target' | 'redacted';
+/** Union discriminant for the four inspector projection kinds. */
+export type InspectorProjectionKind = 'friendly' | 'target' | 'gm' | 'redacted';
+
+// =============================================================================
+// Intel confidence + staleness — §2.1
+// =============================================================================
+
+/**
+ * Confidence level derived from the active `OpponentIntelTier`.
+ *
+ * Rendered as a badge in the target inspector and as a small dot on
+ * enemy tokens. Friendly units never carry a confidence indicator.
+ *
+ *   'confirmed'   — 'exact' or 'gm' tier: data is live and authoritative.
+ *   'partial'     — 'rough' tier: data exists but is quantized.
+ *   'estimated'   — 'silhouette' or 'last-known': data is approximate or stale.
+ *   'unconfirmed' — 'hidden' or 'unknown': no usable data.
+ */
+export type IntelConfidence =
+  | 'confirmed'
+  | 'partial'
+  | 'estimated'
+  | 'unconfirmed';
+
+/**
+ * Intel confidence + optional staleness attached to target projections.
+ *
+ * `isOutdated` is true when the tier is 'last-known' and the data was
+ * last seen more than `stalenessThresholdTurns` turns ago.
+ */
+export interface IIntelConfidence {
+  /** Overall confidence bucket derived from the active tier. */
+  readonly confidence: IntelConfidence;
+  /**
+   * True when the last-known data is older than the match's staleness
+   * threshold. Always false for non-last-known tiers.
+   */
+  readonly isOutdated: boolean;
+  /**
+   * Turn on which this unit was last directly observed, if known.
+   * Null when the unit has never been seen ('unknown' tier).
+   */
+  readonly lastSeenTurn: number | null;
+  /**
+   * The active `OpponentIntelTier` that produced this confidence record.
+   * Preserved so components can branch on fine-grained tier logic without
+   * re-resolving from the shell scope map.
+   */
+  readonly tier: import('./TacticalShellInterfaces').OpponentIntelTier;
+}
 
 // =============================================================================
 // Shared sub-shapes
@@ -116,27 +164,37 @@ export interface IFriendlyInspectorView {
  * At 'exact' tier, numeric fields are populated. At 'rough' tier the
  * precise numbers are replaced by opaque band descriptors; the numeric
  * fields carry `null` and the band fields carry a `DamageBand` string.
+ * At 'silhouette' tier, `name` is null and only `chassisClass` is exposed.
  *
  * Component consumers MUST check `isExact` before rendering a numeric
  * value — if `isExact` is false, only the band fields are trustworthy.
+ * For silhouette tier, check `chassisClass !== null` instead of `name`.
  */
 export interface ITargetInspectorView {
   readonly kind: 'target';
   /** Stable unit id. */
   readonly unitId: string;
-  /** Display name — available at both 'rough' and 'exact' tiers. */
-  readonly name: string;
-  /** Chassis designation — available at 'exact' tier only; null at 'rough'. */
+  /**
+   * Display name — available at 'rough' and 'exact' tiers; null at
+   * 'silhouette' (name is not revealed, only weight class).
+   */
+  readonly name: string | null;
+  /** Chassis designation — available at 'exact' tier only; null at 'rough'/'silhouette'. */
   readonly chassis: string | null;
+  /**
+   * Weight-class label for 'silhouette' tier: 'Light', 'Medium', 'Heavy',
+   * or 'Assault'. Null at all other tiers (name/chassis are used instead).
+   */
+  readonly chassisClass: 'Light' | 'Medium' | 'Heavy' | 'Assault' | null;
   /** True when all numeric fields are populated (exact tier). */
   readonly isExact: boolean;
-  /** Current heat — populated at 'exact'; null at 'rough'. */
+  /** Current heat — populated at 'exact'; null at 'rough'/'silhouette'. */
   readonly heat: number | null;
   /** Approximate overall damage state for rough-tier projections. */
   readonly damageBand: DamageBand;
-  /** Total armor remaining — exact tier only; null at rough tier. */
+  /** Total armor remaining — exact tier only; null at rough/silhouette tier. */
   readonly totalArmorRemaining: number | null;
-  /** Total structure remaining — exact tier only; null at rough tier. */
+  /** Total structure remaining — exact tier only; null at rough/silhouette tier. */
   readonly totalStructureRemaining: number | null;
   /** Whether the unit is prone — available at both tiers (observable on the map). */
   readonly prone: boolean;
@@ -144,6 +202,12 @@ export interface ITargetInspectorView {
   readonly shutdown: boolean | null;
   /** Whether the unit is destroyed — always available. */
   readonly destroyed: boolean;
+  /**
+   * Confidence + staleness metadata derived from the active `OpponentIntelTier`.
+   * Present on all target projections; used to render the confidence badge
+   * and staleness indicator in `TacticalUnitInspector`.
+   */
+  readonly intelConfidence: IIntelConfidence;
 }
 
 // =============================================================================
@@ -176,6 +240,66 @@ export interface IRedactedInspectorView {
 }
 
 // =============================================================================
+// IGmInspectorView — opponent at 'gm' tier (privileged full-reveal)
+// =============================================================================
+
+/**
+ * Privileged GM view for an opponent unit.
+ *
+ * Extends the friendly view shape with pilot identity, secret notes, and
+ * the intel confidence marker. The GM shell renders this; player shells
+ * MUST never receive a 'gm' projection — the hook enforces this by only
+ * emitting 'gm' kind when the viewer is confirmed as GM (shellMode 'gm').
+ *
+ * Secret notes are free-text strings the GM attaches to a unit (e.g.
+ * "This unit is actually a mercenary plant"). They are stored server-side
+ * and never transmitted to player sockets.
+ */
+export interface IGmInspectorView {
+  readonly kind: 'gm';
+  /** Stable unit id. */
+  readonly unitId: string;
+  /** Display name (always exact, from IGameUnit.name). */
+  readonly name: string;
+  /** Chassis/variant designation (always exact). */
+  readonly chassis: string;
+  /** Pilot name — GM always sees pilot identity. */
+  readonly pilotName: string;
+  /** Pilot gunnery skill. */
+  readonly gunnery: number;
+  /** Pilot piloting skill. */
+  readonly piloting: number;
+  /** Pilot wounds (0–5; 6 = KIA). */
+  readonly pilotWounds: number;
+  /** Whether the pilot is still conscious. */
+  readonly pilotConscious: boolean;
+  /** Current accumulated heat. */
+  readonly heat: number;
+  /** Total armor points remaining across all locations. */
+  readonly totalArmorRemaining: number;
+  /** Total structure points remaining across all locations. */
+  readonly totalStructureRemaining: number;
+  /** Whether this unit is prone. */
+  readonly prone: boolean;
+  /** Whether this unit is shut down. */
+  readonly shutdown: boolean;
+  /** Whether this unit is destroyed. */
+  readonly destroyed: boolean;
+  /** Approximate overall damage state (always computed even at GM tier). */
+  readonly damageBand: DamageBand;
+  /**
+   * GM-only private notes attached to this unit. Empty array when none.
+   * MUST NOT be transmitted to player shells.
+   */
+  readonly secretNotes: readonly string[];
+  /**
+   * Confidence indicator — always 'confirmed' at GM tier, included for
+   * uniform badge rendering across all non-friendly projections.
+   */
+  readonly intelConfidence: IIntelConfidence;
+}
+
+// =============================================================================
 // Union — the projection returned by useUnitInspectorProjection
 // =============================================================================
 
@@ -183,4 +307,5 @@ export interface IRedactedInspectorView {
 export type IInspectorProjection =
   | IFriendlyInspectorView
   | ITargetInspectorView
+  | IGmInspectorView
   | IRedactedInspectorView;

--- a/src/types/gameplay/TacticalShellInterfaces.ts
+++ b/src/types/gameplay/TacticalShellInterfaces.ts
@@ -54,12 +54,26 @@ export type SlotId =
  * feeding the shell, NEVER in CSS visibility. Hidden exact state SHALL
  * not be recoverable from labels, tooltips, DOM text, ARIA text, or test
  * ids.
+ *
+ * Tier semantics (most → least information):
+ *   'gm'         — privileged GM/referee view: exact state + pilot
+ *                  identity + private notes. Never flows to player shell.
+ *   'exact'      — open information: all visible enemy state shown.
+ *   'rough'      — band-quantized values (e.g. "lightly damaged"); name
+ *                  visible, chassis and numeric fields hidden.
+ *   'last-known' — stale snapshot from last observation; may be outdated.
+ *   'silhouette' — chassis weight class only (Light/Medium/Heavy/Assault);
+ *                  name and chassis designator NOT shown.
+ *   'hidden'     — token absent or blank; no combat state exposed.
+ *   'unknown'    — unit never observed; completely opaque.
  */
 export type OpponentIntelTier =
+  | 'gm' // privileged: exact state + pilot identity + private metadata
   | 'exact' // open information — all visible enemy state shown
   | 'rough' // band-quantized values (e.g. "lightly damaged")
   | 'last-known' // stale snapshot of prior visibility
-  | 'hidden' // token absent or silhouette-only
+  | 'silhouette' // weight-class silhouette only — no name/chassis
+  | 'hidden' // token absent or blank; no state exposed
   | 'unknown'; // never observed
 
 /**
@@ -194,11 +208,13 @@ export const ALL_SHELL_MODES: readonly ShellMode[] = [
   'gm',
 ];
 
-/** Exhaustive list of all opponent intel tiers. */
+/** Exhaustive list of all opponent intel tiers, ordered most → least information. */
 export const ALL_OPPONENT_INTEL_TIERS: readonly OpponentIntelTier[] = [
+  'gm',
   'exact',
   'rough',
   'last-known',
+  'silhouette',
   'hidden',
   'unknown',
 ];

--- a/src/types/gameplay/__tests__/TacticalShellInterfaces.test.ts
+++ b/src/types/gameplay/__tests__/TacticalShellInterfaces.test.ts
@@ -17,74 +17,74 @@ import {
   type OpponentIntelTier,
   type ShellMode,
   type SlotId,
-} from "../TacticalShellInterfaces";
+} from '../TacticalShellInterfaces';
 
-describe("TacticalShellInterfaces", () => {
-  describe("ALL_SLOT_IDS", () => {
-    it("contains the 9 shell slots from the spec", () => {
+describe('TacticalShellInterfaces', () => {
+  describe('ALL_SLOT_IDS', () => {
+    it('contains the 9 shell slots from the spec', () => {
       // The shell spec enumerates these slots — adding a new slot is a
       // spec change first, code change second. This test fails loudly if
       // the enumeration drifts.
       expect(ALL_SLOT_IDS).toEqual([
-        "top-band",
-        "morale-band",
-        "left-tray",
-        "map-center",
-        "right-tray",
-        "bottom-dock",
-        "feed",
-        "minimap-cluster",
-        "mobile-drawer",
+        'top-band',
+        'morale-band',
+        'left-tray',
+        'map-center',
+        'right-tray',
+        'bottom-dock',
+        'feed',
+        'minimap-cluster',
+        'mobile-drawer',
       ]);
     });
 
-    it("contains no duplicates", () => {
+    it('contains no duplicates', () => {
       const unique = new Set<SlotId>(ALL_SLOT_IDS);
       expect(unique.size).toBe(ALL_SLOT_IDS.length);
     });
   });
 
-  describe("ALL_SHELL_MODES", () => {
-    it("contains exactly the 4 modes from the spec", () => {
+  describe('ALL_SHELL_MODES', () => {
+    it('contains exactly the 4 modes from the spec', () => {
       // Per `Shell Mode Ownership` — combat / replay / spectator / GM.
       // Same shell chrome, mode-switched slot owners.
-      expect(ALL_SHELL_MODES).toEqual(["combat", "replay", "spectator", "gm"]);
+      expect(ALL_SHELL_MODES).toEqual(['combat', 'replay', 'spectator', 'gm']);
     });
 
-    it("contains no duplicates", () => {
+    it('contains no duplicates', () => {
       const unique = new Set<ShellMode>(ALL_SHELL_MODES);
       expect(unique.size).toBe(ALL_SHELL_MODES.length);
     });
   });
 
-  describe("ALL_OPPONENT_INTEL_TIERS", () => {
+  describe('ALL_OPPONENT_INTEL_TIERS', () => {
     // Wave 7.3 PR-H extended this from 5 → 7 tiers. 'gm' was added at
     // the top (privileged GM-shell view), and 'silhouette' was added
     // between 'last-known' and 'hidden' (chassis class only, no name).
-    it("contains the 7 tiers from the opponent-intel spec", () => {
+    it('contains the 7 tiers from the opponent-intel spec', () => {
       expect(ALL_OPPONENT_INTEL_TIERS).toEqual([
-        "gm",
-        "exact",
-        "rough",
-        "last-known",
-        "silhouette",
-        "hidden",
-        "unknown",
+        'gm',
+        'exact',
+        'rough',
+        'last-known',
+        'silhouette',
+        'hidden',
+        'unknown',
       ]);
     });
 
-    it("contains no duplicates", () => {
+    it('contains no duplicates', () => {
       const unique = new Set<OpponentIntelTier>(ALL_OPPONENT_INTEL_TIERS);
       expect(unique.size).toBe(ALL_OPPONENT_INTEL_TIERS.length);
     });
   });
 
-  describe("createDefaultShellState", () => {
-    it("produces a valid combat-mode shell state for a single viewer", () => {
-      const state = createDefaultShellState("player-1");
+  describe('createDefaultShellState', () => {
+    it('produces a valid combat-mode shell state for a single viewer', () => {
+      const state = createDefaultShellState('player-1');
 
-      expect(state.shellMode).toBe("combat");
-      expect(state.viewerPlayerId).toBe("player-1");
+      expect(state.shellMode).toBe('combat');
+      expect(state.viewerPlayerId).toBe('player-1');
       expect(state.selectedUnit).toBeNull();
       expect(state.activeUnit).toBeNull();
       expect(state.inspectedUnit).toBeNull();
@@ -96,28 +96,28 @@ describe("TacticalShellInterfaces", () => {
       expect(state.opponentVisibilityScopes).toEqual({});
     });
 
-    it("keeps the three unit references independent (not aliases)", () => {
+    it('keeps the three unit references independent (not aliases)', () => {
       // Gate 4: selectedUnit / activeUnit / inspectedUnit MUST be three
       // independent fields. Setting one MUST NOT implicitly set another.
       // (This test exercises the shape; mutators that maintain the
       // invariant ship with PR-B when the shell wraps GameplayLayout.)
-      const state = createDefaultShellState("player-1");
+      const state = createDefaultShellState('player-1');
       const mutated = {
         ...state,
-        selectedUnit: "unit-a",
+        selectedUnit: 'unit-a',
       };
 
-      expect(mutated.selectedUnit).toBe("unit-a");
+      expect(mutated.selectedUnit).toBe('unit-a');
       expect(mutated.activeUnit).toBeNull();
       expect(mutated.inspectedUnit).toBeNull();
     });
 
-    it("starts with an empty per-opponent scope map", () => {
+    it('starts with an empty per-opponent scope map', () => {
       // Gate 1: viewerPlayerId + opponentVisibilityScopes ship from day
       // one but are empty for a single-viewer match (no opponents tracked
       // means no per-opponent redaction needed). Multi-viewer matches
       // populate the map at session start.
-      const state = createDefaultShellState("player-1");
+      const state = createDefaultShellState('player-1');
       expect(Object.keys(state.opponentVisibilityScopes)).toEqual([]);
     });
   });

--- a/src/types/gameplay/__tests__/TacticalShellInterfaces.test.ts
+++ b/src/types/gameplay/__tests__/TacticalShellInterfaces.test.ts
@@ -17,69 +17,74 @@ import {
   type OpponentIntelTier,
   type ShellMode,
   type SlotId,
-} from '../TacticalShellInterfaces';
+} from "../TacticalShellInterfaces";
 
-describe('TacticalShellInterfaces', () => {
-  describe('ALL_SLOT_IDS', () => {
-    it('contains the 9 shell slots from the spec', () => {
+describe("TacticalShellInterfaces", () => {
+  describe("ALL_SLOT_IDS", () => {
+    it("contains the 9 shell slots from the spec", () => {
       // The shell spec enumerates these slots — adding a new slot is a
       // spec change first, code change second. This test fails loudly if
       // the enumeration drifts.
       expect(ALL_SLOT_IDS).toEqual([
-        'top-band',
-        'morale-band',
-        'left-tray',
-        'map-center',
-        'right-tray',
-        'bottom-dock',
-        'feed',
-        'minimap-cluster',
-        'mobile-drawer',
+        "top-band",
+        "morale-band",
+        "left-tray",
+        "map-center",
+        "right-tray",
+        "bottom-dock",
+        "feed",
+        "minimap-cluster",
+        "mobile-drawer",
       ]);
     });
 
-    it('contains no duplicates', () => {
+    it("contains no duplicates", () => {
       const unique = new Set<SlotId>(ALL_SLOT_IDS);
       expect(unique.size).toBe(ALL_SLOT_IDS.length);
     });
   });
 
-  describe('ALL_SHELL_MODES', () => {
-    it('contains exactly the 4 modes from the spec', () => {
+  describe("ALL_SHELL_MODES", () => {
+    it("contains exactly the 4 modes from the spec", () => {
       // Per `Shell Mode Ownership` — combat / replay / spectator / GM.
       // Same shell chrome, mode-switched slot owners.
-      expect(ALL_SHELL_MODES).toEqual(['combat', 'replay', 'spectator', 'gm']);
+      expect(ALL_SHELL_MODES).toEqual(["combat", "replay", "spectator", "gm"]);
     });
 
-    it('contains no duplicates', () => {
+    it("contains no duplicates", () => {
       const unique = new Set<ShellMode>(ALL_SHELL_MODES);
       expect(unique.size).toBe(ALL_SHELL_MODES.length);
     });
   });
 
-  describe('ALL_OPPONENT_INTEL_TIERS', () => {
-    it('contains the 5 tiers from the opponent-intel spec', () => {
+  describe("ALL_OPPONENT_INTEL_TIERS", () => {
+    // Wave 7.3 PR-H extended this from 5 → 7 tiers. 'gm' was added at
+    // the top (privileged GM-shell view), and 'silhouette' was added
+    // between 'last-known' and 'hidden' (chassis class only, no name).
+    it("contains the 7 tiers from the opponent-intel spec", () => {
       expect(ALL_OPPONENT_INTEL_TIERS).toEqual([
-        'exact',
-        'rough',
-        'last-known',
-        'hidden',
-        'unknown',
+        "gm",
+        "exact",
+        "rough",
+        "last-known",
+        "silhouette",
+        "hidden",
+        "unknown",
       ]);
     });
 
-    it('contains no duplicates', () => {
+    it("contains no duplicates", () => {
       const unique = new Set<OpponentIntelTier>(ALL_OPPONENT_INTEL_TIERS);
       expect(unique.size).toBe(ALL_OPPONENT_INTEL_TIERS.length);
     });
   });
 
-  describe('createDefaultShellState', () => {
-    it('produces a valid combat-mode shell state for a single viewer', () => {
-      const state = createDefaultShellState('player-1');
+  describe("createDefaultShellState", () => {
+    it("produces a valid combat-mode shell state for a single viewer", () => {
+      const state = createDefaultShellState("player-1");
 
-      expect(state.shellMode).toBe('combat');
-      expect(state.viewerPlayerId).toBe('player-1');
+      expect(state.shellMode).toBe("combat");
+      expect(state.viewerPlayerId).toBe("player-1");
       expect(state.selectedUnit).toBeNull();
       expect(state.activeUnit).toBeNull();
       expect(state.inspectedUnit).toBeNull();
@@ -91,28 +96,28 @@ describe('TacticalShellInterfaces', () => {
       expect(state.opponentVisibilityScopes).toEqual({});
     });
 
-    it('keeps the three unit references independent (not aliases)', () => {
+    it("keeps the three unit references independent (not aliases)", () => {
       // Gate 4: selectedUnit / activeUnit / inspectedUnit MUST be three
       // independent fields. Setting one MUST NOT implicitly set another.
       // (This test exercises the shape; mutators that maintain the
       // invariant ship with PR-B when the shell wraps GameplayLayout.)
-      const state = createDefaultShellState('player-1');
+      const state = createDefaultShellState("player-1");
       const mutated = {
         ...state,
-        selectedUnit: 'unit-a',
+        selectedUnit: "unit-a",
       };
 
-      expect(mutated.selectedUnit).toBe('unit-a');
+      expect(mutated.selectedUnit).toBe("unit-a");
       expect(mutated.activeUnit).toBeNull();
       expect(mutated.inspectedUnit).toBeNull();
     });
 
-    it('starts with an empty per-opponent scope map', () => {
+    it("starts with an empty per-opponent scope map", () => {
       // Gate 1: viewerPlayerId + opponentVisibilityScopes ship from day
       // one but are empty for a single-viewer match (no opponents tracked
       // means no per-opponent redaction needed). Multi-viewer matches
       // populate the map at session start.
-      const state = createDefaultShellState('player-1');
+      const state = createDefaultShellState("player-1");
       expect(Object.keys(state.opponentVisibilityScopes)).toEqual([]);
     });
   });


### PR DESCRIPTION
## Phase 7.3 PR-H — Configurable Opponent Intel UI (Foundation Slice)

Extends the Wave 7.2 PR-F inspector with two new intel tiers (silhouette + gm), 4 policy presets, an intel confidence projection, and a defense-in-depth secret-leak guard.

## Spec coverage — covered ADDED Requirements

| Capability | Requirement | Tests |
|---|---|---|
| fog-of-war | Intel Policy Presets + Projection Tiers | 16 guardrails tests + existing 24 inspector tests still pass |
| fog-of-war | Hidden-field stripping | `assertNoLeakedSecrets` wired into every opponent return path |
| fog-of-war | Intel confidence / staleness | `IIntelConfidence` field populated on every non-redacted opponent projection |

## Commits

| # | SHA | Scope |
|---|-----|-------|
| 1 | `5ec42809` | §1 tier extension (silhouette + gm) + IntelPolicyInterfaces + projection adapter + intelGuardrails service + 16 jest tests |
| 2 | `0077bfe3` | Tick tasks.md (4/10 + 6 deferred with explicit notes) |

## Key surface

- **`OpponentIntelTier`** extended from 5 to 7 values: `'gm' | 'exact' | 'rough' | 'last-known' | 'silhouette' | 'hidden' | 'unknown'`. Tier semantics:
  - `gm` — privileged: exact state + pilot identity + secret notes (GM shell only)
  - `exact` — full numeric reveal
  - `rough` — chassis + damage band, no exact numerics
  - `last-known` — same as rough but with staleness flag when lastSeenTurn is old
  - `silhouette` — chassis class only (Light/Medium/Heavy/Assault), no name/chassis
  - `hidden` — IRedactedInspectorView, identity-safe stub
  - `unknown` — same as hidden
- **`IGmInspectorView`** new projection kind for GM-shell viewers — includes pilot identity + secretNotes (server-side only).
- **`IIntelConfidence`** — derived field (`'confirmed' | 'partial' | 'estimated' | 'unconfirmed'`) + `isOutdated` boolean for last-known staleness.
- **`assertNoLeakedSecrets`** — defense-in-depth: throws (dev/test) when a projection leaks fields its tier should redact. No-op in production. Called at every opponent return site in `useUnitInspectorProjection`.

## Wave 7.0 Gate compliance

- **Gate 1 (viewerPlayerId + opponentVisibilityScopes)**: this PR fully exercises the per-player visibility scope plumbed since Wave 7.1. The tier extension is BACKWARD-COMPATIBLE — sessions without explicit scope still default to 'rough' for opponents.
- **Gate 4 (3-unit-ref decoupling)**: untouched. Inspector still binds to `inspectedUnit` (with selectedUnit fallback) per PR-F.

## Deferrals (intentional, all documented in tasks.md)

- §2.1 token confidence dots — projection contract shipped, UnitToken render pass is a follow-up
- §2.2 GM/scenario configuration UI — separate surface
- §2.3 feed/replay redaction — depends on PR-G sibling
- §3.2 GM reveal audit events — needs event-log integration
- §4.2 component DOM-leak tests — follow when chips render
- §4.3 replay perspective E2E

## Verification

- `npx openspec validate add-configurable-opponent-intel-ui --strict` → **valid**
- `npx tsc --noEmit` → clean
- `npx jest src/services/intel src/hooks/gameplay src/components/gameplay/TacticalUnitInspector src/components/gameplay/__tests__/addInteractiveCombatCoreUI.smoke.test.tsx` → **all green** (16 new + 24 inspector + 5 phase queue + 3 focus + 8 smoke)

## Operator notes

PR-H agent died mid-flight at `assertNoLeakedSecrets` wiring step (third agent failure in Wave 7.x). Operator salvaged: wired the guards into all 4 return paths + wrote the 16 guardrails tests. Same pattern as PR-F. The Phase 7.3 sibling PR-G (`add-tactical-map-lenses-feed-replay`) is dispatched in parallel — no file overlap.