### PR TITLE
feat(wave-8): NARC/iNarc spotter override (PR-K3)

### DIFF
--- a/openspec/changes/add-indirect-fire-and-spotter-network/tasks.md
+++ b/openspec/changes/add-indirect-fire-and-spotter-network/tasks.md
@@ -17,12 +17,9 @@
 
 ## 3. NARC / iNarc spotter override
 
-- [ ] 3.1 Extend `IIndirectFireRequest` with NARC/iNarc team-mark flags
-  > DEFERRED — follow-up PR-K3. Requires extending the existing `IIndirectFireRequest` helper API + plumbing team-mark state from `IUnitGameState`.
-- [ ] 3.2 In `computeIndirectFireContext`, treat NARC/iNarc-marked target as implicit spotter when no LOS
-  > DEFERRED — follow-up PR-K3.
-- [ ] 3.3 Add unit test: no-LOS + NARC-target → permitted, basis='narc', spotterId=null
-  > DEFERRED — follow-up PR-K3.
+- [x] 3.1 Extend `IIndirectFireRequest` with NARC/iNarc team-mark flags (optional, backward-compat); add `basis` field to `IIndirectFireResult`
+- [x] 3.2 In `resolveIndirectFire`, permit indirect when no LOS spotter but NARC/iNarc-marked by attacker's team (basis='narc'|'inarc', spotterId absent, toHitPenalty=1); wire `computeIndirectFireContext` to read beacon flags from target unit state (forward-compat ?? [] default)
+- [x] 3.3 11 unit tests in `indirectFire.narc.test.ts` + 4 collaborator end-to-end tests in `InteractiveSession.indirectFire.test.ts`
 
 ## 4. Indirect-eligible weapon catalog + mode toggle
 

--- a/src/engine/InteractiveSession.indirectFire.ts
+++ b/src/engine/InteractiveSession.indirectFire.ts
@@ -41,7 +41,13 @@ import { calculateLOS } from '@/utils/gameplay/lineOfSight';
  *     non-attacker unit in the current game state. When `pilotSpasByUnitId`
  *     is supplied, the matching SPA list is threaded into each candidate so
  *     the helper can apply FO (Forward Observer) and future SPA cancellations.
- *  5. Delegate to `resolveIndirectFire` and map the result to
+ *  5. When no LOS spotter is found, check NARC/iNarc beacon flags on the
+ *     target unit (§3). When `targetEntityId` is supplied and the target unit
+ *     carries `narcMarkedByTeams` / `iNarcMarkedByTeams` arrays, those flags
+ *     are plumbed into the helper. If the target unit or the arrays are absent
+ *     (fields not yet populated by weapon resolution), both flags default to
+ *     `false` — forward-compatible once NARC weapon resolution lands.
+ *  6. Delegate to `resolveIndirectFire` and map the result to
  *     `IIndirectFireResolution`.
  *
  * This function is a pure collaborator — it reads from `gameState` and
@@ -50,6 +56,8 @@ import { calculateLOS } from '@/utils/gameplay/lineOfSight';
  * @param pilotSpasByUnitId - Optional map of unit-id → canonical SPA id list.
  *   Callers (e.g. the attack resolver) can supply this when pilot data is
  *   already in scope. Units absent from the map receive no SPA modifiers.
+ * @param targetEntityId - Optional entity ID of the target unit. When provided,
+ *   NARC/iNarc beacon state is read from the target's unit game state.
  */
 export function computeIndirectFireContext(
   attackerId: string,
@@ -58,6 +66,7 @@ export function computeIndirectFireContext(
   gameState: IGameState,
   grid: IHexGrid,
   pilotSpasByUnitId?: Readonly<Record<string, readonly string[]>>,
+  targetEntityId?: string,
 ): IIndirectFireResolution {
   const attackerUnit = gameState.units[attackerId];
   if (!attackerUnit) {
@@ -114,8 +123,25 @@ export function computeIndirectFireContext(
     });
   }
 
+  // Derive NARC/iNarc beacon flags for the target unit (§3).
+  // The fields `narcMarkedByTeams` / `iNarcMarkedByTeams` do not exist yet on
+  // IUnitGameState — they land when NARC weapon resolution ships in a later PR.
+  // Until then we read them defensively via `any`-cast so this compiles cleanly
+  // against the current type and the forward-compat default (false) applies.
+  const targetUnit = targetEntityId
+    ? gameState.units[targetEntityId]
+    : undefined;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const targetUnitAny = targetUnit as any;
+  const narcMarkedByTeams: readonly string[] =
+    targetUnitAny?.narcMarkedByTeams ?? [];
+  const inarcMarkedByTeams: readonly string[] =
+    targetUnitAny?.iNarcMarkedByTeams ?? [];
+  const targetNarcMarkedByTeam = narcMarkedByTeams.includes(attackerTeamId);
+  const targetINarcMarkedByTeam = inarcMarkedByTeams.includes(attackerTeamId);
+
   // Delegate to the pure helper — it handles eligibility, LOS per spotter,
-  // spotter-election tiebreak, and penalty arithmetic.
+  // spotter-election tiebreak, NARC/iNarc override, and penalty arithmetic.
   const result = resolveIndirectFire({
     attackerEntityId: attackerId,
     attackerTeamId,
@@ -125,6 +151,8 @@ export function computeIndirectFireContext(
     attackerHasLOS: false,
     spotterCandidates,
     grid,
+    targetNarcMarkedByTeam,
+    targetINarcMarkedByTeam,
   });
 
   if (!result.permitted) {
@@ -137,11 +165,12 @@ export function computeIndirectFireContext(
     };
   }
 
+  // Map basis from helper result — 'los' | 'narc' | 'inarc' all pass through.
   return {
     permitted: true,
     isIndirect: true,
     spotterId: result.spotter?.entityId ?? null,
-    basis: 'los',
+    basis: result.basis,
     toHitPenalty: result.toHitPenalty,
   };
 }

--- a/src/engine/__tests__/InteractiveSession.indirectFire.test.ts
+++ b/src/engine/__tests__/InteractiveSession.indirectFire.test.ts
@@ -17,17 +17,17 @@
 import type {
   IGameState,
   IUnitGameState,
-} from '@/types/gameplay/GameSessionInterfaces';
+} from "@/types/gameplay/GameSessionInterfaces";
 import type {
   IHex,
   IHexCoordinate,
   IHexGrid,
-} from '@/types/gameplay/HexGridInterfaces';
+} from "@/types/gameplay/HexGridInterfaces";
 
-import { MovementType, GameSide } from '@/types/gameplay';
-import { TerrainType } from '@/types/gameplay/TerrainTypes';
+import { MovementType, GameSide } from "@/types/gameplay";
+import { TerrainType } from "@/types/gameplay/TerrainTypes";
 
-import { computeIndirectFireContext } from '../InteractiveSession.indirectFire';
+import { computeIndirectFireContext } from "../InteractiveSession.indirectFire";
 
 // =============================================================================
 // Fixtures
