### PR TITLE
feat(wave-8): spotter gunnery-skill modifier (PR-K9 -- G2)

### DIFF
--- a/src/engine/InteractiveSession.indirectFire.ts
+++ b/src/engine/InteractiveSession.indirectFire.ts
@@ -120,6 +120,11 @@ export function computeIndirectFireContext(
       // Thread pilot SPA list into candidate when caller supplies it.
       // Absent entries leave pilotSpas undefined — no SPA modifier applied.
       pilotSpas: pilotSpasByUnitId?.[unitId],
+      // Thread pilot gunnery into candidate for the spotter-skill modifier.
+      // IUnitGameState.gunnery is optional (seeded at session-creation time from
+      // IGameUnit.gunnery). When absent (synthetic fixtures, legacy saves), the
+      // helper defaults to 4 (MegaMek baseline, modifier = 0).
+      spotterGunnery: unit.gunnery,
     });
   }
 

--- a/src/utils/gameplay/__tests__/indirectFire.test.ts
+++ b/src/utils/gameplay/__tests__/indirectFire.test.ts
@@ -592,3 +592,172 @@ describe('Indirect Fire Edge Cases', () => {
     expect(result.permitted).toBe(false);
   });
 });
+
+// =============================================================================
+// Gunnery Skill Modifier (PR-K9 — MegaMek parity)
+//
+// Per MegaMek ArtilleryWeaponIndirectFireHandler.java L192-194:
+//   int spotterMod = (spotter.getGunnery() - 4) / 2;  // Java integer division
+// Java truncates toward zero (Math.trunc), not floor. Key values:
+//   G2 -> trunc(-2/2) = -1
+//   G3 -> trunc(-1/2) =  0  (Java trunc, NOT Math.floor which gives -1)
+//   G4 -> trunc( 0/2) =  0  (baseline, no change)
+//   G5 -> trunc( 1/2) =  0
+//   G6 -> trunc( 2/2) = +1
+// =============================================================================
+
+describe('Gunnery Skill Modifier', () => {
+  it('G2 spotter (ace) applies -1 modifier to base penalty', () => {
+    // Base=1, gunneryMod=-1, walkedPenalty=0 -> total=0
+    const result = resolveIndirectFire(
+      makeRequest({
+        spotterCandidates: [
+          makeSpotter({
+            movementType: MovementType.Stationary,
+            spotterGunnery: 2,
+          }),
+        ],
+      }),
+    );
+    expect(result.permitted).toBe(true);
+    expect(result.isIndirect).toBe(true);
+    expect(result.toHitPenalty).toBe(0);
+  });
+
+  it('G4 spotter (baseline) applies no modifier', () => {
+    // Base=1, gunneryMod=0 -> total=1 (unchanged from pre-K9 behaviour)
+    const result = resolveIndirectFire(
+      makeRequest({
+        spotterCandidates: [
+          makeSpotter({
+            movementType: MovementType.Stationary,
+            spotterGunnery: 4,
+          }),
+        ],
+      }),
+    );
+    expect(result.permitted).toBe(true);
+    expect(result.toHitPenalty).toBe(1);
+  });
+
+  it('G6 spotter (poor) applies +1 modifier', () => {
+    // Base=1, gunneryMod=+1 -> total=2
+    const result = resolveIndirectFire(
+      makeRequest({
+        spotterCandidates: [
+          makeSpotter({
+            movementType: MovementType.Stationary,
+            spotterGunnery: 6,
+          }),
+        ],
+      }),
+    );
+    expect(result.permitted).toBe(true);
+    expect(result.toHitPenalty).toBe(2);
+  });
+
+  it('G3 spotter applies 0 modifier — Java trunc(-1/2)=0, not Math.floor(-0.5)=-1', () => {
+    // The key parity test: Java integer division truncates toward zero.
+    // Base=1, gunneryMod=0 -> total=1
+    const result = resolveIndirectFire(
+      makeRequest({
+        spotterCandidates: [
+          makeSpotter({
+            movementType: MovementType.Stationary,
+            spotterGunnery: 3,
+          }),
+        ],
+      }),
+    );
+    expect(result.permitted).toBe(true);
+    expect(result.toHitPenalty).toBe(1);
+  });
+
+  it('absent spotterGunnery defaults to G4 (modifier = 0)', () => {
+    // Backward-compat: pre-K9 candidates lack spotterGunnery -> treat as G4.
+    const result = resolveIndirectFire(
+      makeRequest({
+        spotterCandidates: [
+          makeSpotter({ movementType: MovementType.Stationary }),
+        ],
+      }),
+    );
+    expect(result.permitted).toBe(true);
+    expect(result.toHitPenalty).toBe(1);
+  });
+
+  it('G2 spotter + walked: gunnery(-1) and walk(+1) cancel -> penalty=1', () => {
+    // Base=1, walkedPenalty=+1, gunneryMod=-1 -> total=1
+    const result = resolveIndirectFire(
+      makeRequest({
+        spotterCandidates: [
+          makeSpotter({ movementType: MovementType.Walk, spotterGunnery: 2 }),
+        ],
+      }),
+    );
+    expect(result.permitted).toBe(true);
+    expect(result.spotterWalked).toBe(true);
+    expect(result.toHitPenalty).toBe(1);
+  });
+
+  it('G6 spotter + walked: gunnery(+1) and walk(+1) stack -> penalty=3', () => {
+    // Base=1, walkedPenalty=+1, gunneryMod=+1 -> total=3
+    const result = resolveIndirectFire(
+      makeRequest({
+        spotterCandidates: [
+          makeSpotter({ movementType: MovementType.Walk, spotterGunnery: 6 }),
+        ],
+      }),
+    );
+    expect(result.permitted).toBe(true);
+    expect(result.spotterWalked).toBe(true);
+    expect(result.toHitPenalty).toBe(3);
+  });
+
+  it('G2 + Forward Observer SPA: FO cancels walk penalty, gunnery(-1) still applies -> penalty=0', () => {
+    // FO SPA cancels walkedPenalty. Base=1, walkedPenalty=0, gunneryMod=-1 -> total=0
+    const result = resolveIndirectFire(
+      makeRequest({
+        spotterCandidates: [
+          makeSpotter({
+            movementType: MovementType.Walk,
+            spotterGunnery: 2,
+            pilotSpas: ['forward_observer'],
+          }),
+        ],
+      }),
+    );
+    expect(result.permitted).toBe(true);
+    expect(result.spotterWalked).toBe(true);
+    expect(result.toHitPenalty).toBe(0);
+  });
+
+  it('G7 spotter applies +1 (trunc(3/2)=1, same tier as G6)', () => {
+    // Base=1, gunneryMod=+1 -> total=2
+    const result = resolveIndirectFire(
+      makeRequest({
+        spotterCandidates: [
+          makeSpotter({
+            movementType: MovementType.Stationary,
+            spotterGunnery: 7,
+          }),
+        ],
+      }),
+    );
+    expect(result.permitted).toBe(true);
+    expect(result.toHitPenalty).toBe(2);
+  });
+
+  it('NARC-only path: spotter gunnery is irrelevant (no LOS spotter elected)', () => {
+    // NARC path has no elected LOS spotter -> penalty=1 (base only)
+    const result = resolveIndirectFire(
+      makeRequest({
+        spotterCandidates: [],
+        targetNarcMarkedByTeam: true,
+      }),
+    );
+    expect(result.permitted).toBe(true);
+    expect(result.basis).toBe('narc');
+    expect(result.toHitPenalty).toBe(1);
+  });
+});

