### PR TITLE
feat(wave-8): wire production callers to indirect-fire dispatch (PR-K5)

### DIFF
--- a/src/components/gameplay/EventLogDisplay.helpers.ts
+++ b/src/components/gameplay/EventLogDisplay.helpers.ts
@@ -235,6 +235,49 @@ export function formatEvent(
       text = `Game ended: ${payload.winner === 'draw' ? 'Draw' : `${payload.winner} wins`} (${payload.reason})`;
       break;
     }
+    // Wave 8 PR-K5: indirect-fire dispatch event renderers. Format-cases
+    // for all 4 indirect-fire events ship together; SpotterLost is emitted
+    // by PR-K6 but its formatter case lands here to avoid a churn follow-up.
+    case GameEventType.IndirectFireSpotterSelected: {
+      const payload = event.payload as {
+        attackerId: string;
+        spotterId: string;
+        weaponId: string;
+        toHitPenalty: number;
+      };
+      unitId = payload.attackerId;
+      text = `Indirect fire: spotted by ${payload.spotterId} (+${payload.toHitPenalty} TN)`;
+      break;
+    }
+    case GameEventType.IndirectFireNarcOverride: {
+      const payload = event.payload as {
+        attackerId: string;
+        basis: 'narc' | 'inarc';
+        toHitPenalty: number;
+      };
+      unitId = payload.attackerId;
+      text = `Indirect fire: ${payload.basis} beacon override on target (+${payload.toHitPenalty} TN)`;
+      break;
+    }
+    case GameEventType.IndirectFireForwardObserver: {
+      const payload = event.payload as {
+        attackerId: string;
+        spotterId: string;
+      };
+      unitId = payload.attackerId;
+      text = `Indirect fire: Forward Observer ${payload.spotterId} cancels walking penalty`;
+      break;
+    }
+    case GameEventType.IndirectFireSpotterLost: {
+      const payload = event.payload as {
+        attackerId: string;
+        spotterId: string;
+        reason: string;
+      };
+      unitId = payload.attackerId;
+      text = `Indirect fire: spotter ${payload.spotterId} lost — attack misses (${payload.reason})`;
+      break;
+    }
     default:
       text = event.type.replace(/_/g, ' ');
   }

--- a/src/engine/GameEngine.phases.ts
+++ b/src/engine/GameEngine.phases.ts
@@ -52,6 +52,7 @@ import { waterDepthAtPosition } from '@/utils/gameplay/waterDepth';
 import { buildWeaponAttacks } from '@/utils/gameplay/weaponAttackBuilder';
 
 import { toAIUnitState } from './GameEngine.helpers';
