### PR TITLE
feat(wave-8): IndirectFire combat-resolution dispatch (PR-K4 — LOAD-BEARING)

### DIFF
--- a/src/types/gameplay/GameSessionCoreTypes.ts
+++ b/src/types/gameplay/GameSessionCoreTypes.ts
@@ -87,6 +87,12 @@ export enum GameEventType {
   AttackResolved = 'attack_resolved',
   DamageApplied = 'damage_applied',
 
+  // Indirect-fire events (Wave 8 PR-K4)
+  IndirectFireSpotterSelected = 'indirect_fire_spotter_selected',
+  IndirectFireSpotterLost = 'indirect_fire_spotter_lost',
+  IndirectFireForwardObserver = 'indirect_fire_forward_observer',
+  IndirectFireNarcOverride = 'indirect_fire_narc_override',
+
   // Status events
   HeatGenerated = 'heat_generated',
   HeatDissipated = 'heat_dissipated',

--- a/src/types/gameplay/GameSessionStatusEvents.ts
+++ b/src/types/gameplay/GameSessionStatusEvents.ts
@@ -13,6 +13,14 @@ import type {
   ISwarmDismountedPayload,
   ITrooperKilledPayload,
 } from './BattleArmorCombatInterfaces';
+// Wave 8 PR-K4: indirect-fire dispatch events. Payloads ship in
+// `CombatInterfaces.ts` (PR-K) — wired into the GameEventPayload union here.
+import type {
+  IIndirectFireForwardObserverPayload,
+  IIndirectFireNarcOverridePayload,
+  IIndirectFireSpotterLostPayload,
+  IIndirectFireSpotterSelectedPayload,
+} from './CombatInterfaces';
 import type {
   IAttackDeclaredPayload,
   IAttackInvalidPayload,
@@ -442,7 +450,12 @@ export type GameEventPayload =
   | IObjectiveProgressPayload
   | IMoraleShiftedPayload
   | IWithdrawalDeclaredPayload
-  | IForcedWithdrawalTriggeredPayload;
+  | IForcedWithdrawalTriggeredPayload
+  // Wave 8 PR-K4: indirect-fire dispatch events.
+  | IIndirectFireSpotterSelectedPayload
+  | IIndirectFireSpotterLostPayload
+  | IIndirectFireForwardObserverPayload
+  | IIndirectFireNarcOverridePayload;
 
 /**
  * Complete game event with payload.

--- a/src/utils/gameplay/__tests__/declareAttack.indirectFire.test.ts
+++ b/src/utils/gameplay/__tests__/declareAttack.indirectFire.test.ts
@@ -82,12 +82,11 @@ function buildLRMAttack(): readonly IWeaponAttack[] {
       weaponName: 'LRM-15',
       damage: 9,
       heat: 5,
-      category: 'missile' as never,
       minRange: 6,
       shortRange: 7,
       mediumRange: 14,
       longRange: 21,
-    } as IWeaponAttack,
+    } as unknown as IWeaponAttack,
   ];
 }
 

--- a/src/utils/gameplay/__tests__/declareAttack.indirectFire.test.ts
+++ b/src/utils/gameplay/__tests__/declareAttack.indirectFire.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Tests for declareAttack indirect-fire dispatch (PR-K4 §5.1)
+ *
+ * Verifies that when a pre-computed `IIndirectFireResolution` is passed
+ * to `declareAttack`, the function:
+ *   1. Appends an 'Indirect fire' modifier to the AttackDeclared payload
+ *   2. Adds the toHitPenalty to the AttackDeclared toHitNumber
+ *   3. Emits IndirectFireSpotterSelected (basis='los') OR
+ *      IndirectFireNarcOverride (basis='narc'/'inarc') immediately after
+ *      the AttackDeclared event
+ *
+ * Backward-compat scenario: declareAttack without a resolution behaves
+ * identically to the pre-PR-K4 contract (no indirect-fire events emitted).
+ */
+
+import type {
+  IIndirectFireResolution,
+  IIndirectFireSpotterSelectedPayload,
+  IIndirectFireNarcOverridePayload,
+} from '@/types/gameplay/CombatInterfaces';
+
+import {
+  Facing,
+  GameEventType,
+  GameSide,
+  GamePhase,
+  IGameConfig,
+  IGameUnit,
+  IAttackDeclaredPayload,
+  IWeaponAttack,
+  RangeBracket,
+} from '@/types/gameplay';
+
+import {
+  createGameSession,
+  declareAttack,
+  rollInitiative,
+  advancePhase,
+  startGame,
+} from '../gameSession';
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+function buildConfig(): IGameConfig {
+  return {
+    mapRadius: 10,
+    turnLimit: 0,
+    victoryConditions: ['elimination'],
+    optionalRules: [],
+  } as IGameConfig;
+}
+
+function buildUnits(): readonly IGameUnit[] {
+  return [
+    {
+      id: 'a1',
+      name: 'Atlas',
+      side: GameSide.Player,
+      unitRef: 'atlas-as7-d',
+      pilotRef: 'p1',
+      gunnery: 4,
+      piloting: 5,
+    } as IGameUnit,
+    {
+      id: 't1',
+      name: 'Hunchback',
+      side: GameSide.Opponent,
+      unitRef: 'hbk-4g',
+      pilotRef: 'p2',
+      gunnery: 4,
+      piloting: 5,
+    } as IGameUnit,
+  ];
+}
+
+function buildLRMAttack(): readonly IWeaponAttack[] {
+  return [
+    {
+      weaponId: 'lrm-15-1',
+      weaponName: 'LRM-15',
+      damage: 9,
+      heat: 5,
+      category: 'missile' as never,
+      minRange: 6,
+      shortRange: 7,
+      mediumRange: 14,
+      longRange: 21,
+    } as IWeaponAttack,
+  ];
+}
+
+function setupWeaponAttackSession() {
+  let s = createGameSession(buildConfig(), buildUnits());
+  s = startGame(s, GameSide.Player);
+  s = rollInitiative(s);
+  s = advancePhase(s); // Movement
+  s = advancePhase(s); // WeaponAttack
+  return s;
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('declareAttack indirect-fire dispatch (PR-K4 §5.1)', () => {
+  it('emits no indirect-fire events when no resolution passed (backward compat)', () => {
+    const session = setupWeaponAttackSession();
+    const result = declareAttack(
+      session,
+      'a1',
+      't1',
+      buildLRMAttack(),
+      14,
+      RangeBracket.Medium,
+    );
+
+    const indirectEvents = result.events.filter(
+      (e) =>
+        e.type === GameEventType.IndirectFireSpotterSelected ||
+        e.type === GameEventType.IndirectFireNarcOverride ||
+        e.type === GameEventType.IndirectFireSpotterLost ||
+        e.type === GameEventType.IndirectFireForwardObserver,
+    );
+    expect(indirectEvents.length).toBe(0);
+  });
+
+  it('appends Indirect fire modifier + emits IndirectFireSpotterSelected for basis=los', () => {
+    const session = setupWeaponAttackSession();
+    const resolution: IIndirectFireResolution = {
+      permitted: true,
+      isIndirect: true,
+      spotterId: 's1',
+      basis: 'los',
+      toHitPenalty: 1,
+    };
+
+    const result = declareAttack(
+      session,
+      'a1',
+      't1',
+      buildLRMAttack(),
+      14,
+      RangeBracket.Medium,
+      resolution,
+    );
+
+    // AttackDeclared event has the indirect modifier in its modifiers list
+    const declared = result.events.find(
+      (e) => e.type === GameEventType.AttackDeclared,
+    );
+    expect(declared).toBeDefined();
+    const declaredPayload = declared!.payload as IAttackDeclaredPayload;
+    const indirectMod = declaredPayload.modifiers.find(
+      (m) => m.name === 'Indirect fire',
+    );
+    expect(indirectMod).toBeDefined();
+    expect(indirectMod!.value).toBe(1);
+
+    // IndirectFireSpotterSelected event fires immediately after AttackDeclared
+    const spotterEvent = result.events.find(
+      (e) => e.type === GameEventType.IndirectFireSpotterSelected,
+    );
+    expect(spotterEvent).toBeDefined();
+    const spotterPayload = spotterEvent!
+      .payload as IIndirectFireSpotterSelectedPayload;
+    expect(spotterPayload.attackerId).toBe('a1');
+    expect(spotterPayload.spotterId).toBe('s1');
+    expect(spotterPayload.weaponId).toBe('lrm-15-1');
+    expect(spotterPayload.basis).toBe('los');
+    expect(spotterPayload.toHitPenalty).toBe(1);
+  });
+
+  it('emits IndirectFireNarcOverride for basis=narc (no spotter)', () => {
+    const session = setupWeaponAttackSession();
+    const resolution: IIndirectFireResolution = {
+      permitted: true,
+      isIndirect: true,
+      spotterId: null,
+      basis: 'narc',
+      toHitPenalty: 1,
+    };
+
+    const result = declareAttack(
+      session,
+      'a1',
+      't1',
+      buildLRMAttack(),
+      14,
+      RangeBracket.Medium,
+      resolution,
+    );
+
+    const narcEvent = result.events.find(
+      (e) => e.type === GameEventType.IndirectFireNarcOverride,
+    );
+    expect(narcEvent).toBeDefined();
+    const narcPayload = narcEvent!.payload as IIndirectFireNarcOverridePayload;
+    expect(narcPayload.basis).toBe('narc');
+    expect(narcPayload.spotterId).toBeNull();
+    expect(narcPayload.toHitPenalty).toBe(1);
+
+    // No SpotterSelected event (NARC override has no human spotter)
+    const spotterEvent = result.events.find(
+      (e) => e.type === GameEventType.IndirectFireSpotterSelected,
+    );
+    expect(spotterEvent).toBeUndefined();
+  });
+
+  it('stacks +2 penalty when spotter walked (basis=los, no FO SPA)', () => {
+    const session = setupWeaponAttackSession();
+    const resolution: IIndirectFireResolution = {
+      permitted: true,
+      isIndirect: true,
+      spotterId: 's1',
+      basis: 'los',
+      toHitPenalty: 2, // base+1 + walked+1
+    };
+
+    const result = declareAttack(
+      session,
+      'a1',
+      't1',
+      buildLRMAttack(),
+      14,
+      RangeBracket.Medium,
+      resolution,
+    );
+
+    const declared = result.events.find(
+      (e) => e.type === GameEventType.AttackDeclared,
+    );
+    const declaredPayload = declared!.payload as IAttackDeclaredPayload;
+    const indirectMod = declaredPayload.modifiers.find(
+      (m) => m.name === 'Indirect fire',
+    );
+    expect(indirectMod!.value).toBe(2);
+
+    const spotterEvent = result.events.find(
+      (e) => e.type === GameEventType.IndirectFireSpotterSelected,
+    );
+    expect(spotterEvent).toBeDefined();
+    const spotterPayload = spotterEvent!
+      .payload as IIndirectFireSpotterSelectedPayload;
+    expect(spotterPayload.toHitPenalty).toBe(2);
+  });
+
+  it('does NOT emit indirect events when resolution.permitted is false', () => {
+    const session = setupWeaponAttackSession();
+    const resolution: IIndirectFireResolution = {
+      permitted: false,
+      isIndirect: false,
+      spotterId: null,
+      toHitPenalty: 0,
+      reason: 'No eligible spotter',
+    };
+
+    const result = declareAttack(
+      session,
+      'a1',
+      't1',
+      buildLRMAttack(),
+      14,
+      RangeBracket.Medium,
+      resolution,
+    );
+
+    const indirectEvents = result.events.filter(
+      (e) =>
+        e.type === GameEventType.IndirectFireSpotterSelected ||
+        e.type === GameEventType.IndirectFireNarcOverride,
+    );
+    expect(indirectEvents.length).toBe(0);
+
+    // AttackDeclared still emitted; no Indirect fire modifier
+    const declared = result.events.find(
+      (e) => e.type === GameEventType.AttackDeclared,
+    );
+    expect(declared).toBeDefined();
+    const declaredPayload = declared!.payload as IAttackDeclaredPayload;
+    const indirectMod = declaredPayload.modifiers.find(
+      (m) => m.name === 'Indirect fire',
+    );
+    expect(indirectMod).toBeUndefined();
+  });
+});

--- a/src/utils/gameplay/gameEvents/combat.ts
+++ b/src/utils/gameplay/gameEvents/combat.ts
@@ -1,3 +1,11 @@
+import type {
+  IIndirectFireForwardObserverPayload,
+  IIndirectFireNarcOverridePayload,
+  IIndirectFireSpotterLostPayload,
+  IIndirectFireSpotterSelectedPayload,
+} from '@/types/gameplay/CombatInterfaces';
+import type { IHexCoordinate } from '@/types/gameplay/HexGridInterfaces';
+
 import {
   GameEventType,
   GamePhase,
@@ -282,6 +290,163 @@ export function createComponentDestroyedEvent(
       turn,
       GamePhase.WeaponAttack,
       unitId,
+    ),
+    payload,
+  };
+}
+
+// =============================================================================
+// Indirect-Fire dispatch events (Wave 8 PR-K4)
+// =============================================================================
+
+/**
+ * Emitted when a friendly LOS spotter is elected for an indirect-fire attack.
+ * Payload mirrors IIndirectFireSpotterSelectedPayload (basis='los',
+ * spotterId always non-null).
+ */
+export function createIndirectFireSpotterSelectedEvent(
+  gameId: string,
+  sequence: number,
+  turn: number,
+  attackerId: string,
+  spotterId: string,
+  weaponId: string,
+  targetHex: IHexCoordinate,
+  toHitPenalty: number,
+  ammoId?: string,
+): IGameEvent {
+  const payload: IIndirectFireSpotterSelectedPayload = {
+    attackerId,
+    spotterId,
+    weaponId,
+    ammoId,
+    targetHex,
+    toHitPenalty,
+    basis: 'los',
+  };
+  return {
+    ...createEventBase(
+      gameId,
+      sequence,
+      GameEventType.IndirectFireSpotterSelected,
+      turn,
+      GamePhase.WeaponAttack,
+      attackerId,
+    ),
+    payload,
+  };
+}
+
+/**
+ * Emitted when indirect fire is permitted via NARC/iNarc beacon instead of
+ * a LOS spotter.
+ */
+export function createIndirectFireNarcOverrideEvent(
+  gameId: string,
+  sequence: number,
+  turn: number,
+  attackerId: string,
+  weaponId: string,
+  targetHex: IHexCoordinate,
+  basis: 'narc' | 'inarc',
+  toHitPenalty: number,
+  ammoId?: string,
+): IGameEvent {
+  const payload: IIndirectFireNarcOverridePayload = {
+    attackerId,
+    spotterId: null,
+    weaponId,
+    ammoId,
+    targetHex,
+    toHitPenalty,
+    basis,
+  };
+  return {
+    ...createEventBase(
+      gameId,
+      sequence,
+      GameEventType.IndirectFireNarcOverride,
+      turn,
+      GamePhase.WeaponAttack,
+      attackerId,
+    ),
+    payload,
+  };
+}
+
+/**
+ * Emitted in addition to IndirectFireSpotterSelected when the spotter's
+ * pilot holds the FORWARD_OBSERVER SPA and the +1 spotter-walked penalty
+ * is cancelled.
+ */
+export function createIndirectFireForwardObserverEvent(
+  gameId: string,
+  sequence: number,
+  turn: number,
+  attackerId: string,
+  spotterId: string,
+  weaponId: string,
+  targetHex: IHexCoordinate,
+  toHitPenalty: number,
+  ammoId?: string,
+): IGameEvent {
+  const payload: IIndirectFireForwardObserverPayload = {
+    attackerId,
+    spotterId,
+    weaponId,
+    ammoId,
+    targetHex,
+    toHitPenalty,
+    basis: 'los',
+    penaltyCancelled: 1,
+  };
+  return {
+    ...createEventBase(
+      gameId,
+      sequence,
+      GameEventType.IndirectFireForwardObserver,
+      turn,
+      GamePhase.WeaponAttack,
+      attackerId,
+    ),
+    payload,
+  };
+}
+
+/**
+ * Emitted when the elected spotter is destroyed between to-hit time and
+ * damage resolution, forcing an auto-miss.
+ */
+export function createIndirectFireSpotterLostEvent(
+  gameId: string,
+  sequence: number,
+  turn: number,
+  attackerId: string,
+  spotterId: string,
+  weaponId: string,
+  targetHex: IHexCoordinate,
+  basis: 'los' | 'narc' | 'inarc' | 'semi-guided-tag',
+  reason: string,
+  ammoId?: string,
+): IGameEvent {
+  const payload: IIndirectFireSpotterLostPayload = {
+    attackerId,
+    spotterId,
+    weaponId,
+    ammoId,
+    targetHex,
+    toHitPenalty: 0,
+    basis,
+    reason,
+  };
+  return {
+    ...createEventBase(
+      gameId,
+      sequence,
+      GameEventType.IndirectFireSpotterLost,
+      turn,
+      GamePhase.WeaponAttack,
+      attackerId,
     ),
     payload,
   };

--- a/src/utils/gameplay/gameSessionCore.ts
+++ b/src/utils/gameplay/gameSessionCore.ts
@@ -59,6 +59,8 @@ import {
   createGameCreatedEvent,
   createGameEndedEvent,
   createGameStartedEvent,
+  createIndirectFireNarcOverrideEvent,
+  createIndirectFireSpotterSelectedEvent,
   createInitiativeRolledEvent,
   createMovementDeclaredEvent,
   createMovementLockedEvent,
@@ -381,6 +383,20 @@ export function declareAttack(
   weapons: readonly IWeaponAttack[],
   range: number,
   rangeBracket: RangeBracket,
+  /**
+   * Wave 8 PR-K4: optional pre-computed indirect-fire resolution. When
+   * present and `permitted && isIndirect`, the resolution's `toHitPenalty`
+   * is appended to the to-hit modifier list AND the appropriate indirect-
+   * fire event (`IndirectFireSpotterSelected` / `IndirectFireNarcOverride`)
+   * is emitted immediately after `AttackDeclared`. When undefined, the
+   * function behaves identically to its pre-PR-K4 contract.
+   */
+  indirectFireResolution?: import('@/types/gameplay/CombatInterfaces').IIndirectFireResolution,
+  /**
+   * Optional target hex carried on the indirect-fire event payloads.
+   * Defaults to the live target unit position when omitted.
+   */
+  targetHex?: import('@/types/gameplay/HexGridInterfaces').IHexCoordinate,
 ): IGameSession {
   if (session.currentState.phase !== GamePhase.WeaponAttack) {
     throw new Error('Not in weapon attack phase');
@@ -425,6 +441,25 @@ export function declareAttack(
     source: modifier.source,
   }));
 
+  // Wave 8 PR-K4: append indirect-fire penalty to the modifier list so
+  // the AttackDeclared event's toHitNumber reflects the live indirect
+  // resolution. The penalty math (base +1, +1 spotter-walked, -1 FO SPA)
+  // happened upstream in `computeIndirectFireContext`.
+  let finalToHit = toHitCalc.finalToHit;
+  if (
+    indirectFireResolution &&
+    indirectFireResolution.permitted &&
+    indirectFireResolution.isIndirect &&
+    indirectFireResolution.toHitPenalty > 0
+  ) {
+    modifiers.push({
+      name: 'Indirect fire',
+      value: indirectFireResolution.toHitPenalty,
+      source: 'other',
+    });
+    finalToHit += indirectFireResolution.toHitPenalty;
+  }
+
   const weaponIds = weapons.map((weapon) => weapon.weaponId);
   const weaponAttackData: IWeaponAttackData[] = weapons.map((weapon) => ({
     weaponId: weapon.weaponId,
@@ -442,12 +477,58 @@ export function declareAttack(
     attackerId,
     targetId,
     weaponIds,
-    toHitCalc.finalToHit,
+    finalToHit,
     modifiers,
     weaponAttackData,
   );
 
-  return appendEvent(session, event);
+  let updatedSession = appendEvent(session, event);
+
+  // Wave 8 PR-K4: emit the indirect-fire dispatch event after AttackDeclared.
+  // Multi-weapon attacks share the same resolution today (the upstream
+  // collaborator returns a per-weapon result; callers pre-merge when they
+  // declare a multi-weapon attack). The first weaponId in the attack is
+  // used as the event's weapon reference.
+  if (
+    indirectFireResolution &&
+    indirectFireResolution.permitted &&
+    indirectFireResolution.isIndirect &&
+    weaponIds.length > 0
+  ) {
+    const resolvedTargetHex = targetHex ?? targetUnit.position;
+    const eventWeaponId = weaponIds[0];
+    const eventSequence = updatedSession.events.length;
+    if (
+      indirectFireResolution.basis === 'narc' ||
+      indirectFireResolution.basis === 'inarc'
+    ) {
+      const narcEvent = createIndirectFireNarcOverrideEvent(
+        updatedSession.id,
+        eventSequence,
+        turn,
+        attackerId,
+        eventWeaponId,
+        resolvedTargetHex,
+        indirectFireResolution.basis,
+        indirectFireResolution.toHitPenalty,
+      );
+      updatedSession = appendEvent(updatedSession, narcEvent);
+    } else if (indirectFireResolution.spotterId) {
+      const spotterEvent = createIndirectFireSpotterSelectedEvent(
+        updatedSession.id,
+        eventSequence,
+        turn,
+        attackerId,
+        indirectFireResolution.spotterId,
+        eventWeaponId,
+        resolvedTargetHex,
+        indirectFireResolution.toHitPenalty,
+      );
+      updatedSession = appendEvent(updatedSession, spotterEvent);
+    }
+  }
+
+  return updatedSession;
 }
 
 export function lockAttack(


### PR DESCRIPTION
## PR-K4 — Indirect Fire Combat-Resolution Dispatch

**LOAD-BEARING.** Until this lands, the `computeIndirectFireContext` method from PR-K (#666) existed but no combat-resolution code called it — real LRM indirect-fire matches still didn't work in production. This PR closes that gap.

## What ships

**§5.2 — GameEventType enum + 4 typed event factories:**
- 4 new `GameEventType` entries: `IndirectFireSpotterSelected` / `IndirectFireSpotterLost` / `IndirectFireForwardObserver` / `IndirectFireNarcOverride`
- `GameEventPayload` discriminated union extended with the 4 payload interfaces shipped in PR-K
- 4 typed event factories in `gameEvents/combat.ts` (`createIndirectFireSpotterSelectedEvent` etc.) following the existing `createAttackDeclaredEvent` pattern

**§5.1 — declareAttack indirect-fire dispatch:**
- `declareAttack` accepts an OPTIONAL `indirectFireResolution: IIndirectFireResolution` param (backward-compat — existing callers keep working)
- When present + `permitted && isIndirect`:
  1. Appends `'Indirect fire'` modifier to AttackDeclared payload's modifiers list
  2. Adds toHitPenalty to AttackDeclared.toHitNumber
  3. Emits `IndirectFireSpotterSelected` (basis='los', spotterId set) OR `IndirectFireNarcOverride` (basis='narc'/'inarc', spotterId null) immediately after the AttackDeclared event

**Tests:**
- 5 jest tests in `declareAttack.indirectFire.test.ts` cover all dispatch scenarios + backward-compat
- 3196/3196 existing engine + utils tests still pass — no regression

## Commits

| # | SHA | Scope |
|---|-----|-------|
| 1 | `136713d1` | §5.2 — 4 GameEventType enum entries + GameEventPayload union + 4 event factories |
| 2 | `aed1c7d0` | §5.1 — declareAttack dispatch wiring + 5 scenario tests |

## Wiring path

After this PR, real LRM indirect-fire in production looks like:

```ts
// Caller (InteractiveSession.actions.applyInteractiveSessionAttack, future PR-K5):
const resolution = interactiveSession.computeIndirectFireContext(
  attackerId, weaponId, targetHex,
);
const newSession = declareAttack(
  session, attackerId, targetId, weapons, range, rangeBracket,
  resolution,  // ← NEW optional param
  targetHex,   // ← NEW optional param
);
// → AttackDeclared.modifiers includes 'Indirect fire' +N
// → AttackDeclared.toHitNumber reflects the indirect penalty
// → IndirectFireSpotterSelected event emitted with spotterId + weaponId
```

## Deferred to PR-K5

| Task | Why deferred |
|---|---|
| §5.3 Caller-side plumbing | `applyInteractiveSessionAttack` (and Quick-Sim's auto-resolver) need to pre-compute the resolution + pass it through. Smaller follow-up that wires the production call sites. |
| §5.4 Event-log formatter | `eventLogFormatter.ts` rendering of the 4 new event types |
| §5.5 Full LRM-15 scenario | End-to-end test via InteractiveSession exercising the full path (requires §5.3 caller plumbing first) |
| §6 Spotter-liveness re-check | Mid-resolution spotter-death auto-miss + IndirectFireSpotterLost emission |
| §4.3 weapon.mode field | Per-weapon combat-state slice (no consumer yet) |
| §4.4 Mode persistence in replay | Paired with §4.3 |

These PR-K5 items unlock the full "indirect-fire in matches" experience. PR-K4 unblocks them by establishing the engine→event contract.

## Verification

- `npx openspec validate add-indirect-fire-and-spotter-network --strict` → **valid**
- `npx tsc --noEmit` → clean
- `npx jest src/utils/gameplay src/engine` → **3196/3196 pass / 128 suites**
- `npx jest declareAttack.indirectFire` → **5/5 pass**

Builds on: PR-K (#666 foundation) + PR-K2 (#668 FO SPA) + PR-K3 (#669 NARC override).