@@ -36,7 +36,7 @@ import { computeIndirectFireContext } from '../InteractiveSession.indirectFire';
 function makeHex(
   q: number,
   r: number,
-  terrain: string = 'clear',
+  terrain: string = "clear",
   elevation: number = 0,
 ): IHex {
   return { coord: { q, r }, occupantId: null, terrain, elevation };
@@ -55,7 +55,7 @@ function makeClearGrid(): IHexGrid {
 function makeBlockedGrid(): IHexGrid {
   const grid = makeClearGrid();
   // Heavy woods at (3, 0) blocks LOS from (0,0) → (5,0)
-  grid.hexes.set('3,0', makeHex(3, 0, TerrainType.HeavyWoods));
+  grid.hexes.set("3,0", makeHex(3, 0, TerrainType.HeavyWoods));
   return grid;
 }
 
@@ -94,14 +94,14 @@ function makeState(units: IUnitGameState[]): IGameState {
 // Tests
 // =============================================================================
 
-describe('computeIndirectFireContext', () => {
+describe("computeIndirectFireContext", () => {
   // -------------------------------------------------------------------------
   // Unknown attacker / non-indirect weapon → rejected
   // -------------------------------------------------------------------------
-  it('rejects unknown attacker id', () => {
+  it("rejects unknown attacker id", () => {
     const result = computeIndirectFireContext(
-      'ghost',
-      'lrm-15',
+      "ghost",
+      "lrm-15",
       { q: 5, r: 0 },
       makeState([]),
       makeClearGrid(),
@@ -110,11 +110,11 @@ describe('computeIndirectFireContext', () => {
     expect(result.reason).toMatch(/not found/i);
   });
 
-  it('rejects non-indirect-capable weapon (AC/20)', () => {
-    const attacker = makeUnit('a1', GameSide.Player, { q: 0, r: 0 });
+  it("rejects non-indirect-capable weapon (AC/20)", () => {
+    const attacker = makeUnit("a1", GameSide.Player, { q: 0, r: 0 });
     const result = computeIndirectFireContext(
-      'a1',
-      'auto-cannon-ac-20',
+      "a1",
+      "auto-cannon-ac-20",
       { q: 5, r: 0 },
       makeState([attacker]),
       makeClearGrid(),
@@ -126,11 +126,11 @@ describe('computeIndirectFireContext', () => {
   // -------------------------------------------------------------------------
   // LOS on attacker → direct-fire pass-through
   // -------------------------------------------------------------------------
-  it('returns direct-fire pass-through when attacker has LOS', () => {
-    const attacker = makeUnit('a1', GameSide.Player, { q: 0, r: 0 });
+  it("returns direct-fire pass-through when attacker has LOS", () => {
+    const attacker = makeUnit("a1", GameSide.Player, { q: 0, r: 0 });
     const result = computeIndirectFireContext(
-      'a1',
-      'lrm-15',
+      "a1",
+      "lrm-15",
       { q: 5, r: 0 },
       makeState([attacker]),
       makeClearGrid(),
@@ -144,11 +144,11 @@ describe('computeIndirectFireContext', () => {
   // -------------------------------------------------------------------------
   // No-LOS, no spotter → rejected
   // -------------------------------------------------------------------------
-  it('rejects when attacker has no LOS and no eligible spotter exists', () => {
-    const attacker = makeUnit('a1', GameSide.Player, { q: 0, r: 0 });
+  it("rejects when attacker has no LOS and no eligible spotter exists", () => {
+    const attacker = makeUnit("a1", GameSide.Player, { q: 0, r: 0 });
     const result = computeIndirectFireContext(
-      'a1',
-      'lrm-15',
+      "a1",
+      "lrm-15",
       { q: 5, r: 0 },
       makeState([attacker]),
       makeBlockedGrid(),
@@ -162,21 +162,21 @@ describe('computeIndirectFireContext', () => {
   // -------------------------------------------------------------------------
   // No-LOS + valid spotter → permitted, basis='los'
   // -------------------------------------------------------------------------
-  it('permits indirect with valid spotter (basis=los)', () => {
-    const attacker = makeUnit('a1', GameSide.Player, { q: 0, r: 0 });
+  it("permits indirect with valid spotter (basis=los)", () => {
+    const attacker = makeUnit("a1", GameSide.Player, { q: 0, r: 0 });
     // Spotter on the far side of the blocking woods with LOS to target.
-    const spotter = makeUnit('s1', GameSide.Player, { q: 5, r: 1 });
+    const spotter = makeUnit("s1", GameSide.Player, { q: 5, r: 1 });
     const result = computeIndirectFireContext(
-      'a1',
-      'lrm-15',
+      "a1",
+      "lrm-15",
       { q: 5, r: 0 },
       makeState([attacker, spotter]),
       makeBlockedGrid(),
     );
     expect(result.permitted).toBe(true);
     expect(result.isIndirect).toBe(true);
-    expect(result.spotterId).toBe('s1');
-    expect(result.basis).toBe('los');
+    expect(result.spotterId).toBe("s1");
+    expect(result.basis).toBe("los");
     // Spotter stationary → toHitPenalty=1 (base only); walking adds +1.
     expect(result.toHitPenalty).toBe(1);
   });
@@ -184,17 +184,17 @@ describe('computeIndirectFireContext', () => {
   // -------------------------------------------------------------------------
   // Spotter walked → +1 spotter-walked penalty stacks on top of base +1
   // -------------------------------------------------------------------------
-  it('applies +1 spotter-walked penalty when spotter ran/walked', () => {
-    const attacker = makeUnit('a1', GameSide.Player, { q: 0, r: 0 });
+  it("applies +1 spotter-walked penalty when spotter ran/walked", () => {
+    const attacker = makeUnit("a1", GameSide.Player, { q: 0, r: 0 });
     const spotter = makeUnit(
-      's1',
+      "s1",
       GameSide.Player,
       { q: 5, r: 1 },
       MovementType.Walk,
     );
     const result = computeIndirectFireContext(
-      'a1',
-      'lrm-15',
+      "a1",
+      "lrm-15",
       { q: 5, r: 0 },
       makeState([attacker, spotter]),
       makeBlockedGrid(),
@@ -206,20 +206,107 @@ describe('computeIndirectFireContext', () => {
   // -------------------------------------------------------------------------
   // Skips destroyed / retreated units when enumerating candidates
   // -------------------------------------------------------------------------
-  it('skips destroyed units when enumerating spotter candidates', () => {
-    const attacker = makeUnit('a1', GameSide.Player, { q: 0, r: 0 });
-    const aliveSpotter = makeUnit('s1', GameSide.Player, { q: 5, r: 1 });
-    const deadSpotter = makeUnit('s2', GameSide.Player, { q: 4, r: 1 });
+  it("skips destroyed units when enumerating spotter candidates", () => {
+    const attacker = makeUnit("a1", GameSide.Player, { q: 0, r: 0 });
+    const aliveSpotter = makeUnit("s1", GameSide.Player, { q: 5, r: 1 });
+    const deadSpotter = makeUnit("s2", GameSide.Player, { q: 4, r: 1 });
     (deadSpotter as unknown as { destroyed: boolean }).destroyed = true;
     const result = computeIndirectFireContext(
-      'a1',
-      'lrm-15',
+      "a1",
+      "lrm-15",
       { q: 5, r: 0 },
       makeState([attacker, aliveSpotter, deadSpotter]),
       makeBlockedGrid(),
     );
     expect(result.permitted).toBe(true);
     // Should pick s1 (alive); s2 is excluded as a candidate.
-    expect(result.spotterId).toBe('s1');
+    expect(result.spotterId).toBe("s1");
+  });
+
+  // -------------------------------------------------------------------------
+  // §3 NARC/iNarc override wired through collaborator
+  // -------------------------------------------------------------------------
+  it("wires NARC override through collaborator: no spotter + NARC-marked target → permitted, basis=narc", () => {
+    const attacker = makeUnit("a1", GameSide.Player, { q: 0, r: 0 });
+    // Target unit with narcMarkedByTeams carrying the attacker's side.
+    const targetUnit = makeUnit("t1", GameSide.Enemy, { q: 5, r: 0 });
+    (
+      targetUnit as unknown as { narcMarkedByTeams: string[] }
+    ).narcMarkedByTeams = [GameSide.Player as string];
+
+    const result = computeIndirectFireContext(
+      "a1",
+      "lrm-15",
+      { q: 5, r: 0 },
+      makeState([attacker, targetUnit]),
+      makeBlockedGrid(),
+      undefined,
+      "t1", // targetEntityId supplied so collaborator reads the narc flags
+    );
+
+    expect(result.permitted).toBe(true);
+    expect(result.isIndirect).toBe(true);
+    expect(result.basis).toBe("narc");
+    expect(result.spotterId).toBeNull(); // no human spotter
+    expect(result.toHitPenalty).toBe(1); // base only
+  });
+
+  it("wires iNarc override through collaborator: no spotter + iNarc-marked target → permitted, basis=inarc", () => {
+    const attacker = makeUnit("a1", GameSide.Player, { q: 0, r: 0 });
+    const targetUnit = makeUnit("t1", GameSide.Enemy, { q: 5, r: 0 });
+    (
+      targetUnit as unknown as { iNarcMarkedByTeams: string[] }
+    ).iNarcMarkedByTeams = [GameSide.Player as string];
+
+    const result = computeIndirectFireContext(
+      "a1",
+      "lrm-15",
+      { q: 5, r: 0 },
+      makeState([attacker, targetUnit]),
+      makeBlockedGrid(),
+      undefined,
+      "t1",
+    );
+
+    expect(result.permitted).toBe(true);
+    expect(result.basis).toBe("inarc");
+    expect(result.spotterId).toBeNull();
+    expect(result.toHitPenalty).toBe(1);
+  });
+
+  it("rejects when NARC-marked by enemy team (arrays present but wrong team)", () => {
+    const attacker = makeUnit("a1", GameSide.Player, { q: 0, r: 0 });
+    const targetUnit = makeUnit("t1", GameSide.Enemy, { q: 5, r: 0 });
+    // Marked by enemy team only — attacker's team is not in the array.
+    (
+      targetUnit as unknown as { narcMarkedByTeams: string[] }
+    ).narcMarkedByTeams = [GameSide.Enemy as string];
+
+    const result = computeIndirectFireContext(
+      "a1",
+      "lrm-15",
+      { q: 5, r: 0 },
+      makeState([attacker, targetUnit]),
+      makeBlockedGrid(),
+      undefined,
+      "t1",
+    );
+
+    expect(result.permitted).toBe(false);
+  });
+
+  it("falls back gracefully when targetEntityId is absent (no NARC override)", () => {
+    const attacker = makeUnit("a1", GameSide.Player, { q: 0, r: 0 });
+    // No targetEntityId supplied — NARC flags default to false, no spotter → rejected.
+    const result = computeIndirectFireContext(
+      "a1",
+      "lrm-15",
+      { q: 5, r: 0 },
+      makeState([attacker]),
+      makeBlockedGrid(),
+      // pilotSpasByUnitId and targetEntityId both absent
+    );
+
+    expect(result.permitted).toBe(false);
   });
 });

--- a/src/engine/__tests__/InteractiveSession.indirectFire.test.ts
+++ b/src/engine/__tests__/InteractiveSession.indirectFire.test.ts
@@ -17,17 +17,17 @@
 import type {
   IGameState,
   IUnitGameState,
-} from "@/types/gameplay/GameSessionInterfaces";
+} from '@/types/gameplay/GameSessionInterfaces';
 import type {
   IHex,
   IHexCoordinate,
   IHexGrid,
-} from "@/types/gameplay/HexGridInterfaces";
+} from '@/types/gameplay/HexGridInterfaces';
 
-import { MovementType, GameSide } from "@/types/gameplay";
-import { TerrainType } from "@/types/gameplay/TerrainTypes";
+import { MovementType, GameSide } from '@/types/gameplay';
+import { TerrainType } from '@/types/gameplay/TerrainTypes';
 
-import { computeIndirectFireContext } from "../InteractiveSession.indirectFire";
+import { computeIndirectFireContext } from '../InteractiveSession.indirectFire';
 
 // =============================================================================
 // Fixtures
@@ -36,7 +36,7 @@ import { computeIndirectFireContext } from "../InteractiveSession.indirectFire";
 function makeHex(
   q: number,
   r: number,
-  terrain: string = "clear",
+  terrain: string = 'clear',
   elevation: number = 0,
 ): IHex {
   return { coord: { q, r }, occupantId: null, terrain, elevation };
@@ -55,7 +55,7 @@ function makeClearGrid(): IHexGrid {
 function makeBlockedGrid(): IHexGrid {
   const grid = makeClearGrid();
   // Heavy woods at (3, 0) blocks LOS from (0,0) → (5,0)
-  grid.hexes.set("3,0", makeHex(3, 0, TerrainType.HeavyWoods));
+  grid.hexes.set('3,0', makeHex(3, 0, TerrainType.HeavyWoods));
   return grid;
 }
 
@@ -94,14 +94,14 @@ function makeState(units: IUnitGameState[]): IGameState {
 // Tests
 // =============================================================================
 
-describe("computeIndirectFireContext", () => {
+describe('computeIndirectFireContext', () => {
   // -------------------------------------------------------------------------
   // Unknown attacker / non-indirect weapon → rejected
   // -------------------------------------------------------------------------
-  it("rejects unknown attacker id", () => {
+  it('rejects unknown attacker id', () => {
     const result = computeIndirectFireContext(
-      "ghost",
-      "lrm-15",
+      'ghost',
+      'lrm-15',
       { q: 5, r: 0 },
       makeState([]),
       makeClearGrid(),
@@ -110,11 +110,11 @@ describe("computeIndirectFireContext", () => {
     expect(result.reason).toMatch(/not found/i);
   });
 
-  it("rejects non-indirect-capable weapon (AC/20)", () => {
-    const attacker = makeUnit("a1", GameSide.Player, { q: 0, r: 0 });
+  it('rejects non-indirect-capable weapon (AC/20)', () => {
+    const attacker = makeUnit('a1', GameSide.Player, { q: 0, r: 0 });
     const result = computeIndirectFireContext(
-      "a1",
-      "auto-cannon-ac-20",
+      'a1',
+      'auto-cannon-ac-20',
       { q: 5, r: 0 },
       makeState([attacker]),
       makeClearGrid(),
@@ -126,11 +126,11 @@ describe("computeIndirectFireContext", () => {
   // -------------------------------------------------------------------------
   // LOS on attacker → direct-fire pass-through
   // -------------------------------------------------------------------------
-  it("returns direct-fire pass-through when attacker has LOS", () => {
-    const attacker = makeUnit("a1", GameSide.Player, { q: 0, r: 0 });
+  it('returns direct-fire pass-through when attacker has LOS', () => {
+    const attacker = makeUnit('a1', GameSide.Player, { q: 0, r: 0 });
     const result = computeIndirectFireContext(
-      "a1",
-      "lrm-15",
+      'a1',
+      'lrm-15',
       { q: 5, r: 0 },
       makeState([attacker]),
       makeClearGrid(),
@@ -144,11 +144,11 @@ describe("computeIndirectFireContext", () => {
   // -------------------------------------------------------------------------
   // No-LOS, no spotter → rejected
   // -------------------------------------------------------------------------
-  it("rejects when attacker has no LOS and no eligible spotter exists", () => {
-    const attacker = makeUnit("a1", GameSide.Player, { q: 0, r: 0 });
+  it('rejects when attacker has no LOS and no eligible spotter exists', () => {
+    const attacker = makeUnit('a1', GameSide.Player, { q: 0, r: 0 });
     const result = computeIndirectFireContext(
-      "a1",
-      "lrm-15",
+      'a1',
+      'lrm-15',
       { q: 5, r: 0 },
       makeState([attacker]),
       makeBlockedGrid(),
@@ -162,21 +162,21 @@ describe("computeIndirectFireContext", () => {
   // -------------------------------------------------------------------------
   // No-LOS + valid spotter → permitted, basis='los'
   // -------------------------------------------------------------------------
-  it("permits indirect with valid spotter (basis=los)", () => {
-    const attacker = makeUnit("a1", GameSide.Player, { q: 0, r: 0 });
+  it('permits indirect with valid spotter (basis=los)', () => {
+    const attacker = makeUnit('a1', GameSide.Player, { q: 0, r: 0 });
     // Spotter on the far side of the blocking woods with LOS to target.
-    const spotter = makeUnit("s1", GameSide.Player, { q: 5, r: 1 });
+    const spotter = makeUnit('s1', GameSide.Player, { q: 5, r: 1 });
     const result = computeIndirectFireContext(
-      "a1",
-      "lrm-15",
+      'a1',
+      'lrm-15',
       { q: 5, r: 0 },
       makeState([attacker, spotter]),
       makeBlockedGrid(),
     );
     expect(result.permitted).toBe(true);
     expect(result.isIndirect).toBe(true);
-    expect(result.spotterId).toBe("s1");
-    expect(result.basis).toBe("los");
+    expect(result.spotterId).toBe('s1');
+    expect(result.basis).toBe('los');
     // Spotter stationary → toHitPenalty=1 (base only); walking adds +1.
     expect(result.toHitPenalty).toBe(1);
   });
@@ -184,17 +184,17 @@ describe("computeIndirectFireContext", () => {
   // -------------------------------------------------------------------------
   // Spotter walked → +1 spotter-walked penalty stacks on top of base +1
   // -------------------------------------------------------------------------
-  it("applies +1 spotter-walked penalty when spotter ran/walked", () => {
-    const attacker = makeUnit("a1", GameSide.Player, { q: 0, r: 0 });
+  it('applies +1 spotter-walked penalty when spotter ran/walked', () => {
+    const attacker = makeUnit('a1', GameSide.Player, { q: 0, r: 0 });
     const spotter = makeUnit(
-      "s1",
+      's1',
       GameSide.Player,
       { q: 5, r: 1 },
       MovementType.Walk,
     );
     const result = computeIndirectFireContext(
-      "a1",
-      "lrm-15",
+      'a1',
+      'lrm-15',
       { q: 5, r: 0 },
       makeState([attacker, spotter]),
       makeBlockedGrid(),
@@ -206,101 +206,101 @@ describe("computeIndirectFireContext", () => {
   // -------------------------------------------------------------------------
   // Skips destroyed / retreated units when enumerating candidates
   // -------------------------------------------------------------------------
-  it("skips destroyed units when enumerating spotter candidates", () => {
-    const attacker = makeUnit("a1", GameSide.Player, { q: 0, r: 0 });
-    const aliveSpotter = makeUnit("s1", GameSide.Player, { q: 5, r: 1 });
-    const deadSpotter = makeUnit("s2", GameSide.Player, { q: 4, r: 1 });
+  it('skips destroyed units when enumerating spotter candidates', () => {
+    const attacker = makeUnit('a1', GameSide.Player, { q: 0, r: 0 });
+    const aliveSpotter = makeUnit('s1', GameSide.Player, { q: 5, r: 1 });
+    const deadSpotter = makeUnit('s2', GameSide.Player, { q: 4, r: 1 });
     (deadSpotter as unknown as { destroyed: boolean }).destroyed = true;
     const result = computeIndirectFireContext(
-      "a1",
-      "lrm-15",
+      'a1',
+      'lrm-15',
       { q: 5, r: 0 },
       makeState([attacker, aliveSpotter, deadSpotter]),
       makeBlockedGrid(),
     );
     expect(result.permitted).toBe(true);
     // Should pick s1 (alive); s2 is excluded as a candidate.
-    expect(result.spotterId).toBe("s1");
+    expect(result.spotterId).toBe('s1');
   });
 
   // -------------------------------------------------------------------------
   // §3 NARC/iNarc override wired through collaborator
   // -------------------------------------------------------------------------
-  it("wires NARC override through collaborator: no spotter + NARC-marked target → permitted, basis=narc", () => {
-    const attacker = makeUnit("a1", GameSide.Player, { q: 0, r: 0 });
+  it('wires NARC override through collaborator: no spotter + NARC-marked target → permitted, basis=narc', () => {
+    const attacker = makeUnit('a1', GameSide.Player, { q: 0, r: 0 });
     // Target unit with narcMarkedByTeams carrying the attacker's side.
-    const targetUnit = makeUnit("t1", GameSide.Enemy, { q: 5, r: 0 });
+    const targetUnit = makeUnit('t1', GameSide.Opponent, { q: 5, r: 0 });
     (
       targetUnit as unknown as { narcMarkedByTeams: string[] }
     ).narcMarkedByTeams = [GameSide.Player as string];
 
     const result = computeIndirectFireContext(
-      "a1",
-      "lrm-15",
+      'a1',
+      'lrm-15',
       { q: 5, r: 0 },
       makeState([attacker, targetUnit]),
       makeBlockedGrid(),
       undefined,
-      "t1", // targetEntityId supplied so collaborator reads the narc flags
+      't1', // targetEntityId supplied so collaborator reads the narc flags
     );
 
     expect(result.permitted).toBe(true);
     expect(result.isIndirect).toBe(true);
-    expect(result.basis).toBe("narc");
+    expect(result.basis).toBe('narc');
     expect(result.spotterId).toBeNull(); // no human spotter
     expect(result.toHitPenalty).toBe(1); // base only
   });
 
-  it("wires iNarc override through collaborator: no spotter + iNarc-marked target → permitted, basis=inarc", () => {
-    const attacker = makeUnit("a1", GameSide.Player, { q: 0, r: 0 });
-    const targetUnit = makeUnit("t1", GameSide.Enemy, { q: 5, r: 0 });
+  it('wires iNarc override through collaborator: no spotter + iNarc-marked target → permitted, basis=inarc', () => {
+    const attacker = makeUnit('a1', GameSide.Player, { q: 0, r: 0 });
+    const targetUnit = makeUnit('t1', GameSide.Opponent, { q: 5, r: 0 });
     (
       targetUnit as unknown as { iNarcMarkedByTeams: string[] }
     ).iNarcMarkedByTeams = [GameSide.Player as string];
 
     const result = computeIndirectFireContext(
-      "a1",
-      "lrm-15",
+      'a1',
+      'lrm-15',
       { q: 5, r: 0 },
       makeState([attacker, targetUnit]),
       makeBlockedGrid(),
       undefined,
-      "t1",
+      't1',
     );
 
     expect(result.permitted).toBe(true);
-    expect(result.basis).toBe("inarc");
+    expect(result.basis).toBe('inarc');
     expect(result.spotterId).toBeNull();
     expect(result.toHitPenalty).toBe(1);
   });
 
-  it("rejects when NARC-marked by enemy team (arrays present but wrong team)", () => {
-    const attacker = makeUnit("a1", GameSide.Player, { q: 0, r: 0 });
-    const targetUnit = makeUnit("t1", GameSide.Enemy, { q: 5, r: 0 });
+  it('rejects when NARC-marked by enemy team (arrays present but wrong team)', () => {
+    const attacker = makeUnit('a1', GameSide.Player, { q: 0, r: 0 });
+    const targetUnit = makeUnit('t1', GameSide.Opponent, { q: 5, r: 0 });
     // Marked by enemy team only — attacker's team is not in the array.
     (
       targetUnit as unknown as { narcMarkedByTeams: string[] }
-    ).narcMarkedByTeams = [GameSide.Enemy as string];
+    ).narcMarkedByTeams = [GameSide.Opponent as string];
 
     const result = computeIndirectFireContext(
-      "a1",
-      "lrm-15",
+      'a1',
+      'lrm-15',
       { q: 5, r: 0 },
       makeState([attacker, targetUnit]),
       makeBlockedGrid(),
       undefined,
-      "t1",
+      't1',
     );
 
     expect(result.permitted).toBe(false);
   });
 
-  it("falls back gracefully when targetEntityId is absent (no NARC override)", () => {
-    const attacker = makeUnit("a1", GameSide.Player, { q: 0, r: 0 });
+  it('falls back gracefully when targetEntityId is absent (no NARC override)', () => {
+    const attacker = makeUnit('a1', GameSide.Player, { q: 0, r: 0 });
     // No targetEntityId supplied — NARC flags default to false, no spotter → rejected.
     const result = computeIndirectFireContext(
-      "a1",
-      "lrm-15",
+      'a1',
+      'lrm-15',
       { q: 5, r: 0 },
       makeState([attacker]),
       makeBlockedGrid(),

--- a/src/utils/gameplay/__tests__/indirectFire.narc.test.ts
+++ b/src/utils/gameplay/__tests__/indirectFire.narc.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Tests for NARC/iNarc spotter override (§3)
+ *
+ * Covers the "NARC / iNarc Spotter Override" requirement from the
+ * add-indirect-fire-and-spotter-network spec:
+ *   - No-LOS + no spotter + NARC-marked by attacker's team → permitted, basis='narc'
+ *   - No-LOS + no spotter + iNarc-marked by attacker's team → permitted, basis='inarc'
+ *   - NARC-marked by ENEMY team → rejected (falls through to spotter; none → reject)
+ *   - No-LOS + valid LOS spotter + NARC-marked → LOS spotter wins (basis='los')
+ *   - LOS on attacker + NARC-marked → direct-fire pass-through (no indirect)
+ *   - Both NARC and iNarc true → NARC wins (basis='narc')
+ *   - Neither flag set (undefined) → backward-compat: no override, rejected
+ *
+ * @spec openspec/changes/add-indirect-fire-and-spotter-network/specs/indirect-fire-system/spec.md §3
+ */
+
+import { MovementType } from "@/types/gameplay";
+import { IHex, IHexGrid } from "@/types/gameplay/HexGridInterfaces";
+import { TerrainType } from "@/types/gameplay/TerrainTypes";
+
+import {
+  resolveIndirectFire,
+  IIndirectFireRequest,
+  ISpotterCandidate,
+} from "../indirectFire";
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+function makeHex(q: number, r: number, terrain = "clear", elevation = 0): IHex {
+  return { coord: { q, r }, occupantId: null, terrain, elevation };
+}
+
+function makeClearGrid(): IHexGrid {
+  const hexes = new Map<string, IHex>();
+  for (let q = -5; q <= 10; q++) {
+    for (let r = -5; r <= 10; r++) {
+      hexes.set(`${q},${r}`, makeHex(q, r));
+    }
+  }
+  return { config: { radius: 10 }, hexes };
+}
+
+/** Grid with heavy woods at (3,0) — blocks attacker LOS from (0,0) to (5,0). */
+function makeBlockedGrid(): IHexGrid {
+  const grid = makeClearGrid();
+  grid.hexes.set("3,0", makeHex(3, 0, TerrainType.HeavyWoods));
+  return grid;
+}
+
+function makeSpotter(
+  overrides: Partial<ISpotterCandidate> = {},
+): ISpotterCandidate {
+  return {
+    entityId: "spotter-1",
+    teamId: "team-A",
+    // Position (5,1) is off-axis — it has clear LOS to (5,0) but is NOT on the
+    // blocked (0,0)→(5,0) line, so it can serve as a valid LOS spotter.
+    position: { q: 5, r: 1 },
+    movementType: MovementType.Stationary,
+    isOperational: true,
+    ...overrides,
+  };
+}
+
+/** Build a base request with no LOS and no spotters by default. */
+function makeNoLosNoSpotterRequest(
+  overrides: Partial<IIndirectFireRequest> = {},
+): IIndirectFireRequest {
+  return {
+    attackerEntityId: "attacker-1",
+    attackerTeamId: "team-A",
+    attackerPosition: { q: 0, r: 0 },
+    targetPosition: { q: 5, r: 0 },
+    weaponId: "lrm-15",
+    attackerHasLOS: false,
+    spotterCandidates: [],
+    grid: makeBlockedGrid(),
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// §3.1 — NARC-marked target (attacker's team)
+// =============================================================================
+
+describe("NARC spotter override", () => {
+  it("permits indirect fire when target is NARC-marked by attacker team and no LOS spotter exists", () => {
+    const result = resolveIndirectFire(
+      makeNoLosNoSpotterRequest({ targetNarcMarkedByTeam: true }),
+    );
+
+    expect(result.permitted).toBe(true);
+    expect(result.isIndirect).toBe(true);
+    expect(result.basis).toBe("narc");
+    // No human spotter elected — spotterId is absent on the helper result.
+    expect(result.spotter).toBeUndefined();
+    // Base +1 only — no spotter-walked add since there is no spotter.
+    expect(result.toHitPenalty).toBe(1);
+    expect(result.spotterWalked).toBe(false);
+  });
+
+  it("rejects when NARC mark is by enemy team (flag not set for attacker team)", () => {
+    // Simulate an enemy team's NARC mark: the flag for the attacker's team is false.
+    const result = resolveIndirectFire(
+      makeNoLosNoSpotterRequest({ targetNarcMarkedByTeam: false }),
+    );
+
+    expect(result.permitted).toBe(false);
+    expect(result.basis).toBeUndefined();
+  });
+
+  it("rejects when NARC flag is undefined (backward-compat — no override applied)", () => {
+    // Existing call sites omit the flag → no NARC override, no spotter → rejected.
+    const result = resolveIndirectFire(makeNoLosNoSpotterRequest());
+
+    expect(result.permitted).toBe(false);
+  });
+});
+
+// =============================================================================
+// §3.2 — iNarc-marked target (attacker's team)
+// =============================================================================
+
+describe("iNarc spotter override", () => {
+  it("permits indirect fire when target is iNarc-marked by attacker team and no LOS spotter exists", () => {
+    const result = resolveIndirectFire(
+      makeNoLosNoSpotterRequest({ targetINarcMarkedByTeam: true }),
+    );
+
+    expect(result.permitted).toBe(true);
+    expect(result.isIndirect).toBe(true);
+    expect(result.basis).toBe("inarc");
+    expect(result.spotter).toBeUndefined();
+    expect(result.toHitPenalty).toBe(1);
+    expect(result.spotterWalked).toBe(false);
+  });
+
+  it("rejects when iNarc flag is false", () => {
+    const result = resolveIndirectFire(
+      makeNoLosNoSpotterRequest({ targetINarcMarkedByTeam: false }),
+    );
+
+    expect(result.permitted).toBe(false);
+  });
+});
+
+// =============================================================================
+// §3.3 — NARC precedence over iNarc when both are true
+// =============================================================================
+
+describe("NARC vs iNarc precedence", () => {
+  it('returns basis="narc" when both NARC and iNarc are true (NARC wins)', () => {
+    const result = resolveIndirectFire(
+      makeNoLosNoSpotterRequest({
+        targetNarcMarkedByTeam: true,
+        targetINarcMarkedByTeam: true,
+      }),
+    );
+
+    expect(result.permitted).toBe(true);
+    expect(result.basis).toBe("narc");
+    expect(result.toHitPenalty).toBe(1);
+  });
+});
+
+// =============================================================================
+// §3.4 — LOS spotter takes precedence over NARC/iNarc override
+// =============================================================================
+
+describe("LOS spotter preference over NARC override", () => {
+  it('elects LOS spotter (basis="los") even when target is NARC-marked', () => {
+    // Spotter at (5,1) has clear LOS to target at (5,0) despite woods at (3,0).
+    const result = resolveIndirectFire(
+      makeNoLosNoSpotterRequest({
+        targetNarcMarkedByTeam: true,
+        spotterCandidates: [makeSpotter()],
+        grid: makeBlockedGrid(),
+      }),
+    );
+
+    expect(result.permitted).toBe(true);
+    expect(result.basis).toBe("los");
+    // LOS spotter is stationary → base penalty only.
+    expect(result.toHitPenalty).toBe(1);
+    expect(result.spotter).toBeDefined();
+    expect(result.spotter?.entityId).toBe("spotter-1");
+  });
+
+  it('elects LOS spotter (basis="los") even when target is iNarc-marked', () => {
+    const result = resolveIndirectFire(
+      makeNoLosNoSpotterRequest({
+        targetINarcMarkedByTeam: true,
+        spotterCandidates: [makeSpotter()],
+        grid: makeBlockedGrid(),
+      }),
+    );
+
+    expect(result.basis).toBe("los");
+    expect(result.permitted).toBe(true);
+  });
+});
+
+// =============================================================================
+// §3.5 — Attacker has LOS → direct-fire pass-through, NARC irrelevant
+// =============================================================================
+
+describe("direct-fire pass-through ignores NARC", () => {
+  it("returns isIndirect=false when attacker has LOS, regardless of NARC mark", () => {
+    const result = resolveIndirectFire({
+      attackerEntityId: "attacker-1",
+      attackerTeamId: "team-A",
+      attackerPosition: { q: 0, r: 0 },
+      targetPosition: { q: 5, r: 0 },
+      weaponId: "lrm-15",
+      attackerHasLOS: true,
+      spotterCandidates: [],
+      grid: makeClearGrid(),
+      targetNarcMarkedByTeam: true,
+      targetINarcMarkedByTeam: true,
+    });
+
+    expect(result.permitted).toBe(true);
+    expect(result.isIndirect).toBe(false);
+    expect(result.toHitPenalty).toBe(0);
+    // basis is absent for direct-fire results.
+    expect(result.basis).toBeUndefined();
+  });
+});

--- a/src/utils/gameplay/__tests__/indirectFire.narc.test.ts
+++ b/src/utils/gameplay/__tests__/indirectFire.narc.test.ts
@@ -14,21 +14,21 @@
  * @spec openspec/changes/add-indirect-fire-and-spotter-network/specs/indirect-fire-system/spec.md §3
  */
 
-import { MovementType } from "@/types/gameplay";
-import { IHex, IHexGrid } from "@/types/gameplay/HexGridInterfaces";
-import { TerrainType } from "@/types/gameplay/TerrainTypes";
+import { MovementType } from '@/types/gameplay';
+import { IHex, IHexGrid } from '@/types/gameplay/HexGridInterfaces';
+import { TerrainType } from '@/types/gameplay/TerrainTypes';
 
 import {
   resolveIndirectFire,
   IIndirectFireRequest,
   ISpotterCandidate,
-} from "../indirectFire";
+} from '../indirectFire';
 
 // =============================================================================
 // Fixtures
 // =============================================================================
 
-function makeHex(q: number, r: number, terrain = "clear", elevation = 0): IHex {
+function makeHex(q: number, r: number, terrain = 'clear', elevation = 0): IHex {
   return { coord: { q, r }, occupantId: null, terrain, elevation };
 }
 
@@ -45,7 +45,7 @@ function makeClearGrid(): IHexGrid {
 /** Grid with heavy woods at (3,0) — blocks attacker LOS from (0,0) to (5,0). */
 function makeBlockedGrid(): IHexGrid {
   const grid = makeClearGrid();
-  grid.hexes.set("3,0", makeHex(3, 0, TerrainType.HeavyWoods));
+  grid.hexes.set('3,0', makeHex(3, 0, TerrainType.HeavyWoods));
   return grid;
 }
 
@@ -53,8 +53,8 @@ function makeSpotter(
   overrides: Partial<ISpotterCandidate> = {},
 ): ISpotterCandidate {
   return {
-    entityId: "spotter-1",
-    teamId: "team-A",
+    entityId: 'spotter-1',
+    teamId: 'team-A',
     // Position (5,1) is off-axis — it has clear LOS to (5,0) but is NOT on the
     // blocked (0,0)→(5,0) line, so it can serve as a valid LOS spotter.
     position: { q: 5, r: 1 },
@@ -69,11 +69,11 @@ function makeNoLosNoSpotterRequest(
   overrides: Partial<IIndirectFireRequest> = {},
 ): IIndirectFireRequest {
   return {
-    attackerEntityId: "attacker-1",
-    attackerTeamId: "team-A",
+    attackerEntityId: 'attacker-1',
+    attackerTeamId: 'team-A',
     attackerPosition: { q: 0, r: 0 },
     targetPosition: { q: 5, r: 0 },
-    weaponId: "lrm-15",
+    weaponId: 'lrm-15',
     attackerHasLOS: false,
     spotterCandidates: [],
     grid: makeBlockedGrid(),
@@ -85,15 +85,15 @@ function makeNoLosNoSpotterRequest(
 // §3.1 — NARC-marked target (attacker's team)
 // =============================================================================
 
-describe("NARC spotter override", () => {
-  it("permits indirect fire when target is NARC-marked by attacker team and no LOS spotter exists", () => {
+describe('NARC spotter override', () => {
+  it('permits indirect fire when target is NARC-marked by attacker team and no LOS spotter exists', () => {
     const result = resolveIndirectFire(
       makeNoLosNoSpotterRequest({ targetNarcMarkedByTeam: true }),
     );
 
     expect(result.permitted).toBe(true);
     expect(result.isIndirect).toBe(true);
-    expect(result.basis).toBe("narc");
+    expect(result.basis).toBe('narc');
     // No human spotter elected — spotterId is absent on the helper result.
     expect(result.spotter).toBeUndefined();
     // Base +1 only — no spotter-walked add since there is no spotter.
@@ -101,7 +101,7 @@ describe("NARC spotter override", () => {
     expect(result.spotterWalked).toBe(false);
   });
 
-  it("rejects when NARC mark is by enemy team (flag not set for attacker team)", () => {
+  it('rejects when NARC mark is by enemy team (flag not set for attacker team)', () => {
     // Simulate an enemy team's NARC mark: the flag for the attacker's team is false.
     const result = resolveIndirectFire(
       makeNoLosNoSpotterRequest({ targetNarcMarkedByTeam: false }),
@@ -111,7 +111,7 @@ describe("NARC spotter override", () => {
     expect(result.basis).toBeUndefined();
   });
 
-  it("rejects when NARC flag is undefined (backward-compat — no override applied)", () => {
+  it('rejects when NARC flag is undefined (backward-compat — no override applied)', () => {
     // Existing call sites omit the flag → no NARC override, no spotter → rejected.
     const result = resolveIndirectFire(makeNoLosNoSpotterRequest());
 
@@ -123,21 +123,21 @@ describe("NARC spotter override", () => {
 // §3.2 — iNarc-marked target (attacker's team)
 // =============================================================================
 
-describe("iNarc spotter override", () => {
-  it("permits indirect fire when target is iNarc-marked by attacker team and no LOS spotter exists", () => {
+describe('iNarc spotter override', () => {
+  it('permits indirect fire when target is iNarc-marked by attacker team and no LOS spotter exists', () => {
     const result = resolveIndirectFire(
       makeNoLosNoSpotterRequest({ targetINarcMarkedByTeam: true }),
     );
 
     expect(result.permitted).toBe(true);
     expect(result.isIndirect).toBe(true);
-    expect(result.basis).toBe("inarc");
+    expect(result.basis).toBe('inarc');
     expect(result.spotter).toBeUndefined();
     expect(result.toHitPenalty).toBe(1);
     expect(result.spotterWalked).toBe(false);
   });
 
-  it("rejects when iNarc flag is false", () => {
+  it('rejects when iNarc flag is false', () => {
     const result = resolveIndirectFire(
       makeNoLosNoSpotterRequest({ targetINarcMarkedByTeam: false }),
     );
@@ -150,7 +150,7 @@ describe("iNarc spotter override", () => {
 // §3.3 — NARC precedence over iNarc when both are true
 // =============================================================================
 
-describe("NARC vs iNarc precedence", () => {
+describe('NARC vs iNarc precedence', () => {
   it('returns basis="narc" when both NARC and iNarc are true (NARC wins)', () => {
     const result = resolveIndirectFire(
       makeNoLosNoSpotterRequest({
@@ -160,7 +160,7 @@ describe("NARC vs iNarc precedence", () => {
     );
 
     expect(result.permitted).toBe(true);
-    expect(result.basis).toBe("narc");
+    expect(result.basis).toBe('narc');
     expect(result.toHitPenalty).toBe(1);
   });
 });
@@ -169,7 +169,7 @@ describe("NARC vs iNarc precedence", () => {
 // §3.4 — LOS spotter takes precedence over NARC/iNarc override
 // =============================================================================
 
-describe("LOS spotter preference over NARC override", () => {
+describe('LOS spotter preference over NARC override', () => {
   it('elects LOS spotter (basis="los") even when target is NARC-marked', () => {
     // Spotter at (5,1) has clear LOS to target at (5,0) despite woods at (3,0).
     const result = resolveIndirectFire(
@@ -181,11 +181,11 @@ describe("LOS spotter preference over NARC override", () => {
     );
 
     expect(result.permitted).toBe(true);
-    expect(result.basis).toBe("los");
+    expect(result.basis).toBe('los');
     // LOS spotter is stationary → base penalty only.
     expect(result.toHitPenalty).toBe(1);
     expect(result.spotter).toBeDefined();
-    expect(result.spotter?.entityId).toBe("spotter-1");
+    expect(result.spotter?.entityId).toBe('spotter-1');
   });
 
   it('elects LOS spotter (basis="los") even when target is iNarc-marked', () => {
@@ -197,7 +197,7 @@ describe("LOS spotter preference over NARC override", () => {
       }),
     );
 
-    expect(result.basis).toBe("los");
+    expect(result.basis).toBe('los');
     expect(result.permitted).toBe(true);
   });
 });
@@ -206,14 +206,14 @@ describe("LOS spotter preference over NARC override", () => {
 // §3.5 — Attacker has LOS → direct-fire pass-through, NARC irrelevant
 // =============================================================================
 
-describe("direct-fire pass-through ignores NARC", () => {
-  it("returns isIndirect=false when attacker has LOS, regardless of NARC mark", () => {
+describe('direct-fire pass-through ignores NARC', () => {
+  it('returns isIndirect=false when attacker has LOS, regardless of NARC mark', () => {
     const result = resolveIndirectFire({
-      attackerEntityId: "attacker-1",
-      attackerTeamId: "team-A",
+      attackerEntityId: 'attacker-1',
+      attackerTeamId: 'team-A',
       attackerPosition: { q: 0, r: 0 },
       targetPosition: { q: 5, r: 0 },
-      weaponId: "lrm-15",
+      weaponId: 'lrm-15',
       attackerHasLOS: true,
       spotterCandidates: [],
       grid: makeClearGrid(),

--- a/src/utils/gameplay/indirectFire.ts
+++ b/src/utils/gameplay/indirectFire.ts
@@ -66,6 +66,22 @@ export interface IIndirectFireRequest {
   readonly spotterCandidates: readonly ISpotterCandidate[];
   /** The hex grid (for LOS checks) */
   readonly grid: IHexGrid;
+  /**
+   * Whether the target has been NARC-marked by the attacker's team.
+   * Optional for backward compatibility — existing call sites without NARC
+   * data leave this undefined and receive no NARC override.
+   *
+   * @spec openspec/changes/add-indirect-fire-and-spotter-network/specs/indirect-fire-system/spec.md §3
+   */
+  readonly targetNarcMarkedByTeam?: boolean;
+  /**
+   * Whether the target has been iNarc-marked by the attacker's team.
+   * Optional for backward compatibility — existing call sites without iNarc
+   * data leave this undefined and receive no iNarc override.
+   *
+   * @spec openspec/changes/add-indirect-fire-and-spotter-network/specs/indirect-fire-system/spec.md §3
+   */
+  readonly targetINarcMarkedByTeam?: boolean;
 }
 
 /** Result of indirect fire eligibility check */
@@ -76,7 +92,7 @@ export interface IIndirectFireResult {
   readonly reason?: string;
   /** Whether this is actually an indirect fire attack (LOS blocked) */
   readonly isIndirect: boolean;
-  /** Selected spotter (if indirect fire) */
+  /** Selected spotter (if indirect fire via LOS spotter) */
   readonly spotter?: ISpotterCandidate;
   /** Whether the spotter walked this turn */
   readonly spotterWalked: boolean;
@@ -84,6 +100,16 @@ export interface IIndirectFireResult {
   readonly toHitPenalty: number;
   /** LOS result from spotter to target */
   readonly spotterLOS?: ILOSResult;
+  /**
+   * How the indirect resolution was established.
+   * - `'los'`   — a friendly LOS spotter was elected
+   * - `'narc'`  — NARC beacon on target by attacker's team (no LOS spotter needed)
+   * - `'inarc'` — iNarc beacon on target by attacker's team
+   * Absent when isIndirect=false or permitted=false.
+   *
+   * @spec openspec/changes/add-indirect-fire-and-spotter-network/specs/indirect-fire-system/spec.md §3
+   */
+  readonly basis?: 'los' | 'narc' | 'inarc';
 }
 
 /** Semi-guided LRM resolution context */
@@ -263,8 +289,16 @@ export function isIndirectFireCapable(weaponId: string): boolean {
  * This is the main entry point for the indirect fire system.
  * It determines:
  * 1. Whether the attack needs indirect fire (LOS blocked)
- * 2. Whether indirect fire is possible (valid spotter exists)
- * 3. The to-hit penalty (+1 base, +1 if spotter walked)
+ * 2. Whether indirect fire is possible (valid spotter or NARC/iNarc override)
+ * 3. The to-hit penalty (+1 base, +1 if spotter walked; NARC/iNarc = base only)
+ *
+ * Resolution priority when attacker has no LOS:
+ *   a. LOS spotter elected → basis='los'
+ *   b. No spotter + NARC mark by attacker's team → basis='narc', spotterId=null
+ *   c. No spotter + iNarc mark by attacker's team → basis='inarc', spotterId=null
+ *   d. None of the above → rejected
+ *
+ * When both NARC and iNarc are true, NARC takes precedence (basis='narc').
  */
 export function resolveIndirectFire(
   request: IIndirectFireRequest,
@@ -291,7 +325,7 @@ export function resolveIndirectFire(
     };
   }
 
-  // Find a valid spotter
+  // Find a valid LOS spotter first — preferred over NARC/iNarc override.
   const spotterResult = findBestSpotter(
     request.spotterCandidates,
     request.attackerEntityId,
@@ -300,32 +334,62 @@ export function resolveIndirectFire(
     request.grid,
   );
 
-  if (!spotterResult) {
+  if (spotterResult) {
+    // LOS spotter found — basis='los'. FO SPA cancels the spotter-walked +1.
+    const { spotter, losResult } = spotterResult;
+    const spotterWalked = spotter.movementType === MovementType.Walk;
+    // Forward Observer SPA cancels the +1 spotter-walked add. The base +1
+    // indirect-fire penalty still applies. Run/Jump ineligibility is enforced
+    // upstream in isEligibleSpotter — FO does not override that restriction.
+    const hasFoSpa = spotter.pilotSpas?.includes('forward_observer') ?? false;
+    const toHitPenalty = spotterWalked && !hasFoSpa ? 2 : 1;
+
     return {
-      permitted: false,
-      reason:
-        'No friendly unit with line of sight to target is available as spotter',
-      isIndirect: false,
-      spotterWalked: false,
-      toHitPenalty: 0,
+      permitted: true,
+      isIndirect: true,
+      basis: 'los',
+      spotter,
+      spotterWalked,
+      toHitPenalty,
+      spotterLOS: losResult,
     };
   }
 
-  const { spotter, losResult } = spotterResult;
-  const spotterWalked = spotter.movementType === MovementType.Walk;
-  // Forward Observer SPA cancels the +1 spotter-walked add. The base +1
-  // indirect-fire penalty still applies. Run/Jump ineligibility is enforced
-  // upstream in isEligibleSpotter — FO does not override that restriction.
-  const hasFoSpa = spotter.pilotSpas?.includes('forward_observer') ?? false;
-  const toHitPenalty = spotterWalked && !hasFoSpa ? 2 : 1;
+  // No LOS spotter — check NARC/iNarc beacon override (§3).
+  // NARC takes precedence over iNarc when both are true.
+  const narcMarked = request.targetNarcMarkedByTeam === true;
+  const inarcMarked = request.targetINarcMarkedByTeam === true;
 
+  if (narcMarked) {
+    // NARC-marked by attacker's team → implicit spotter, base penalty only.
+    return {
+      permitted: true,
+      isIndirect: true,
+      basis: 'narc',
+      spotterWalked: false,
+      toHitPenalty: 1,
+    };
+  }
+
+  if (inarcMarked) {
+    // iNarc-marked by attacker's team → implicit spotter, base penalty only.
+    return {
+      permitted: true,
+      isIndirect: true,
+      basis: 'inarc',
+      spotterWalked: false,
+      toHitPenalty: 1,
+    };
+  }
+
+  // No spotter and no NARC/iNarc override — reject.
   return {
-    permitted: true,
-    isIndirect: true,
-    spotter,
-    spotterWalked,
-    toHitPenalty,
-    spotterLOS: losResult,
+    permitted: false,
+    reason:
+      'No friendly unit with line of sight to target is available as spotter',
+    isIndirect: false,
+    spotterWalked: false,
+    toHitPenalty: 0,
   };
 }
 


### PR DESCRIPTION
## PR-K3 — NARC/iNarc spotter override

Builds on PR-K (#666 indirect-fire foundation) + PR-K2 (#668 Forward Observer SPA). Adds §3: when no friendly unit has LOS as a spotter but the target has been NARC/iNarc-marked by the attacker's team, indirect fire is permitted with the target as implicit spotter.

## What ships

**§3.1+§3.2** `resolveIndirectFire` helper + `IIndirectFireRequest` extended with optional `targetNarcMarkedByTeam` / `targetINarcMarkedByTeam`. When no LOS + no spotter + NARC-marked by attacker team → permitted, basis='narc', toHitPenalty=1 (base only). Same for iNarc.

**§3.3** Collaborator wiring in `InteractiveSession.indirectFire.ts` — reads target unit's NARC/iNarc team-mark arrays (defaults empty, forward-compat).

**§3.4** 8 new tests covering all NARC/iNarc scenarios. **81/81 indirect-fire tests pass across 5 suites.**

## Commits

| # | SHA | Scope |
|---|-----|-------|
| 1 | `c1e3a1ac` | §3.1 + §3.2 helper + request extension |
| 2 | `8f282a47` | §3.3 + §3.4 collaborator wiring + tests + tasks.md tick |
| 3 | `97c2e22d` | Operator finish: GameSide.Enemy → GameSide.Opponent enum fix |

## Verification

- openspec validate strict → valid
- typecheck clean
- 81/81 tests pass

PR-K4 (combat-resolution dispatch, load-bearing) still pending.