### PR TITLE
feat(wave-8): spotter rendering on map (PR-K8 — G1)

### DIFF
--- a/src/components/gameplay/TacticalCommandShell/TacticalCommandShell.tsx
+++ b/src/components/gameplay/TacticalCommandShell/TacticalCommandShell.tsx
@@ -235,7 +235,13 @@ export function TacticalCommandShell({
 
   useEffect(() => {
     if (!session) return;
-    const events = session.events;
+    // Some test fixtures and early-mount paths construct a session
+    // without an `events` array. Coerce to [] so the rollover branch
+    // still runs and the walk safely bails. Without this guard the
+    // `events.length` read at the early-return crashes consumers that
+    // wrap the shell with a minimal session (e.g.
+    // `useActivationFocusRequest.test.tsx`).
+    const events = session.events ?? [];
     const currentTurn = session.currentState?.turn ?? null;
 
     // Turn rollover → clear elected spotters.

--- a/src/components/gameplay/TacticalCommandShell/TacticalCommandShell.tsx
+++ b/src/components/gameplay/TacticalCommandShell/TacticalCommandShell.tsx
@@ -28,8 +28,11 @@ import {
   type ReactNode,
 } from 'react';
 
+import { useGameplayStore } from '@/stores/useGameplayStore';
+import { GameEventType } from '@/types/gameplay/GameSessionCoreTypes';
 import {
   createDefaultShellState,
+  type IElectedSpotter,
   type ITacticalShellState,
   type PlayerId,
   type ShellMode,
@@ -221,6 +224,72 @@ export function TacticalCommandShell({
   const updateState = useCallback((partial: Partial<ITacticalShellState>) => {
     setState((prev) => ({ ...prev, ...partial }));
   }, []);
+
+  // Wave 8 PR-K8 — G1: subscribe to IndirectFireSpotterSelected /
+  // IndirectFireSpotterLost events from the gameplay store and project
+  // them into `electedSpotters` for token-ring / inspector consumption.
+  // Cleared on turn rollover so stale spotter visuals don't persist.
+  const session = useGameplayStore((s) => s.session);
+  const lastProcessedEventIndex = useRef<number>(0);
+  const lastSeenTurn = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!session) return;
+    const events = session.events;
+    const currentTurn = session.currentState?.turn ?? null;
+
+    // Turn rollover → clear elected spotters.
+    if (
+      lastSeenTurn.current !== null &&
+      currentTurn !== null &&
+      currentTurn !== lastSeenTurn.current
+    ) {
+      setState((prev) =>
+        prev.electedSpotters.length === 0
+          ? prev
+          : { ...prev, electedSpotters: [] },
+      );
+    }
+    lastSeenTurn.current = currentTurn;
+
+    // Walk new events since last process. Process Selected/Lost in order.
+    const startIdx = lastProcessedEventIndex.current;
+    if (startIdx >= events.length) return;
+
+    let nextSpotters: IElectedSpotter[] | null = null;
+    for (let i = startIdx; i < events.length; i++) {
+      const evt = events[i];
+      if (evt.type === GameEventType.IndirectFireSpotterSelected) {
+        const p = evt.payload as {
+          attackerId: string;
+          spotterId: string;
+        };
+        if (!nextSpotters) nextSpotters = [...state.electedSpotters];
+        // Idempotent: skip if pair already present.
+        const exists = nextSpotters.some(
+          (s) => s.spotterId === p.spotterId && s.attackerId === p.attackerId,
+        );
+        if (!exists) {
+          nextSpotters.push({
+            spotterId: p.spotterId,
+            attackerId: p.attackerId,
+          });
+        }
+      } else if (evt.type === GameEventType.IndirectFireSpotterLost) {
+        const p = evt.payload as { attackerId: string; spotterId: string };
+        if (!nextSpotters) nextSpotters = [...state.electedSpotters];
+        nextSpotters = nextSpotters.filter(
+          (s) =>
+            !(s.spotterId === p.spotterId && s.attackerId === p.attackerId),
+        );
+      }
+    }
+    lastProcessedEventIndex.current = events.length;
+
+    if (nextSpotters !== null) {
+      setState((prev) => ({ ...prev, electedSpotters: nextSpotters! }));
+    }
+  }, [session, state.electedSpotters]);
 
   // Memoize context value so consumers don't churn re-renders when no
   // shell-relevant prop changed. The state object identity changes on

--- a/src/components/gameplay/TacticalCommandShell/TacticalCommandShell.tsx
+++ b/src/components/gameplay/TacticalCommandShell/TacticalCommandShell.tsx
@@ -335,3 +335,19 @@ export function useTacticalShell(): ITacticalShellContext {
 export function useShellSlotRegistryContext(): IShellSlotRegistry {
   return useTacticalShell().registry;
 }
+
+/**
+ * Non-throwing accessor for elected-spotter state (PR-K8 — G1).
+ *
+ * Unlike `useTacticalShell()`, this hook returns an empty array when
+ * called outside a `<TacticalCommandShell>` — used by token / inspector
+ * components that may also render in storybook / standalone test
+ * contexts where wrapping the whole shell would be over-scaffolding.
+ *
+ * Inside a shell, returns the live `electedSpotters` list (event-driven
+ * projection of `IndirectFireSpotterSelected` / `IndirectFireSpotterLost`).
+ */
+export function useElectedSpotters(): readonly IElectedSpotter[] {
+  const ctx = useContext(ShellContext);
+  return ctx?.state.electedSpotters ?? [];
+}

--- a/src/components/gameplay/TacticalCommandShell/__tests__/TacticalCommandShell.spotter.test.tsx
+++ b/src/components/gameplay/TacticalCommandShell/__tests__/TacticalCommandShell.spotter.test.tsx
@@ -1,0 +1,259 @@
+/**
+ * Tests for TacticalCommandShell elected-spotter state (PR-K8 §1+§1.5).
+ *
+ * Verifies the event-driven projection of IndirectFireSpotterSelected /
+ * IndirectFireSpotterLost into `state.electedSpotters`:
+ *   - Selected event → spotter pair appended
+ *   - Lost event → matching pair removed
+ *   - Turn rollover → list cleared
+ *   - Idempotent: same Selected event twice doesn't double-add
+ */
+
+import { act, renderHook } from '@testing-library/react';
+
+import { useGameplayStore } from '@/stores/useGameplayStore';
+import {
+  GameEventType,
+  GamePhase,
+  type IGameEvent,
+  type IGameSession,
+} from '@/types/gameplay';
+
+import { TacticalCommandShell, useTacticalShell } from '../index';
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+function buildEvent(
+  type: GameEventType,
+  sequence: number,
+  payload: Record<string, unknown>,
+  turn = 1,
+): IGameEvent {
+  return {
+    id: `evt-${sequence}`,
+    sequence,
+    timestamp: new Date('2026-05-21T00:00:00Z').toISOString(),
+    type,
+    turn,
+    phase: GamePhase.WeaponAttack,
+    actorUnitId: payload.attackerId as string | undefined,
+    payload,
+  } as unknown as IGameEvent;
+}
+
+function buildSession(events: readonly IGameEvent[], turn = 1): IGameSession {
+  return {
+    id: 'test-session',
+    events: [...events],
+    currentState: {
+      turn,
+      phase: GamePhase.WeaponAttack,
+      units: {},
+    },
+    units: [],
+  } as unknown as IGameSession;
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('TacticalCommandShell — electedSpotters (PR-K8)', () => {
+  afterEach(() => {
+    useGameplayStore.setState({ session: null });
+  });
+
+  it('seeds an empty electedSpotters list by default', () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <TacticalCommandShell viewerPlayerId="p1" shellMode="combat">
+        {children}
+      </TacticalCommandShell>
+    );
+    const { result } = renderHook(() => useTacticalShell(), { wrapper });
+    expect(result.current.state.electedSpotters).toEqual([]);
+  });
+
+  it('projects IndirectFireSpotterSelected into electedSpotters', () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <TacticalCommandShell viewerPlayerId="p1" shellMode="combat">
+        {children}
+      </TacticalCommandShell>
+    );
+    const { result, rerender } = renderHook(() => useTacticalShell(), {
+      wrapper,
+    });
+
+    act(() => {
+      useGameplayStore.setState({
+        session: buildSession([
+          buildEvent(GameEventType.IndirectFireSpotterSelected, 0, {
+            attackerId: 'a1',
+            spotterId: 's1',
+            weaponId: 'lrm-15-1',
+            basis: 'los',
+            toHitPenalty: 1,
+            targetHex: { q: 5, r: 0 },
+          }),
+        ]),
+      });
+    });
+    rerender();
+
+    expect(result.current.state.electedSpotters).toEqual([
+      { spotterId: 's1', attackerId: 'a1' },
+    ]);
+  });
+
+  it('removes pair on IndirectFireSpotterLost', () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <TacticalCommandShell viewerPlayerId="p1" shellMode="combat">
+        {children}
+      </TacticalCommandShell>
+    );
+    const { result, rerender } = renderHook(() => useTacticalShell(), {
+      wrapper,
+    });
+
+    act(() => {
+      useGameplayStore.setState({
+        session: buildSession([
+          buildEvent(GameEventType.IndirectFireSpotterSelected, 0, {
+            attackerId: 'a1',
+            spotterId: 's1',
+            weaponId: 'lrm-15-1',
+            basis: 'los',
+            toHitPenalty: 1,
+            targetHex: { q: 5, r: 0 },
+          }),
+        ]),
+      });
+    });
+    rerender();
+    expect(result.current.state.electedSpotters.length).toBe(1);
+
+    act(() => {
+      useGameplayStore.setState({
+        session: buildSession([
+          buildEvent(GameEventType.IndirectFireSpotterSelected, 0, {
+            attackerId: 'a1',
+            spotterId: 's1',
+            weaponId: 'lrm-15-1',
+            basis: 'los',
+            toHitPenalty: 1,
+            targetHex: { q: 5, r: 0 },
+          }),
+          buildEvent(GameEventType.IndirectFireSpotterLost, 1, {
+            attackerId: 'a1',
+            spotterId: 's1',
+            weaponId: 'lrm-15-1',
+            basis: 'los',
+            toHitPenalty: 0,
+            targetHex: { q: 5, r: 0 },
+            reason: 'Spotter destroyed before resolution',
+          }),
+        ]),
+      });
+    });
+    rerender();
+
+    expect(result.current.state.electedSpotters).toEqual([]);
+  });
+
+  it('clears electedSpotters on turn rollover', () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <TacticalCommandShell viewerPlayerId="p1" shellMode="combat">
+        {children}
+      </TacticalCommandShell>
+    );
+    const { result, rerender } = renderHook(() => useTacticalShell(), {
+      wrapper,
+    });
+
+    act(() => {
+      useGameplayStore.setState({
+        session: buildSession(
+          [
+            buildEvent(
+              GameEventType.IndirectFireSpotterSelected,
+              0,
+              {
+                attackerId: 'a1',
+                spotterId: 's1',
+                weaponId: 'lrm-15-1',
+                basis: 'los',
+                toHitPenalty: 1,
+                targetHex: { q: 5, r: 0 },
+              },
+              1,
+            ),
+          ],
+          1,
+        ),
+      });
+    });
+    rerender();
+    expect(result.current.state.electedSpotters.length).toBe(1);
+
+    // Advance turn — list clears
+    act(() => {
+      useGameplayStore.setState({
+        session: buildSession(
+          [
+            buildEvent(
+              GameEventType.IndirectFireSpotterSelected,
+              0,
+              {
+                attackerId: 'a1',
+                spotterId: 's1',
+                weaponId: 'lrm-15-1',
+                basis: 'los',
+                toHitPenalty: 1,
+                targetHex: { q: 5, r: 0 },
+              },
+              1,
+            ),
+          ],
+          2, // turn advanced
+        ),
+      });
+    });
+    rerender();
+
+    expect(result.current.state.electedSpotters).toEqual([]);
+  });
+
+  it('is idempotent — same Selected event twice does not double-add', () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <TacticalCommandShell viewerPlayerId="p1" shellMode="combat">
+        {children}
+      </TacticalCommandShell>
+    );
+    const { result, rerender } = renderHook(() => useTacticalShell(), {
+      wrapper,
+    });
+
+    const event = buildEvent(GameEventType.IndirectFireSpotterSelected, 0, {
+      attackerId: 'a1',
+      spotterId: 's1',
+      weaponId: 'lrm-15-1',
+      basis: 'los',
+      toHitPenalty: 1,
+      targetHex: { q: 5, r: 0 },
+    });
+
+    act(() => {
+      useGameplayStore.setState({ session: buildSession([event]) });
+    });
+    rerender();
+    expect(result.current.state.electedSpotters.length).toBe(1);
+
+    // Re-trigger with the same event (e.g., shell re-mounts) — list stays length 1
+    act(() => {
+      useGameplayStore.setState({ session: buildSession([event]) });
+    });
+    rerender();
+    expect(result.current.state.electedSpotters.length).toBe(1);
+  });
+});

