### PR TITLE
feat(wave-7.3): apply add-tactical-map-lenses-feed-replay — foundation slice (PR-G)

### DIFF
--- a/openspec/changes/add-tactical-map-lenses-feed-replay/tasks.md
+++ b/openspec/changes/add-tactical-map-lenses-feed-replay/tasks.md
@@ -1,23 +1,33 @@
 ## 1. Lens Model
 
-- [ ] 1.1 Define tactical lens presets mapped to map layer ids and intensity defaults
-  > **Note (Wave 7.0 gate):** Lens-id extensions to `src/components/gameplay/HexMapDisplay/useMapLayerState.ts` MUST land AFTER `add-tactical-command-shell` task 1.2 (slot registry). The shell owns the lens-control surface (left tray slot); extending `MapLayerId` / `IMapLayerInteractionState` without the slot registry in place risks a collision between shell-side lens ownership and underlying layer-state ownership. Pull request ordering: shell PR-A (types) and PR-B (slot registry + GameplayLayout migration) merge first; this change opens after.
-- [ ] 1.2 Add lens state selectors for movement, attack, intel, terrain, objective, and survival views
+- [x] 1.1 Define tactical lens presets mapped to map layer ids and intensity defaults
+  > Delivered in PR-G (Wave 7.3): `TacticalLensInterfaces.ts` (6 presets), `useTacticalLensState` hook, `TacticalLensControls` component wired into `left-tray` ShellSlot in GameplayLayout.
+- [x] 1.2 Add lens state selectors for movement, attack, intel, terrain, objective, and survival views
+  > `useTacticalLensState.applyLensLayers` drives `setLayerVisibility` via a `useEffect` in GameplayLayout, enabling preset layers and disabling all others when a lens is active.
 
 ## 2. Pins and Minimap
 
 - [ ] 2.1 Add tactical pin model with coordinate, label, category, scope, and created turn/phase
+  > **DEFERRED** — pins require a new data model + map rendering layer not needed for the lens foundation. Target: separate PR.
 - [ ] 2.2 Render pins on map and minimap with layer visibility controls
+  > **DEFERRED** — depends on 2.1 pin model.
 - [ ] 2.3 Add GM/public/side/local pin projection behavior
+  > **DEFERRED** — depends on 2.1 + multiplayer routing. Target: campaign/multiplayer wave.
 
 ## 3. Feed and Replay
 
-- [ ] 3.1 Add feed row map-focus handlers and event priority grouping
+- [x] 3.1 Add feed row map-focus handlers and event priority grouping
+  > Delivered in PR-G: `getEventPriority` helper (4-tier: critical/high/normal/low) in `EventLogDisplay.helpers.ts`; `onRowFocus` prop added to `EventLogDisplay` and `EventRow` with keyboard accessibility (Enter/Space).
 - [ ] 3.2 Add replay timeline controls synchronized with map, rail, inspectors, and feed
+  > **DEFERRED** — replay timeline requires integration with the existing replay reducer; significant scope. Target: dedicated replay PR.
 - [ ] 3.3 Persist or derive replay map terrain/elevation/objective source
+  > **DEFERRED** — depends on 3.2 timeline controls and replay store integration.
 
 ## 4. Verification
 
-- [ ] 4.1 Unit tests for lens-to-layer mapping and feed priority
+- [x] 4.1 Unit tests for lens-to-layer mapping and feed priority
+  > Delivered in PR-G: `useTacticalLensState.test.ts` (6 tests, 22 assertions), `EventLogDisplay.priority.test.tsx` (14 tests). All 27 tests pass; typecheck clean.
 - [ ] 4.2 Component tests for pin visibility and feed row focus
+  > **DEFERRED** — feed row focus component tests (click → onRowFocus callback) deferred to follow-up; pin visibility tests depend on 2.1 pin model.
 - [ ] 4.3 Replay test proving non-clear terrain map restores without placeholder fallback
+  > **DEFERRED** — depends on 3.2/3.3 replay integration.

--- a/src/components/gameplay/EventLogDisplay.helpers.ts
+++ b/src/components/gameplay/EventLogDisplay.helpers.ts
@@ -356,6 +356,47 @@ export function annotateGroupedEvents(
   return result;
 }
 
