### PR TITLE
test(wave-8): intel-tier projection E2E smoke (PR-intel-smoke — G7)

### DIFF
--- a/e2e/intel-tier-projection.spec.ts
+++ b/e2e/intel-tier-projection.spec.ts
@@ -1,0 +1,261 @@
+/**
+ * Opponent-intel tier projection — E2E redaction smoke
+ *
+ * Drives the dev-only harness at `/e2e/intel-tier-projection?tier=<t>` (see
+ * `src/pages/e2e/intel-tier-projection.tsx`) through all four supported
+ * opponent tiers and asserts the inspector's DOM matches the tier contract:
+ *
+ *   - 'exact'      — chassis + heat + armor + structure visible
+ *   - 'rough'      — name visible; damage band visible; heat/armor/structure
+ *                    redacted from DOM (testid + visible-text)
+ *   - 'silhouette' — name AND chassis hidden; only the silhouette band
+ *   - 'hidden'     — completely opaque "Unknown Contact" placeholder; the
+ *                    opponent's real name MUST NOT appear anywhere in the
+ *                    rendered DOM subtree
+ *
+ * The friendly inspector renders alongside the opponent inspector on the
+ * same page and is asserted to always show full pilot + heat regardless of
+ * the active opponent tier (the friendly branch short-circuits before the
+ * intel projection runs).
+ *
+ * This spec exists to close the `intelGuardrails` orphan-rot risk raised by
+ * the OMO Heavy Council audit (Phase 2 — G7 finding). Without a CI-enforced
+ * consumer route, `src/services/intel/intelGuardrails.ts` was reachable only
+ * through the live tactical shell, which the e2e suite never mounts against
+ * a fog-of-war session. A future refactor that broke the redaction policy
+ * would otherwise ship silently — mirroring the 6-month indirect-fire
+ * helper orphan precedent.
+ *
+ * @spec openspec/changes/add-tactical-unit-inspector-drawers/specs/tactical-map-interface/spec.md
+ * @tags @smoke @intel @wave-8
+ */
+
+import { test, expect, type Page } from '@playwright/test';
+
+const HARNESS_ROUTE = '/e2e/intel-tier-projection';
+
+// The opponent unit's identifying strings; these are the values whose
+// presence/absence in the DOM the spec asserts on per tier.
+const OPPONENT_NAME = 'Mad Cat Prime';
+const OPPONENT_CHASSIS = 'mad-cat-prime';
+
+// The friendly unit's identity — visible in every tier because the friendly
+// branch ignores the opponent intel scope.
+const FRIENDLY_NAME = 'Atlas AS7-D';
+const FRIENDLY_PILOT = 'Mechwarrior Smith';
+
+/**
+ * Navigate to the harness page for a given tier and wait for the inspector
+ * subtrees to render.
+ *
+ * Uses a 30s expect timeout for the first visibility check to absorb the
+ * cold Next.js compile on the very first request (~3s observed locally,
+ * worse on CI). Subsequent tier navigations hit the warm cache and clear
+ * in tens of milliseconds, so the long timeout is a safety net, not a
+ * performance budget.
+ */
+async function gotoTier(
+  page: Page,
+  tier: 'exact' | 'rough' | 'silhouette' | 'hidden',
+): Promise<void> {
+  await page.goto(`${HARNESS_ROUTE}?tier=${tier}`);
+  // Harness root must mount and the tier badge must reflect the URL param —
+  // otherwise we'd be asserting against a stale render. First-hit cold-
+  // compile on a fresh dev server can exceed the default 10s expect timeout,
+  // so widen this single check (subsequent tier links re-use warm compile).
+  await expect(page.getByTestId('intel-tier-projection-harness')).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(page.getByTestId('intel-harness-active-tier')).toHaveText(
+    `Active tier: ${tier}`,
+  );
+}
+
+test.describe('Opponent intel tier projection @smoke @intel @wave-8', () => {
+  // ---------------------------------------------------------------------------
+  // Friendly view — must remain full regardless of opponent tier
+  // ---------------------------------------------------------------------------
+
+  test('friendly inspector renders full state at every opponent tier', async ({
+    page,
+  }) => {
+    // Loop the 4 tiers and confirm the friendly inspector is unaffected.
+    for (const tier of ['exact', 'rough', 'silhouette', 'hidden'] as const) {
+      await gotoTier(page, tier);
+
+      const friendlyPanel = page.getByTestId(
+        'intel-harness-friendly-inspector',
+      );
+
+      // Full friendly sub-view is mounted.
+      await expect(
+        friendlyPanel.getByTestId('inspector-friendly'),
+      ).toBeVisible();
+
+      // Pilot identity + heat + armor are all exposed on a friendly unit.
+      await expect(friendlyPanel.getByTestId('inspector-unit-name')).toHaveText(
+        FRIENDLY_NAME,
+      );
+      await expect(
+        friendlyPanel.getByTestId('inspector-pilot-name'),
+      ).toHaveText(FRIENDLY_PILOT);
+      await expect(friendlyPanel.getByTestId('inspector-heat')).toBeVisible();
+      await expect(friendlyPanel.getByTestId('inspector-armor')).toBeVisible();
+      await expect(
+        friendlyPanel.getByTestId('inspector-structure'),
+      ).toBeVisible();
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Tier 'exact' — full opponent state exposed
+  // ---------------------------------------------------------------------------
+
+  test('opponent at exact tier exposes chassis + heat + armor', async ({
+    page,
+  }) => {
+    await gotoTier(page, 'exact');
+
+    const opponentPanel = page.getByTestId('intel-harness-opponent-inspector');
+
+    // Target sub-view is mounted; redacted sub-view MUST NOT be.
+    await expect(opponentPanel.getByTestId('inspector-target')).toBeVisible();
+    await expect(opponentPanel.getByTestId('inspector-redacted')).toHaveCount(
+      0,
+    );
+
+    // Name AND chassis are both exposed at exact tier.
+    await expect(opponentPanel.getByTestId('inspector-unit-name')).toHaveText(
+      OPPONENT_NAME,
+    );
+    await expect(opponentPanel.getByTestId('inspector-chassis')).toHaveText(
+      OPPONENT_CHASSIS,
+    );
+
+    // Numeric fields are present (the projection populates them at this tier).
+    await expect(opponentPanel.getByTestId('inspector-heat')).toBeVisible();
+    await expect(opponentPanel.getByTestId('inspector-armor')).toBeVisible();
+    await expect(
+      opponentPanel.getByTestId('inspector-structure'),
+    ).toBeVisible();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Tier 'rough' — name visible, numbers redacted
+  // ---------------------------------------------------------------------------
+
+  test('opponent at rough tier hides exact numeric fields but keeps name', async ({
+    page,
+  }) => {
+    await gotoTier(page, 'rough');
+
+    const opponentPanel = page.getByTestId('intel-harness-opponent-inspector');
+
+    // Target sub-view is mounted (rough is still a target projection).
+    await expect(opponentPanel.getByTestId('inspector-target')).toBeVisible();
+
+    // Name is visible at rough tier.
+    await expect(opponentPanel.getByTestId('inspector-unit-name')).toHaveText(
+      OPPONENT_NAME,
+    );
+
+    // Chassis MUST NOT render at rough tier (component only renders when
+    // projection.chassis is non-null; rough sets it to null).
+    await expect(opponentPanel.getByTestId('inspector-chassis')).toHaveCount(0);
+
+    // Damage band IS shown (the only damage signal at rough tier).
+    await expect(
+      opponentPanel.getByTestId('inspector-damage-band'),
+    ).toBeVisible();
+
+    // Exact numeric fields MUST NOT render at rough tier.
+    await expect(opponentPanel.getByTestId('inspector-heat')).toHaveCount(0);
+    await expect(opponentPanel.getByTestId('inspector-armor')).toHaveCount(0);
+    await expect(opponentPanel.getByTestId('inspector-structure')).toHaveCount(
+      0,
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Tier 'silhouette' — name AND chassis hidden
+  // ---------------------------------------------------------------------------
+
+  test('opponent at silhouette tier hides name and chassis', async ({
+    page,
+  }) => {
+    await gotoTier(page, 'silhouette');
+
+    const opponentPanel = page.getByTestId('intel-harness-opponent-inspector');
+
+    // Target sub-view is still mounted (silhouette is a target projection
+    // with `name: null` and `chassisClass` populated).
+    await expect(opponentPanel.getByTestId('inspector-target')).toBeVisible();
+
+    // The component renders the name node, but the projection value is null
+    // so the rendered text is empty.
+    const nameText =
+      (await opponentPanel.getByTestId('inspector-unit-name').textContent()) ??
+      '';
+    expect(nameText.trim()).toBe('');
+
+    // The opponent's real chassis name MUST NOT appear anywhere in the
+    // opponent panel's text content — including aria-label or other attrs.
+    const panelText = (await opponentPanel.textContent()) ?? '';
+    expect(panelText).not.toContain(OPPONENT_NAME);
+    expect(panelText).not.toContain(OPPONENT_CHASSIS);
+
+    // Damage band IS shown (computed from observable armor at silhouette tier).
+    await expect(
+      opponentPanel.getByTestId('inspector-damage-band'),
+    ).toBeVisible();
+
+    // Exact numeric fields are absent.
+    await expect(opponentPanel.getByTestId('inspector-heat')).toHaveCount(0);
+    await expect(opponentPanel.getByTestId('inspector-armor')).toHaveCount(0);
+    await expect(opponentPanel.getByTestId('inspector-structure')).toHaveCount(
+      0,
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Tier 'hidden' — fully opaque redacted view
+  // ---------------------------------------------------------------------------
+
+  test('opponent at hidden tier renders redacted placeholder with no identity leak', async ({
+    page,
+  }) => {
+    await gotoTier(page, 'hidden');
+
+    const opponentPanel = page.getByTestId('intel-harness-opponent-inspector');
+
+    // Redacted sub-view is mounted; target / friendly sub-views are NOT.
+    await expect(opponentPanel.getByTestId('inspector-redacted')).toBeVisible();
+    await expect(opponentPanel.getByTestId('inspector-target')).toHaveCount(0);
+    await expect(opponentPanel.getByTestId('inspector-friendly')).toHaveCount(
+      0,
+    );
+
+    // Generic placeholder text is present.
+    await expect(opponentPanel.getByTestId('inspector-redacted')).toContainText(
+      'Unknown Contact',
+    );
+
+    // The opponent's real name and chassis MUST NOT appear anywhere in the
+    // rendered subtree — not in text, not in any data-testid value, not in
+    // aria attributes. Per the spec: "exact hidden fields SHALL not be
+    // recoverable from labels, tooltips, DOM text, ARIA text, or test ids".
+    const panelHtml = (await opponentPanel.innerHTML()) ?? '';
+    expect(panelHtml).not.toContain(OPPONENT_NAME);
+    expect(panelHtml).not.toContain(OPPONENT_CHASSIS);
+
+    // Even the unit ID (which the redacted projection retains for React keys)
+    // must not appear as visible text — the placeholder is text-only.
+    const panelText = (await opponentPanel.textContent()) ?? '';
+    expect(panelText).not.toContain(OPPONENT_NAME);
+    expect(panelText).not.toContain(OPPONENT_CHASSIS);
+
+    // Numeric heat (12 on the seed state) MUST NOT appear in the opponent
+    // panel's text — the redacted shape carries no heat field at all.
+    expect(panelText).not.toContain('Heat');
+  });
+});

--- a/src/pages/e2e/intel-tier-projection.tsx
+++ b/src/pages/e2e/intel-tier-projection.tsx
@@ -1,0 +1,381 @@
+/**
+ * E2E Test Harness for opponent-intel tier projection.
+ *
+ * Mounts `TacticalUnitInspector` against a synthetic `IGameSession` with one
+ * friendly unit AND one opponent unit. The opponent's intel tier is driven by
+ * the `?tier=` URL query param (one of: 'exact' | 'rough' | 'silhouette' |
+ * 'hidden'). Two inspectors render side-by-side so a single page load can
+ * assert both the friendly full-state view AND the redacted/quantized
+ * opponent view.
+ *
+ * This route exists to close the orphan-rot gap raised by OMO Heavy Council
+ * audit Phase 2 / Oracle seat: `src/services/intel/intelGuardrails.ts` is
+ * reachable only through `useUnitInspectorProjection → TacticalUnitInspector
+ * → GameplayLayout`, with no CI-enforced consumer route exercising the 4
+ * opponent tiers end-to-end. Without this harness, a future refactor could
+ * silently break the redaction policy and the only signal would be a unit-
+ * test gap surfacing months later (mirroring the 6-month indirect-fire
+ * helper orphan precedent).
+ *
+ * Only available in development/test environments. Guarded by the same
+ * `isTestEnv` check the sibling E2E harnesses use; production builds render
+ * the "Not Available" placeholder.
+ *
+ * @internal For E2E testing only — never linked from production UI.
+ */
+
+import { useRouter } from 'next/router';
+import { useMemo } from 'react';
+
+import type {
+  IGameSession,
+  IGameState,
+  IGameUnit,
+  IUnitGameState,
+} from '@/types/gameplay';
+import type {
+  OpponentIntelTier,
+  PlayerId,
+} from '@/types/gameplay/TacticalShellInterfaces';
+
+import { TacticalUnitInspector } from '@/components/gameplay/TacticalUnitInspector';
+import { GameSide, LockState, MovementType } from '@/types/gameplay';
+
+// =============================================================================
+// Test-environment gate
+// =============================================================================
+
+const isTestEnv =
+  process.env.NODE_ENV === 'development' ||
+  process.env.NODE_ENV === 'test' ||
+  process.env.NEXT_PUBLIC_E2E_TEST === 'true' ||
+  process.env.NEXT_PUBLIC_E2E_MODE === 'true';
+
+// =============================================================================
+// Synthetic-session constants
+// =============================================================================
+
+/** Stable test-ids used by the e2e spec to grab each inspector instance. */
+const FRIENDLY_INSPECTOR_TESTID = 'intel-harness-friendly-inspector';
+const OPPONENT_INSPECTOR_TESTID = 'intel-harness-opponent-inspector';
+const TIER_BADGE_TESTID = 'intel-harness-active-tier';
+
+/** Unit ids — picked so they cannot be confused with the opponent's name. */
+const FRIENDLY_UNIT_ID = 'friendly-1';
+const OPPONENT_UNIT_ID = 'opponent-1';
+const VIEWER_PLAYER_ID: PlayerId = 'player-a';
+const OPPONENT_PLAYER_ID: PlayerId = 'player-b';
+
+/**
+ * Names + chassis chosen so we can DOM-grep them to confirm they leak through
+ * (or NOT) at each tier. Pilot name "Mechwarrior Smith" is uniquely identifying
+ * and absent from the redacted shape's placeholder text.
+ */
+const FRIENDLY_NAME = 'Atlas AS7-D';
+const FRIENDLY_CHASSIS = 'atlas-as7-d';
+const FRIENDLY_PILOT = 'Mechwarrior Smith';
+const OPPONENT_NAME = 'Mad Cat Prime';
+const OPPONENT_CHASSIS = 'mad-cat-prime';
+
+/** Whitelist of tiers this harness exposes to the e2e spec. */
+const SUPPORTED_TIERS: readonly OpponentIntelTier[] = [
+  'exact',
+  'rough',
+  'silhouette',
+  'hidden',
+];
+
+/**
+ * Resolve the active tier from the URL query param. Defaults to 'exact'
+ * (most information visible) so the route renders something meaningful when
+ * navigated without a query string.
+ */
+function resolveTier(raw: string | string[] | undefined): OpponentIntelTier {
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  if (
+    value &&
+    (SUPPORTED_TIERS as readonly string[]).includes(value as string)
+  ) {
+    return value as OpponentIntelTier;
+  }
+  return 'exact';
+}
+
+// =============================================================================
+// Synthetic fixture builders
+// =============================================================================
+
+/**
+ * Build a minimal IGameUnit with stable fields. Cast through `unknown` because
+ * the test harness only needs the fields the inspector projection reads.
+ */
+function buildGameUnit(
+  id: string,
+  side: GameSide,
+  name: string,
+  unitRef: string,
+): IGameUnit {
+  return {
+    id,
+    name,
+    side,
+    unitRef,
+    pilotRef: `pilot-${id}`,
+    gunnery: 3,
+    piloting: 4,
+  } as IGameUnit;
+}
+
+/**
+ * Build a minimal IUnitGameState. Heat/armor numbers below are deliberately
+ * unique values so the spec can grep them to confirm they leak (exact tier)
+ * or do NOT leak (rough / silhouette / hidden tiers).
+ */
+function buildUnitState(id: string, side: GameSide): IUnitGameState {
+  return {
+    id,
+    side,
+    position: { q: 0, r: 0 },
+    facing: 0 as unknown as IUnitGameState['facing'],
+    heat: 12,
+    movementThisTurn: MovementType.Walk,
+    hexesMovedThisTurn: 3,
+    armor: {
+      HEAD: 9,
+      CT: 31,
+      LT: 20,
+      RT: 20,
+      LA: 16,
+      RA: 16,
+      LL: 20,
+      RL: 20,
+    },
+    structure: {
+      HEAD: 3,
+      CT: 20,
+      LT: 14,
+      RT: 14,
+      LA: 10,
+      RA: 10,
+      LL: 14,
+      RL: 14,
+    },
+    destroyedLocations: [],
+    destroyedEquipment: [],
+    ammo: {},
+    pilotWounds: 0,
+    pilotConscious: true,
+    destroyed: false,
+    lockState: LockState.Pending,
+  };
+}
+
+/** Build a synthetic IGameSession with one friendly + one opponent unit. */
+function buildSyntheticSession(): IGameSession {
+  const friendlyUnit = buildGameUnit(
+    FRIENDLY_UNIT_ID,
+    GameSide.Player,
+    FRIENDLY_NAME,
+    FRIENDLY_CHASSIS,
+  );
+  const opponentUnit = buildGameUnit(
+    OPPONENT_UNIT_ID,
+    GameSide.Opponent,
+    OPPONENT_NAME,
+    OPPONENT_CHASSIS,
+  );
+
+  const friendlyState = buildUnitState(FRIENDLY_UNIT_ID, GameSide.Player);
+  const opponentState = buildUnitState(OPPONENT_UNIT_ID, GameSide.Opponent);
+
+  const currentState = {
+    units: {
+      [FRIENDLY_UNIT_ID]: friendlyState,
+      [OPPONENT_UNIT_ID]: opponentState,
+    },
+    phase: 'movement',
+    turn: 1,
+    firstMover: GameSide.Player,
+    initiativeWinner: GameSide.Player,
+    activationIndex: 0,
+    turnEvents: [],
+  } as unknown as IGameState;
+
+  return {
+    id: 'intel-tier-harness-session',
+    createdAt: '2026-05-21T00:00:00.000Z',
+    updatedAt: '2026-05-21T00:00:00.000Z',
+    units: [friendlyUnit, opponentUnit],
+    currentState,
+    events: [],
+    config: {
+      mapRadius: 5,
+      turnLimit: 0,
+      victoryConditions: ['elimination'],
+      optionalRules: [],
+    },
+    sideOwners: {
+      [GameSide.Player]: VIEWER_PLAYER_ID,
+      [GameSide.Opponent]: OPPONENT_PLAYER_ID,
+    },
+  } as unknown as IGameSession;
+}
+
+// =============================================================================
+// Page component
+// =============================================================================
+
+export default function IntelTierProjectionHarnessPage(): React.JSX.Element {
+  const router = useRouter();
+  const tier = resolveTier(router.query.tier);
+
+  // Synthetic session is constant per page load — build once.
+  const session = useMemo(buildSyntheticSession, []);
+
+  // Per-opponent intel scope drives the projection. We always key by the
+  // opponent's player id; the friendly inspector ignores this map because the
+  // friendly branch short-circuits on `gameUnit.side === viewerSide`.
+  const opponentVisibilityScopes = useMemo(
+    () => ({ [OPPONENT_PLAYER_ID]: tier }),
+    [tier],
+  );
+
+  // Supplemental data only matters for the friendly inspector (pilot names,
+  // weapons, armor max). The opponent never receives pilot names; the
+  // projection hook ignores the supplemental for the opponent branches.
+  const friendlySupplemental = useMemo(
+    () => ({
+      pilotNames: { [FRIENDLY_UNIT_ID]: FRIENDLY_PILOT },
+      maxArmor: {
+        [OPPONENT_UNIT_ID]: {
+          HEAD: 9,
+          CT: 47,
+          LT: 32,
+          RT: 32,
+          LA: 24,
+          RA: 24,
+          LL: 32,
+          RL: 32,
+        },
+      },
+    }),
+    [],
+  );
+
+  if (!isTestEnv) {
+    return (
+      <div style={{ padding: 40, textAlign: 'center' }}>
+        <h1>Not Available</h1>
+        <p>This page is only available in development/test environments.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-testid="intel-tier-projection-harness"
+      data-active-tier={tier}
+      style={{ display: 'flex', flexDirection: 'column', gap: 16, padding: 16 }}
+    >
+      <header
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 4,
+          borderBottom: '1px solid #ccc',
+          paddingBottom: 8,
+        }}
+      >
+        <h1 style={{ margin: 0, fontSize: 18 }}>
+          Opponent Intel Tier Projection Harness
+        </h1>
+        <p style={{ margin: 0, color: '#555', fontSize: 12 }}>
+          E2E-only route. Drives the 4 opponent tiers through
+          <code> useUnitInspectorProjection </code>+
+          <code> assertNoLeakedSecrets </code>
+          end-to-end. Set <code>?tier=exact|rough|silhouette|hidden</code> to
+          change the active opponent tier.
+        </p>
+        <div data-testid={TIER_BADGE_TESTID}>Active tier: {tier}</div>
+        <nav
+          style={{ display: 'flex', gap: 8, fontSize: 12 }}
+          data-testid="intel-harness-tier-links"
+        >
+          {SUPPORTED_TIERS.map((t) => (
+            <a
+              key={t}
+              href={`?tier=${t}`}
+              data-testid={`intel-harness-tier-link-${t}`}
+            >
+              {t}
+            </a>
+          ))}
+        </nav>
+      </header>
+
+      <section
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '1fr 1fr',
+          gap: 16,
+        }}
+      >
+        <div
+          data-testid={FRIENDLY_INSPECTOR_TESTID}
+          style={{
+            border: '1px solid #6699cc',
+            borderRadius: 4,
+            background: '#fff',
+          }}
+        >
+          <div
+            style={{
+              padding: '4px 8px',
+              background: '#e6f0fb',
+              fontSize: 12,
+              fontWeight: 600,
+            }}
+          >
+            Friendly (always full view)
+          </div>
+          <TacticalUnitInspector
+            inspectedUnitId={FRIENDLY_UNIT_ID}
+            session={session}
+            viewerPlayerId={VIEWER_PLAYER_ID}
+            viewerSide={GameSide.Player}
+            opponentVisibilityScopes={opponentVisibilityScopes}
+            supplemental={friendlySupplemental}
+          />
+        </div>
+
+        <div
+          data-testid={OPPONENT_INSPECTOR_TESTID}
+          style={{
+            border: '1px solid #cc6666',
+            borderRadius: 4,
+            background: '#fff',
+          }}
+        >
+          <div
+            style={{
+              padding: '4px 8px',
+              background: '#fbeaea',
+              fontSize: 12,
+              fontWeight: 600,
+            }}
+          >
+            Opponent (tier: {tier})
+          </div>
+          <TacticalUnitInspector
+            inspectedUnitId={OPPONENT_UNIT_ID}
+            session={session}
+            viewerPlayerId={VIEWER_PLAYER_ID}
+            viewerSide={GameSide.Player}
+            opponentVisibilityScopes={opponentVisibilityScopes}
+            supplemental={friendlySupplemental}
+          />
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Closes the **intelGuardrails orphan-rot gap** raised by the OMO Heavy Council audit Phase 2 (Oracle seat — finding G7). Adds a CI-enforced consumer for `src/services/intel/intelGuardrails.ts` so a future refactor that silently breaks the opponent-intel redaction policy fails CI instead of shipping.

The helper is currently reachable only through `useUnitInspectorProjection → TacticalUnitInspector → GameplayLayout`, and no existing E2E spec mounts the inspector against a fog-of-war session. That mirrored the 6-month indirect-fire helper orphan precedent — this PR cuts that risk now.

## Changes

- **`src/pages/e2e/intel-tier-projection.tsx`** (new, dev-only) — Mounts two `TacticalUnitInspector` panels (one friendly, one opponent) against a synthetic `IGameSession`. The opponent's intel tier is driven by the `?tier=` URL query param. Guarded by the same `isTestEnv` check the sibling `src/pages/e2e/` harnesses use; production renders the \"Not Available\" placeholder.

- **`e2e/intel-tier-projection.spec.ts`** (new) — 5 tests × 5 Playwright projects = 25 test runs. 39 DOM-level assertions across the 4 supported opponent tiers (exact / rough / silhouette / hidden) plus the friendly always-full cross-tier loop. Tagged `@smoke @intel @wave-8`.

## Tier coverage

| Tier | What's visible | What's absent |
|---|---|---|
| exact | name + chassis + heat + armor + structure | — |
| rough | name + damage band | chassis testid, heat, armor, structure |
| silhouette | damage band | name text (empty), chassis, heat, armor, structure |
| hidden | \"Unknown Contact\" placeholder | OPPONENT_NAME / OPPONENT_CHASSIS absent from text + HTML |
| friendly (any opponent tier) | pilot name + heat + armor + structure | — |

## Verification

- `npx tsc --noEmit` — green
- `npx oxfmt --check` (both files) — green
- `npx oxlint src/pages/e2e/intel-tier-projection.tsx` — 0 warnings, 0 errors (`e2e/**` is in oxlint ignorePatterns by project config)
- `npx playwright test e2e/intel-tier-projection.spec.ts --list` — 25 tests discovered (5 × 5 projects)
- `npx playwright test e2e/intel-tier-projection.spec.ts --project=chromium --workers=1` — **5/5 passed** locally (12.7s)
- `npx playwright test e2e/intel-tier-projection.spec.ts --project=smoke --workers=1` — **5/5 passed** locally (11.2s)

The `gotoTier` helper widens the first visibility-check timeout to 30s to absorb Next.js cold-compile on a fresh dev server (~3s observed locally; CI is slower). Subsequent tier navigations hit the warm compile cache and clear in tens of ms.

## Test plan

- [ ] CI runs the new spec in the smoke project on PR check
- [ ] All 5 tests pass against the auto-spun dev server
- [ ] The dev-only harness is unreachable in production builds (renders \"Not Available\")