--- a/src/components/gameplay/TacticalCommandShell/index.ts
+++ b/src/components/gameplay/TacticalCommandShell/index.ts
@@ -16,6 +16,7 @@ export {
   TacticalCommandShell,
   useTacticalShell,
   useShellSlotRegistryContext,
+  useElectedSpotters,
   type ITacticalShellContext,
   type TacticalCommandShellProps,
 } from './TacticalCommandShell';

--- a/src/components/gameplay/TacticalUnitInspector/TacticalUnitInspector.tsx
+++ b/src/components/gameplay/TacticalUnitInspector/TacticalUnitInspector.tsx
@@ -19,22 +19,21 @@
  * @see openspec/changes/add-tactical-unit-inspector-drawers/tasks.md §2.1
  */
 
-import React from "react";
+import React from 'react';
 
-import type { GameSide } from "@/types/gameplay";
-import type { IGameSession } from "@/types/gameplay";
-import type { IWeaponStatus } from "@/types/gameplay";
-import type { IInspectorProjection } from "@/types/gameplay/TacticalInspectorInterfaces";
+import type { GameSide } from '@/types/gameplay';
+import type { IGameSession } from '@/types/gameplay';
+import type { IInspectorProjection } from '@/types/gameplay/TacticalInspectorInterfaces';
 import type {
   OpponentIntelTier,
   PlayerId,
-} from "@/types/gameplay/TacticalShellInterfaces";
+} from '@/types/gameplay/TacticalShellInterfaces';
 
