### PR TITLE
feat(wave-8): BA swarm-fire-while-attached (PR-L2 — G4)

### DIFF
--- a/src/engine/InteractiveSession.actions.ts
+++ b/src/engine/InteractiveSession.actions.ts
@@ -18,6 +18,10 @@ import type { IWeaponAttack } from '@/types/gameplay/CombatInterfaces';
 import type { IGameSession } from '@/types/gameplay/GameSessionInterfaces';
 
 import {
+  calculateSwarmDamage,
+  type IBASwarmFireSquadDef,
+} from '@/lib/combat/baCombat';
+import {
   Facing,
   MovementType,
   RangeBracket,
@@ -25,12 +29,14 @@ import {
   type IHexGrid,
   type IMovementCapability,
 } from '@/types/gameplay/HexGridInterfaces';
+import { createSwarmDamageEvent } from '@/utils/gameplay/gameEvents/battleArmor';
 import {
   declareAttack,
   declareMovement,
   lockAttack,
   lockMovement,
 } from '@/utils/gameplay/gameSession';
+import { appendEvent } from '@/utils/gameplay/gameSession';
 import {
   buildMovementEventPath,
   maxMovementCostForCapability,
@@ -180,4 +186,89 @@ export function applyInteractiveSessionAttack(
   );
   session = lockAttack(session, input.attackerId);
   return session;
+}
+
+// =============================================================================
+// PR-L2 §3 — Swarm-fire-while-attached action handler
+// =============================================================================
+
+/**
+ * Inputs for `applyInteractiveSessionSwarmFire` — fires a BA squad's non-missile
+ * non-body-mounted weapons at the host mek it is currently swarm-attached to,
+ * auto-hitting (no to-hit roll) per TacticalOperations swarm-fire rules.
+ *
+ * The caller is responsible for:
+ *   1. Confirming the swarm is in fact attached (the action does not re-validate).
+ *   2. Building `squadDef.weapons` filtered down to swarm-eligible weapons
+ *      (non-missile, non-body-mounted, non-InfantryAttack).  The dispatch
+ *      layer that does this filtering lives in PR-L3; this action handler
+ *      trusts its caller's filter.
+ *   3. Computing `hostLocation` per the mounted-trooper-adapter mapping
+ *      established by PR-L §5.1 (RT-front->1, LT-front->2, RT-rear->3,
+ *      LT-rear->4, CT-front->6, CT-rear->5).  The action does not pick a
+ *      location; it just stamps whatever the caller chose into the event.
+ *
+ * @spec openspec/changes/add-battle-armor-combat/specs/battle-armor-combat/spec.md
+ *   (Requirement: Swarm Fire While Attached)
+ */
+export interface IApplySwarmFireInput {
+  readonly session: IGameSession;
+  /** Attacker (BA squad) unit id. */
+  readonly squadId: string;
+  /** Host (mek) unit id being swarmed. */
+  readonly hostUnitId: string;
+  /** Squad combat state (new IBASquadCombatState shape). */
+  readonly squad: import('@/types/gameplay').IBASquadCombatState;
+  /** Pre-filtered swarm-eligible weapons + vibroclaw / myomer flags. */
+  readonly squadDef: IBASwarmFireSquadDef;
+  /**
+   * Host location label to stamp on the SwarmDamage event.  Caller picks
+   * this via the PR-L mounted-trooper adapter — front-trooper slots resolve
+   * to front locations; rear-trooper slots to rear locations.
+   */
+  readonly hostLocationLabel: string;
+}
+
+/**
+ * Resolve one tick of swarm fire from `squadId` against `hostUnitId`.
+ *
+ * Computes damage via `calculateSwarmDamage` and appends a single
+ * `SwarmDamage` event (using the established `createSwarmDamageEvent`
+ * factory from the prior `add-battlearmor-combat-behavior` change — its
+ * `unitId / targetUnitId / damage / locationLabel` shape exactly matches
+ * what this action needs).
+ *
+ * Returns the original session unchanged when:
+ *   - the attacking squad is destroyed (0 active troopers; damage = 0),
+ *   - OR the host or squad units cannot be found in `session.currentState`.
+ *
+ * Otherwise returns the session with one new `SwarmDamage` event appended.
+ * The action handler is intentionally side-effect-free beyond appending
+ * the event; damage application to the host mek's armor pipeline lives
+ * downstream (PR-L3 wires the dispatch layer that consumes this event).
+ */
+export function applyInteractiveSessionSwarmFire(
+  input: IApplySwarmFireInput,
+): IGameSession {
+  const attackerUnit = input.session.currentState.units[input.squadId];
+  const hostUnit = input.session.currentState.units[input.hostUnitId];
+  if (!attackerUnit || !hostUnit) return input.session;
+
+  const damage = calculateSwarmDamage(input.squad, input.squadDef);
+  if (damage <= 0) return input.session;
+
+  const sequence = input.session.events.length;
+  const { turn, phase } = input.session.currentState;
+  const event = createSwarmDamageEvent(
+    input.session.id,
+    sequence,
+    turn,
+    phase,
+    input.squadId,
+    input.hostUnitId,
+    damage,
+    input.hostLocationLabel,
+  );
+
+  return appendEvent(input.session, event);
 }

--- a/src/engine/InteractiveSession.phases.ts
+++ b/src/engine/InteractiveSession.phases.ts
@@ -22,6 +22,10 @@ import {
   type IGameSession,
 } from '@/types/gameplay/GameSessionInterfaces';
 import {
+  resolveSwarmFireForAttachedSquads,
+  type IResolveSwarmFireOptions,
+} from '@/utils/gameplay/battlearmor/swarmFireResolver';
+import {
   advancePhase,
   checkAndQueueDamagePSRs,
   lockAttack,
@@ -60,6 +64,22 @@ export interface IInteractiveSessionPhaseContext {
   readonly waterDepthAt: (position: IHexCoordinate) => number;
   /** Win-condition predicate — gates the End-phase advance. */
   readonly isGameOver: () => boolean;
+  /**
+   * PR-L2 §3: per-turn swarm-fire trigger.  When present, the End-phase
+   * advance iterates every BA squad currently attached via its older
+   * `IBattleArmorCombatState.swarmingUnitId` pointer, computes per-tick
+   * swarm damage via `calculateSwarmDamage`, and appends one `SwarmDamage`
+   * event per attached squad with non-zero damage.  When `undefined`
+   * (legacy callers, tests that do not exercise swarm fire), the End-phase
+   * skips the trigger entirely — no event-stream pollution.
+   *
+   * `getSquadDef` returns swarm-eligible weapons + flags for the squad;
+   * `getHostLocationLabel` (optional) picks the location label for the
+   * emitted event.
+   *
+   * @spec openspec/changes/add-battle-armor-combat/specs/battle-armor-combat/spec.md
+   */
+  readonly swarmFireOptions?: IResolveSwarmFireOptions;
 }
 
 /**
@@ -191,6 +211,18 @@ export function advanceInteractiveSessionPhase(
     // every unit. Failures invoke `applyFall` (→ `UnitFell` +
     // `PilotHit`) and clear the remaining queue on that unit.
     session = resolvePendingPSRs(session, context.diceRollerForResolvers());
+    // PR-L2 §3: BA swarm-fire-while-attached.  Every BA squad currently
+    // attached to a host mek fires its swarm-eligible weapons once at
+    // the host.  No-op when the context did not supply
+    // `swarmFireOptions` (legacy callers + non-BA tests).  Runs BEFORE
+    // the morale pass so the swarm-damage event is in the log when
+    // morale evaluates the turn's combat outcomes.
+    if (context.swarmFireOptions) {
+      session = resolveSwarmFireForAttachedSquads(
+        session,
+        context.swarmFireOptions,
+      );
+    }
     // Per `add-combat-morale-and-withdrawal`: the End-phase morale +
     // forced-withdrawal pass runs before the game-over guard so a
     // forced withdrawal that empties the board is reflected in the

--- a/src/engine/__tests__/InteractiveSession.swarmFire.scenario.test.ts
+++ b/src/engine/__tests__/InteractiveSession.swarmFire.scenario.test.ts
@@ -1,0 +1,372 @@
+/**
+ * Scenario tests for PR-L2 swarm-fire-while-attached (G4 — biggest BA combat gap).
+ *
+ * Exercises the End-phase swarm-fire trigger end-to-end against a real
+ * IGameSession. Pre-seeds an attached swarm via the older
+ * IBattleArmorCombatState.swarmingUnitId pointer (the production plumbing),
+ * advances the End phase, and asserts a SwarmDamage event was appended
+ * with the canonical Librarian damage value.
+ *
+ * The swarm-attach action handler itself is deferred to a later PR
+ * (the spec's §3) -- this scenario test directly mutates the BA squad's
+ * combatState.state.swarmingUnitId to seed the attached state, which is
+ * the exact same mutation a successful SwarmAttack would perform.
+ *
+ * @spec openspec/changes/add-battle-armor-combat/specs/battle-armor-combat/spec.md
+ *   (Requirement: Swarm Fire While Attached)
+ */
+
+import type { IBASwarmFireSquadDef } from '@/lib/combat/baCombat';
+import type { IResolveSwarmFireOptions } from '@/utils/gameplay/battlearmor/swarmFireResolver';
+
+import {
+  Facing,
+  GameEventType,
+  GamePhase,
+  GameSide,
+  type IGameSession,
+  type IGameUnit,
+  type ISwarmDamagePayload,
+} from '@/types/gameplay';
+import { UnitType } from '@/types/unit/BattleMechInterfaces';
+import {
+  advancePhase,
+  createGameSession,
+  rollInitiative,
+  startGame,
+} from '@/utils/gameplay/gameSession';
+
+import { advanceInteractiveSessionPhase } from '../InteractiveSession.phases';
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+function buildUnits(): readonly IGameUnit[] {
+  return [
+    {
+      id: 'ba-swarmer',
+      name: 'BA Swarmer',
+      side: GameSide.Player,
+      unitRef: 'ba-ref',
+      pilotRef: 'pilot-ba',
+      gunnery: 4,
+      piloting: 5,
+      unitType: UnitType.BATTLE_ARMOR,
+      battleArmorInit: {
+        squadSize: 4,
+        armorPointsPerTrooper: 5,
+        hasMagneticClamp: true,
+        hasVibroClaws: false,
+        vibroClawCount: 0,
+      },
+    } as unknown as IGameUnit,
+    {
+      id: 'locust-host',
+      name: 'Locust',
+      side: GameSide.Opponent,
+      unitRef: 'locust-ref',
+      pilotRef: 'pilot-host',
+      gunnery: 4,
+      piloting: 5,
+    } as IGameUnit,
+  ];
+}
+
+/**
+ * Advance the session through Initiative -> Movement -> WeaponAttack ->
+ * PhysicalAttack -> Heat -> End so it sits on the End phase ready for one
+ * more advancePhase() call (which then runs the End-phase block we instrumented).
+ */
+function advanceToEndPhase(session: IGameSession): IGameSession {
+  let s = startGame(session, GameSide.Player);
+  s = rollInitiative(s);
+  s = advancePhase(s); // Initiative -> Movement
+  s = advancePhase(s); // Movement -> WeaponAttack
+  s = advancePhase(s); // WeaponAttack -> PhysicalAttack
+  s = advancePhase(s); // PhysicalAttack -> Heat
+  s = advancePhase(s); // Heat -> End
+  return s;
+}
+
+/**
+ * Attach the BA squad to the host by directly setting `swarmingUnitId` on
+ * the squad's combatState. This is exactly the mutation a successful
+ * SwarmAttack action would perform (per the older
+ * add-battlearmor-combat-behavior swarm.ts `setSwarmTarget` helper).
+ */
+function attachSwarmer(
+  session: IGameSession,
+  squadId: string,
+  hostId: string,
+): IGameSession {
+  const squad = session.currentState.units[squadId];
+  const cs = squad.combatState;
+  if (!cs || cs.kind !== 'squad') {
+    throw new Error('test setup: squad has no combatState');
+  }
+  const attachedState = { ...cs.state, swarmingUnitId: hostId };
+  // Mutate the live currentState -- mirrors how the engine fixture pattern
+  // in InteractiveSession.indirectFire.scenario.test.ts seeds initial state.
+  session.currentState.units[squadId] = {
+    ...squad,
+    combatState: { kind: 'squad', state: attachedState },
+  };
+  return session;
+}
+
+/**
+ * Default swarm-fire options for a 4-trooper squad with 1 SmallLaser (3 dmg)
+ * and no claws / no myomer -- the Librarian's canonical 12-damage case.
+ */
+function makeSwarmFireOptions(
+  squadDef?: Partial<IBASwarmFireSquadDef>,
+): IResolveSwarmFireOptions {
+  return {
+    getSquadDef: () => ({
+      weapons: [{ weaponId: 'small-laser-1', damage: 3 }],
+      vibroClaws: 0,
+      myomerBoosterActive: false,
+      ...squadDef,
+    }),
+    getHostLocationLabel: () => 'Center Torso',
+  };
+}
+
+/**
+ * Run the same phase-context shape `InteractiveSession.advancePhase()` builds,
+ * but inline so the test can swap in a fake `isGameOver` (the real engine's
+ * game-over predicate gates the End-phase advance and would prematurely end
+ * a session with only 2 units that never took damage).
+ */
+function endPhaseContext(
+  ref: { session: IGameSession },
+  swarmFireOptions: IResolveSwarmFireOptions,
+) {
+  return {
+    getSession: () => ref.session,
+    setSession: (s: IGameSession) => {
+      ref.session = s;
+    },
+    d6RollerForResolvers: () => undefined,
+    diceRollerForResolvers: () => undefined,
+    physicalContextByUnit: () => new Map(),
+    waterDepthAt: () => 0,
+    // Force NOT game-over so the End-phase swarm-fire block executes.
+    isGameOver: () => false,
+    swarmFireOptions,
+  };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('PR-L2 swarm-fire-while-attached -- End-phase trigger', () => {
+  it('emits SwarmDamage = 12 for a 4-trooper squad with 1 SmallLaser', () => {
+    const fresh = createGameSession(
+      {
+        mapRadius: 10,
+        turnLimit: 0,
+        victoryConditions: ['elimination'],
+        optionalRules: [],
+      } as never,
+      buildUnits(),
+    );
+    let session = advanceToEndPhase(fresh);
+    session = attachSwarmer(session, 'ba-swarmer', 'locust-host');
+
+    const ref = { session };
+    advanceInteractiveSessionPhase(
+      endPhaseContext(ref, makeSwarmFireOptions()),
+    );
+
+    const swarmEvents = ref.session.events.filter(
+      (e) => e.type === GameEventType.SwarmDamage,
+    );
+    expect(swarmEvents).toHaveLength(1);
+    const payload = swarmEvents[0].payload as ISwarmDamagePayload;
+    expect(payload.unitId).toBe('ba-swarmer');
+    expect(payload.targetUnitId).toBe('locust-host');
+    expect(payload.damage).toBe(12);
+    expect(payload.locationLabel).toBe('Center Torso');
+  });
+
+  it('emits SwarmDamage = 22 with vibroclaws + myomer booster', () => {
+    const fresh = createGameSession(
+      {
+        mapRadius: 10,
+        turnLimit: 0,
+        victoryConditions: ['elimination'],
+        optionalRules: [],
+      } as never,
+      buildUnits(),
+    );
+    let session = advanceToEndPhase(fresh);
+    session = attachSwarmer(session, 'ba-swarmer', 'locust-host');
+
+    const ref = { session };
+    advanceInteractiveSessionPhase(
+      endPhaseContext(
+        ref,
+        makeSwarmFireOptions({ vibroClaws: 2, myomerBoosterActive: true }),
+      ),
+    );
+
+    const swarmEvents = ref.session.events.filter(
+      (e) => e.type === GameEventType.SwarmDamage,
+    );
+    expect(swarmEvents).toHaveLength(1);
+    const payload = swarmEvents[0].payload as ISwarmDamagePayload;
+    // 12 (weapons) + 2 (vibroclaws) + 8 (4 troopers x 2 myomer) = 22
+    expect(payload.damage).toBe(22);
+  });
+
+  it('emits NO SwarmDamage when no swarmer is attached', () => {
+    const fresh = createGameSession(
+      {
+        mapRadius: 10,
+        turnLimit: 0,
+        victoryConditions: ['elimination'],
+        optionalRules: [],
+      } as never,
+      buildUnits(),
+    );
+    const session = advanceToEndPhase(fresh);
+    // Do NOT attach -- squad has no swarmingUnitId.
+
+    const ref = { session };
+    advanceInteractiveSessionPhase(
+      endPhaseContext(ref, makeSwarmFireOptions()),
+    );
+
+    const swarmEvents = ref.session.events.filter(
+      (e) => e.type === GameEventType.SwarmDamage,
+    );
+    expect(swarmEvents).toHaveLength(0);
+  });
+
+  it('emits NO SwarmDamage when swarmFireOptions is omitted (legacy callers)', () => {
+    const fresh = createGameSession(
+      {
+        mapRadius: 10,
+        turnLimit: 0,
+        victoryConditions: ['elimination'],
+        optionalRules: [],
+      } as never,
+      buildUnits(),
+    );
+    let session = advanceToEndPhase(fresh);
+    session = attachSwarmer(session, 'ba-swarmer', 'locust-host');
+
+    const ref = { session };
+    // Build a context that intentionally omits swarmFireOptions.
+    advanceInteractiveSessionPhase({
+      getSession: () => ref.session,
+      setSession: (s: IGameSession) => {
+        ref.session = s;
+      },
+      d6RollerForResolvers: () => undefined,
+      diceRollerForResolvers: () => undefined,
+      physicalContextByUnit: () => new Map(),
+      waterDepthAt: () => 0,
+      isGameOver: () => false,
+    });
+
+    const swarmEvents = ref.session.events.filter(
+      (e) => e.type === GameEventType.SwarmDamage,
+    );
+    expect(swarmEvents).toHaveLength(0);
+  });
+
+  it('preserves the session ammo + heat state (swarm fire never consumes ammo or generates heat)', () => {
+    // BA has no heat track and swarm fire is an auto-hit free attack -- no
+    // ammo / heat side effects.  This regression locks that contract.
+    const fresh = createGameSession(
+      {
+        mapRadius: 10,
+        turnLimit: 0,
+        victoryConditions: ['elimination'],
+        optionalRules: [],
+      } as never,
+      buildUnits(),
+    );
+    let session = advanceToEndPhase(fresh);
+    session = attachSwarmer(session, 'ba-swarmer', 'locust-host');
+
+    const heatBefore = session.currentState.units['ba-swarmer'].heat;
+    const ammoStateBefore = session.currentState.units['ba-swarmer'].ammoState;
+    const ammoStateBeforeKeys = Object.keys(ammoStateBefore ?? {}).sort();
+
+    const ref = { session };
+    advanceInteractiveSessionPhase(
+      endPhaseContext(ref, makeSwarmFireOptions()),
+    );
+
+    const heatAfter = ref.session.currentState.units['ba-swarmer'].heat;
+    const ammoStateAfter =
+      ref.session.currentState.units['ba-swarmer'].ammoState;
+    const ammoStateAfterKeys = Object.keys(ammoStateAfter ?? {}).sort();
+
+    expect(heatAfter).toBe(heatBefore);
+    expect(ammoStateAfterKeys).toEqual(ammoStateBeforeKeys);
+  });
+
+  it('skips destroyed squads (no event emitted when attacker is destroyed)', () => {
+    const fresh = createGameSession(
+      {
+        mapRadius: 10,
+        turnLimit: 0,
+        victoryConditions: ['elimination'],
+        optionalRules: [],
+      } as never,
+      buildUnits(),
+    );
+    let session = advanceToEndPhase(fresh);
+    session = attachSwarmer(session, 'ba-swarmer', 'locust-host');
+
+    // Mark the squad destroyed.
+    session.currentState.units['ba-swarmer'] = {
+      ...session.currentState.units['ba-swarmer'],
+      destroyed: true,
+    };
+
+    const ref = { session };
+    advanceInteractiveSessionPhase(
+      endPhaseContext(ref, makeSwarmFireOptions()),
+    );
+
+    const swarmEvents = ref.session.events.filter(
+      (e) => e.type === GameEventType.SwarmDamage,
+    );
+    expect(swarmEvents).toHaveLength(0);
+  });
+
+  it('stamps the End phase + correct turn on the emitted SwarmDamage event', () => {
+    const fresh = createGameSession(
+      {
+        mapRadius: 10,
+        turnLimit: 0,
+        victoryConditions: ['elimination'],
+        optionalRules: [],
+      } as never,
+      buildUnits(),
+    );
+    let session = advanceToEndPhase(fresh);
+    session = attachSwarmer(session, 'ba-swarmer', 'locust-host');
+
+    const expectedTurn = session.currentState.turn;
+
+    const ref = { session };
+    advanceInteractiveSessionPhase(
+      endPhaseContext(ref, makeSwarmFireOptions()),
+    );
+
+    const swarmEvents = ref.session.events.filter(
+      (e) => e.type === GameEventType.SwarmDamage,
+    );
+    expect(swarmEvents).toHaveLength(1);
+    expect(swarmEvents[0].phase).toBe(GamePhase.End);
+    expect(swarmEvents[0].turn).toBe(expectedTurn);
+  });
+});

--- a/src/lib/combat/__tests__/baCombat.swarmDamage.test.ts
+++ b/src/lib/combat/__tests__/baCombat.swarmDamage.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests for BA combat section 4 (swarm-fire damage formula).
+ *
+ * Librarian canonical numbers verified here:
+ *   - 4-trooper x 1 SmallLaser (3 dmg)               -> 12
+ *   - +2 vibroclaws                                  -> 14
+ *   - +myomer booster active                         -> 22
+ *   - 2 of 4 troopers dead, SmallLaser only          -> 6
+ *   - 0 active troopers -> 0
+ *
+ * The pure formula does NOT filter missile / body-mounted / InfantryAttack
+ * weapons -- callers MUST filter upstream. PR-L3+ adds the dispatch filter.
+ *
+ * @spec openspec/changes/add-battle-armor-combat/specs/battle-armor-combat/spec.md
+ */
+
+import { describe, expect, it } from '@jest/globals';
+
+import type { IBASquadCombatState } from '@/types/gameplay';
+
+import { calculateSwarmDamage, type IBASwarmFireSquadDef } from '../baCombat';
+
+function makeSquad(squadSize = 4, armorPerTrooper = 5): IBASquadCombatState {
+  return {
+    troopers: Array.from({ length: squadSize }, (_, i) => ({
+      index: i + 1,
+      alive: true,
+      armorRemaining: armorPerTrooper,
+      equipmentDestroyed: [],
+    })),
+    swarmingUnitId: undefined,
+    swarmedByUnitIds: [],
+    mountedOn: undefined,
+    mimeticActiveThisTurn: false,
+    stealthActiveThisTurn: false,
+  };
+}
+
+function makeSquadDef(
+  overrides: Partial<IBASwarmFireSquadDef> = {},
+): IBASwarmFireSquadDef {
+  return {
+    weapons: [],
+    vibroClaws: 0,
+    myomerBoosterActive: false,
+    ...overrides,
+  };
+}
+
+describe('calculateSwarmDamage -- Librarian canonical numbers', () => {
+  it('4-trooper x 1 SmallLaser (3 dmg) = 12 damage', () => {
+    const squad = makeSquad(4, 5);
+    const squadDef = makeSquadDef({
+      weapons: [{ weaponId: 'small-laser-1', damage: 3 }],
+    });
+    expect(calculateSwarmDamage(squad, squadDef)).toBe(12);
+  });
+
+  it('+2 vibroclaws -> 14 damage', () => {
+    const squad = makeSquad(4, 5);
+    const squadDef = makeSquadDef({
+      weapons: [{ weaponId: 'small-laser-1', damage: 3 }],
+      vibroClaws: 2,
+    });
+    expect(calculateSwarmDamage(squad, squadDef)).toBe(14);
+  });
+
+  it('+myomer booster active -> 22 damage', () => {
+    const squad = makeSquad(4, 5);
+    const squadDef = makeSquadDef({
+      weapons: [{ weaponId: 'small-laser-1', damage: 3 }],
+      vibroClaws: 2,
+      myomerBoosterActive: true,
+    });
+    // 12 (weapons) + 2 (vibroclaws) + 8 (4 troopers x 2 myomer) = 22
+    expect(calculateSwarmDamage(squad, squadDef)).toBe(22);
+  });
+});
+
+describe('calculateSwarmDamage -- edge cases', () => {
+  it('returns 0 when no troopers are alive', () => {
+    const squad = makeSquad(4, 5);
+    squad.troopers.forEach((t) => {
+      t.alive = false;
+      t.armorRemaining = 0;
+    });
+    const squadDef = makeSquadDef({
+      weapons: [{ weaponId: 'small-laser-1', damage: 3 }],
+      vibroClaws: 2,
+      myomerBoosterActive: true,
+    });
+    expect(calculateSwarmDamage(squad, squadDef)).toBe(0);
+  });
+
+  it('returns 0 with empty weapon list and no bonuses', () => {
+    const squad = makeSquad(4, 5);
+    const squadDef = makeSquadDef();
+    expect(calculateSwarmDamage(squad, squadDef)).toBe(0);
+  });
+
+  it('damage scales down: 2 of 4 alive with SmallLaser = 6', () => {
+    const squad = makeSquad(4, 5);
+    squad.troopers[0].alive = false;
+    squad.troopers[0].armorRemaining = 0;
+    squad.troopers[2].alive = false;
+    squad.troopers[2].armorRemaining = 0;
+    const squadDef = makeSquadDef({
+      weapons: [{ weaponId: 'small-laser-1', damage: 3 }],
+    });
+    // 3 dmg x 2 active = 6
+    expect(calculateSwarmDamage(squad, squadDef)).toBe(6);
+  });
+
+  it('vibroclaws alone contribute their count', () => {
+    const squad = makeSquad(4, 5);
+    const squadDef = makeSquadDef({ vibroClaws: 2 });
+    // Vibroclaws are FLAT damage equal to their count (not x troopers).
+    expect(calculateSwarmDamage(squad, squadDef)).toBe(2);
+  });
+
+  it('myomer alone with 4 troopers contributes 8', () => {
+    const squad = makeSquad(4, 5);
+    const squadDef = makeSquadDef({ myomerBoosterActive: true });
+    // 4 troopers x 2 = 8 (no weapons, no claws).
+    expect(calculateSwarmDamage(squad, squadDef)).toBe(8);
+  });
+
+  it('myomer scales with active troopers (2 of 4 dead -> +4 myomer)', () => {
+    const squad = makeSquad(4, 5);
+    squad.troopers[0].alive = false;
+    squad.troopers[0].armorRemaining = 0;
+    squad.troopers[1].alive = false;
+    squad.troopers[1].armorRemaining = 0;
+    const squadDef = makeSquadDef({
+      weapons: [{ weaponId: 'small-laser-1', damage: 3 }],
+      myomerBoosterActive: true,
+    });
+    // 3 x 2 (weapons) + 0 (no claws) + 2 x 2 (myomer) = 6 + 4 = 10
+    expect(calculateSwarmDamage(squad, squadDef)).toBe(10);
+  });
+
+  it('multiple eligible weapons sum independently', () => {
+    const squad = makeSquad(4, 5);
+    const squadDef = makeSquadDef({
+      weapons: [
+        { weaponId: 'small-laser-1', damage: 3 },
+        { weaponId: 'flamer-1', damage: 2 },
+      ],
+    });
+    // (3 + 2) x 4 = 20
+    expect(calculateSwarmDamage(squad, squadDef)).toBe(20);
+  });
+});
+
+describe('calculateSwarmDamage -- caller-contract regression', () => {
+  it('formula sums whatever weapons it is given (no internal filtering)', () => {
+    const squad = makeSquad(4, 5);
+    const squadDef = makeSquadDef({
+      weapons: [{ weaponId: 'srm-2-body-fake', damage: 2 }],
+    });
+    // 2 x 4 = 8 -- formula trusts the caller. PR-L3+ filters at dispatch.
+    expect(calculateSwarmDamage(squad, squadDef)).toBe(8);
+  });
+});

--- a/src/lib/combat/baCombat.ts
+++ b/src/lib/combat/baCombat.ts
@@ -1,5 +1,6 @@
 /**
- * Battle Armor Combat — §1 squad state helpers + §2 damage allocation.
+ * Battle Armor Combat — §1 squad state helpers + §2 damage allocation +
+ * §4 swarm-fire damage formula.
  *
  * This module is the canonical compute layer for the new `IBASquadCombatState`
  * / `ITrooperState` shape defined in `CombatInterfaces.ts`.  It intentionally
@@ -7,8 +8,9 @@
  * `BattleArmorCombatInterfaces.ts` — the two shapes co-exist during migration;
  * future PRs will consolidate.
  *
- * Swarm attach/fire (§3-§4) and leg/vibroclaw/brush-off (§5-§8) are deferred
- * to PR-L2, PR-L3, and PR-L4 respectively.
+ * §3 swarm attach to-hit + state-machine, §5 mounted-trooper adapter,
+ * §6 leg attack, §7 vibroclaw, and §8 brush-off / dislodge are deferred
+ * to PR-L3 and PR-L4 respectively.
  *
  * @spec openspec/changes/add-battle-armor-combat/specs/battle-armor-combat/spec.md
  * @spec openspec/changes/add-battle-armor-combat/specs/combat-resolution/spec.md
@@ -215,4 +217,100 @@ function selectAliveTrooper(
   }
 
   return -1;
+}
+
+// =============================================================================
+// §4 — Swarm-fire damage formula (PR-L2)
+// =============================================================================
+
+/**
+ * Squad-mounted weapon contributing to swarm-fire damage. Only non-missile,
+ * non-body-mounted, non-InfantryAttack weapons feed the formula — callers
+ * filter the squad's full weapon set before invoking `calculateSwarmDamage`.
+ *
+ * `damage` is the published per-shot damage value (catalog field) — the
+ * formula multiplies it by the squad's active-trooper count (shootingStrength)
+ * to scale with squad health.
+ */
+export interface IBASwarmFireWeapon {
+  /** Catalog weapon id (used only for event attribution; not for math). */
+  readonly weaponId: string;
+  /** Per-shot damage value. */
+  readonly damage: number;
+}
+
+/**
+ * Squad-level loadout fields required by the swarm-fire formula. Kept narrow
+ * on purpose: this struct represents what `calculateSwarmDamage` actually
+ * reads, not the full BA squad definition (which lives in
+ * `IBattleArmorUnit`). Callers extract these from the canonical squad data.
+ */
+export interface IBASwarmFireSquadDef {
+  /** Eligible squad-mounted weapons (already filtered by the caller). */
+  readonly weapons: readonly IBASwarmFireWeapon[];
+  /**
+   * Squad-level vibroclaw count (0, 1, or 2). Adds flat damage equal to the
+   * count when > 0 (per MegaMek `SwarmWeaponAttackHandler.calculateSwarmDamage`
+   * — vibroclaws contribute the count, not the count × troopers). Matches the
+   * spec scenario "Vibroclaws add flat squad damage" (12 + 2 = 14).
+   */
+  readonly vibroClaws: number;
+  /**
+   * True when the squad has a Myomer Booster AND it is currently active
+   * (booster active = not destroyed and powered on this turn). Adds
+   * `activeTroopers × 2` to total damage when true.
+   */
+  readonly myomerBoosterActive: boolean;
+}
+
+/**
+ * Pure swarm-fire damage formula for a BA squad attached to a host mek.
+ *
+ * Formula (per MegaMek `SwarmWeaponAttackHandler.calculateSwarmDamage`
+ * referenced in the OMO Council Librarian seat):
+ *
+ * ```
+ * total = sum(weapon.damage × activeTroopers) over squadDef.weapons
+ *       + (squadDef.vibroClaws > 0 ? squadDef.vibroClaws : 0)
+ *       + (squadDef.myomerBoosterActive ? activeTroopers × 2 : 0)
+ * ```
+ *
+ * Missile, body-mounted, and Infantry-Attack weapons SHALL be excluded —
+ * callers filter them out before passing `squadDef.weapons`.
+ *
+ * Returns 0 when no troopers are alive (a destroyed squad cannot fire).
+ *
+ * Spec test cases:
+ *   - 4-trooper × 1 SmallLaser (3 dmg)                       → 12
+ *   - +2 vibroclaws                                          → 14
+ *   - +myomer booster active                                 → 22
+ *   - 2 of 4 troopers dead (only SmallLaser, no claws/myomer)→ 6
+ *
+ * @spec openspec/changes/add-battle-armor-combat/specs/battle-armor-combat/spec.md
+ *   (Requirement: Swarm Fire While Attached)
+ */
+export function calculateSwarmDamage(
+  squad: IBASquadCombatState,
+  squadDef: IBASwarmFireSquadDef,
+): number {
+  const activeTroopers = getNumberActiveTroopers(squad);
+  if (activeTroopers === 0) return 0;
+
+  // Sum per-weapon damage × shootingStrength. Caller has already filtered out
+  // missile / body-mounted / InfantryAttack weapons, so every entry in
+  // `squadDef.weapons` contributes.
+  let weaponSum = 0;
+  for (const w of squadDef.weapons) {
+    weaponSum += w.damage * activeTroopers;
+  }
+
+  // Vibroclaws contribute the squad-level count as flat damage (0, 1, or 2).
+  // Spec: "Vibroclaws add flat squad damage" → +2 for a 2-vibroclaw squad.
+  const vibroclawBonus = squadDef.vibroClaws > 0 ? squadDef.vibroClaws : 0;
+
+  // Myomer Booster (when active) adds activeTroopers × 2.
+  // Spec: "Myomer Booster adds per-trooper damage" → +(4 × 2) = +8 for 4 troopers.
+  const myomerBonus = squadDef.myomerBoosterActive ? activeTroopers * 2 : 0;
+
+  return weaponSum + vibroclawBonus + myomerBonus;
 }

--- a/src/utils/gameplay/battlearmor/index.ts
+++ b/src/utils/gameplay/battlearmor/index.ts
@@ -17,3 +17,4 @@ export * from './legAttack';
 export * from './swarm';
 export * from './vibroClaw';
 export * from './stealth';
+export * from './swarmFireResolver';

--- a/src/utils/gameplay/battlearmor/swarmFireResolver.ts
+++ b/src/utils/gameplay/battlearmor/swarmFireResolver.ts
@@ -1,0 +1,152 @@
+/**
+ * BA swarm-fire-while-attached phase-advance resolver (PR-L2 step 3).
+ *
+ * Drives the per-turn auto-fire pulse for every BA squad that is currently
+ * attached to a host mek via the older `IBattleArmorCombatState.swarmingUnitId`
+ * pointer (the production plumbing established by the prior
+ * `add-battlearmor-combat-behavior` change).  The resolver synthesizes a
+ * thin `IBASquadCombatState` view from the older shape so it can drive
+ * `calculateSwarmDamage` (the PR-L formula in `src/lib/combat/baCombat.ts`)
+ * and then emits one `SwarmDamage` event per attached squad.
+ *
+ * Determinism:
+ *   - Squads are processed in lexical order of their unit id.  The natural
+ *     `Object.keys(units)` order is not deterministic across engines, so
+ *     we explicitly sort before iterating.  Spec scenarios that pre-seed
+ *     two swarmers and expect a stable event order rely on this.
+ *
+ * Caller-supplied callbacks:
+ *   - `getSquadWeapons(squadId, unit)` returns the swarm-eligible weapons
+ *     for the squad — caller pre-filters to non-missile, non-body-mounted,
+ *     non-InfantryAttack.  Returning an empty array is valid and degenerates
+ *     to vibroclaw / myomer-only damage (which may be 0; the action then
+ *     no-ops).
+ *   - `getHostLocationLabel(squadId, hostId)` picks the host location label
+ *     stamped on the emitted event.  Production callers route this through
+ *     the PR-L mounted-trooper adapter (CT-front/back, LT, RT — first
+ *     attached trooper's slot).  The integration test stubs a fixed label.
+ *
+ * @spec openspec/changes/add-battle-armor-combat/specs/battle-armor-combat/spec.md
+ *   (Requirement: Swarm Fire While Attached)
+ */
+
+import type {
+  IBASquadCombatState,
+  IBattleArmorCombatState,
+  IGameSession,
+  IUnitGameState,
+} from '@/types/gameplay';
+
+import { applyInteractiveSessionSwarmFire } from '@/engine/InteractiveSession.actions';
+import { type IBASwarmFireSquadDef } from '@/lib/combat/baCombat';
+
+/**
+ * Inputs for `resolveSwarmFireForAttachedSquads` — the live session plus the
+ * caller-supplied callbacks that source per-squad weapon and host-location
+ * data the engine cannot infer on its own.
+ */
+export interface IResolveSwarmFireOptions {
+  /**
+   * Return the swarm-eligible weapons + squad-level flags for the attached
+   * BA squad whose unit id is `squadId`.  Caller is responsible for
+   * filtering out missile / body-mounted / InfantryAttack weapons before
+   * returning — the formula trusts whatever it gets.  Returning `null`
+   * skips the squad entirely (no event emitted).
+   */
+  readonly getSquadDef: (
+    squadId: string,
+    unitState: IUnitGameState,
+  ) => IBASwarmFireSquadDef | null;
+  /**
+   * Pick the location label for the emitted `SwarmDamage` event.  Production
+   * callers route this through the PR-L mounted-trooper adapter — by
+   * convention, the first attached trooper's slot.  Defaults to
+   * `'Center Torso'` when the option is omitted, so smoke tests that don't
+   * care about the label can stay terse.
+   */
+  readonly getHostLocationLabel?: (squadId: string, hostId: string) => string;
+}
+
+/**
+ * Synthesize an `IBASquadCombatState` view from the older
+ * `IBattleArmorCombatState` shape so the PR-L `calculateSwarmDamage`
+ * formula can read it without a migration.  The two shapes co-exist
+ * during PR-L / PR-L2 — see the header comment of `src/lib/combat/baCombat.ts`.
+ */
+function adaptOldSquadState(
+  old: IBattleArmorCombatState,
+  hostId: string,
+): IBASquadCombatState {
+  const troopers = old.troopers.map((t, i) => ({
+    index: i + 1,
+    alive: t.alive && t.armorRemaining > 0,
+    armorRemaining: t.armorRemaining,
+    equipmentDestroyed: [...t.equipmentDestroyed],
+  }));
+  return {
+    troopers,
+    swarmingUnitId: hostId,
+    swarmedByUnitIds: [],
+    mountedOn: undefined,
+    mimeticActiveThisTurn: old.mimeticActiveThisTurn,
+    stealthActiveThisTurn: false,
+  };
+}
+
+/**
+ * Resolve one tick of swarm fire for every BA squad currently attached
+ * to a host mek.  Returns a new session with `SwarmDamage` events appended
+ * (one per attached squad with non-zero computed damage).
+ *
+ * Iteration order is lexical by squad unit id so the resulting event
+ * sequence is deterministic across runs — required by replay-stability
+ * regressions and the spec scenarios that expect a stable per-tick order.
+ *
+ * No-ops cleanly when the session has zero attached swarmers (no event
+ * stream pollution).
+ */
+export function resolveSwarmFireForAttachedSquads(
+  session: IGameSession,
+  options: IResolveSwarmFireOptions,
+): IGameSession {
+  const units = session.currentState.units;
+  // Determinism: sort by squad id before iterating.  Object.keys ordering
+  // is engine-dependent for non-numeric-string keys, and replay tests rely
+  // on a stable per-tick event order.
+  const squadIds = Object.keys(units).sort();
+
+  let current = session;
+  for (const squadId of squadIds) {
+    const unit = units[squadId];
+    if (!unit || unit.destroyed) continue;
+
+    // Only BA squad combat-state envelopes carry `swarmingUnitId`.
+    const cs = unit.combatState;
+    if (!cs || cs.kind !== 'squad') continue;
+
+    const oldSquadState = cs.state;
+    const hostId = oldSquadState.swarmingUnitId;
+    if (!hostId) continue;
+
+    const host = current.currentState.units[hostId];
+    if (!host || host.destroyed) continue;
+
+    const squadDef = options.getSquadDef(squadId, unit);
+    if (!squadDef) continue;
+
+    const squadView = adaptOldSquadState(oldSquadState, hostId);
+    const hostLocationLabel =
+      options.getHostLocationLabel?.(squadId, hostId) ?? 'Center Torso';
+
+    current = applyInteractiveSessionSwarmFire({
+      session: current,
+      squadId,
+      hostUnitId: hostId,
+      squad: squadView,
+      squadDef,
+      hostLocationLabel,
+    });
+  }
+
+  return current;
+}


### PR DESCRIPTION
## Summary

Ships PR-L2 (Wave 8 G4 — biggest BA combat gap): a BA squad that is attached
(swarming) a Mek/Vehicle now auto-fires its non-missile body-mounted weapons
at the host every turn it remains attached.

Builds on PR-L (#667) which established the new \`IBASquadCombatState\` shape,
\`allocateSquadDamage\`, the mounted-trooper adapter, and the \`BASquadDamaged\`
event factory.

## Step-by-step deliverables

### Step 1 (commit \`aab53352\`) — Pure formula + unit tests

\`src/lib/combat/baCombat.ts\` gains \`calculateSwarmDamage(squad, squadDef)\`,
a pure function operating on the new \`IBASquadCombatState\` shape. Formula
matches MegaMek \`SwarmWeaponAttackHandler.calculateSwarmDamage\` parity:

\`\`\`
total = sum(weapon.damage × activeTroopers) over squadDef.weapons
      + (vibroClaws > 0 ? vibroClaws : 0)            // flat (not × troopers)
      + (myomerBoosterActive ? activeTroopers × 2 : 0)
\`\`\`

11 new tests in \`baCombat.swarmDamage.test.ts\` verify the Librarian's
canonical numbers:
- 4-trooper × 1 SmallLaser (3 dmg)  → **12** damage
- +2 vibroclaws                     → **14**
- +myomer booster active            → **22**
- 2 of 4 troopers dead, SmallLaser  → **6** (scales down)
- 0 active troopers                 → 0

The caller-contract regression test documents that missile / body-mounted /
InfantryAttack weapon filtering happens UPSTREAM (PR-L3 dispatch layer).

### Step 1 — Event types (no-op)

\`GameEventType.SwarmDamage\` + \`ISwarmDamagePayload\` already exist (from the
older \`add-battlearmor-combat-behavior\` change) with exactly the
\`{ unitId, targetUnitId, damage, locationLabel }\` shape this work needs.
Reusing avoids a duplicate event variant — documented in the step-1 commit.

### Step 2 (commit \`5b7f1873\`) — Action handler

\`src/engine/InteractiveSession.actions.ts\` gains
\`applyInteractiveSessionSwarmFire({ session, squadId, hostUnitId, squad, squadDef, hostLocationLabel })\`
that computes damage via \`calculateSwarmDamage\` and appends a \`SwarmDamage\`
event via the established \`createSwarmDamageEvent\` factory. Returns the
session unchanged when damage is 0 or units are missing.

### Step 3+4 (commit \`08c1226d\`) — Phase trigger + scenario test

New module \`src/utils/gameplay/battlearmor/swarmFireResolver.ts\` exports
\`resolveSwarmFireForAttachedSquads(session, options) → session\` which:
1. Iterates \`session.currentState.units\` sorted by squad id (deterministic
   event order — required by replay-stability regressions).
2. For each BA squad with \`combatState.kind === 'squad'\` AND
   \`state.swarmingUnitId\` set, synthesizes an \`IBASquadCombatState\` view
   from the older \`IBattleArmorCombatState\` shape.
3. Invokes the action handler from step 2 → \`SwarmDamage\` event emitted.

Phase integration in \`src/engine/InteractiveSession.phases.ts\`:
- \`IInteractiveSessionPhaseContext\` gains an OPTIONAL \`swarmFireOptions\`
  field. Legacy callers and non-BA tests omit it; the End-phase block then
  skips the trigger entirely (no event-stream pollution).
- When supplied, the End phase invokes \`resolveSwarmFireForAttachedSquads\`
  BEFORE the morale pass so the swarm-damage event lands in the log when
  morale evaluates the turn's combat outcomes.

Integration scenario test \`InteractiveSession.swarmFire.scenario.test.ts\` —
7 scenarios using a real \`IGameSession\` and the production
\`advanceInteractiveSessionPhase\` function:
- \`SwarmDamage = 12\` for 4-trooper × 1 SmallLaser
- \`SwarmDamage = 22\` with vibroclaws + myomer
- No event when no swarmer attached
- No event when \`swarmFireOptions\` omitted
- Ammo + heat preserved (swarm fire is auto-hit, no heat)
- Destroyed squads skipped
- Event stamped with End phase + correct turn

## Scope notes — what's NOT in this PR

- **Dispatch-layer weapon filtering** (missile / body-mounted /
  InfantryAttack exclusion at the squad-def builder layer) — deferred to
  PR-L3 with the squad-def builder that reads BA construction data.
- **\`InteractiveSession.advancePhase()\` production wiring** — does not yet
  pass \`swarmFireOptions\` because the squad-def builder requires the BA
  construction-data filtering above. The trigger code is in place; PR-L3
  threads the production data through.
- **§3 SwarmAttack action handler** (the to-hit + state-machine that sets
  \`swarmingUnitId\` in the first place) — deferred per the PR-L tasks.md
  note. Integration test seeds the swarm directly via the same mutation
  a successful SwarmAttack would perform.

## Verification

- \`npx tsc --noEmit\` clean
- \`npx oxfmt --check src/lib/combat src/engine src/utils/gameplay/battlearmor\` clean
- \`npx oxlint src/lib/combat src/engine src/utils/gameplay/battlearmor\` clean
  (0 warnings, 0 errors)
- 18 new tests pass (11 unit + 7 scenario)
- 267 tests pass across \`src/engine\` + \`src/lib/combat\` + \`src/utils/gameplay/battlearmor\`
- 3129 tests pass across full \`src/utils/gameplay\` sweep (no regressions)
- Husky pre-commit (lint-staged + full \`npm run build\`) passed on all 3 commits

## Test plan

- [ ] CI green on all 6 parallel jobs (lint / format / typecheck / test / validate-bv / storybook)
- [ ] Branch protection's \"Lint and Test\" + \"Build Test / win/mac/linux\" aggregators green
- [ ] No regressions in any of the 17 existing BA tests