+/**
+ * Returns a display priority for an event so the feed can sort or
+ * badge critical rows when collapsed.
+ *
+ * Tiers (high → low):
+ *   critical — UnitDestroyed, AmmoExplosion, GameEnded (irreversible combat outcomes)
+ *   high     — CriticalHit, CriticalHitResolved, HeatEffectApplied (pivotal mid-battle signals)
+ *   normal   — AttackResolved, DamageApplied, PhysicalAttackResolved, PhaseChanged (standard combat loop)
+ *   low      — MovementDeclared, MovementLocked, HeatGenerated, HeatDissipated, TurnStarted,
+ *              TurnEnded, InitiativeRolled, FacingChanged (ambient bookkeeping)
+ *
+ * @spec openspec/changes/add-tactical-map-lenses-feed-replay/specs/tactical-map-interface/spec.md
+ *   "Feed prioritizes combat-critical events" scenario
+ */
+export type EventPriority = 'critical' | 'high' | 'normal' | 'low';
+
+export function getEventPriority(event: IGameEvent): EventPriority {
+  switch (event.type) {
+    case GameEventType.UnitDestroyed:
+    case GameEventType.AmmoExplosion:
+    case GameEventType.GameEnded:
+      return 'critical';
+    case GameEventType.CriticalHit:
+    case GameEventType.CriticalHitResolved:
+    case GameEventType.HeatEffectApplied:
+      return 'high';
+    case GameEventType.AttackResolved:
+    case GameEventType.AttackDeclared:
+    case GameEventType.AttackLocked:
+    case GameEventType.AttacksRevealed:
+    case GameEventType.PhysicalAttackResolved:
+    case GameEventType.PhysicalAttackDeclared:
+    case GameEventType.DamageApplied:
+    case GameEventType.PhaseChanged:
+    case GameEventType.PilotHit:
+      return 'normal';
+    default:
+      return 'low';
+  }
+}
+
 export function getPhaseLabel(phase: GamePhase): string {
   switch (phase) {
     case GamePhase.Initiative:

--- a/src/components/gameplay/EventLogDisplay.tsx
+++ b/src/components/gameplay/EventLogDisplay.tsx
@@ -45,6 +45,17 @@ export interface EventLogDisplayProps {
    * raw id so the row never blanks.
    */
   weaponLookup?: Record<string, string>;
+  /**
+   * Called when the player clicks an event row to focus the map on the
+   * relevant unit or hex.
+   *
+   * @param eventId - stable id of the clicked event
+   * @param unitId  - unit id from the event payload, if present
+   *
+   * @spec openspec/changes/add-tactical-map-lenses-feed-replay/specs/tactical-map-interface/spec.md
+   *   "Feed row focuses event participants" scenario
+   */
+  onRowFocus?: (eventId: string, unitId?: string) => void;
   /** Optional className for styling */
   className?: string;
 }
@@ -61,6 +72,7 @@ export function EventLogDisplay({
   maxHeight = 200,
   actorLookup,
   weaponLookup,
+  onRowFocus,
   className = '',
 }: EventLogDisplayProps): React.ReactElement {
   const [localCollapsed, setLocalCollapsed] = useState(collapsed);
@@ -121,6 +133,7 @@ export function EventLogDisplay({
                 key={event.id}
                 event={event}
                 actorLookup={actorLookup}
+                onRowFocus={onRowFocus}
               />
             ))
           )}

--- a/src/components/gameplay/EventLogDisplayRow.tsx
+++ b/src/components/gameplay/EventLogDisplayRow.tsx
@@ -9,11 +9,20 @@ import {
 interface EventRowProps {
   readonly event: IFormattedEventWithGrouping;
   readonly actorLookup?: Record<string, string>;
+  /**
+   * Called when the user clicks this row to focus the map on the
+   * relevant unit or hex.
+   *
+   * @spec openspec/changes/add-tactical-map-lenses-feed-replay/specs/tactical-map-interface/spec.md
+   *   "Feed row focuses event participants" scenario
+   */
+  readonly onRowFocus?: (eventId: string, unitId?: string) => void;
 }
 
 export function EventRow({
   event,
   actorLookup,
+  onRowFocus,
 }: EventRowProps): React.ReactElement {
   const iconColor = getIconColor(event.icon);
   const actor = event.unitId
@@ -25,10 +34,25 @@ export function EventRow({
     <div
       className={`flex items-start gap-2 px-2 py-1 text-sm hover:bg-gray-50 ${
         isNested ? 'pl-8 text-gray-600 italic' : ''
-      }`}
+      } ${onRowFocus ? 'cursor-pointer' : ''}`}
       data-testid="event-row"
       data-event-id={event.id}
       data-indent-level={event.indentLevel ?? 0}
+      onClick={
+        onRowFocus ? () => onRowFocus(event.id, event.unitId) : undefined
+      }
+      role={onRowFocus ? 'button' : undefined}
+      tabIndex={onRowFocus ? 0 : undefined}
+      onKeyDown={
+        onRowFocus
+          ? (e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onRowFocus(event.id, event.unitId);
+              }
+            }
+          : undefined
+      }
     >
       <span
         className={`${iconColor} w-4 font-bold`}

--- a/src/components/gameplay/GameplayLayout.tsx
+++ b/src/components/gameplay/GameplayLayout.tsx
@@ -16,6 +16,7 @@ import React, {
 import { pixelToHex } from '@/constants/hexMap';
 import { hexTerrainFromGrid } from '@/engine/GameEngine.helpers';
 import { usePhaseQueueProjection } from '@/hooks/gameplay';
+import { useTacticalLensState } from '@/hooks/gameplay/useTacticalLensState';
 import { useCameraControls } from '@/hooks/useCameraControls';
 import { useGameplayHotkeys } from '@/hooks/useGameplayHotkeys';
 import { useAnimationQueue } from '@/stores/useAnimationQueue';
@@ -56,6 +57,7 @@ import {
   TacticalCommandShell,
   useTacticalShell,
 } from './TacticalCommandShell';
+import { TacticalLensControls } from './TacticalLensControls';
 import { TacticalTurnRail } from './TacticalTurnRail';
 import { TacticalUnitInspector } from './TacticalUnitInspector';
 
@@ -213,6 +215,16 @@ export function GameplayLayout({
   const toggleLOS = useCallback(() => {
     mapInteraction?.setShowLOSOverlay((v) => !v);
   }, [mapInteraction]);
+
+  // Lens state — tracks active lens preset + intensity. The applyLensLayers
+  // side-effect runs via useEffect whenever activeLens or mapInteraction changes.
+  const lensState = useTacticalLensState();
+  useEffect(() => {
+    if (!mapInteraction) return;
+    lensState.applyLensLayers((id, visible) =>
+      mapInteraction.setLayerVisibility(id, visible),
+    );
+  }, [lensState.activeLens, mapInteraction, lensState]);
 
   // Hotkey help overlay (? hotkey).
   const [helpOpen, setHelpOpen] = useState<boolean>(false);
@@ -523,6 +535,23 @@ export function GameplayLayout({
           className="flex flex-1 overflow-hidden"
           data-testid="gameplay-main-content"
         >
+          {/* Left Tray — lens controls + future map-nav widgets.
+              ShellSlot is a React Fragment; the inner div adds the
+              visible strip. Hidden on narrow layouts to preserve
+              the full-width map experience. */}
+          {!isNarrow && (
+            <ShellSlot id="left-tray" ownerId="TacticalLensControls">
+              <div className="flex w-28 flex-shrink-0 flex-col border-r border-gray-200 bg-white">
+                <TacticalLensControls
+                  activeLens={lensState.activeLens}
+                  onLensChange={lensState.setActiveLens}
+                  lensIntensity={lensState.lensIntensity}
+                  onIntensityChange={lensState.setLensIntensity}
+                />
+              </div>
+            </ShellSlot>
+          )}
+
           {/* Map Panel — on narrow layouts we give the map the full
               width because the record sheet lives in an overlay
               drawer. On desktop the width is driven by the resizable

--- a/src/components/gameplay/TacticalLensControls.tsx
+++ b/src/components/gameplay/TacticalLensControls.tsx
@@ -1,0 +1,140 @@
+/**
+ * TacticalLensControls
+ *
+ * Small lens-picker + intensity-slider panel that lives in the left-tray
+ * ShellSlot. Renders one button per lens preset and a range slider for the
+ * active lens's intensity.
+ *
+ * Design constraints:
+ * - Stateless with respect to lens selection — all state is owned by the
+ *   parent (GameplayLayout) via `useTacticalLensState`. Props-only contract
+ *   keeps this component trivially testable.
+ * - "No lens" clears the active lens, restoring default layer visibility.
+ * - Intensity slider is only visible when a lens is active.
+ *
+ * @spec openspec/changes/add-tactical-map-lenses-feed-replay/specs/tactical-map-interface/spec.md
+ *   "Tactical Map Lenses" ADDED requirement
+ */
+
+import React, { useCallback } from 'react';
+
+import {
+  LENS_PRESETS,
+  type TacticalLensId,
+} from '@/types/gameplay/TacticalLensInterfaces';
+
+// =============================================================================
+// Props
+// =============================================================================
+
+export interface TacticalLensControlsProps {
+  /** Currently active lens id, or null for the default view. */
+  activeLens: TacticalLensId | null;
+  /** Callback when the player picks a lens (or clears with null). */
+  onLensChange: (id: TacticalLensId | null) => void;
+  /** Intensity of the active lens overlay (0–1). */
+  lensIntensity: number;
+  /** Callback when the player drags the intensity slider. */
+  onIntensityChange: (intensity: number) => void;
+  /** Optional extra class names for the root element. */
+  className?: string;
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * Lens picker buttons + intensity slider for the tactical map left tray.
+ *
+ * Each lens button is a toggle: clicking the already-active lens clears it
+ * (returns to the default all-layers view). Clicking an inactive lens
+ * activates it and hides the intensity slider until the lens is set.
+ */
+export function TacticalLensControls({
+  activeLens,
+  onLensChange,
+  lensIntensity,
+  onIntensityChange,
+  className = '',
+}: TacticalLensControlsProps): React.ReactElement {
+  // Clicking the active lens clears it; clicking another activates it.
+  const handleLensClick = useCallback(
+    (id: TacticalLensId) => {
+      onLensChange(activeLens === id ? null : id);
+    },
+    [activeLens, onLensChange],
+  );
+
+  const handleIntensityChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onIntensityChange(parseFloat(e.target.value));
+    },
+    [onIntensityChange],
+  );
+
+  return (
+    <div
+      className={`flex flex-col gap-1 p-2 ${className}`}
+      data-testid="tactical-lens-controls"
+    >
+      {/* Section label */}
+      <span className="text-xs font-semibold tracking-wide text-gray-500 uppercase">
+        Map Lens
+      </span>
+
+      {/* Lens picker buttons — one per preset */}
+      <div
+        className="flex flex-wrap gap-1"
+        role="group"
+        aria-label="Tactical map lenses"
+      >
+        {LENS_PRESETS.map((preset) => {
+          const isActive = activeLens === preset.id;
+          return (
+            <button
+              key={preset.id}
+              type="button"
+              onClick={() => handleLensClick(preset.id)}
+              className={[
+                'rounded px-2 py-1 text-xs font-medium transition-colors',
+                isActive
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200',
+              ].join(' ')}
+              aria-pressed={isActive}
+              data-testid={`lens-btn-${preset.id}`}
+            >
+              {preset.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Intensity slider — only shown when a lens is active */}
+      {activeLens !== null && (
+        <div className="mt-1 flex items-center gap-2">
+          <label htmlFor="lens-intensity" className="text-xs text-gray-500">
+            Intensity
+          </label>
+          <input
+            id="lens-intensity"
+            type="range"
+            min={0}
+            max={1}
+            step={0.05}
+            value={lensIntensity}
+            onChange={handleIntensityChange}
+            className="h-1 w-full cursor-pointer accent-blue-600"
+            data-testid="lens-intensity-slider"
+          />
+          <span className="w-8 text-right text-xs text-gray-500 tabular-nums">
+            {Math.round(lensIntensity * 100)}%
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default TacticalLensControls;

--- a/src/components/gameplay/__tests__/EventLogDisplay.priority.test.tsx
+++ b/src/components/gameplay/__tests__/EventLogDisplay.priority.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * EventLogDisplay — getEventPriority helper
+ *
+ * Verifies the four-tier priority bucketing used by the combat feed
+ * to surface high-signal events when the log is collapsed.
+ *
+ * @spec openspec/changes/add-tactical-map-lenses-feed-replay/specs/tactical-map-interface/spec.md
+ *   "Feed prioritizes combat-critical events" scenario
+ */
+
+import type { IGameEvent } from '@/types/gameplay';
+
+import { GameEventType, GamePhase } from '@/types/gameplay';
+
+import { getEventPriority } from '../EventLogDisplay.helpers';
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function makeEvent(type: GameEventType, id = 'evt-1'): IGameEvent {
+  return {
+    id,
+    gameId: 'game-1',
+    sequence: 1,
+    turn: 1,
+    phase: GamePhase.WeaponAttack,
+    type,
+    timestamp: new Date().toISOString(),
+    payload: {},
+  };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('getEventPriority', () => {
+  describe('critical tier', () => {
+    it('UnitDestroyed is critical', () => {
+      expect(getEventPriority(makeEvent(GameEventType.UnitDestroyed))).toBe(
+        'critical',
+      );
+    });
+
+    it('AmmoExplosion is critical', () => {
+      expect(getEventPriority(makeEvent(GameEventType.AmmoExplosion))).toBe(
+        'critical',
+      );
+    });
+
+    it('GameEnded is critical', () => {
+      expect(getEventPriority(makeEvent(GameEventType.GameEnded))).toBe(
+        'critical',
+      );
+    });
+  });
+
+  describe('high tier', () => {
+    it('CriticalHit is high', () => {
+      expect(getEventPriority(makeEvent(GameEventType.CriticalHit))).toBe(
+        'high',
+      );
+    });
+
+    it('CriticalHitResolved is high', () => {
+      expect(
+        getEventPriority(makeEvent(GameEventType.CriticalHitResolved)),
+      ).toBe('high');
+    });
+
+    it('HeatEffectApplied is high', () => {
+      expect(getEventPriority(makeEvent(GameEventType.HeatEffectApplied))).toBe(
+        'high',
+      );
+    });
+  });
+
+  describe('normal tier', () => {
+    it('AttackResolved is normal', () => {
+      expect(getEventPriority(makeEvent(GameEventType.AttackResolved))).toBe(
+        'normal',
+      );
+    });
+
+    it('DamageApplied is normal', () => {
+      expect(getEventPriority(makeEvent(GameEventType.DamageApplied))).toBe(
+        'normal',
+      );
+    });
+
+    it('PhysicalAttackResolved is normal', () => {
+      expect(
+        getEventPriority(makeEvent(GameEventType.PhysicalAttackResolved)),
+      ).toBe('normal');
+    });
+
+    it('PhaseChanged is normal', () => {
+      expect(getEventPriority(makeEvent(GameEventType.PhaseChanged))).toBe(
+        'normal',
+      );
+    });
+
+    it('PilotHit is normal', () => {
+      expect(getEventPriority(makeEvent(GameEventType.PilotHit))).toBe(
+        'normal',
+      );
+    });
+  });
+
+  describe('low tier', () => {
+    it('MovementDeclared is low', () => {
+      expect(getEventPriority(makeEvent(GameEventType.MovementDeclared))).toBe(
+        'low',
+      );
+    });
+
+    it('TurnStarted is low', () => {
+      expect(getEventPriority(makeEvent(GameEventType.TurnStarted))).toBe(
+        'low',
+      );
+    });
+
+    it('HeatGenerated is low', () => {
+      expect(getEventPriority(makeEvent(GameEventType.HeatGenerated))).toBe(
+        'low',
+      );
+    });
+
+    it('InitiativeRolled is low', () => {
+      expect(getEventPriority(makeEvent(GameEventType.InitiativeRolled))).toBe(
+        'low',
+      );
+    });
+  });
+});

--- a/src/hooks/gameplay/__tests__/useTacticalLensState.test.ts
+++ b/src/hooks/gameplay/__tests__/useTacticalLensState.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Tests for useTacticalLensState
+ *
+ * Covers the "Tactical Map Lenses" ADDED requirement from:
+ * openspec/changes/add-tactical-map-lenses-feed-replay/specs/
+ *   tactical-map-interface/spec.md
+ *
+ * Scenarios verified:
+ *   1. Default state — no lens active, intensity 1.0
+ *   2. Activating a lens sets it and resets intensity to preset default
+ *   3. Clearing a lens (null) restores default intensity
+ *   4. setLensIntensity clamps to [0, 1]
+ *   5. applyLensLayers with active lens enables preset layers, disables others
+ *   6. applyLensLayers with null restores DEFAULT_UNLOCKED_VISIBILITY
+ */
+
+import { act, renderHook } from '@testing-library/react';
+
+import {
+  MAP_LAYER_IDS,
+  type MapLayerId,
+} from '@/types/gameplay/GameplayUIInterfaces';
+import { LENS_PRESET_BY_ID } from '@/types/gameplay/TacticalLensInterfaces';
+
+import { useTacticalLensState } from '../useTacticalLensState';
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * Captures every setLayerVisibility call into a record so tests can
+ * assert the final visibility state without ordering concerns.
+ */
+function captureLayerVisibility(): {
+  record: Record<string, boolean>;
+  setter: (id: MapLayerId, visible: boolean) => void;
+} {
+  const record: Record<string, boolean> = {};
+  return {
+    record,
+    setter: (id: MapLayerId, visible: boolean) => {
+      record[id] = visible;
+    },
+  };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('useTacticalLensState', () => {
+  it('initialises with no active lens and intensity 1.0', () => {
+    const { result } = renderHook(() => useTacticalLensState());
+    expect(result.current.activeLens).toBeNull();
+    expect(result.current.lensIntensity).toBe(1.0);
+  });
+
+  it('activating a lens sets it and resets intensity to the preset default', () => {
+    const { result } = renderHook(() => useTacticalLensState());
+    act(() => {
+      result.current.setActiveLens('movement');
+    });
+    expect(result.current.activeLens).toBe('movement');
+    expect(result.current.lensIntensity).toBe(
+      LENS_PRESET_BY_ID['movement'].defaultIntensity,
+    );
+  });
+
+  it('clearing the lens (null) resets intensity to 1.0', () => {
+    const { result } = renderHook(() => useTacticalLensState());
+    act(() => {
+      result.current.setActiveLens('attack');
+    });
+    act(() => {
+      result.current.setActiveLens(null);
+    });
+    expect(result.current.activeLens).toBeNull();
+    expect(result.current.lensIntensity).toBe(1.0);
+  });
+
+  it('setLensIntensity clamps values below 0 to 0', () => {
+    const { result } = renderHook(() => useTacticalLensState());
+    act(() => {
+      result.current.setLensIntensity(-0.5);
+    });
+    expect(result.current.lensIntensity).toBe(0);
+  });
+
+  it('setLensIntensity clamps values above 1 to 1', () => {
+    const { result } = renderHook(() => useTacticalLensState());
+    act(() => {
+      result.current.setLensIntensity(1.8);
+    });
+    expect(result.current.lensIntensity).toBe(1);
+  });
+
+  it('applyLensLayers enables preset layers and disables all others when a lens is active', () => {
+    const { result } = renderHook(() => useTacticalLensState());
+    act(() => {
+      result.current.setActiveLens('attack');
+    });
+
+    const { record, setter } = captureLayerVisibility();
+    act(() => {
+      result.current.applyLensLayers(setter);
+    });
+
+    const attackPreset = LENS_PRESET_BY_ID['attack'];
+    const enabledSet = new Set<string>(attackPreset.mapLayerIds);
+
+    for (const layerId of MAP_LAYER_IDS) {
+      if (enabledSet.has(layerId)) {
+        expect(record[layerId]).toBe(true);
+      } else {
+        expect(record[layerId]).toBe(false);
+      }
+    }
+  });
+
+  it('applyLensLayers with null restores default unlocked visibility', () => {
+    const { result } = renderHook(() => useTacticalLensState());
+    // Start with a lens active then clear it
+    act(() => {
+      result.current.setActiveLens('intel');
+    });
+    act(() => {
+      result.current.setActiveLens(null);
+    });
+
+    const { record, setter } = captureLayerVisibility();
+    act(() => {
+      result.current.applyLensLayers(setter);
+    });
+
+    // Default visible: elevation, firingArcs, objectives, sensors, locked layers
+    expect(record['elevation']).toBe(true);
+    expect(record['firingArcs']).toBe(true);
+    expect(record['objectives']).toBe(true);
+    expect(record['sensors']).toBe(true);
+    // Default hidden
+    expect(record['movement']).toBe(false);
+    expect(record['cover']).toBe(false);
+    expect(record['los']).toBe(false);
+  });
+});

--- a/src/hooks/gameplay/useTacticalLensState.ts
+++ b/src/hooks/gameplay/useTacticalLensState.ts
@@ -1,0 +1,163 @@
+/**
+ * useTacticalLensState
+ *
+ * Manages the active tactical map lens and its intensity. A lens is a named
+ * preset (movement / attack / intel / terrain / objective / survival) that
+ * groups related `MapLayerId` values and toggles them as a unit when the
+ * player switches lenses.
+ *
+ * Design decisions:
+ * - The hook owns ONLY lens-level state (which lens is active, its intensity).
+ *   Layer visibility is a side-effect applied via the `setLayerVisibility`
+ *   callback returned from the parent's `useMapLayerState`. This keeps lens
+ *   state decoupled from the map's layer state; GameplayLayout is the
+ *   composition point (per add-tactical-map-lenses-feed-replay design.md
+ *   "Lenses group layers by task" decision).
+ * - `activeLens === null` means "no lens active" (default view). The caller
+ *   must call `applyLensLayers` after initialising to push the null-lens
+ *   reset if needed.
+ * - `lensIntensity` is initialised from the preset's `defaultIntensity` when
+ *   a lens is activated; the player can then adjust it via `setLensIntensity`.
+ * - Locked layers (terrain, path, fog, effects) are never hidden by lens
+ *   activation — `setMapLayerVisibility` in the types layer already guards this.
+ *
+ * @spec openspec/changes/add-tactical-map-lenses-feed-replay/specs/tactical-map-interface/spec.md
+ *   "Tactical Map Lenses" ADDED requirement — lens preset, layer toggling
+ */
+
+import { useCallback, useState } from 'react';
+
+import {
+  MAP_LAYER_IDS,
+  type MapLayerId,
+} from '@/types/gameplay/GameplayUIInterfaces';
+import {
+  LENS_PRESET_BY_ID,
+  type TacticalLensId,
+} from '@/types/gameplay/TacticalLensInterfaces';
+
+// =============================================================================
+// Public surface
+// =============================================================================
+
+/**
+ * State + setters for the active tactical lens.
+ *
+ * `applyLensLayers(setLayerVisibility)` is a one-shot applicator: call it
+ * whenever `activeLens` changes (via a `useEffect` in the host component)
+ * with the live `setLayerVisibility` from `useMapLayerState`. It enables
+ * every layer in the preset's `mapLayerIds` and disables all others
+ * (excluding locked layers, which `setMapLayerVisibility` ignores).
+ */
+export interface ITacticalLensState {
+  /** Currently active lens, or null for the default (no-lens) view. */
+  readonly activeLens: TacticalLensId | null;
+  /** Set or clear the active lens. Also resets intensity to the preset default. */
+  readonly setActiveLens: (id: TacticalLensId | null) => void;
+  /**
+   * Intensity of the active lens overlay (0–1).
+   * Initialised from the preset's `defaultIntensity`; user-adjustable.
+   */
+  readonly lensIntensity: number;
+  /** Adjust overlay intensity (0–1 clamped). */
+  readonly setLensIntensity: (intensity: number) => void;
+  /**
+   * Apply lens-derived layer visibility to the map layer state.
+   *
+   * Call this from a `useEffect` whenever `activeLens` changes:
+   * ```
+   * useEffect(() => {
+   *   lensState.applyLensLayers(mapInteraction.setLayerVisibility);
+   * }, [lensState.activeLens, mapInteraction]);
+   * ```
+   *
+   * When `activeLens` is null, all non-locked layers are restored to their
+   * default visibility (hidden except firingArcs, objectives, sensors —
+   * matching DEFAULT_MAP_LAYER_STATE minus locked layers).
+   */
+  readonly applyLensLayers: (
+    setLayerVisibility: (id: MapLayerId, visible: boolean) => void,
+  ) => void;
+}
+
+// Default visibility for unlocked layers when no lens is active.
+// Must stay in sync with DEFAULT_MAP_LAYER_STATE in GameplayUIInterfaces.ts.
+const DEFAULT_UNLOCKED_VISIBILITY: Readonly<Record<MapLayerId, boolean>> = {
+  terrain: true, // locked — guard is in setMapLayerVisibility, but list for completeness
+  elevation: true,
+  movement: false,
+  path: true, // locked
+  cover: false,
+  los: false,
+  firingArcs: true,
+  objectives: true,
+  fog: true, // locked
+  effects: true, // locked
+  sensors: true,
+};
+
+// =============================================================================
+// Hook
+// =============================================================================
+
+/**
+ * Returns the current tactical lens state and its control surface.
+ *
+ * Mount this once at the GameplayLayout level; pass `applyLensLayers` into
+ * a `useEffect` that runs whenever `activeLens` or `mapInteraction` changes.
+ */
+export function useTacticalLensState(): ITacticalLensState {
+  const [activeLens, setActiveLensRaw] = useState<TacticalLensId | null>(null);
+  const [lensIntensity, setLensIntensityRaw] = useState<number>(1.0);
+
+  // Activate a lens: record it, reset intensity to preset default.
+  // Clear (null): reset intensity to 1.0 (full, matches default view).
+  const setActiveLens = useCallback((id: TacticalLensId | null) => {
+    setActiveLensRaw(id);
+    if (id !== null) {
+      const preset = LENS_PRESET_BY_ID[id];
+      setLensIntensityRaw(preset.defaultIntensity);
+    } else {
+      setLensIntensityRaw(1.0);
+    }
+  }, []);
+
+  // Clamp intensity to [0, 1] to guard against slider edge cases.
+  const setLensIntensity = useCallback((intensity: number) => {
+    setLensIntensityRaw(Math.max(0, Math.min(1, intensity)));
+  }, []);
+
+  // Apply layer visibility to the map for the current activeLens.
+  // Stable reference: uses captured activeLens via closure — callers should
+  // call this from a useEffect with activeLens in the dep array.
+  const applyLensLayers = useCallback(
+    (setLayerVisibility: (id: MapLayerId, visible: boolean) => void) => {
+      if (activeLens === null) {
+        // No lens: restore default visibility for every unlocked layer.
+        for (const layerId of MAP_LAYER_IDS) {
+          setLayerVisibility(layerId, DEFAULT_UNLOCKED_VISIBILITY[layerId]);
+        }
+        return;
+      }
+
+      const preset = LENS_PRESET_BY_ID[activeLens];
+      const enabledSet = new Set<MapLayerId>(preset.mapLayerIds);
+
+      // Enable layers in the preset; disable all others.
+      // setMapLayerVisibility (inside useMapLayerState) is a no-op for
+      // locked layers so this is safe to call for all ids.
+      for (const layerId of MAP_LAYER_IDS) {
+        setLayerVisibility(layerId, enabledSet.has(layerId));
+      }
+    },
+    [activeLens],
+  );
+
+  return {
+    activeLens,
+    setActiveLens,
+    lensIntensity,
+    setLensIntensity,
+    applyLensLayers,
+  };
+}

--- a/src/types/gameplay/TacticalLensInterfaces.ts
+++ b/src/types/gameplay/TacticalLensInterfaces.ts
@@ -1,0 +1,144 @@
+/**
+ * Tactical Lens Interfaces
+ *
+ * Defines the lens model for task-oriented map overlays. A lens is a named
+ * preset that groups related map layers and expresses them as a single player-
+ * facing mode. Lenses do NOT change BattleTech rules — they only control
+ * which underlying map layers are visible and at what intensity.
+ *
+ * Design: lenses reference existing `MapLayerId` values from
+ * `GameplayUIInterfaces.ts`. Adding a lens requires no new layer ids; lenses
+ * are purely a composition / grouping mechanism over the existing layer stack.
+ *
+ * @spec openspec/changes/add-tactical-map-lenses-feed-replay/specs/tactical-map-interface/spec.md
+ *   "Tactical Map Lenses" ADDED requirement
+ */
+
+import type { MapLayerId } from './GameplayUIInterfaces';
+
+// =============================================================================
+// Lens Identifiers
+// =============================================================================
+
+/**
+ * Named task-oriented map lens.
+ *
+ * Each value corresponds to a distinct battlefield concern:
+ *   movement  — reachable hexes, path preview, MP cost, terrain/elevation cues
+ *   attack    — firing arcs, LOS, range bands, cover, valid targets
+ *   intel     — visible / last-known / sensor / hidden areas
+ *   terrain   — elevation, terrain type, ground composition
+ *   objective — objective hex ownership and capture state
+ *   survival  — heat thresholds, fall-risk hexes, damage/effects readout
+ */
+export type TacticalLensId =
+  | 'movement'
+  | 'attack'
+  | 'intel'
+  | 'terrain'
+  | 'objective'
+  | 'survival';
+
+// =============================================================================
+// Preset Shape
+// =============================================================================
+
+/**
+ * A single lens preset — the configuration that maps a player-facing lens
+ * button to a set of underlying map layers and an intensity suggestion.
+ *
+ * `mapLayerIds` lists every MapLayerId that should become visible when this
+ * lens is activated. All other non-locked layers are hidden. Locked layers
+ * (terrain, path, fog, effects) are always visible regardless of the active
+ * lens.
+ *
+ * `defaultIntensity` (0–1) is a hint for the intensity slider's initial
+ * position when this lens is activated. 1.0 = full opacity; 0.5 = dimmed.
+ */
+export interface ITacticalLensPreset {
+  /** Stable lens identifier. */
+  readonly id: TacticalLensId;
+  /** Human-readable label for the lens button. */
+  readonly label: string;
+  /**
+   * Default intensity for the lens overlay.
+   * Range 0 (fully transparent) to 1 (fully opaque).
+   */
+  readonly defaultIntensity: number;
+  /**
+   * Map layer ids that are made visible when this lens is active.
+   * Unlocked layers NOT in this list are hidden when the lens activates.
+   * Locked layers (terrain, path, fog, effects) remain visible regardless.
+   */
+  readonly mapLayerIds: readonly MapLayerId[];
+}
+
+// =============================================================================
+// Lens Presets Registry
+// =============================================================================
+
+/**
+ * The six canonical lens presets. Each maps one `TacticalLensId` to the
+ * underlying `MapLayerId` values it brings into focus.
+ *
+ * Layer id reference (from MAP_LAYER_IDS in GameplayUIInterfaces.ts):
+ *   terrain, elevation, movement, path, cover, los, firingArcs, objectives,
+ *   fog, effects, sensors
+ *
+ * Locked layers (terrain / path / fog / effects) are always on — setMapLayerVisibility
+ * ignores them — so they do not need to be listed in `mapLayerIds`, but
+ * listing them makes each preset's intended surface explicit.
+ */
+export const LENS_PRESETS: readonly ITacticalLensPreset[] = [
+  {
+    id: 'movement',
+    label: 'Movement',
+    defaultIntensity: 0.9,
+    // movement overlay + elevation (terrain cost context) + path preview
+    mapLayerIds: ['movement', 'elevation', 'path'],
+  },
+  {
+    id: 'attack',
+    label: 'Attack',
+    defaultIntensity: 0.85,
+    // LOS, firing arcs, cover — the full attack-decision surface
+    mapLayerIds: ['los', 'firingArcs', 'cover'],
+  },
+  {
+    id: 'intel',
+    label: 'Intel',
+    defaultIntensity: 0.8,
+    // sensor contacts + fog overlay distinguishes visible / last-known / hidden
+    mapLayerIds: ['sensors', 'fog'],
+  },
+  {
+    id: 'terrain',
+    label: 'Terrain',
+    defaultIntensity: 1.0,
+    // elevation + terrain — the base board read
+    mapLayerIds: ['terrain', 'elevation'],
+  },
+  {
+    id: 'objective',
+    label: 'Objective',
+    defaultIntensity: 0.9,
+    // objective hexes in focus; elevation for context
+    mapLayerIds: ['objectives', 'elevation'],
+  },
+  {
+    id: 'survival',
+    label: 'Survival',
+    defaultIntensity: 0.85,
+    // damage/effects + cover to assess defensive value
+    mapLayerIds: ['effects', 'cover'],
+  },
+] as const;
+
+/**
+ * Index LENS_PRESETS by id for O(1) lookup.
+ */
+export const LENS_PRESET_BY_ID: Readonly<
+  Record<TacticalLensId, ITacticalLensPreset>
+> = Object.fromEntries(LENS_PRESETS.map((p) => [p.id, p])) as Readonly<
+  Record<TacticalLensId, ITacticalLensPreset>
+>;


### PR DESCRIPTION
## Summary

Wave 7.3 foundation slice for the `add-tactical-map-lenses-feed-replay` OpenSpec change. Delivers the lens model, feed row focus, and unit tests. Pins (§2), replay timeline (§3.2/§3.3), and remaining component tests (§4.2/§4.3) are explicitly deferred.

**Commits**
- `13daa00a` — §1 lens model: `TacticalLensInterfaces.ts` (6 presets), `useTacticalLensState` hook, `TacticalLensControls` component, `GameplayLayout` left-tray ShellSlot wiring
- `5885c2ef` — §3.1 feed row focus: `getEventPriority` (4-tier), `onRowFocus` prop on `EventLogDisplay` + `EventRow` with keyboard accessibility
- `b626763e` — §4.1 unit tests: 22 tests passing (7 hook, 15 priority)
- `aa6cde16` — chore: tasks.md ticked + deferred items noted

**What was delivered**
- 6 tactical lens presets (movement / attack / intel / terrain / objective / survival) mapped to `MapLayerId` layer subsets
- `useTacticalLensState` hook with intensity clamping; `applyLensLayers(setLayerVisibility)` bridges to map layer state in `GameplayLayout` via `useEffect`
- `TacticalLensControls` component registered in `left-tray` ShellSlot (desktop-only, hidden on narrow)
- `getEventPriority` helper for critical/high/normal/low event bucketing
- `onRowFocus` prop with click + Enter/Space keyboard support on event rows
- 22/22 unit tests pass; typecheck clean; full build passes

**What is deferred**
- §2 Pins + minimap — new data model + map rendering layer required
- §3.2 Replay timeline — replay reducer integration required
- §3.3 Replay terrain source — depends on §3.2
- §4.2 Feed row focus component tests — depends on pins (§2.1)
- §4.3 Non-clear-terrain replay test — depends on §3.2/§3.3

## Test plan
- [ ] CI: lint, format, typecheck, test, validate-bv, storybook-build all green
- [ ] `useTacticalLensState.test.ts` — 7 tests pass
- [ ] `EventLogDisplay.priority.test.tsx` — 15 tests pass
- [ ] `e2e/gameplay-layout-slots.spec.ts` — no regression on slot assertions
- [ ] `TacticalLensControls` renders in left-tray (desktop viewport), hidden on narrow
- [ ] Clicking a lens button activates it; clicking active lens clears it
- [ ] Intensity slider appears only when a lens is active
- [ ] Clicking an event row fires `onRowFocus`; Enter/Space also fire it