--- a/src/utils/gameplay/indirectFire.ts
+++ b/src/utils/gameplay/indirectFire.ts
@@ -46,6 +46,15 @@ export interface ISpotterCandidate {
    * penalty (the unit still must have walked, not run/jumped, to be eligible).
    */
   readonly pilotSpas?: readonly string[];
+  /**
+   * Gunnery skill of the spotter's pilot. Optional for backward compatibility —
+   * call sites that pre-date PR-K9 leave this undefined, which is treated as
+   * the MegaMek default gunnery of 4 (modifier = 0).
+   *
+   * Per MegaMek ArtilleryWeaponIndirectFireHandler.java L192-194:
+   *   int spotterMod = (spotter.getGunnery() - 4) / 2;  // Java integer division
+   */
+  readonly spotterGunnery?: number;
 }
 
 /** The firing unit's indirect fire context */
@@ -342,7 +351,18 @@ export function resolveIndirectFire(
     // indirect-fire penalty still applies. Run/Jump ineligibility is enforced
     // upstream in isEligibleSpotter — FO does not override that restriction.
     const hasFoSpa = spotter.pilotSpas?.includes('forward_observer') ?? false;
-    const toHitPenalty = spotterWalked && !hasFoSpa ? 2 : 1;
+    const walkedPenalty = spotterWalked && !hasFoSpa ? 1 : 0;
+
+    // Per MegaMek ArtilleryWeaponIndirectFireHandler.java L192-194:
+    //   int spotterMod = (spotter.getGunnery() - 4) / 2;
+    // Java uses integer division which truncates toward zero (NOT floor).
+    // G2 → -1, G3 → 0, G4 → 0, G5 → 0, G6 → +1.
+    // Absent spotterGunnery defaults to 4 (MegaMek default, modifier = 0).
+    const effectiveGunnery = spotter.spotterGunnery ?? 4;
+    const gunneryMod = Math.trunc((effectiveGunnery - 4) / 2);
+
+    // Base +1 indirect-fire penalty + walked penalty + gunnery modifier.
+    const toHitPenalty = 1 + walkedPenalty + gunneryMod;
 
     return {
       permitted: true,


### PR DESCRIPTION
## Summary

Adds the MegaMek-parity spotter gunnery-skill modifier to indirect-fire to-hit penalty calculation. Previously a G2 ace spotter gave the same +1 base penalty as a G6 conscript — this PR closes that gap.

### MegaMek source

`ArtilleryWeaponIndirectFireHandler.java` L192–194:
\`\`\`java
int spotterMod = (spotter.getGunnery() - 4) / 2;
toHitData.addModifier(spotterMod, "spotter gunnery");
\`\`\`

Java uses **integer division** (truncate toward zero), not floor. `Math.trunc` is used — not `Math.floor` — to preserve exact parity:

| Gunnery | Java trunc((g−4)/2) | Math.floor |
|---------|---------------------|------------|
| 2       | −1                  | −1 |
| 3       | 0 (**parity key**) | −1 (wrong) |
| 4       | 0                   | 0 |
| 5       | 0                   | 0 |
| 6       | +1                  | +1 |
| 7       | +1                  | +1 |

## Changes (3 commits)

**§1 — `src/utils/gameplay/indirectFire.ts`**
- Added optional `spotterGunnery?: number` to `ISpotterCandidate` (backward-compat: absent → treated as G4, modifier = 0)
- Replaced the flat `toHitPenalty = spotterWalked && !hasFoSpa ? 2 : 1` with three-term arithmetic: `1 (base) + walkedPenalty + gunneryMod`
- `gunneryMod = Math.trunc((effectiveGunnery - 4) / 2)` with MegaMek source citation in comment

**§2 — `src/engine/InteractiveSession.indirectFire.ts`**
- Plumbs `unit.gunnery` (optional on `IUnitGameState`, seeded at session-creation time) into each spotter candidate as `spotterGunnery`
- Falls back to `undefined` → helper default G4 for synthetic fixtures and legacy saves

**§3 — `src/utils/gameplay/__tests__/indirectFire.test.ts`**
- New `describe('Gunnery Skill Modifier')` with 10 cases:
  - G2 stationary: penalty = 0
  - G4 stationary (baseline): penalty = 1 (pre-K9 behaviour unchanged)
  - G6 stationary: penalty = 2
  - G3 stationary: penalty = 1 (Java trunc parity boundary)
  - Absent `spotterGunnery`: penalty = 1 (backward-compat)
  - G2 + walked: gunnery(−1) + walk(+1) cancel → penalty = 1
  - G6 + walked: gunnery(+1) + walk(+1) stack → penalty = 3
  - G2 + FO SPA + walked: FO cancels walk, gunnery(−1) still applies → penalty = 0
  - G7 stationary: same tier as G6, penalty = 2
  - NARC-only path: no LOS spotter elected, gunnery irrelevant → penalty = 1

## Regression

K5/K6/K7 scenario tests all use G4 spotters (modifier = 0) — no behaviour delta. 190/190 unit tests pass, 56/56 scenario tests pass.