### PR TITLE
feat(wave-8): Quick-Sim indirect-fire dispatch (PR-K7)

### DIFF
--- a/src/simulation/runner/__tests__/weaponAttackIndirectFire.test.ts
+++ b/src/simulation/runner/__tests__/weaponAttackIndirectFire.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Tests for Quick-Sim indirect-fire dispatch (PR-K7).
+ *
+ * The interactive path + bot AI path both pre-compute indirect-fire
+ * resolution via `computeIndirectFireContext` and thread it through
+ * `declareAttack` (PR-K4/K5). The Quick-Sim runner uses a PARALLEL
+ * pipeline that hand-rolls `AttackDeclared` / `AttackResolved` from
+ * `calculateToHit` directly — it does NOT go through `declareAttack`.
+ *
+ * PR-K7 wires the same dispatch into the Quick-Sim path so mass-scale
+ * BV-balance Monte Carlo runs reflect indirect-fire to-hit math.
+ *
+ * Verifies:
+ *   - LRM attacker with NO LOS + friendly spotter with LOS → AttackDeclared
+ *     carries 'Indirect fire' modifier AND IndirectFireSpotterSelected event
+ *     emitted with basis='los' + spotterId set
+ *   - Direct LOS path: clear-grid LRM attacker → no indirect events (LOS
+ *     present, direct fire works)
+ *   - Backward-compat: no grid → no indirect events emitted
+ */
+
+import type { IIndirectFireSpotterSelectedPayload } from '@/types/gameplay/CombatInterfaces';
+import type { IHex, IHexGrid } from '@/types/gameplay/HexGridInterfaces';
+
+import {
+  Facing,
+  GamePhase,
+  GameSide,
+  GameStatus,
+  IAttackDeclaredPayload,
+  IGameEvent,
+  IGameState,
+  IUnitGameState,
+  LockState,
+  MovementType,
+  GameEventType,
+} from '@/types/gameplay';
+import { TerrainType } from '@/types/gameplay/TerrainTypes';
+
+import type { IWeapon } from '../../ai/types';
+
+import { BotPlayer } from '../../ai/BotPlayer';
+import { SeededRandom } from '../../core/SeededRandom';
+import { InvariantRunner } from '../../invariants/InvariantRunner';
+import { IViolation } from '../../invariants/types';
+import { runAttackPhase } from '../phases/weaponAttack';
+import { DEFAULT_COMPONENT_DAMAGE } from '../SimulationRunnerConstants';
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+function makeLRM15(): IWeapon {
+  return {
+    id: 'lrm-15-1',
+    name: 'LRM-15',
+    shortRange: 7,
+    mediumRange: 14,
+    longRange: 21,
+    damage: 9,
+    heat: 5,
+    minRange: 6,
+    ammoPerTon: 8,
+    destroyed: false,
+  };
+}
+
+function makeUnit(
+  id: string,
+  side: GameSide,
+  position: { q: number; r: number },
+): IUnitGameState {
+  return {
+    id,
+    side,
+    position,
+    facing: side === GameSide.Player ? Facing.South : Facing.North,
+    heat: 0,
+    movementThisTurn: MovementType.Stationary,
+    hexesMovedThisTurn: 0,
+    armor: {
+      head: 9,
+      center_torso: 47,
+      center_torso_rear: 14,
+      left_torso: 32,
+      left_torso_rear: 10,
+      right_torso: 32,
+      right_torso_rear: 10,
+      left_arm: 34,
+      right_arm: 34,
+      left_leg: 41,
+      right_leg: 41,
+    },
+    structure: {
+      head: 3,
+      center_torso: 31,
+      left_torso: 21,
+      right_torso: 21,
+      left_arm: 17,
+      right_arm: 17,
+      left_leg: 21,
+      right_leg: 21,
+    },
+    destroyedLocations: [],
+    destroyedEquipment: [],
+    ammo: {},
+    pilotWounds: 0,
+    pilotConscious: true,
+    destroyed: false,
+    lockState: LockState.Pending,
+    componentDamage: DEFAULT_COMPONENT_DAMAGE,
+    prone: false,
+    shutdown: false,
+    pendingPSRs: [],
+    damageThisPhase: 0,
+    weaponsFiredThisTurn: [],
+    gunnery: 4,
+    piloting: 5,
+  };
+}
+
+function makeHex(
+  q: number,
+  r: number,
+  terrain: string = 'clear',
+  elevation: number = 0,
+): IHex {
+  return { coord: { q, r }, occupantId: null, terrain, elevation };
+}
+
+function makeBlockedGrid(): IHexGrid {
+  const hexes = new Map<string, IHex>();
+  for (let q = -5; q <= 15; q++) {
+    for (let r = -5; r <= 15; r++) {
+      hexes.set(`${q},${r}`, makeHex(q, r));
+    }
+  }
+  // Heavy woods at (5, 0) blocks LOS from attacker (0,0) → target (10,0).
+  hexes.set('5,0', makeHex(5, 0, TerrainType.HeavyWoods));
+  return { config: { radius: 15 }, hexes };
+}
+
+function makeClearGrid(): IHexGrid {
+  const hexes = new Map<string, IHex>();
+  for (let q = -5; q <= 15; q++) {
+    for (let r = -5; r <= 15; r++) {
+      hexes.set(`${q},${r}`, makeHex(q, r));
+    }
+  }
+  return { config: { radius: 15 }, hexes };
+}
+
+function buildScenario(options: { includeSpotter: boolean }): {
+  state: IGameState;
+  weaponsByUnit: ReadonlyMap<string, readonly IWeapon[]>;
+} {
+  const attacker = makeUnit('player-1', GameSide.Player, { q: 0, r: 0 });
+  const target = makeUnit('opponent-1', GameSide.Opponent, { q: 10, r: 0 });
+  const units: Record<string, IUnitGameState> = {
+    'player-1': attacker,
+    'opponent-1': target,
+  };
+  const weaponsMap = new Map<string, readonly IWeapon[]>([
+    ['player-1', [makeLRM15()]],
+    ['opponent-1', []],
+  ]);
+  if (options.includeSpotter) {
+    units['player-2'] = makeUnit('player-2', GameSide.Player, { q: 10, r: 1 });
+    weaponsMap.set('player-2', []);
+  }
+  const state: IGameState = {
+    gameId: 'test-game',
+    status: GameStatus.Active,
+    turn: 1,
+    phase: GamePhase.WeaponAttack,
+    activationIndex: 0,
+    units,
+    turnEvents: [],
+  } as unknown as IGameState;
+  return { state, weaponsByUnit: weaponsMap };
+}
+
+function runPhase(options: {
+  state: IGameState;
+  weaponsByUnit: ReadonlyMap<string, readonly IWeapon[]>;
+  grid?: IHexGrid;
+  seed?: number;
+}): IGameEvent[] {
+  const random = new SeededRandom(options.seed ?? 12345);
+  const botPlayer = new BotPlayer(random);
+  const invariantRunner = new InvariantRunner();
+  const violations: IViolation[] = [];
+  const events: IGameEvent[] = [];
+  runAttackPhase({
+    state: options.state,
+    botPlayer,
+    grid: options.grid,
+    invariantRunner,
+    violations,
+    events,
+    gameId: options.state.gameId,
+    random,
+    weaponsByUnit: options.weaponsByUnit,
+  });
+  return events;
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('runAttackPhase — Quick-Sim indirect-fire dispatch (PR-K7)', () => {
+  it('POSITIVE: no LOS + spotter → Indirect fire modifier + IndirectFireSpotterSelected event', () => {
+    const { state, weaponsByUnit } = buildScenario({ includeSpotter: true });
+    const events = runPhase({ state, weaponsByUnit, grid: makeBlockedGrid() });
+
+    const declared = events.find(
+      (e) =>
+        e.type === GameEventType.AttackDeclared &&
+        (e.payload as IAttackDeclaredPayload).attackerId === 'player-1',
+    );
+    expect(declared).toBeDefined();
+    const declaredPayload = declared!.payload as IAttackDeclaredPayload;
+    const indirectMod = declaredPayload.modifiers.find(
+      (m) => m.name === 'Indirect fire',
+    );
+    expect(indirectMod).toBeDefined();
+    expect(indirectMod!.value).toBeGreaterThanOrEqual(1);
+
+    const spotterEvent = events.find(
+      (e) => e.type === GameEventType.IndirectFireSpotterSelected,
+    );
+    expect(spotterEvent).toBeDefined();
+    const spotterPayload = spotterEvent!
+      .payload as IIndirectFireSpotterSelectedPayload;
+    expect(spotterPayload.attackerId).toBe('player-1');
+    expect(spotterPayload.spotterId).toBe('player-2');
+    expect(spotterPayload.weaponId).toBe('lrm-15-1');
+    expect(spotterPayload.basis).toBe('los');
+  });
+
+  it('BACKWARD-COMPAT: no grid passed → no indirect events emitted', () => {
+    const { state, weaponsByUnit } = buildScenario({ includeSpotter: true });
+    const events = runPhase({ state, weaponsByUnit });
+
+    const indirectEvents = events.filter(
+      (e) =>
+        e.type === GameEventType.IndirectFireSpotterSelected ||
+        e.type === GameEventType.IndirectFireNarcOverride,
+    );
+    expect(indirectEvents.length).toBe(0);
+
+    const declared = events.find(
+      (e) =>
+        e.type === GameEventType.AttackDeclared &&
+        (e.payload as IAttackDeclaredPayload).attackerId === 'player-1',
+    );
+    if (declared) {
+      const declaredPayload = declared.payload as IAttackDeclaredPayload;
+      const indirectMod = declaredPayload.modifiers.find(
+        (m) => m.name === 'Indirect fire',
+      );
+      expect(indirectMod).toBeUndefined();
+    }
+  });
+
+  it('DIRECT-LOS PATH: clear grid → no indirect events (LRM uses direct fire)', () => {
+    const { state, weaponsByUnit } = buildScenario({ includeSpotter: false });
+    const events = runPhase({ state, weaponsByUnit, grid: makeClearGrid() });
+
+    const indirectEvents = events.filter(
+      (e) =>
+        e.type === GameEventType.IndirectFireSpotterSelected ||
+        e.type === GameEventType.IndirectFireNarcOverride,
+    );
+    expect(indirectEvents.length).toBe(0);
+
+    const declared = events.find(
+      (e) =>
+        e.type === GameEventType.AttackDeclared &&
+        (e.payload as IAttackDeclaredPayload).attackerId === 'player-1',
+    );
+    if (declared) {
+      const declaredPayload = declared.payload as IAttackDeclaredPayload;
+      const indirectMod = declaredPayload.modifiers.find(
+        (m) => m.name === 'Indirect fire',
+      );
+      expect(indirectMod).toBeUndefined();
+    }
+  });
+});

--- a/src/simulation/runner/phases/weaponAttack.ts
+++ b/src/simulation/runner/phases/weaponAttack.ts
@@ -1,5 +1,6 @@
 import type { CriticalSlotManifest } from '@/utils/gameplay/criticalHitResolution/types';
 
+import { computeIndirectFireContext } from '@/engine/InteractiveSession.indirectFire';
 import {
   GameEventType,
   GamePhase,
@@ -245,6 +246,31 @@ export function runAttackPhase(options: {
         weapon.minRange,
       );
 
+      // Wave 8 PR-K7: Quick-Sim indirect-fire dispatch.
+      // The interactive path (declareAttack) and bot path (runAttackPhase)
+      // pre-compute indirect-fire resolution via computeIndirectFireContext
+      // and thread the +1/+2 penalty + spotter event through the engine. The
+      // Quick-Sim pipeline doesn't go through declareAttack — it hand-rolls
+      // AttackDeclared / AttackResolved. Wire the same dispatch here so
+      // mass-scale BV-balance Monte Carlo runs reflect indirect-fire to-hit
+      // math when LRMs fire against units the attacker has no LOS to.
+      const indirectFireResolution = grid
+        ? computeIndirectFireContext(
+            unitId,
+            weaponId,
+            targetNow.position,
+            currentState,
+            grid,
+          )
+        : null;
+      const indirectFirePenalty =
+        indirectFireResolution &&
+        indirectFireResolution.permitted &&
+        indirectFireResolution.isIndirect
+          ? indirectFireResolution.toHitPenalty
+          : 0;
+      const adjustedToHit = toHitCalc.finalToHit + indirectFirePenalty;
+
       const firingArc = calculateFiringArc(
         attackerNow.position,
         targetNow.position,
@@ -255,6 +281,18 @@ export function runAttackPhase(options: {
       // the to-hit roll. Carries the weapon id, range bracket, firing
       // arc, and the full modifier breakdown so replay / metrics
       // consumers can show the GATOR math without recomputing it.
+      const baseModifiers = modifiersToPayload(toHitCalc.modifiers);
+      const declaredModifiers =
+        indirectFirePenalty > 0
+          ? [
+              ...baseModifiers,
+              {
+                name: 'Indirect fire',
+                value: indirectFirePenalty,
+                source: 'other' as const,
+              },
+            ]
+          : baseModifiers;
       events.push(
         createGameEvent(
           gameId,
@@ -266,8 +304,8 @@ export function runAttackPhase(options: {
             attackerId: unitId,
             targetId,
             weapons: [weaponId],
-            toHitNumber: toHitCalc.finalToHit,
-            modifiers: modifiersToPayload(toHitCalc.modifiers),
+            toHitNumber: adjustedToHit,
+            modifiers: declaredModifiers,
             range: bracketToPayloadRange(rangeBracket),
             firingArc,
           },
@@ -275,10 +313,62 @@ export function runAttackPhase(options: {
         ),
       );
 
+      // Wave 8 PR-K7: emit IndirectFireSpotterSelected (basis='los') or
+      // IndirectFireNarcOverride immediately after AttackDeclared when
+      // indirect fire is in effect — mirrors PR-K4's declareAttack
+      // dispatch so the event log + downstream consumers see the same
+      // sequence regardless of which pipeline ran.
+      if (
+        indirectFireResolution &&
+        indirectFireResolution.permitted &&
+        indirectFireResolution.isIndirect
+      ) {
+        const basis = indirectFireResolution.basis;
+        if (basis === 'narc' || basis === 'inarc') {
+          events.push(
+            createGameEvent(
+              gameId,
+              events.length,
+              GameEventType.IndirectFireNarcOverride,
+              currentState.turn,
+              GamePhase.WeaponAttack,
+              {
+                attackerId: unitId,
+                spotterId: null,
+                weaponId,
+                targetHex: targetNow.position,
+                toHitPenalty: indirectFirePenalty,
+                basis,
+              },
+              unitId,
+            ),
+          );
+        } else if (indirectFireResolution.spotterId) {
+          events.push(
+            createGameEvent(
+              gameId,
+              events.length,
+              GameEventType.IndirectFireSpotterSelected,
+              currentState.turn,
+              GamePhase.WeaponAttack,
+              {
+                attackerId: unitId,
+                spotterId: indirectFireResolution.spotterId,
+                weaponId,
+                targetHex: targetNow.position,
+                toHitPenalty: indirectFirePenalty,
+                basis: 'los' as const,
+              },
+              unitId,
+            ),
+          );
+        }
+      }
+
       const die1 = d6Roller();
       const die2 = d6Roller();
       const attackRoll = die1 + die2;
-      const hit = attackRoll >= toHitCalc.finalToHit;
+      const hit = attackRoll >= adjustedToHit;
 
       if (!hit) {
         // Per `combat-resolution` delta: emit `AttackResolved` even on
@@ -297,7 +387,9 @@ export function runAttackPhase(options: {
               targetId,
               weaponId,
               roll: attackRoll,
-              toHitNumber: toHitCalc.finalToHit,
+              // Wave 8 PR-K7: `toHitNumber` matches AttackDeclared so the
+              // event-log + invariant pairs line up under indirect-fire.
+              toHitNumber: adjustedToHit,
               hit: false,
               heat: weapon.heat,
               attackerArc: firingArc,
@@ -317,7 +409,9 @@ export function runAttackPhase(options: {
         weaponId,
         weapon,
         attackRoll,
-        toHitNumber: toHitCalc.finalToHit,
+        // Wave 8 PR-K7: use the indirect-fire-adjusted to-hit so the
+        // AttackResolved.toHitNumber on hits matches AttackDeclared.
+        toHitNumber: adjustedToHit,
         firingArc,
         partialCover: targetPartialCover,
         d6Roller,


### PR DESCRIPTION
## PR-K7 — Quick-Sim Indirect-Fire Dispatch

Closes the final indirect-fire dispatch gap. PR-K + PR-K4 + PR-K5 + PR-K6 wired the interactive path (`declareAttack` via `applyInteractiveSessionAttack`) and the bot AI path (`runAttackPhase`). PR-K7 wires the **Quick-Sim parallel pipeline** at `src/simulation/runner/phases/weaponAttack.ts` — which hand-rolls `AttackDeclared` / `AttackResolved` from `calculateToHit` directly and never goes through `declareAttack`.

## What ships

After `calculateToHit` + before `AttackDeclared` emission:
- When `grid` is supplied, call `computeIndirectFireContext(unitId, weaponId, targetNow.position, currentState, grid)`
- If permitted+isIndirect, append `'Indirect fire'` modifier to the payload modifiers list AND add toHitPenalty to `AttackDeclared.toHitNumber`
- After `AttackDeclared`, emit `IndirectFireSpotterSelected` (basis='los') OR `IndirectFireNarcOverride` (basis='narc'/'inarc') matching PR-K4's declareAttack dispatch — same event sequence regardless of which pipeline ran
- `AttackResolved.toHitNumber` uses the adjusted value so the event-log + AttackDeclared/AttackResolved invariant pair under indirect fire

Mass-scale BV-balance Monte Carlo runs now reflect indirect-fire to-hit math when LRMs fire against units the attacker has no LOS to.

## Tests (3)

`src/simulation/runner/__tests__/weaponAttackIndirectFire.test.ts`:
- POSITIVE: heavy-woods + spotter at q=10,r=1 → `Indirect fire` modifier + `IndirectFireSpotterSelected` with basis='los'
- BACKWARD-COMPAT: no grid passed → no indirect events emitted
- DIRECT-LOS: clear grid → no indirect events (LRM uses direct fire)

## Verification

- `npx tsc --noEmit` → clean
- `npx jest src/simulation` → **2970/2970 pass / 194 suites** (no regression)
- 3 new PR-K7 tests pass
- `npx openspec validate add-indirect-fire-and-spotter-network --strict` → valid

## Indirect-fire pipeline now COMPLETE across all 3 dispatch paths

| Pipeline | PR |
|---|---|
| Interactive (declareAttack via applyInteractiveSessionAttack) | PR-K5 #671 |
| Bot AI tactical loop (runAttackPhase) | PR-K5 #671 |
| **Quick-Sim parallel pipeline** | **PR-K7 (this PR)** |

Plus PR-K (#666) engine method, PR-K2 (#668) FO SPA, PR-K3 (#669) NARC/iNarc override, PR-K4 (#670) declareAttack dispatch, PR-K6 (#672) spotter-liveness re-check.