+import { useElectedSpotters } from '@/components/gameplay/TacticalCommandShell';
 import {
   useUnitInspectorProjection,
   type IInspectorSupplementalData,
-} from "@/hooks/gameplay/useUnitInspectorProjection";
-import { useTacticalShell } from "@/components/gameplay/TacticalCommandShell";
+} from '@/hooks/gameplay/useUnitInspectorProjection';
 
 // =============================================================================
 // Props
@@ -77,13 +76,13 @@ export interface TacticalUnitInspectorProps {
 function FriendlyView({
   projection,
 }: {
-  projection: Extract<IInspectorProjection, { kind: "friendly" }>;
+  projection: Extract<IInspectorProjection, { kind: 'friendly' }>;
 }): React.ReactElement {
   const pilotStatusColor = !projection.pilotConscious
-    ? "text-red-600"
+    ? 'text-red-600'
     : projection.pilotWounds >= 3
-      ? "text-amber-600"
-      : "text-gray-700";
+      ? 'text-amber-600'
+      : 'text-gray-700';
 
   // Wave 8 PR-K8 — G1: render a "Spotting for: {attackerId}" badge when
   // the inspected unit is currently an elected LOS spotter. Pulls from
@@ -91,13 +90,9 @@ function FriendlyView({
   // subscription in TacticalCommandShell). Only shown for friendly
   // inspectors — opponent unit's spotting role for ITS team is hidden
   // from the player by the fog-of-war contract.
-  const shellSpotters = (() => {
-    try {
-      return useTacticalShell().state.electedSpotters;
-    } catch {
-      return [];
-    }
-  })();
+  // useElectedSpotters returns [] when no TacticalCommandShell is in the
+  // ancestry — inspector degrades to no-badge in standalone test contexts.
+  const shellSpotters = useElectedSpotters();
   const spotterEntry = shellSpotters.find(
     (s) => s.spotterId === projection.unitId,
   );
@@ -148,7 +143,7 @@ function FriendlyView({
             className={pilotStatusColor}
             data-testid="inspector-pilot-wounds"
           >
-            {projection.pilotConscious ? `${projection.pilotWounds}/5` : "KIA"}
+            {projection.pilotConscious ? `${projection.pilotWounds}/5` : 'KIA'}
           </span>
         </div>
       )}
@@ -159,10 +154,10 @@ function FriendlyView({
         <span
           className={
             projection.heat >= 20
-              ? "font-semibold text-red-600"
+              ? 'font-semibold text-red-600'
               : projection.heat >= 10
-                ? "font-medium text-amber-600"
-                : "text-gray-800"
+                ? 'font-medium text-amber-600'
+                : 'text-gray-800'
           }
           data-testid="inspector-heat"
         >
@@ -239,7 +234,7 @@ function FriendlyView({
         <span className="text-gray-600">Movement</span>
         <span className="text-gray-800" data-testid="inspector-movement">
           {projection.movementThisTurn} ({projection.hexesMoved} hex
-          {projection.hexesMoved !== 1 ? "es" : ""})
+          {projection.hexesMoved !== 1 ? 'es' : ''})
         </span>
       </div>
 
@@ -250,10 +245,10 @@ function FriendlyView({
           {projection.weapons.map((w) => (
             <div
               key={w.weaponId}
-              className={`flex items-center justify-between text-xs ${w.disabled ? "opacity-50" : ""}`}
+              className={`flex items-center justify-between text-xs ${w.disabled ? 'opacity-50' : ''}`}
               data-testid={`inspector-weapon-${w.weaponId}`}
             >
-              <span className={w.disabled ? "line-through" : ""}>
+              <span className={w.disabled ? 'line-through' : ''}>
                 {w.displayName}
               </span>
               {w.disabledReason && (
@@ -274,21 +269,21 @@ function FriendlyView({
 function TargetView({
   projection,
 }: {
-  projection: Extract<IInspectorProjection, { kind: "target" }>;
+  projection: Extract<IInspectorProjection, { kind: 'target' }>;
 }): React.ReactElement {
   const bandLabel: Record<string, string> = {
-    pristine: "Pristine",
-    "lightly-damaged": "Lightly Damaged",
-    "moderately-damaged": "Moderately Damaged",
-    "heavily-damaged": "Heavily Damaged",
-    crippled: "Crippled",
+    pristine: 'Pristine',
+    'lightly-damaged': 'Lightly Damaged',
+    'moderately-damaged': 'Moderately Damaged',
+    'heavily-damaged': 'Heavily Damaged',
+    crippled: 'Crippled',
   };
   const bandColor: Record<string, string> = {
-    pristine: "text-green-600",
-    "lightly-damaged": "text-green-700",
-    "moderately-damaged": "text-amber-600",
-    "heavily-damaged": "text-orange-600",
-    crippled: "text-red-600",
+    pristine: 'text-green-600',
+    'lightly-damaged': 'text-green-700',
+    'moderately-damaged': 'text-amber-600',
+    'heavily-damaged': 'text-orange-600',
+    crippled: 'text-red-600',
   };
 
   return (
@@ -318,7 +313,7 @@ function TargetView({
       <div className="flex items-center justify-between text-xs">
         <span className="text-gray-600">Damage</span>
         <span
-          className={`font-medium ${bandColor[projection.damageBand] ?? "text-gray-800"}`}
+          className={`font-medium ${bandColor[projection.damageBand] ?? 'text-gray-800'}`}
           data-testid="inspector-damage-band"
         >
           {bandLabel[projection.damageBand] ?? projection.damageBand}
@@ -333,10 +328,10 @@ function TargetView({
             <span
               className={
                 (projection.heat ?? 0) >= 20
-                  ? "font-semibold text-red-600"
+                  ? 'font-semibold text-red-600'
                   : (projection.heat ?? 0) >= 10
-                    ? "font-medium text-amber-600"
-                    : "text-gray-800"
+                    ? 'font-medium text-amber-600'
+                    : 'text-gray-800'
               }
               data-testid="inspector-heat"
             >
@@ -423,7 +418,7 @@ export function TacticalUnitInspector({
   viewerSide,
   opponentVisibilityScopes,
   supplemental,
-  className = "",
+  className = '',
 }: TacticalUnitInspectorProps): React.ReactElement {
   const projection = useUnitInspectorProjection({
     unitId: inspectedUnitId,
@@ -450,11 +445,11 @@ export function TacticalUnitInspector({
       className={`h-full overflow-y-auto bg-white ${className}`}
       data-testid="tactical-unit-inspector"
     >
-      {projection.kind === "friendly" && (
+      {projection.kind === 'friendly' && (
         <FriendlyView projection={projection} />
       )}
-      {projection.kind === "target" && <TargetView projection={projection} />}
-      {projection.kind === "redacted" && <RedactedView />}
+      {projection.kind === 'target' && <TargetView projection={projection} />}
+      {projection.kind === 'redacted' && <RedactedView />}
     </div>
   );
 }

--- a/src/components/gameplay/TacticalUnitInspector/TacticalUnitInspector.tsx
+++ b/src/components/gameplay/TacticalUnitInspector/TacticalUnitInspector.tsx
@@ -19,21 +19,22 @@
  * @see openspec/changes/add-tactical-unit-inspector-drawers/tasks.md §2.1
  */
 
-import React from 'react';
+import React from "react";
 
-import type { GameSide } from '@/types/gameplay';
-import type { IGameSession } from '@/types/gameplay';
-import type { IWeaponStatus } from '@/types/gameplay';
-import type { IInspectorProjection } from '@/types/gameplay/TacticalInspectorInterfaces';
+import type { GameSide } from "@/types/gameplay";
+import type { IGameSession } from "@/types/gameplay";
+import type { IWeaponStatus } from "@/types/gameplay";
+import type { IInspectorProjection } from "@/types/gameplay/TacticalInspectorInterfaces";
 import type {
   OpponentIntelTier,
   PlayerId,
-} from '@/types/gameplay/TacticalShellInterfaces';
+} from "@/types/gameplay/TacticalShellInterfaces";
 
 import {
   useUnitInspectorProjection,
   type IInspectorSupplementalData,
-} from '@/hooks/gameplay/useUnitInspectorProjection';
+} from "@/hooks/gameplay/useUnitInspectorProjection";
+import { useTacticalShell } from "@/components/gameplay/TacticalCommandShell";
 
 // =============================================================================
 // Props
@@ -76,13 +77,30 @@ export interface TacticalUnitInspectorProps {
 function FriendlyView({
   projection,
 }: {
-  projection: Extract<IInspectorProjection, { kind: 'friendly' }>;
+  projection: Extract<IInspectorProjection, { kind: "friendly" }>;
 }): React.ReactElement {
   const pilotStatusColor = !projection.pilotConscious
-    ? 'text-red-600'
+    ? "text-red-600"
     : projection.pilotWounds >= 3
-      ? 'text-amber-600'
-      : 'text-gray-700';
+      ? "text-amber-600"
+      : "text-gray-700";
+
+  // Wave 8 PR-K8 — G1: render a "Spotting for: {attackerId}" badge when
+  // the inspected unit is currently an elected LOS spotter. Pulls from
+  // the shell context's electedSpotters list (populated by event
+  // subscription in TacticalCommandShell). Only shown for friendly
+  // inspectors — opponent unit's spotting role for ITS team is hidden
+  // from the player by the fog-of-war contract.
+  const shellSpotters = (() => {
+    try {
+      return useTacticalShell().state.electedSpotters;
+    } catch {
+      return [];
+    }
+  })();
+  const spotterEntry = shellSpotters.find(
+    (s) => s.spotterId === projection.unitId,
+  );
 
   return (
     <div className="flex flex-col gap-2 p-3" data-testid="inspector-friendly">
@@ -97,6 +115,14 @@ function FriendlyView({
         <div className="text-xs text-gray-500" data-testid="inspector-chassis">
           {projection.chassis}
         </div>
+        {spotterEntry && (
+          <div
+            className="mt-1 inline-block rounded bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800"
+            data-testid="inspector-spotting-badge"
+          >
+            Spotting for: {spotterEntry.attackerId}
+          </div>
+        )}
       </div>
 
       {/* Pilot */}
@@ -122,7 +148,7 @@ function FriendlyView({
             className={pilotStatusColor}
             data-testid="inspector-pilot-wounds"
           >
-            {projection.pilotConscious ? `${projection.pilotWounds}/5` : 'KIA'}
+            {projection.pilotConscious ? `${projection.pilotWounds}/5` : "KIA"}
           </span>
         </div>
       )}
@@ -133,10 +159,10 @@ function FriendlyView({
         <span
           className={
             projection.heat >= 20
-              ? 'font-semibold text-red-600'
+              ? "font-semibold text-red-600"
               : projection.heat >= 10
-                ? 'font-medium text-amber-600'
-                : 'text-gray-800'
+                ? "font-medium text-amber-600"
+                : "text-gray-800"
           }
           data-testid="inspector-heat"
         >
@@ -213,7 +239,7 @@ function FriendlyView({
         <span className="text-gray-600">Movement</span>
         <span className="text-gray-800" data-testid="inspector-movement">
           {projection.movementThisTurn} ({projection.hexesMoved} hex
-          {projection.hexesMoved !== 1 ? 'es' : ''})
+          {projection.hexesMoved !== 1 ? "es" : ""})
         </span>
       </div>
 
@@ -224,10 +250,10 @@ function FriendlyView({
           {projection.weapons.map((w) => (
             <div
               key={w.weaponId}
-              className={`flex items-center justify-between text-xs ${w.disabled ? 'opacity-50' : ''}`}
+              className={`flex items-center justify-between text-xs ${w.disabled ? "opacity-50" : ""}`}
               data-testid={`inspector-weapon-${w.weaponId}`}
             >
-              <span className={w.disabled ? 'line-through' : ''}>
+              <span className={w.disabled ? "line-through" : ""}>
                 {w.displayName}
               </span>
               {w.disabledReason && (
@@ -248,21 +274,21 @@ function FriendlyView({
 function TargetView({
   projection,
 }: {
-  projection: Extract<IInspectorProjection, { kind: 'target' }>;
+  projection: Extract<IInspectorProjection, { kind: "target" }>;
 }): React.ReactElement {
   const bandLabel: Record<string, string> = {
-    pristine: 'Pristine',
-    'lightly-damaged': 'Lightly Damaged',
-    'moderately-damaged': 'Moderately Damaged',
-    'heavily-damaged': 'Heavily Damaged',
-    crippled: 'Crippled',
+    pristine: "Pristine",
+    "lightly-damaged": "Lightly Damaged",
+    "moderately-damaged": "Moderately Damaged",
+    "heavily-damaged": "Heavily Damaged",
+    crippled: "Crippled",
   };
   const bandColor: Record<string, string> = {
-    pristine: 'text-green-600',
-    'lightly-damaged': 'text-green-700',
-    'moderately-damaged': 'text-amber-600',
-    'heavily-damaged': 'text-orange-600',
-    crippled: 'text-red-600',
+    pristine: "text-green-600",
+    "lightly-damaged": "text-green-700",
+    "moderately-damaged": "text-amber-600",
+    "heavily-damaged": "text-orange-600",
+    crippled: "text-red-600",
   };
 
   return (
@@ -292,7 +318,7 @@ function TargetView({
       <div className="flex items-center justify-between text-xs">
         <span className="text-gray-600">Damage</span>
         <span
-          className={`font-medium ${bandColor[projection.damageBand] ?? 'text-gray-800'}`}
+          className={`font-medium ${bandColor[projection.damageBand] ?? "text-gray-800"}`}
           data-testid="inspector-damage-band"
         >
           {bandLabel[projection.damageBand] ?? projection.damageBand}
@@ -307,10 +333,10 @@ function TargetView({
             <span
               className={
                 (projection.heat ?? 0) >= 20
-                  ? 'font-semibold text-red-600'
+                  ? "font-semibold text-red-600"
                   : (projection.heat ?? 0) >= 10
-                    ? 'font-medium text-amber-600'
-                    : 'text-gray-800'
+                    ? "font-medium text-amber-600"
+                    : "text-gray-800"
               }
               data-testid="inspector-heat"
             >
@@ -397,7 +423,7 @@ export function TacticalUnitInspector({
   viewerSide,
   opponentVisibilityScopes,
   supplemental,
-  className = '',
+  className = "",
 }: TacticalUnitInspectorProps): React.ReactElement {
   const projection = useUnitInspectorProjection({
     unitId: inspectedUnitId,
@@ -424,11 +450,11 @@ export function TacticalUnitInspector({
       className={`h-full overflow-y-auto bg-white ${className}`}
       data-testid="tactical-unit-inspector"
     >
-      {projection.kind === 'friendly' && (
+      {projection.kind === "friendly" && (
         <FriendlyView projection={projection} />
       )}
-      {projection.kind === 'target' && <TargetView projection={projection} />}
-      {projection.kind === 'redacted' && <RedactedView />}
+      {projection.kind === "target" && <TargetView projection={projection} />}
+      {projection.kind === "redacted" && <RedactedView />}
     </div>
   );
 }

--- a/src/components/gameplay/UnitToken/UnitTokenForType.tsx
+++ b/src/components/gameplay/UnitToken/UnitTokenForType.tsx
@@ -15,31 +15,32 @@
  *        §Per-Type Token Rendering — dispatcher routes to correct renderer
  */
 
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo } from "react";
 
-import type { TacticalAnimation } from '@/stores/useAnimationQueue';
-import type { IGameEvent, IUnitToken } from '@/types/gameplay';
+import type { TacticalAnimation } from "@/stores/useAnimationQueue";
+import type { IGameEvent, IUnitToken } from "@/types/gameplay";
 
-import { useMovementTween } from '@/components/gameplay/animation/useMovementTween';
-import { hexToPixel } from '@/components/gameplay/HexMapDisplay/renderHelpers';
-import { useAnimationQueue } from '@/stores/useAnimationQueue';
-import { MovementType, TokenUnitType } from '@/types/gameplay';
+import { useMovementTween } from "@/components/gameplay/animation/useMovementTween";
+import { hexToPixel } from "@/components/gameplay/HexMapDisplay/renderHelpers";
+import { useTacticalShell } from "@/components/gameplay/TacticalCommandShell";
+import { useAnimationQueue } from "@/stores/useAnimationQueue";
+import { MovementType, TokenUnitType } from "@/types/gameplay";
 
-import { AerospaceToken } from './AerospaceToken';
-import { BattleArmorToken } from './BattleArmorToken';
-import { InfantryToken } from './InfantryToken';
-import { MechToken } from './MechToken';
-import { ProtoMechToken } from './ProtoMechToken';
+import { AerospaceToken } from "./AerospaceToken";
+import { BattleArmorToken } from "./BattleArmorToken";
+import { InfantryToken } from "./InfantryToken";
+import { MechToken } from "./MechToken";
+import { ProtoMechToken } from "./ProtoMechToken";
 import {
   renderFogMarker,
   renderJumpArc,
   TokenVisualEffects,
-} from './UnitTokenForType.effects';
+} from "./UnitTokenForType.effects";
 import {
   projectEvents,
   projectThermalVisualState,
-} from './UnitTokenForType.projectors';
-import { VehicleToken } from './VehicleToken';
+} from "./UnitTokenForType.projectors";
+import { VehicleToken } from "./VehicleToken";
 
 // =============================================================================
 // Props
@@ -72,6 +73,15 @@ export interface UnitTokenForTypeProps {
 }
 
 // =============================================================================
+// Constants
+// =============================================================================
+
+/** Radius of the spotter-ring overlay drawn around units currently elected
+ *  as LOS spotters for indirect fire. Tuned to fit just outside the typical
+ *  token chrome at the standard `HEX_SIZE = 25` rendering scale. */
+const HEX_SPOTTER_RING_RADIUS = 22;
+
+// =============================================================================
 // Dispatcher Component
 // =============================================================================
 
@@ -97,7 +107,7 @@ export const UnitTokenForType = React.memo(function UnitTokenForType({
       movementAnimation?.path && movementAnimation.path.length > 0
         ? movementAnimation.path
         : [
-            token.fogStatus === 'lastKnown' && token.lastKnownPosition
+            token.fogStatus === "lastKnown" && token.lastKnownPosition
               ? token.lastKnownPosition
               : token.position,
           ],
@@ -151,7 +161,7 @@ export const UnitTokenForType = React.memo(function UnitTokenForType({
             onClick(token.unitId);
           }}
           onDoubleClick={handleDoubleClick}
-          style={{ cursor: 'pointer' }}
+          style={{ cursor: "pointer" }}
           data-testid={`unit-token-${token.unitId}`}
         >
           <BattleArmorToken
@@ -166,15 +176,15 @@ export const UnitTokenForType = React.memo(function UnitTokenForType({
   }
 
   const displayPosition =
-    token.fogStatus === 'lastKnown' && token.lastKnownPosition
+    token.fogStatus === "lastKnown" && token.lastKnownPosition
       ? token.lastKnownPosition
       : token.position;
   const { x, y } = movementAnimation
     ? { x: tween.x, y: tween.y }
     : hexToPixel(displayPosition);
   const fogDisplayFields =
-    token.fogStatus === 'hidden'
-      ? { designation: '?', name: 'Hidden contact' }
+    token.fogStatus === "hidden"
+      ? { designation: "?", name: "Hidden contact" }
       : {};
   // Build the render-time token. The spread preserves `unitType`, but TS
   // can't infer that, so we re-narrow via a generic helper that re-tags the
@@ -188,9 +198,9 @@ export const UnitTokenForType = React.memo(function UnitTokenForType({
         position: displayPosition,
       } as IUnitToken);
   const fogOpacity =
-    token.fogStatus === 'hidden'
+    token.fogStatus === "hidden"
       ? 0.45
-      : token.fogStatus === 'lastKnown'
+      : token.fogStatus === "lastKnown"
         ? 0.62
         : 1;
 
@@ -199,15 +209,31 @@ export const UnitTokenForType = React.memo(function UnitTokenForType({
     onClick(token.unitId);
   };
 
+  // Wave 8 PR-K8 — G1: subscribe to elected-spotter state from the shell
+  // context. When this token's unit is currently spotting for an
+  // indirect-fire attack, render a yellow/amber ring overlay. Cleared
+  // automatically on IndirectFireSpotterLost / turn rollover.
+  const shellSpotters = (() => {
+    try {
+      return useTacticalShell().state.electedSpotters;
+    } catch {
+      // Token may render outside a TacticalCommandShell in storybook /
+      // standalone tests — degrade gracefully (no ring).
+      return [];
+    }
+  })();
+  const isSpotter = shellSpotters.some((s) => s.spotterId === token.unitId);
+
   const wrapperProps = {
     transform: `translate(${x}, ${y}) scale(${tween.scale})`,
     onClick: handleClick,
     onDoubleClick: handleDoubleClick,
-    style: { cursor: 'pointer' as const, opacity: fogOpacity },
-    'data-testid': `unit-token-${token.unitId}`,
-    'data-animating': movementAnimation ? 'true' : undefined,
-    'data-animation-id': movementAnimationId,
-    'data-fog-status': token.fogStatus,
+    style: { cursor: "pointer" as const, opacity: fogOpacity },
+    "data-testid": `unit-token-${token.unitId}`,
+    "data-animating": movementAnimation ? "true" : undefined,
+    "data-animation-id": movementAnimationId,
+    "data-fog-status": token.fogStatus,
+    "data-spotter": isSpotter ? "true" : undefined,
   };
 
   const jumpArc = renderJumpArc(token.unitId, movementAnimation, tween);
@@ -221,6 +247,27 @@ export const UnitTokenForType = React.memo(function UnitTokenForType({
           thermalVisualState={thermalVisualState}
         >
           <>
+            {isSpotter && (
+              <circle
+                cx={0}
+                cy={0}
+                r={HEX_SPOTTER_RING_RADIUS}
+                fill="none"
+                stroke="#facc15"
+                strokeWidth={2.5}
+                strokeDasharray="4 3"
+                opacity={0.85}
+                pointerEvents="none"
+                data-testid={`spotter-ring-${token.unitId}`}
+              >
+                <animate
+                  attributeName="opacity"
+                  values="0.85;0.45;0.85"
+                  dur="1.6s"
+                  repeatCount="indefinite"
+                />
+              </circle>
+            )}
             {children}
             {renderFogMarker(token)}
           </>

--- a/src/components/gameplay/UnitToken/UnitTokenForType.tsx
+++ b/src/components/gameplay/UnitToken/UnitTokenForType.tsx
@@ -15,32 +15,32 @@
  *        §Per-Type Token Rendering — dispatcher routes to correct renderer
  */
 
-import React, { useCallback, useEffect, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo } from 'react';
 
-import type { TacticalAnimation } from "@/stores/useAnimationQueue";
-import type { IGameEvent, IUnitToken } from "@/types/gameplay";
+import type { TacticalAnimation } from '@/stores/useAnimationQueue';
+import type { IGameEvent, IUnitToken } from '@/types/gameplay';
 
-import { useMovementTween } from "@/components/gameplay/animation/useMovementTween";
-import { hexToPixel } from "@/components/gameplay/HexMapDisplay/renderHelpers";
-import { useTacticalShell } from "@/components/gameplay/TacticalCommandShell";
-import { useAnimationQueue } from "@/stores/useAnimationQueue";
-import { MovementType, TokenUnitType } from "@/types/gameplay";
+import { useMovementTween } from '@/components/gameplay/animation/useMovementTween';
+import { hexToPixel } from '@/components/gameplay/HexMapDisplay/renderHelpers';
+import { useElectedSpotters } from '@/components/gameplay/TacticalCommandShell';
+import { useAnimationQueue } from '@/stores/useAnimationQueue';
+import { MovementType, TokenUnitType } from '@/types/gameplay';
 
-import { AerospaceToken } from "./AerospaceToken";
-import { BattleArmorToken } from "./BattleArmorToken";
-import { InfantryToken } from "./InfantryToken";
-import { MechToken } from "./MechToken";
-import { ProtoMechToken } from "./ProtoMechToken";
+import { AerospaceToken } from './AerospaceToken';
+import { BattleArmorToken } from './BattleArmorToken';
+import { InfantryToken } from './InfantryToken';
+import { MechToken } from './MechToken';
+import { ProtoMechToken } from './ProtoMechToken';
 import {
   renderFogMarker,
   renderJumpArc,
   TokenVisualEffects,
-} from "./UnitTokenForType.effects";
+} from './UnitTokenForType.effects';
 import {
   projectEvents,
   projectThermalVisualState,
-} from "./UnitTokenForType.projectors";
-import { VehicleToken } from "./VehicleToken";
+} from './UnitTokenForType.projectors';
+import { VehicleToken } from './VehicleToken';
 
 // =============================================================================
 // Props
@@ -107,7 +107,7 @@ export const UnitTokenForType = React.memo(function UnitTokenForType({
       movementAnimation?.path && movementAnimation.path.length > 0
         ? movementAnimation.path
         : [
-            token.fogStatus === "lastKnown" && token.lastKnownPosition
+            token.fogStatus === 'lastKnown' && token.lastKnownPosition
               ? token.lastKnownPosition
               : token.position,
           ],
@@ -146,6 +146,18 @@ export const UnitTokenForType = React.memo(function UnitTokenForType({
     onDoubleClick(token.unitId);
   };
 
+  // Wave 8 PR-K8 — G1: subscribe to elected-spotter state from the shell
+  // context. When this token's unit is currently spotting for an
+  // indirect-fire attack, render a yellow/amber ring overlay. Cleared
+  // automatically on IndirectFireSpotterLost / turn rollover.
+  //
+  // Hook MUST be called BEFORE the conditional BA-mounted early return
+  // below so React's rules-of-hooks ordering invariant is preserved.
+  // `useElectedSpotters` returns [] when no TacticalCommandShell is in
+  // the ancestry — token degrades to no-ring in storybook / standalone.
+  const shellSpotters = useElectedSpotters();
+  const isSpotter = shellSpotters.some((s) => s.spotterId === token.unitId);
+
   // BA mounted on a mech: render as a badge overlaid on the host mech token,
   // not as a standalone token at its own hex position.
   if (token.unitType === TokenUnitType.BattleArmor && token.mountedOn) {
@@ -161,7 +173,7 @@ export const UnitTokenForType = React.memo(function UnitTokenForType({
             onClick(token.unitId);
           }}
           onDoubleClick={handleDoubleClick}
-          style={{ cursor: "pointer" }}
+          style={{ cursor: 'pointer' }}
           data-testid={`unit-token-${token.unitId}`}
         >
           <BattleArmorToken
@@ -176,15 +188,15 @@ export const UnitTokenForType = React.memo(function UnitTokenForType({
   }
 
   const displayPosition =
-    token.fogStatus === "lastKnown" && token.lastKnownPosition
+    token.fogStatus === 'lastKnown' && token.lastKnownPosition
       ? token.lastKnownPosition
       : token.position;
   const { x, y } = movementAnimation
     ? { x: tween.x, y: tween.y }
     : hexToPixel(displayPosition);
   const fogDisplayFields =
-    token.fogStatus === "hidden"
-      ? { designation: "?", name: "Hidden contact" }
+    token.fogStatus === 'hidden'
+      ? { designation: '?', name: 'Hidden contact' }
       : {};
   // Build the render-time token. The spread preserves `unitType`, but TS
   // can't infer that, so we re-narrow via a generic helper that re-tags the
@@ -198,9 +210,9 @@ export const UnitTokenForType = React.memo(function UnitTokenForType({
         position: displayPosition,
       } as IUnitToken);
   const fogOpacity =
-    token.fogStatus === "hidden"
+    token.fogStatus === 'hidden'
       ? 0.45
-      : token.fogStatus === "lastKnown"
+      : token.fogStatus === 'lastKnown'
         ? 0.62
         : 1;
 
@@ -209,31 +221,16 @@ export const UnitTokenForType = React.memo(function UnitTokenForType({
     onClick(token.unitId);
   };
 
-  // Wave 8 PR-K8 — G1: subscribe to elected-spotter state from the shell
-  // context. When this token's unit is currently spotting for an
-  // indirect-fire attack, render a yellow/amber ring overlay. Cleared
-  // automatically on IndirectFireSpotterLost / turn rollover.
-  const shellSpotters = (() => {
-    try {
-      return useTacticalShell().state.electedSpotters;
-    } catch {
-      // Token may render outside a TacticalCommandShell in storybook /
-      // standalone tests — degrade gracefully (no ring).
-      return [];
-    }
-  })();
-  const isSpotter = shellSpotters.some((s) => s.spotterId === token.unitId);
-
   const wrapperProps = {
     transform: `translate(${x}, ${y}) scale(${tween.scale})`,
     onClick: handleClick,
     onDoubleClick: handleDoubleClick,
-    style: { cursor: "pointer" as const, opacity: fogOpacity },
-    "data-testid": `unit-token-${token.unitId}`,
-    "data-animating": movementAnimation ? "true" : undefined,
-    "data-animation-id": movementAnimationId,
-    "data-fog-status": token.fogStatus,
-    "data-spotter": isSpotter ? "true" : undefined,
+    style: { cursor: 'pointer' as const, opacity: fogOpacity },
+    'data-testid': `unit-token-${token.unitId}`,
+    'data-animating': movementAnimation ? 'true' : undefined,
+    'data-animation-id': movementAnimationId,
+    'data-fog-status': token.fogStatus,
+    'data-spotter': isSpotter ? 'true' : undefined,
   };
 
   const jumpArc = renderJumpArc(token.unitId, movementAnimation, tween);

--- a/src/types/gameplay/TacticalShellInterfaces.ts
+++ b/src/types/gameplay/TacticalShellInterfaces.ts
@@ -114,6 +114,20 @@ export interface IShellActiveContext {
 }
 
 /**
+ * A single elected spotter entry tracked by the shell for indirect-fire
+ * visual feedback.
+ *
+ * Carrying both `spotterId` and `attackerId` allows the inspector badge to
+ * display "Spotting for: {attackerDesignation}" without a secondary lookup.
+ */
+export interface IElectedSpotter {
+  /** The unit acting as spotter (elected via IndirectFireSpotterSelected). */
+  readonly spotterId: UnitId;
+  /** The unit whose LRM/indirect attack this spotter supports. */
+  readonly attackerId: UnitId;
+}
+
+/**
  * Typed state contract for the tactical command shell.
  *
  * MUST distinguish three independent unit references (Wave 7.0 gate 4 —
@@ -133,6 +147,12 @@ export interface IShellActiveContext {
  *   - `opponentVisibilityScopes`   per-opponent intel tier; redaction
  *                                  happens in the data adapter, NEVER in
  *                                  CSS visibility (see `OpponentIntelTier`)
+ *
+ * `electedSpotters` tracks units currently acting as LOS spotters for
+ * in-flight indirect-fire attacks (Wave 8 PR-K8 — G1). Entries are added on
+ * `IndirectFireSpotterSelected` events, removed on `IndirectFireSpotterLost`,
+ * and cleared entirely at turn rollover. Cleared at turn boundary so stale
+ * spotter rings don't persist into the next turn.
  */
 export interface ITacticalShellState {
   /** Current shell rendering mode. */
@@ -156,6 +176,15 @@ export interface ITacticalShellState {
   readonly opponentVisibilityScopes: Readonly<
     Record<PlayerId, OpponentIntelTier>
   >;
+
+  /**
+   * Units currently elected as LOS spotters for in-flight indirect-fire
+   * attacks. Cleared at turn rollover so stale rings don't persist.
+   *
+   * Carrying `attackerId` alongside `spotterId` avoids a secondary lookup
+   * in the unit inspector badge ("Spotting for: {attacker}").
+   */
+  readonly electedSpotters: readonly IElectedSpotter[];
 }
 
 /**
@@ -180,6 +209,7 @@ export function createDefaultShellState(
     inspectedUnit: null,
     viewerPlayerId,
     opponentVisibilityScopes: {},
+    electedSpotters: [],
   };
 }
 


### PR DESCRIPTION
## PR-K8 — Spotter Rendering on Map (G1)

Closes G1 from the gap-closeout plan (`~/.claude/plans/wave-8-gap-closeout.md`). The OMO Heavy Council surfaced this as the #1 playtest blocker: `IndirectFireSpotterSelected` events are emitted by the engine (PR-K4 / K5 / K7) but had **zero UI consumers outside the event-log formatter** — a playtester's turn-1 question "which mech is the spotter for the LRM attack I just declared?" had no answer.

## What ships

### §1 Shell state (types + event projection)
- `IElectedSpotter` type in `TacticalShellInterfaces.ts` — `{ spotterId, attackerId }` pair
- `ITacticalShellState.electedSpotters: readonly IElectedSpotter[]` field; default `[]`
- TacticalCommandShell subscribes to `useGameplayStore.session.events` and projects `IndirectFireSpotterSelected` → append; `IndirectFireSpotterLost` → remove; turn rollover → clear
- Idempotent: same Selected event twice does not double-add

### §2 UnitToken spotter ring overlay
- `useElectedSpotters()` non-throwing hook variant — returns `[]` outside a shell (degrades gracefully in storybook / standalone tests without violating React rules-of-hooks)
- Yellow (#facc15) dashed circle, 22px radius, 2.5px stroke, 4-3 dash pattern, 0.85 base opacity
- Animated pulse (0.85→0.45→0.85 over 1.6s, repeating)
- `data-spotter='true'` + `data-testid='spotter-ring-{unitId}'`

### §3 TacticalUnitInspector "Spotting for" badge
- Friendly view only — opponent unit's spotting role for ITS team is hidden by fog-of-war contract
- Amber badge below chassis line: "Spotting for: {attackerId}"
- `data-testid='inspector-spotting-badge'`

### §4 Tests
- `TacticalCommandShell.spotter.test.tsx` — 5 tests covering empty seed, Selected→append, Lost→remove, turn rollover→clear, idempotency
- Existing 124 component tests still pass (TacticalCommandShell + UnitToken + TacticalUnitInspector)

## Commits (4)

| # | SHA | Scope |
|---|-----|-------|
| 1 | `40158e7d` | §1+§1.5 — IElectedSpotter type + electedSpotters field + event subscription |
| 2 | `b8a3e8ad` | §2 — UnitToken spotter ring overlay |
| 3 | `38647670` | §3 — TacticalUnitInspector "Spotting for" badge |
| 4 | `9ab7a5ec` | §4 — useElectedSpotters non-throwing hook + 5 spotter tests + dead import cleanup |

## Architecture decisions

- **useElectedSpotters vs useTacticalShell**: tried try/catch around the throwing hook first; oxlint flagged rules-of-hooks violation. Extracted a non-throwing variant that does a single `useContext` call — clean React semantics, single allowed source of truth.
- **Hook placement in UnitTokenForType**: moved BEFORE the conditional BA-mounted early return so rules-of-hooks ordering invariant is preserved across all render paths.
- **`{ spotterId, attackerId }` pair vs separate maps**: pair carries both so the inspector badge can render "Spotting for: {attackerId}" without a secondary lookup. JSDoc explains the choice.

## Verification

- `npx tsc --noEmit` → clean
- `npx oxlint src/components/gameplay/{TacticalCommandShell,UnitToken,TacticalUnitInspector}` → **0 warnings 0 errors**
- `npx jest src/components/gameplay/{TacticalCommandShell,TacticalUnitInspector,UnitToken}` → **129/129 pass / 10 suites**

## Operator notes

PR-K8 agent died at §1 → §2 transition (truncated tail: "The formatter changed single quotes to double quotes. Now I can edit:"). Agent's §1 type work was solid and shipped cleanly. Operator finished §1.5 (event subscription), §2 (token ring), §3 (inspector badge), §4 (tests + rules-of-hooks refactor).

This closes the **first** of the council-surfaced playtest blockers. Next: PR-L2 (BA swarm-fire-while-attached — G4) per the dispatch order in `wave-8-gap-closeout.md`.