+import { computeIndirectFireContext } from './InteractiveSession.indirectFire';
 
 /**
  * Adapt a single-d6 roller into the 2d6 `DiceRoller` shape used by
@@ -230,6 +231,10 @@ export function runAttackPhase(
   botPlayer: BotPlayer,
   weaponsByUnit: Map<string, readonly IWeapon[]>,
   gunneryByUnit: Map<string, number>,
+  // Wave 8 PR-K5: optional grid for indirect-fire LOS + spotter election.
+  // When omitted, the bot's attack-phase loop behaves identically to its
+  // pre-K5 contract — no indirect-fire dispatch.
+  grid?: IHexGrid,
 ): IGameSession {
   // Per `wire-bot-ai-helpers-and-capstone`: re-evaluate retreat — a
   // unit might have crossed the threshold from damage taken during
@@ -274,6 +279,32 @@ export function runAttackPhase(
         unitId,
       );
 
+      // Wave 8 PR-K5: pre-compute indirect-fire resolution when grid
+      // available. Pick the FIRST weapon whose resolution is
+      // permitted+isIndirect (LRM volleys share a single spotter
+      // election per declaration).
+      let indirectFireResolution:
+        | import('@/types/gameplay/CombatInterfaces').IIndirectFireResolution
+        | undefined;
+      const targetUnit =
+        updatedSession.currentState.units[atkEvt.payload.targetId];
+      const targetHex = targetUnit?.position;
+      if (grid && targetHex && targetUnit) {
+        for (const weaponId of atkEvt.payload.weapons) {
+          const result = computeIndirectFireContext(
+            unitId,
+            weaponId,
+            targetHex,
+            updatedSession.currentState,
+            grid,
+          );
+          if (result.permitted && result.isIndirect) {
+            indirectFireResolution = result;
+            break;
+          }
+        }
+      }
+
       // Arc is computed inside resolveAttack at resolve time.
       updatedSession = declareAttack(
         updatedSession,
@@ -282,6 +313,8 @@ export function runAttackPhase(
         weaponAttacks,
         3,
         RangeBracket.Short,
+        indirectFireResolution,
+        targetHex,
       );
     }
     updatedSession = lockAttack(updatedSession, unitId);

--- a/src/engine/GameEngine.ts
+++ b/src/engine/GameEngine.ts
@@ -140,6 +140,7 @@ export class GameEngine {
         botPlayer,
         weaponsByUnit,
         gunneryByUnit,
+        this.grid,
       );
       session = resolveAllAttacks(session, diceRoller);
       session = advancePhase(session);

--- a/src/engine/InteractiveSession.actions.ts
+++ b/src/engine/InteractiveSession.actions.ts
@@ -37,6 +37,8 @@ import {
 } from '@/utils/gameplay/movement/eventPath';
 import { buildWeaponAttacks } from '@/utils/gameplay/weaponAttackBuilder';
 
+import { computeIndirectFireContext } from './InteractiveSession.indirectFire';
+
 /**
  * Inputs for `applyInteractiveSessionMovement` — the live session, the
  * grid the pathfinder uses, and the cached per-unit movement maps.
@@ -95,6 +97,14 @@ export function applyInteractiveSessionMovement(
 /**
  * Inputs for `applyInteractiveSessionAttack` — the live session and the
  * cached per-unit weapon map.
+ *
+ * Wave 8 PR-K5: `grid` and `targetHex` are OPTIONAL fields. When `grid`
+ * is supplied, `applyInteractiveSessionAttack` pre-computes the
+ * indirect-fire resolution per weapon and threads the first
+ * `permitted && isIndirect` result into `declareAttack` (the engine path
+ * established by PR-K + PR-K4). When omitted, the function behaves
+ * identically to its pre-K5 contract — no resolution computed, no
+ * indirect-fire events emitted.
  */
 export interface IApplyAttackInput {
   readonly session: IGameSession;
@@ -102,12 +112,26 @@ export interface IApplyAttackInput {
   readonly attackerId: string;
   readonly targetId: string;
   readonly weaponIds: readonly string[];
+  /** Wave 8 PR-K5: optional grid for indirect-fire LOS + spotter election. */
+  readonly grid?: IHexGrid;
+  /**
+   * Wave 8 PR-K5: optional override of the target hex carried on the
+   * indirect-fire event payloads. Defaults to the target unit's live
+   * position when omitted.
+   */
+  readonly targetHex?: IHexCoordinate;
 }
 
 /**
  * Declare and lock a weapon attack for the current WeaponAttack phase.
  * Firing arc is intentionally NOT pre-computed here — `resolveAttack`
  * derives it from live positions + target facing at resolve time.
+ *
+ * Wave 8 PR-K5: when `input.grid` is supplied, walks weapon ids and
+ * picks the first weapon whose `computeIndirectFireContext` returns
+ * `permitted && isIndirect` to thread into `declareAttack`. LRM volleys
+ * share a single spotter election per declaration (matches MegaMek
+ * `Compute.findSpottersForArtillery`).
  */
 export function applyInteractiveSessionAttack(
   input: IApplyAttackInput,
@@ -119,6 +143,31 @@ export function applyInteractiveSessionAttack(
     input.attackerId,
   );
 
+  // Wave 8 PR-K5: pre-compute indirect-fire resolution when grid available.
+  let indirectFireResolution:
+    | import('@/types/gameplay/CombatInterfaces').IIndirectFireResolution
+    | undefined;
+  let resolvedTargetHex = input.targetHex;
+  if (input.grid) {
+    const targetUnit = input.session.currentState.units[input.targetId];
+    resolvedTargetHex = resolvedTargetHex ?? targetUnit?.position;
+    if (resolvedTargetHex && targetUnit) {
+      for (const weaponId of input.weaponIds) {
+        const result = computeIndirectFireContext(
+          input.attackerId,
+          weaponId,
+          resolvedTargetHex,
+          input.session.currentState,
+          input.grid,
+        );
+        if (result.permitted && result.isIndirect) {
+          indirectFireResolution = result;
+          break;
+        }
+      }
+    }
+  }
+
   let session = declareAttack(
     input.session,
     input.attackerId,
@@ -126,6 +175,8 @@ export function applyInteractiveSessionAttack(
     weaponAttacks,
     3,
     RangeBracket.Short,
+    indirectFireResolution,
+    resolvedTargetHex,
   );
   session = lockAttack(session, input.attackerId);
   return session;

--- a/src/engine/InteractiveSession.ts
+++ b/src/engine/InteractiveSession.ts
@@ -350,12 +350,18 @@ export class InteractiveSession {
     weaponIds: readonly string[],
   ): void {
     // Declare-then-lock logic lives in `InteractiveSession.actions`.
+    // Wave 8 PR-K5: pass the grid + target hex so the action layer can
+    // pre-compute the indirect-fire resolution and thread it into
+    // `declareAttack` (engine path established by PR-K + PR-K4).
+    const targetUnit = this.session.currentState.units[targetId];
     this.session = applyInteractiveSessionAttack({
       session: this.session,
       weaponsByUnit: this.weaponsByUnit,
       attackerId,
       targetId,
       weaponIds,
+      grid: this.grid,
+      targetHex: targetUnit?.position,
     });
     this.tryFinalizeAndPublish();
   }

--- a/src/engine/__tests__/InteractiveSession.indirectFire.scenario.test.ts
+++ b/src/engine/__tests__/InteractiveSession.indirectFire.scenario.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Scenario tests for the indirect-fire production wiring (PR-K5).
+ *
+ * Exercises `applyInteractiveSessionAttack` (which `InteractiveSession.applyAttack`
+ * delegates to) with a heavy-woods grid that blocks attacker LOS but leaves
+ * the spotter with LOS to the target. Verifies:
+ *
+ *   1. POSITIVE — when a spotter has LOS, applyInteractiveSessionAttack
+ *      pre-computes the indirect-fire resolution and threads it into
+ *      declareAttack, emitting AttackDeclared with `'Indirect fire'` modifier
+ *      + IndirectFireSpotterSelected with basis='los'.
+ *   2. NEGATIVE — when no friendly spotter exists, the resolution is
+ *      permitted=false and declareAttack falls through unchanged (no
+ *      indirect-fire events emitted).
+ *
+ * Uses the pure-function path rather than the full InteractiveSession
+ * instance to stay focused on the K5 wiring contract.
+ */
+
+import type { IWeapon } from '@/simulation/ai/types';
+import type { IIndirectFireSpotterSelectedPayload } from '@/types/gameplay/CombatInterfaces';
+import type { IHex, IHexGrid } from '@/types/gameplay/HexGridInterfaces';
+
+import {
+  GameEventType,
+  GamePhase,
+  GameSide,
+  Facing,
+  MovementType,
+  type IGameUnit,
+  type IGameSession,
+  type IAttackDeclaredPayload,
+} from '@/types/gameplay';
+import { TerrainType } from '@/types/gameplay/TerrainTypes';
+import {
+  advancePhase,
+  createGameSession,
+  rollInitiative,
+  startGame,
+} from '@/utils/gameplay/gameSession';
+
+import { applyInteractiveSessionAttack } from '../InteractiveSession.actions';
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+function makeHex(
+  q: number,
+  r: number,
+  terrain: string = 'clear',
+  elevation: number = 0,
+): IHex {
+  return { coord: { q, r }, occupantId: null, terrain, elevation };
+}
+
+function makeBlockedGrid(): IHexGrid {
+  const hexes = new Map<string, IHex>();
+  for (let q = -5; q <= 12; q++) {
+    for (let r = -5; r <= 12; r++) {
+      hexes.set(`${q},${r}`, makeHex(q, r));
+    }
+  }
+  // Heavy woods at (3, 0) blocks LOS from attacker (0,0) → target (5,0)
+  hexes.set('3,0', makeHex(3, 0, TerrainType.HeavyWoods));
+  return { config: { radius: 12 }, hexes };
+}
+
+function buildUnits(includeSpotter: boolean): readonly IGameUnit[] {
+  const units: IGameUnit[] = [
+    {
+      id: 'a1',
+      name: 'LRM Attacker',
+      side: GameSide.Player,
+      unitRef: 'lrm-mech',
+      pilotRef: 'p1',
+      gunnery: 4,
+      piloting: 5,
+    } as IGameUnit,
+    {
+      id: 't1',
+      name: 'Target',
+      side: GameSide.Opponent,
+      unitRef: 'target-mech',
+      pilotRef: 'p2',
+      gunnery: 4,
+      piloting: 5,
+    } as IGameUnit,
+  ];
+  if (includeSpotter) {
+    units.push({
+      id: 's1',
+      name: 'Spotter',
+      side: GameSide.Player,
+      unitRef: 'spotter-mech',
+      pilotRef: 'p3',
+      gunnery: 4,
+      piloting: 5,
+    } as IGameUnit);
+  }
+  return units;
+}
+
+function buildWeaponsMap(): Map<string, readonly IWeapon[]> {
+  const lrm15: IWeapon = {
+    id: 'lrm-15-1',
+    name: 'LRM-15',
+    damage: 9,
+    heat: 5,
+    minRange: 6,
+    shortRange: 7,
+    mediumRange: 14,
+    longRange: 21,
+  } as unknown as IWeapon;
+  const map = new Map<string, readonly IWeapon[]>();
+  map.set('a1', [lrm15]);
+  return map;
+}
+
+function setupSessionAtWeaponAttack(includeSpotter: boolean): IGameSession {
+  let s = createGameSession(
+    {
+      mapRadius: 12,
+      turnLimit: 0,
+      victoryConditions: ['elimination'],
+      optionalRules: [],
+    } as never,
+    buildUnits(includeSpotter),
+  );
+  s = startGame(s, GameSide.Player);
+  s = rollInitiative(s);
+  s = advancePhase(s); // Initiative → Movement
+  s = advancePhase(s); // Movement → WeaponAttack
+  // Mutate position on the FINAL state (advancePhase re-derives currentState
+  // from events, so earlier mutations would be discarded). This is a
+  // fixture-only path — production session state mutates via events.
+  s.currentState.units.a1 = {
+    ...s.currentState.units.a1,
+    position: { q: 0, r: 0 },
+    movementThisTurn: MovementType.Stationary,
+  };
+  s.currentState.units.t1 = {
+    ...s.currentState.units.t1,
+    position: { q: 5, r: 0 },
+    facing: Facing.South,
+  };
+  if (includeSpotter) {
+    s.currentState.units.s1 = {
+      ...s.currentState.units.s1,
+      position: { q: 5, r: 1 },
+      movementThisTurn: MovementType.Stationary,
+    };
+  }
+  return s;
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('applyInteractiveSessionAttack — indirect-fire wiring (PR-K5)', () => {
+  it('POSITIVE: spotter with LOS triggers IndirectFireSpotterSelected', () => {
+    const session = setupSessionAtWeaponAttack(true);
+    const grid = makeBlockedGrid();
+
+    const result = applyInteractiveSessionAttack({
+      session,
+      weaponsByUnit: buildWeaponsMap(),
+      attackerId: 'a1',
+      targetId: 't1',
+      weaponIds: ['lrm-15-1'],
+      grid,
+    });
+
+    // AttackDeclared has the indirect-fire modifier
+    const declared = result.events.find(
+      (e) => e.type === GameEventType.AttackDeclared,
+    );
+    expect(declared).toBeDefined();
+    const declaredPayload = declared!.payload as IAttackDeclaredPayload;
+    const indirectMod = declaredPayload.modifiers.find(
+      (m) => m.name === 'Indirect fire',
+    );
+    expect(indirectMod).toBeDefined();
+    expect(indirectMod!.value).toBeGreaterThanOrEqual(1);
+
+    // IndirectFireSpotterSelected event fires
+    const spotterEvent = result.events.find(
+      (e) => e.type === GameEventType.IndirectFireSpotterSelected,
+    );
+    expect(spotterEvent).toBeDefined();
+    const spotterPayload = spotterEvent!
+      .payload as IIndirectFireSpotterSelectedPayload;
+    expect(spotterPayload.attackerId).toBe('a1');
+    expect(spotterPayload.spotterId).toBe('s1');
+    expect(spotterPayload.weaponId).toBe('lrm-15-1');
+    expect(spotterPayload.basis).toBe('los');
+  });
+
+  it('NEGATIVE: no spotter present — no indirect-fire events emitted', () => {
+    const session = setupSessionAtWeaponAttack(false);
+    const grid = makeBlockedGrid();
+
+    const result = applyInteractiveSessionAttack({
+      session,
+      weaponsByUnit: buildWeaponsMap(),
+      attackerId: 'a1',
+      targetId: 't1',
+      weaponIds: ['lrm-15-1'],
+      grid,
+    });
+
+    // AttackDeclared still emitted, but no Indirect fire modifier
+    const declared = result.events.find(
+      (e) => e.type === GameEventType.AttackDeclared,
+    );
+    expect(declared).toBeDefined();
+    const declaredPayload = declared!.payload as IAttackDeclaredPayload;
+    const indirectMod = declaredPayload.modifiers.find(
+      (m) => m.name === 'Indirect fire',
+    );
+    expect(indirectMod).toBeUndefined();
+
+    // No indirect-fire events
+    const indirectEvents = result.events.filter(
+      (e) =>
+        e.type === GameEventType.IndirectFireSpotterSelected ||
+        e.type === GameEventType.IndirectFireNarcOverride,
+    );
+    expect(indirectEvents.length).toBe(0);
+  });
+
+  it('BACKWARD-COMPAT: no grid passed — behaves identically to pre-K5', () => {
+    const session = setupSessionAtWeaponAttack(true);
+
+    const result = applyInteractiveSessionAttack({
+      session,
+      weaponsByUnit: buildWeaponsMap(),
+      attackerId: 'a1',
+      targetId: 't1',
+      weaponIds: ['lrm-15-1'],
+      // grid intentionally omitted
+    });
+
+    const indirectEvents = result.events.filter(
+      (e) =>
+        e.type === GameEventType.IndirectFireSpotterSelected ||
+        e.type === GameEventType.IndirectFireNarcOverride,
+    );
+    expect(indirectEvents.length).toBe(0);
+
+    const declared = result.events.find(
+      (e) => e.type === GameEventType.AttackDeclared,
+    );
+    const declaredPayload = declared!.payload as IAttackDeclaredPayload;
+    const indirectMod = declaredPayload.modifiers.find(
+      (m) => m.name === 'Indirect fire',
+    );
+    expect(indirectMod).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## PR-K5 — Production Callers Wiring + Event-Log Formatter + Scenario Test

Closes the load-bearing wiring gap from PR-K4 (#670). Until this PR, `declareAttack` accepted an optional `indirectFireResolution` but no production caller pre-computed + passed it. Now both interactive and bot-AI paths thread the resolution through.

## What ships

### §1 `applyInteractiveSessionAttack` (interactive path)
- `IApplyAttackInput` extended with optional `grid?: IHexGrid` + `targetHex?: IHexCoordinate`
- When `grid` supplied, walks weaponIds and picks the FIRST weapon whose `computeIndirectFireContext` returns `permitted && isIndirect` — threads that single resolution to `declareAttack` (LRM volleys share one election per spec, matching MegaMek `Compute.findSpottersForArtillery`)
- Backward-compat: no grid → behaves identically to pre-K5

### §2 `InteractiveSession.applyAttack` (instance method)
- Passes `this.grid` and `targetUnit.position` into `applyInteractiveSessionAttack`

### §3 `runAttackPhase` (bot AI loop)
- Accepts optional `grid: IHexGrid` parameter
- Pre-computes resolution per weapon using same first-permitted election pattern
- `GameEngine.runRound` (caller at `src/engine/GameEngine.ts:138`) passes `this.grid` through

### §4 `EventLogDisplay.helpers` (formatter)
- 4 new `case` blocks render the 4 indirect-fire event types:
  - `IndirectFireSpotterSelected` → `"Indirect fire: spotted by {spotterId} (+{toHitPenalty} TN)"`
  - `IndirectFireNarcOverride` → `"Indirect fire: {basis} beacon override on target (+{toHitPenalty} TN)"`
  - `IndirectFireForwardObserver` → `"Indirect fire: Forward Observer {spotterId} cancels walking penalty"`
  - `IndirectFireSpotterLost` → `"Indirect fire: spotter {spotterId} lost — attack misses ({reason})"` (event emitted by PR-K6; format-case ships now to avoid a churn follow-up)

### §5 Scenario test
- `src/engine/__tests__/InteractiveSession.indirectFire.scenario.test.ts` — 3 tests
- POSITIVE: heavy-woods grid + LRM-15 attacker + spotter at q=5,r=1 → `AttackDeclared` carries `'Indirect fire'` modifier + `IndirectFireSpotterSelected` event with basis='los' + spotterId='s1'
- NEGATIVE: no spotter → no indirect-fire events, no `'Indirect fire'` modifier
- BACKWARD-COMPAT: no grid → identical to pre-K5 behavior

## Commits (1)

| # | SHA | Scope |
|---|-----|-------|
| 1 | `79ffab71` | §1+§2+§3 wiring + §4 formatter cases + §5 scenario test |

## Deferred to PR-K7

**Quick-Sim wiring** — `src/simulation/runner/phases/weaponAttack.ts` is a PARALLEL PIPELINE that does NOT call `declareAttack` (hand-rolls `AttackDeclared` + `AttackResolved` from `calculateToHit` directly). Wiring it requires its own emission path. Tracked as PR-K7.

PR-K6 (spotter-liveness mid-resolution auto-miss) is the next item — the `IndirectFireSpotterLost` formatter case shipped here will render its events once PR-K6 emits them.

## Verification

- `npx tsc --noEmit` → clean
- `npx oxlint` → 2 pre-existing warnings (`max-lines` on `gameSessionCore.ts`), 0 errors
- `npx jest src/engine src/utils/gameplay src/components/gameplay/__tests__` → **3549/3549 pass / 155 suites**
- `npx openspec validate add-indirect-fire-and-spotter-network --strict` → valid

Builds on: PR-K (#666) + PR-K2 (#668) + PR-K3 (#669) + PR-K4 (#670).