### PR TITLE
feat(wave-8): spotter-liveness mid-resolution re-check (PR-K6)

### DIFF
--- a/src/utils/gameplay/__tests__/resolveAttack.spotterLost.test.ts
+++ b/src/utils/gameplay/__tests__/resolveAttack.spotterLost.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Tests for resolveAttack spotter-liveness mid-resolution re-check (PR-K6).
+ *
+ * Verifies that when an indirect-fire attack has been declared (with
+ * `IndirectFireSpotterSelected` event emitted by PR-K4/K5 dispatch) and
+ * the elected spotter is destroyed between attack-declaration and
+ * resolution, `resolveAttack`:
+ *
+ *   1. Detects the destroyed spotter via session.events walkback
+ *   2. Emits `IndirectFireSpotterLost` event with reason
+ *   3. Forces the attack to auto-miss (hit=false) regardless of dice roll
+ *   4. Preserves ammo consumption (already happened upstream) + heat (on
+ *      AttackResolved payload regardless of hit) per spec
+ *
+ * Test pattern: pre-build a session with the AttackDeclared +
+ * IndirectFireSpotterSelected events already in the log; mutate
+ * `gameState.units[spotterId].destroyed = true`; call resolveAttack.
+ */
+
+import type { IWeapon } from '@/simulation/ai/types';
+import type { IIndirectFireSpotterLostPayload } from '@/types/gameplay/CombatInterfaces';
+import type { IHex, IHexGrid } from '@/types/gameplay/HexGridInterfaces';
+
+import { applyInteractiveSessionAttack } from '@/engine/InteractiveSession.actions';
+import {
+  GameEventType,
+  GamePhase,
+  GameSide,
+  Facing,
+  MovementType,
+  RangeBracket,
+  type IAttackResolvedPayload,
+  type IGameSession,
+  type IGameUnit,
+  type IWeaponAttack,
+} from '@/types/gameplay';
+import { TerrainType } from '@/types/gameplay/TerrainTypes';
+
+import { createUnitDestroyedEvent } from '../gameEvents';
+import {
+  advancePhase,
+  createGameSession,
+  rollInitiative,
+  startGame,
+} from '../gameSession';
+import { resolveAttack } from '../gameSessionAttackResolution';
+import { appendEvent } from '../gameSessionCore';
+
+// =============================================================================
+// Fixtures — mirror the PR-K5 scenario test setup so a real
+// IndirectFireSpotterSelected event lands in the log.
+// =============================================================================
+
+function makeHex(
+  q: number,
+  r: number,
+  terrain: string = 'clear',
+  elevation: number = 0,
+): IHex {
+  return { coord: { q, r }, occupantId: null, terrain, elevation };
+}
+
+function makeBlockedGrid(): IHexGrid {
+  const hexes = new Map<string, IHex>();
+  for (let q = -5; q <= 12; q++) {
+    for (let r = -5; r <= 12; r++) {
+      hexes.set(`${q},${r}`, makeHex(q, r));
+    }
+  }
+  hexes.set('3,0', makeHex(3, 0, TerrainType.HeavyWoods));
+  return { config: { radius: 12 }, hexes };
+}
+
+function buildUnits(): readonly IGameUnit[] {
+  return [
+    {
+      id: 'a1',
+      name: 'LRM Attacker',
+      side: GameSide.Player,
+      unitRef: 'lrm-mech',
+      pilotRef: 'p1',
+      gunnery: 4,
+      piloting: 5,
+      ammoConstruction: [
+        {
+          binId: 'bin-lrm15-1',
+          weaponType: 'LRM-15',
+          location: 'ct',
+          maxRounds: 40,
+          damagePerRound: 1,
+          isExplosive: true,
+        },
+      ],
+    } as IGameUnit,
+    {
+      id: 't1',
+      name: 'Target',
+      side: GameSide.Opponent,
+      unitRef: 'target-mech',
+      pilotRef: 'p2',
+      gunnery: 4,
+      piloting: 5,
+    } as IGameUnit,
+    {
+      id: 's1',
+      name: 'Spotter',
+      side: GameSide.Player,
+      unitRef: 'spotter-mech',
+      pilotRef: 'p3',
+      gunnery: 4,
+      piloting: 5,
+    } as IGameUnit,
+  ];
+}
+
+function buildWeaponsMap(): Map<string, readonly IWeapon[]> {
+  const lrm15: IWeapon = {
+    id: 'lrm-15-1',
+    name: 'LRM-15',
+    damage: 9,
+    heat: 5,
+    minRange: 6,
+    shortRange: 7,
+    mediumRange: 14,
+    longRange: 21,
+  } as unknown as IWeapon;
+  const map = new Map<string, readonly IWeapon[]>();
+  map.set('a1', [lrm15]);
+  return map;
+}
+
+function setupSessionWithSpotterEvent(): IGameSession {
+  let s = createGameSession(
+    {
+      mapRadius: 12,
+      turnLimit: 0,
+      victoryConditions: ['elimination'],
+      optionalRules: [],
+    } as never,
+    buildUnits(),
+  );
+  s = startGame(s, GameSide.Player);
+  s = rollInitiative(s);
+  s = advancePhase(s); // → Movement
+  s = advancePhase(s); // → WeaponAttack
+  // Position units AFTER advancePhase (state re-derives from events)
+  s.currentState.units.a1 = {
+    ...s.currentState.units.a1,
+    position: { q: 0, r: 0 },
+    movementThisTurn: MovementType.Stationary,
+  };
+  s.currentState.units.t1 = {
+    ...s.currentState.units.t1,
+    position: { q: 5, r: 0 },
+    facing: Facing.South,
+  };
+  s.currentState.units.s1 = {
+    ...s.currentState.units.s1,
+    position: { q: 5, r: 1 },
+    movementThisTurn: MovementType.Stationary,
+  };
+
+  // Declare attack — this emits AttackDeclared + IndirectFireSpotterSelected
+  s = applyInteractiveSessionAttack({
+    session: s,
+    weaponsByUnit: buildWeaponsMap(),
+    attackerId: 'a1',
+    targetId: 't1',
+    weaponIds: ['lrm-15-1'],
+    grid: makeBlockedGrid(),
+  });
+
+  return s;
+}
+
+/** Always-hit roller — produces a TN-beating roll so a default attack would land. */
+function alwaysHitRoller() {
+  return {
+    dice: [6, 6] as const,
+    total: 12,
+    isSnakeEyes: false,
+    isBoxcars: true,
+  };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('resolveAttack — spotter-liveness mid-resolution (PR-K6)', () => {
+  it('auto-misses + emits IndirectFireSpotterLost when elected spotter is destroyed before resolution', () => {
+    const session = setupSessionWithSpotterEvent();
+
+    // Verify pre-condition: the SpotterSelected event was emitted by K5 dispatch.
+    const spotterSelected = session.events.find(
+      (e) => e.type === GameEventType.IndirectFireSpotterSelected,
+    );
+    expect(spotterSelected).toBeDefined();
+
+    // Destroy the spotter mid-resolution (between declare and resolve).
+    // Emit a real UnitDestroyed event so event-sourced state derivation
+    // reflects destroyed=true after subsequent appendEvent calls (direct
+    // currentState mutation gets wiped by deriveState).
+    const sessionWithDeadSpotter = appendEvent(
+      session,
+      createUnitDestroyedEvent(
+        session.id,
+        session.events.length,
+        session.currentState.turn,
+        GamePhase.WeaponAttack,
+        's1',
+        'damage',
+      ),
+    );
+
+    // Find the AttackDeclared event to pass into resolveAttack.
+    const attackDeclared = sessionWithDeadSpotter.events.find(
+      (e) => e.type === GameEventType.AttackDeclared,
+    );
+    expect(attackDeclared).toBeDefined();
+
+    // Sanity: verify the event-derived state correctly shows spotter destroyed
+    expect(sessionWithDeadSpotter.currentState.units.s1.destroyed).toBe(true);
+
+    const result = resolveAttack(
+      sessionWithDeadSpotter,
+      attackDeclared!,
+      alwaysHitRoller,
+    );
+
+    // IndirectFireSpotterLost event emitted
+    const spotterLost = result.events.find(
+      (e) => e.type === GameEventType.IndirectFireSpotterLost,
+    );
+    expect(spotterLost).toBeDefined();
+    const lostPayload = spotterLost!.payload as IIndirectFireSpotterLostPayload;
+    expect(lostPayload.attackerId).toBe('a1');
+    expect(lostPayload.spotterId).toBe('s1');
+    expect(lostPayload.weaponId).toBe('lrm-15-1');
+    expect(lostPayload.reason).toBe('Spotter destroyed before resolution');
+
+    // AttackResolved event present with hit=false (auto-miss)
+    const resolved = result.events.find(
+      (e) => e.type === GameEventType.AttackResolved,
+    );
+    expect(resolved).toBeDefined();
+    const resolvedPayload = resolved!.payload as IAttackResolvedPayload;
+    expect(resolvedPayload.hit).toBe(false);
+
+    // No DamageApplied events (auto-miss skips damage)
+    const damageEvents = result.events.filter(
+      (e) => e.type === GameEventType.DamageApplied,
+    );
+    expect(damageEvents.length).toBe(0);
+  });
+
+  it('preserves ammo consumption when spotter lost (ammo consumed upstream of spotter-liveness check)', () => {
+    const session = setupSessionWithSpotterEvent();
+    const sessionWithDeadSpotter = appendEvent(
+      session,
+      createUnitDestroyedEvent(
+        session.id,
+        session.events.length,
+        session.currentState.turn,
+        GamePhase.WeaponAttack,
+        's1',
+        'damage',
+      ),
+    );
+
+    const attackDeclared = sessionWithDeadSpotter.events.find(
+      (e) => e.type === GameEventType.AttackDeclared,
+    );
+
+    const result = resolveAttack(
+      sessionWithDeadSpotter,
+      attackDeclared!,
+      alwaysHitRoller,
+    );
+
+    // AmmoConsumed event MUST be present — ammo consumption runs UPSTREAM of
+    // the spotter-liveness check, so the spotter-lost branch does not
+    // short-circuit it. (Heat is carried on AttackResolved.heat — also
+    // preserved regardless of hit.)
+    const ammoConsumed = result.events.find(
+      (e) => e.type === GameEventType.AmmoConsumed,
+    );
+    expect(ammoConsumed).toBeDefined();
+  });
+
+  it('does NOT emit SpotterLost when spotter is still alive at resolution', () => {
+    const session = setupSessionWithSpotterEvent();
+    // Spotter remains alive (no destroyed mutation).
+
+    const attackDeclared = session.events.find(
+      (e) => e.type === GameEventType.AttackDeclared,
+    );
+    const result = resolveAttack(session, attackDeclared!, alwaysHitRoller);
+
+    const spotterLost = result.events.find(
+      (e) => e.type === GameEventType.IndirectFireSpotterLost,
+    );
+    expect(spotterLost).toBeUndefined();
+  });
+});

--- a/src/utils/gameplay/gameSessionAttackResolution.ts
+++ b/src/utils/gameplay/gameSessionAttackResolution.ts
@@ -24,6 +24,7 @@ import {
   createAttackInvalidEvent,
   createAttackResolvedEvent,
   createDamageAppliedEvent,
+  createIndirectFireSpotterLostEvent,
   createLocationDestroyedEvent,
   createPilotHitEvent,
   createPSRTriggeredEvent,
@@ -120,7 +121,55 @@ export function resolveAttack(
     }
 
     const attackRoll = diceRoller();
-    const hit = attackRoll.total >= toHitNumber;
+    let hit = attackRoll.total >= toHitNumber;
+
+    // Wave 8 PR-K6: spotter-liveness mid-resolution re-check.
+    // Walk session.events backward to find the IndirectFireSpotterSelected
+    // event matching this attacker + weapon (most-recent first). If the
+    // elected spotter has been destroyed between attack declaration and
+    // resolution, force the attack to auto-miss + emit IndirectFireSpotterLost.
+    // Ammo is already consumed above (lines 80-119); heat carries on
+    // AttackResolved.heat regardless of hit — both preserved.
+    for (let i = currentSession.events.length - 1; i >= 0; i--) {
+      const evt = currentSession.events[i];
+      if (evt.type !== GameEventType.IndirectFireSpotterSelected) continue;
+      const ifPayload = evt.payload as {
+        attackerId: string;
+        weaponId: string;
+        spotterId: string;
+        targetHex: { q: number; r: number };
+        basis: 'los' | 'narc' | 'inarc' | 'semi-guided-tag';
+      };
+      if (
+        ifPayload.attackerId !== attackerId ||
+        ifPayload.weaponId !== weaponId
+      ) {
+        continue;
+      }
+      const spotterUnit =
+        currentSession.currentState.units[ifPayload.spotterId];
+      if (spotterUnit?.destroyed) {
+        const lostSequence = currentSession.events.length;
+        const lostTurn = currentSession.currentState.turn;
+        currentSession = appendEvent(
+          currentSession,
+          createIndirectFireSpotterLostEvent(
+            currentSession.id,
+            lostSequence,
+            lostTurn,
+            attackerId,
+            ifPayload.spotterId,
+            weaponId,
+            ifPayload.targetHex,
+            ifPayload.basis,
+            'Spotter destroyed before resolution',
+            ammoBinIdForResolved ?? undefined,
+          ),
+        );
+        hit = false;
+      }
+      break; // most-recent spotter selection found — stop walking
+    }
 
     const sequence = currentSession.events.length;
     const { turn } = currentSession.currentState;


### PR DESCRIPTION
## PR-K6 — Spotter-Liveness Mid-Resolution Auto-Miss

Closes §6 of the indirect-fire spec. When the elected spotter is destroyed between attack-declaration and resolution, `resolveAttack` auto-misses + emits `IndirectFireSpotterLost`.

## What ships

**Hook in `src/utils/gameplay/gameSessionAttackResolution.ts`** (between line 123 hit-roll and line 186 damage application):

1. Walk `currentSession.events` backward to find the most-recent `IndirectFireSpotterSelected` event matching `attackerId + weaponId`
2. If found AND `gameState.units[spotterId].destroyed === true`:
   - Emit `IndirectFireSpotterLost` event with reason `'Spotter destroyed before resolution'`
   - Force `hit = false` → skip damage application + location roll
   - Continue to `AttackResolved` emission with `hit: false`
3. Ammo consumption (already happens upstream of the hook) and heat (carried on `AttackResolved.heat` regardless of hit) both preserved per spec

**Spotter discovery decision** — chose event-log walkback over:
- Option (b) extending `IAttackDeclaredPayload` with `indirectFire?: { spotterId }` — adds parallel source-of-truth alongside the already-emitted event
- Option (c) re-running `computeIndirectFireContext` at resolve time — could re-elect a *different* spotter, violating "spotter at declare time" invariant

Walkback is bounded O(events-since-this-declaration); typically <20 events.

**Tests** — `src/utils/gameplay/__tests__/resolveAttack.spotterLost.test.ts` (3 tests):
- auto-miss + IndirectFireSpotterLost emission when spotter destroyed
- ammo consumption preserved (runs upstream of spotter-liveness check)
- no SpotterLost when spotter alive at resolution

Fixture uses event-sourced state derivation — emits real `UnitDestroyed` event for the spotter so `deriveState` reflects `destroyed: true` after `appendEvent` rebuilds currentState (direct mutations get wiped by deriveState).

## Wave 8 indirect-fire pipeline — COMPLETE

After this PR, real LRM indirect-fire matches now work end-to-end:

| Step | PR |
|---|---|
| Engine method `computeIndirectFireContext` | PR-K #666 |
| `declareAttack` accepts `indirectFireResolution` | PR-K4 #670 |
| Production callers pre-compute + thread resolution | PR-K5 #671 |
| Spotter-liveness re-check at resolve time | **PR-K6 (this PR)** |

Plus PR-K2 #668 (Forward Observer SPA) and PR-K3 #669 (NARC/iNarc override) extend the resolution logic itself.

## Verification

- `npx tsc --noEmit` → clean
- `npx jest src/utils/gameplay src/engine src/components/gameplay/__tests__` → **3552/3552 pass / 156 suites**
- `npx openspec validate add-indirect-fire-and-spotter-network --strict` → valid
- `npx oxlint` → 1 pre-existing max-lines warning (resolveAttack now 555 lines), 0 errors

## Remaining queue

- **PR-K7** Quick-Sim wiring (`src/simulation/runner/phases/weaponAttack.ts` parallel pipeline)
- **PR-L2/L3/L4** battle-armor combat follow-ups (swarm attack, leg attack, vibroclaw/brush-off/dislodge)
- **PR-M** aerospace deployment (XL — own wave)