### PR TITLE
feat(wave-8): BA leg attack + wire vehicle orphan helpers (PR-L3 — G5 + G6)

### DIFF
--- a/src/engine/InteractiveSession.actions.ts
+++ b/src/engine/InteractiveSession.actions.ts
@@ -19,6 +19,7 @@ import type { IGameSession } from '@/types/gameplay/GameSessionInterfaces';
 
 import {
   calculateSwarmDamage,
+  type IBALegAttackSquadDef,
   type IBASwarmFireSquadDef,
 } from '@/lib/combat/baCombat';
 import {
@@ -29,7 +30,10 @@ import {
   type IHexGrid,
   type IMovementCapability,
 } from '@/types/gameplay/HexGridInterfaces';
-import { createSwarmDamageEvent } from '@/utils/gameplay/gameEvents/battleArmor';
+import {
+  createLegAttackResolvedEvent,
+  createSwarmDamageEvent,
+} from '@/utils/gameplay/gameEvents/battleArmor';
 import {
   declareAttack,
   declareMovement,
@@ -272,3 +276,86 @@ export function applyInteractiveSessionSwarmFire(
 
   return appendEvent(input.session, event);
 }
+// =============================================================================
+// PR-L3 §3 — BA leg-attack action handler (Mek + Vehicle targets)
+// =============================================================================
+
+/**
+ * Inputs for `applyInteractiveSessionLegAttack`. The action handler is
+ * intentionally thin — it does NOT pick the rolled leg, does NOT compute
+ * the firing arc, and does NOT apply damage to the target's armor. Those
+ * concerns live in `resolveMekLegAttack` / `resolveVehicleLegAttack`
+ * (in `src/utils/gameplay/battlearmor/legAttackResolver.ts`) and the
+ * downstream damage pipeline that consumes the emitted
+ * `LegAttackResolved` event.
+ *
+ * Callers (the dispatch layer) MUST:
+ *   1. confirm the attack is legal (squad in same hex as target, etc.),
+ *   2. build `squadDef` with the squad's vibroclaw / myomer flags,
+ *   3. supply the pre-resolved `ILegAttackResolution` from the resolver
+ *      (carries hit / damage / hitLocation / critModifier).
+ *
+ * Pattern mirror: `applyInteractiveSessionSwarmFire` (PR-L2 §3).
+ *
+ * @spec openspec/changes/add-battle-armor-combat/specs/battle-armor-combat/spec.md
+ *   (Requirement: Leg Attack)
+ */
+export interface IApplyLegAttackInput {
+  readonly session: IGameSession;
+  /** Attacker (BA squad) unit id. */
+  readonly squadId: string;
+  /** Target Mek or Vehicle unit id. */
+  readonly targetUnitId: string;
+  /**
+   * Pre-resolved leg-attack outcome from `resolveMekLegAttack` /
+   * `resolveVehicleLegAttack`. The action handler stamps these fields
+   * onto the emitted `LegAttackResolved` event.
+   */
+  readonly resolution: import('@/utils/gameplay/battlearmor/legAttackResolver').ILegAttackResolution;
+  /** Surviving troopers in the attacking squad after the resolution. */
+  readonly survivingTroopers: number;
+}
+
+/**
+ * Resolve one BA leg attack from `squadId` against `targetUnitId`.
+ *
+ * Appends a single `LegAttackResolved` event carrying the pre-resolved
+ * outcome. Returns the original session unchanged when the attacking
+ * squad or target unit cannot be found.
+ *
+ * The action handler is intentionally side-effect-free beyond appending
+ * the event; damage application to the target's armor pipeline (Mek leg
+ * armor or Vehicle arc armor) lives downstream in the dispatch layer
+ * that consumes this event. The squad's attack action is considered
+ * consumed in BOTH the hit and clean-miss cases.
+ */
+export function applyInteractiveSessionLegAttack(
+  input: IApplyLegAttackInput,
+): IGameSession {
+  const attackerUnit = input.session.currentState.units[input.squadId];
+  const targetUnit = input.session.currentState.units[input.targetUnitId];
+  if (!attackerUnit || !targetUnit) return input.session;
+
+  const sequence = input.session.events.length;
+  const { turn, phase } = input.session.currentState;
+  const event = createLegAttackResolvedEvent(
+    input.session.id,
+    sequence,
+    turn,
+    phase,
+    input.squadId,
+    input.targetUnitId,
+    input.resolution.hit,
+    input.resolution.damage,
+    input.resolution.hitLocation,
+    input.resolution.critModifier,
+    input.survivingTroopers,
+  );
+
+  return appendEvent(input.session, event);
+}
+
+// Re-export the squad-def type so callers can build it without reaching
+// into `@/lib/combat/baCombat` directly. Mirrors the IBASwarmFireSquadDef
+// re-export pattern established by PR-L2.
+export type { IBALegAttackSquadDef };

--- a/src/engine/__tests__/InteractiveSession.legAttack.scenario.test.ts
+++ b/src/engine/__tests__/InteractiveSession.legAttack.scenario.test.ts
@@ -1,0 +1,603 @@
+/**
+ * Scenario tests for PR-L3 BA leg-attack against Mek + Vehicle targets
+ * (G5 + G6 — first production callers of `vehicleFiringArc.ts` and
+ * `vehicleCriticalHitResolution.ts`).
+ *
+ * Exercises the leg-attack pipeline end-to-end:
+ *   - the pure damage formula (`calculateLegAttackDamage`)
+ *   - the Mek-path resolver (`resolveMekLegAttack`) with d6 leg-side
+ *     mapping, destroyed-leg fallback, and the both-legs-destroyed
+ *     clean-miss case
+ *   - the Vehicle-path resolver (`resolveVehicleLegAttack`) wired to
+ *     `calculateFiringArc` (G5)
+ *   - the vehicle-crit pipeline (`applyVehicleLegAttackCrit`) wired to
+ *     `applyVehicleCritEffect` (G6)
+ *   - the action handler (`applyInteractiveSessionLegAttack`) emitting
+ *     `LegAttackResolved` events on a real `IGameSession`
+ *   - the spec modifier table (HARDENED -2; HUMAN_TRO_MEK SPA +1)
+ *
+ * @spec openspec/changes/add-battle-armor-combat/specs/battle-armor-combat/spec.md
+ *   (Requirement: Leg Attack)
+ */
+
+import type { D6Roller } from '@/utils/gameplay/diceTypes';
+
+import { type IBALegAttackSquadDef } from '@/lib/combat/baCombat';
+import { EngineType } from '@/types/construction/EngineType';
+import {
+  VehicleLocation,
+  VTOLLocation,
+} from '@/types/construction/UnitLocation';
+import {
+  Facing,
+  GameEventType,
+  GamePhase,
+  GameSide,
+  type IGameSession,
+  type IGameUnit,
+  type ILegAttackResolvedPayload,
+} from '@/types/gameplay';
+import { GroundMotionType } from '@/types/unit/BaseUnitInterfaces';
+import { UnitType } from '@/types/unit/BattleMechInterfaces';
+import {
+  applyVehicleLegAttackCrit,
+  resolveMekLegAttack,
+  resolveVehicleLegAttack,
+} from '@/utils/gameplay/battlearmor/legAttackResolver';
+import {
+  advancePhase,
+  createGameSession,
+  rollInitiative,
+  startGame,
+} from '@/utils/gameplay/gameSession';
+import { createVehicleCombatState } from '@/utils/gameplay/vehicleDamage';
+
+import { applyInteractiveSessionLegAttack } from '../InteractiveSession.actions';
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+function buildUnits(): readonly IGameUnit[] {
+  return [
+    {
+      id: 'ba-leg',
+      name: 'BA Leg Attacker',
+      side: GameSide.Player,
+      unitRef: 'ba-ref',
+      pilotRef: 'pilot-ba',
+      gunnery: 4,
+      piloting: 5,
+      unitType: UnitType.BATTLE_ARMOR,
+      battleArmorInit: {
+        squadSize: 4,
+        armorPointsPerTrooper: 5,
+        hasMagneticClamp: false,
+        hasVibroClaws: false,
+        vibroClawCount: 0,
+      },
+    } as unknown as IGameUnit,
+    {
+      id: 'atlas-target',
+      name: 'Atlas',
+      side: GameSide.Opponent,
+      unitRef: 'atlas-ref',
+      pilotRef: 'pilot-atlas',
+      gunnery: 4,
+      piloting: 5,
+    } as IGameUnit,
+    {
+      id: 'tank-target',
+      name: 'Demolisher',
+      side: GameSide.Opponent,
+      unitRef: 'tank-ref',
+      pilotRef: 'pilot-tank',
+      gunnery: 4,
+      piloting: 5,
+    } as IGameUnit,
+  ];
+}
+
+/**
+ * Advance the session to the PhysicalAttack phase so leg attacks are
+ * stamped with the appropriate phase value on their emitted events.
+ */
+function advanceToPhysicalAttack(session: IGameSession): IGameSession {
+  let s = startGame(session, GameSide.Player);
+  s = rollInitiative(s);
+  s = advancePhase(s); // Initiative -> Movement
+  s = advancePhase(s); // Movement -> WeaponAttack
+  s = advancePhase(s); // WeaponAttack -> PhysicalAttack
+  return s;
+}
+
+function freshSession(): IGameSession {
+  return createGameSession(
+    {
+      mapRadius: 10,
+      turnLimit: 0,
+      victoryConditions: ['elimination'],
+      optionalRules: [],
+    } as never,
+    buildUnits(),
+  );
+}
+
+function scriptedRoller(values: readonly number[]): D6Roller {
+  let i = 0;
+  return () => {
+    const v = values[i % values.length];
+    i += 1;
+    return v;
+  };
+}
+
+function makeSquadDef(
+  overrides: Partial<IBALegAttackSquadDef> = {},
+): IBALegAttackSquadDef {
+  return {
+    vibroClaws: 0,
+    myomerBoosterActive: false,
+    ...overrides,
+  };
+}
+
+// Pull the live `IBASquadCombatState` out of the seeded session by adapting
+// the older `IBattleArmorCombatState` envelope -- mirrors the swarm-fire
+// scenario test's adaptOldSquadState pattern.
+function getSquadState(session: IGameSession, squadId: string) {
+  const unit = session.currentState.units[squadId];
+  const cs = unit.combatState;
+  if (!cs || cs.kind !== 'squad') {
+    throw new Error('test setup: squad has no combatState');
+  }
+  const old = cs.state;
+  return {
+    troopers: old.troopers.map((t, i) => ({
+      index: i + 1,
+      alive: t.alive && t.armorRemaining > 0,
+      armorRemaining: t.armorRemaining,
+      equipmentDestroyed: [...t.equipmentDestroyed],
+    })),
+    swarmingUnitId: undefined,
+    swarmedByUnitIds: [],
+    mountedOn: undefined,
+    mimeticActiveThisTurn: false,
+    stealthActiveThisTurn: false,
+  };
+}
+
+// =============================================================================
+// Tests — Mek target path
+// =============================================================================
+
+describe('PR-L3 leg attack against Mek targets', () => {
+  it('emits LegAttackResolved with hit:true on a leg with both legs intact', () => {
+    const session = advanceToPhysicalAttack(freshSession());
+    const squad = getSquadState(session, 'ba-leg');
+
+    // d6=1 → left leg, both intact, base damage = 4.
+    const resolution = resolveMekLegAttack({
+      squad,
+      squadDef: makeSquadDef(),
+      legDestroyed: () => false,
+      diceRoller: scriptedRoller([1]),
+    });
+
+    const next = applyInteractiveSessionLegAttack({
+      session,
+      squadId: 'ba-leg',
+      targetUnitId: 'atlas-target',
+      resolution,
+      survivingTroopers: 4,
+    });
+
+    const events = next.events.filter(
+      (e) => e.type === GameEventType.LegAttackResolved,
+    );
+    expect(events).toHaveLength(1);
+    const payload = events[0].payload as ILegAttackResolvedPayload;
+    expect(payload.unitId).toBe('ba-leg');
+    expect(payload.targetUnitId).toBe('atlas-target');
+    expect(payload.hit).toBe(true);
+    expect(payload.damage).toBe(4);
+    expect(payload.hitLocation).toBe('Left Leg');
+    expect(payload.critModifier).toBe(0);
+    expect(payload.survivingTroopers).toBe(4);
+    expect(events[0].phase).toBe(GamePhase.PhysicalAttack);
+  });
+
+  it('destroyed rolled leg → resolver fallback to the OTHER leg (right leg destroyed → hit Left)', () => {
+    const session = advanceToPhysicalAttack(freshSession());
+    const squad = getSquadState(session, 'ba-leg');
+
+    // d6=5 → right leg rolled, but right leg destroyed → fallback to left.
+    const resolution = resolveMekLegAttack({
+      squad,
+      squadDef: makeSquadDef({ vibroClaws: 1 }),
+      legDestroyed: (side) => side === 'right',
+      diceRoller: scriptedRoller([5]),
+    });
+
+    expect(resolution.rolledLegSide).toBe('right');
+    expect(resolution.hit).toBe(true);
+    expect(resolution.hitLocation).toBe('Left Leg');
+    expect(resolution.damage).toBe(5); // 4 + 1 vibroclaw
+
+    const next = applyInteractiveSessionLegAttack({
+      session,
+      squadId: 'ba-leg',
+      targetUnitId: 'atlas-target',
+      resolution,
+      survivingTroopers: 4,
+    });
+
+    const payload = next.events.find(
+      (e) => e.type === GameEventType.LegAttackResolved,
+    )!.payload as ILegAttackResolvedPayload;
+    expect(payload.hit).toBe(true);
+    expect(payload.hitLocation).toBe('Left Leg');
+    expect(payload.damage).toBe(5);
+  });
+
+  it('both legs destroyed → clean miss (hit:false, damage:0, action still consumed)', () => {
+    const session = advanceToPhysicalAttack(freshSession());
+    const squad = getSquadState(session, 'ba-leg');
+
+    const resolution = resolveMekLegAttack({
+      squad,
+      squadDef: makeSquadDef({ vibroClaws: 4, myomerBoosterActive: true }),
+      legDestroyed: () => true,
+      diceRoller: scriptedRoller([1]),
+    });
+    expect(resolution.hit).toBe(false);
+    expect(resolution.damage).toBe(0);
+
+    const next = applyInteractiveSessionLegAttack({
+      session,
+      squadId: 'ba-leg',
+      targetUnitId: 'atlas-target',
+      resolution,
+      survivingTroopers: 4,
+    });
+
+    // The miss STILL emits an event -- the squad's attack action is consumed.
+    const events = next.events.filter(
+      (e) => e.type === GameEventType.LegAttackResolved,
+    );
+    expect(events).toHaveLength(1);
+    const payload = events[0].payload as ILegAttackResolvedPayload;
+    expect(payload.hit).toBe(false);
+    expect(payload.damage).toBe(0);
+    // hitLocation stamps the rolled-then-rejected leg so replay can show it.
+    expect(payload.hitLocation).toBe('Left Leg');
+  });
+
+  it('HARDENED target leg → critModifier -2 on emitted event', () => {
+    const session = advanceToPhysicalAttack(freshSession());
+    const squad = getSquadState(session, 'ba-leg');
+
+    const resolution = resolveMekLegAttack({
+      squad,
+      squadDef: makeSquadDef(),
+      legDestroyed: () => false,
+      hardenedArmor: true,
+      diceRoller: scriptedRoller([2]),
+    });
+    expect(resolution.critModifier).toBe(-2);
+
+    const next = applyInteractiveSessionLegAttack({
+      session,
+      squadId: 'ba-leg',
+      targetUnitId: 'atlas-target',
+      resolution,
+      survivingTroopers: 4,
+    });
+
+    const payload = next.events.find(
+      (e) => e.type === GameEventType.LegAttackResolved,
+    )!.payload as ILegAttackResolvedPayload;
+    expect(payload.critModifier).toBe(-2);
+  });
+
+  it('HUMAN_TRO_MEK SPA on attacker → critModifier +1 on emitted event', () => {
+    const session = advanceToPhysicalAttack(freshSession());
+    const squad = getSquadState(session, 'ba-leg');
+
+    const resolution = resolveMekLegAttack({
+      squad,
+      squadDef: makeSquadDef(),
+      legDestroyed: () => false,
+      humanTroMekSpa: true,
+      diceRoller: scriptedRoller([1]),
+    });
+
+    const next = applyInteractiveSessionLegAttack({
+      session,
+      squadId: 'ba-leg',
+      targetUnitId: 'atlas-target',
+      resolution,
+      survivingTroopers: 4,
+    });
+
+    const payload = next.events.find(
+      (e) => e.type === GameEventType.LegAttackResolved,
+    )!.payload as ILegAttackResolvedPayload;
+    expect(payload.critModifier).toBe(1);
+  });
+
+  it('HARDENED + HUMAN_TRO_MEK stack additively → critModifier -1', () => {
+    const session = advanceToPhysicalAttack(freshSession());
+    const squad = getSquadState(session, 'ba-leg');
+
+    const resolution = resolveMekLegAttack({
+      squad,
+      squadDef: makeSquadDef(),
+      legDestroyed: () => false,
+      hardenedArmor: true,
+      humanTroMekSpa: true,
+      diceRoller: scriptedRoller([1]),
+    });
+
+    const next = applyInteractiveSessionLegAttack({
+      session,
+      squadId: 'ba-leg',
+      targetUnitId: 'atlas-target',
+      resolution,
+      survivingTroopers: 4,
+    });
+
+    const payload = next.events.find(
+      (e) => e.type === GameEventType.LegAttackResolved,
+    )!.payload as ILegAttackResolvedPayload;
+    expect(payload.critModifier).toBe(-1);
+  });
+
+  it('myomer + vibroclaws + 4 troopers → 16 damage on emitted event', () => {
+    const session = advanceToPhysicalAttack(freshSession());
+    const squad = getSquadState(session, 'ba-leg');
+
+    const resolution = resolveMekLegAttack({
+      squad,
+      squadDef: makeSquadDef({ vibroClaws: 4, myomerBoosterActive: true }),
+      legDestroyed: () => false,
+      diceRoller: scriptedRoller([1]),
+    });
+
+    const next = applyInteractiveSessionLegAttack({
+      session,
+      squadId: 'ba-leg',
+      targetUnitId: 'atlas-target',
+      resolution,
+      survivingTroopers: 4,
+    });
+
+    const payload = next.events.find(
+      (e) => e.type === GameEventType.LegAttackResolved,
+    )!.payload as ILegAttackResolvedPayload;
+    expect(payload.damage).toBe(16);
+  });
+});
+
+// =============================================================================
+// Tests — Vehicle target path (G5 + G6 first prod callers)
+// =============================================================================
+
+describe('PR-L3 leg attack against Vehicle targets (G5 + G6 orphan helpers wired)', () => {
+  it('calls calculateFiringArc and stamps the resolved arc on the event (G5)', () => {
+    const session = advanceToPhysicalAttack(freshSession());
+    const squad = getSquadState(session, 'ba-leg');
+
+    // Attacker directly north of target, target facing North → front arc.
+    const resolution = resolveVehicleLegAttack({
+      squad,
+      squadDef: makeSquadDef(),
+      attackerPos: { q: 0, r: -2 },
+      targetPos: { q: 0, r: 0 },
+      targetFacing: Facing.North,
+    });
+    expect(resolution.hit).toBe(true);
+    expect(resolution.hitLocation).toBe('front');
+
+    const next = applyInteractiveSessionLegAttack({
+      session,
+      squadId: 'ba-leg',
+      targetUnitId: 'tank-target',
+      resolution,
+      survivingTroopers: 4,
+    });
+
+    const payload = next.events.find(
+      (e) => e.type === GameEventType.LegAttackResolved,
+    )!.payload as ILegAttackResolvedPayload;
+    expect(payload.hit).toBe(true);
+    expect(payload.hitLocation).toBe('front');
+    expect(payload.targetUnitId).toBe('tank-target');
+    expect(payload.damage).toBe(4);
+  });
+
+  it('rear-arc resolution stamps "rear" on the event payload', () => {
+    const session = advanceToPhysicalAttack(freshSession());
+    const squad = getSquadState(session, 'ba-leg');
+
+    const resolution = resolveVehicleLegAttack({
+      squad,
+      squadDef: makeSquadDef({ vibroClaws: 2 }),
+      // Target facing North, attacker south → rear arc.
+      attackerPos: { q: 0, r: 2 },
+      targetPos: { q: 0, r: 0 },
+      targetFacing: Facing.North,
+    });
+
+    const next = applyInteractiveSessionLegAttack({
+      session,
+      squadId: 'ba-leg',
+      targetUnitId: 'tank-target',
+      resolution,
+      survivingTroopers: 4,
+    });
+
+    const payload = next.events.find(
+      (e) => e.type === GameEventType.LegAttackResolved,
+    )!.payload as ILegAttackResolvedPayload;
+    expect(payload.hitLocation).toBe('rear');
+    expect(payload.damage).toBe(6); // 4 + 2 vibroclaws
+  });
+
+  it('vehicle crit pipeline (G6) — applyVehicleLegAttackCrit invokes applyVehicleCritEffect end-to-end', () => {
+    // This test exercises BOTH orphan helpers through the leg-attack path.
+    const vehicleState = createVehicleCombatState({
+      unitId: 'tank-target',
+      motionType: GroundMotionType.TRACKED,
+      originalCruiseMP: 4,
+      armor: {
+        [VehicleLocation.FRONT]: 10,
+      } as Partial<Record<VehicleLocation | VTOLLocation, number>>,
+      structure: {
+        [VehicleLocation.FRONT]: 5,
+      } as Partial<Record<VehicleLocation | VTOLLocation, number>>,
+    });
+
+    // 2d6 roll of 5+6 = 11 → engine_hit (no modifier).
+    const critResult = applyVehicleLegAttackCrit({
+      vehicleState,
+      engineType: EngineType.ICE,
+      hasAmmoInSlot: false,
+      critModifier: 0,
+      diceRoller: scriptedRoller([5, 6]),
+    });
+    expect(critResult.applied.kind).toBe('engine_hit');
+    expect(critResult.state.motive.engineHits).toBe(1);
+    expect(critResult.state.destroyed).toBe(false);
+  });
+
+  it('vehicle crit with HUMAN_TRO_MEK +1 promotes 11 → 12 → ammo_explosion (vehicle destroyed)', () => {
+    const vehicleState = createVehicleCombatState({
+      unitId: 'tank-target',
+      motionType: GroundMotionType.TRACKED,
+      originalCruiseMP: 4,
+      armor: {
+        [VehicleLocation.FRONT]: 10,
+      } as Partial<Record<VehicleLocation | VTOLLocation, number>>,
+      structure: {
+        [VehicleLocation.FRONT]: 5,
+      } as Partial<Record<VehicleLocation | VTOLLocation, number>>,
+    });
+
+    // 11 + 1 = 12 → ammo_explosion when ammo present.
+    const critResult = applyVehicleLegAttackCrit({
+      vehicleState,
+      engineType: EngineType.ICE,
+      hasAmmoInSlot: true,
+      critModifier: 1,
+      diceRoller: scriptedRoller([5, 6]),
+    });
+    expect(critResult.applied.kind).toBe('ammo_explosion');
+    expect(critResult.ammoExplosion).toBe(true);
+    expect(critResult.state.destroyed).toBe(true);
+  });
+
+  it('vehicle crit with HARDENED -2 demotes 7 → 5 → no crit', () => {
+    const vehicleState = createVehicleCombatState({
+      unitId: 'tank-target',
+      motionType: GroundMotionType.TRACKED,
+      originalCruiseMP: 4,
+      armor: {
+        [VehicleLocation.FRONT]: 10,
+      } as Partial<Record<VehicleLocation | VTOLLocation, number>>,
+      structure: {
+        [VehicleLocation.FRONT]: 5,
+      } as Partial<Record<VehicleLocation | VTOLLocation, number>>,
+    });
+
+    const critResult = applyVehicleLegAttackCrit({
+      vehicleState,
+      engineType: EngineType.ICE,
+      hasAmmoInSlot: false,
+      critModifier: -2,
+      diceRoller: scriptedRoller([3, 4]),
+    });
+    expect(critResult.applied.kind).toBe('none');
+  });
+});
+
+// =============================================================================
+// Tests — Negative cases & idempotency
+// =============================================================================
+
+describe('PR-L3 leg attack — negative cases', () => {
+  it('emits NO event when the squad id is unknown', () => {
+    const session = advanceToPhysicalAttack(freshSession());
+    const squad = getSquadState(session, 'ba-leg');
+
+    const resolution = resolveMekLegAttack({
+      squad,
+      squadDef: makeSquadDef(),
+      legDestroyed: () => false,
+      diceRoller: scriptedRoller([1]),
+    });
+
+    const beforeCount = session.events.length;
+    const next = applyInteractiveSessionLegAttack({
+      session,
+      squadId: 'no-such-squad',
+      targetUnitId: 'atlas-target',
+      resolution,
+      survivingTroopers: 4,
+    });
+    expect(next.events.length).toBe(beforeCount);
+    expect(
+      next.events.filter((e) => e.type === GameEventType.LegAttackResolved),
+    ).toHaveLength(0);
+  });
+
+  it('emits NO event when the target id is unknown', () => {
+    const session = advanceToPhysicalAttack(freshSession());
+    const squad = getSquadState(session, 'ba-leg');
+
+    const resolution = resolveMekLegAttack({
+      squad,
+      squadDef: makeSquadDef(),
+      legDestroyed: () => false,
+      diceRoller: scriptedRoller([1]),
+    });
+
+    const next = applyInteractiveSessionLegAttack({
+      session,
+      squadId: 'ba-leg',
+      targetUnitId: 'no-such-target',
+      resolution,
+      survivingTroopers: 4,
+    });
+    expect(
+      next.events.filter((e) => e.type === GameEventType.LegAttackResolved),
+    ).toHaveLength(0);
+  });
+
+  it('stamps the current turn + phase on the emitted event', () => {
+    const session = advanceToPhysicalAttack(freshSession());
+    const squad = getSquadState(session, 'ba-leg');
+
+    const resolution = resolveMekLegAttack({
+      squad,
+      squadDef: makeSquadDef(),
+      legDestroyed: () => false,
+      diceRoller: scriptedRoller([1]),
+    });
+
+    const expectedTurn = session.currentState.turn;
+    const next = applyInteractiveSessionLegAttack({
+      session,
+      squadId: 'ba-leg',
+      targetUnitId: 'atlas-target',
+      resolution,
+      survivingTroopers: 4,
+    });
+
+    const event = next.events.find(
+      (e) => e.type === GameEventType.LegAttackResolved,
+    )!;
+    expect(event.turn).toBe(expectedTurn);
+    expect(event.phase).toBe(GamePhase.PhysicalAttack);
+  });
+});

--- a/src/lib/combat/__tests__/baCombat.legAttack.test.ts
+++ b/src/lib/combat/__tests__/baCombat.legAttack.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Tests for BA combat §5 (leg-attack damage formula, PR-L3).
+ *
+ * Canonical numbers (per the PR-L3 task spec + `add-battle-armor-combat`
+ * Requirement: Leg Attack):
+ *   - 4 troopers, no equipment                  → 4   (4 + 0 + 0)
+ *   - +1 squad vibroclaw                        → 5   (4 + 1 + 0)
+ *   - +4 squad vibroclaws (one per trooper)     → 8   (4 + 4 + 0)
+ *   - +myomer booster active, 4 troopers        → 12  (4 + 0 + 8)
+ *   - +4 vibroclaws + myomer + 4 troopers       → 16  (4 + 4 + 8)
+ *   - 0 active troopers                         → 0
+ *
+ * Distinct from swarm-fire — leg attack has NO per-weapon damage and
+ * the vibroclaw bonus is FLAT (not multiplied by troopers).
+ *
+ * @spec openspec/changes/add-battle-armor-combat/specs/battle-armor-combat/spec.md
+ */
+
+import { describe, expect, it } from '@jest/globals';
+
+import type { IBASquadCombatState } from '@/types/gameplay';
+
+import {
+  calculateLegAttackDamage,
+  type IBALegAttackSquadDef,
+} from '../baCombat';
+
+function makeSquad(squadSize = 4, armorPerTrooper = 5): IBASquadCombatState {
+  return {
+    troopers: Array.from({ length: squadSize }, (_, i) => ({
+      index: i + 1,
+      alive: true,
+      armorRemaining: armorPerTrooper,
+      equipmentDestroyed: [],
+    })),
+    swarmingUnitId: undefined,
+    swarmedByUnitIds: [],
+    mountedOn: undefined,
+    mimeticActiveThisTurn: false,
+    stealthActiveThisTurn: false,
+  };
+}
+
+function makeSquadDef(
+  overrides: Partial<IBALegAttackSquadDef> = {},
+): IBALegAttackSquadDef {
+  return {
+    vibroClaws: 0,
+    myomerBoosterActive: false,
+    ...overrides,
+  };
+}
+
+describe('calculateLegAttackDamage — canonical numbers', () => {
+  it('4 troopers, no equipment → 4 damage (base only)', () => {
+    const squad = makeSquad(4);
+    expect(calculateLegAttackDamage(squad, makeSquadDef())).toBe(4);
+  });
+
+  it('+1 squad vibroclaw → 5 damage (4 + 1)', () => {
+    const squad = makeSquad(4);
+    expect(
+      calculateLegAttackDamage(squad, makeSquadDef({ vibroClaws: 1 })),
+    ).toBe(5);
+  });
+
+  it('+4 squad vibroclaws (one per trooper) → 8 damage (4 + 4)', () => {
+    const squad = makeSquad(4);
+    expect(
+      calculateLegAttackDamage(squad, makeSquadDef({ vibroClaws: 4 })),
+    ).toBe(8);
+  });
+
+  it('+myomer booster active, 4 troopers → 12 damage (4 + 0 + 8)', () => {
+    const squad = makeSquad(4);
+    expect(
+      calculateLegAttackDamage(
+        squad,
+        makeSquadDef({ myomerBoosterActive: true }),
+      ),
+    ).toBe(12);
+  });
+
+  it('+4 vibroclaws + myomer + 4 troopers → 16 damage (4 + 4 + 8)', () => {
+    const squad = makeSquad(4);
+    expect(
+      calculateLegAttackDamage(
+        squad,
+        makeSquadDef({ vibroClaws: 4, myomerBoosterActive: true }),
+      ),
+    ).toBe(16);
+  });
+
+  it('0 active troopers → 0 damage (no base component when squad is destroyed)', () => {
+    const squad = makeSquad(4);
+    squad.troopers.forEach((t) => {
+      t.alive = false;
+      t.armorRemaining = 0;
+    });
+    expect(
+      calculateLegAttackDamage(
+        squad,
+        makeSquadDef({ vibroClaws: 4, myomerBoosterActive: true }),
+      ),
+    ).toBe(0);
+  });
+});
+
+describe('calculateLegAttackDamage — additional scenarios', () => {
+  it('matches the spec "Basic leg attack" scenario: 4 troopers + 1 vibroclaw → 5', () => {
+    // GIVEN a 4-trooper BA squad with 1 vibroclaw, no myomer booster
+    // WHEN the squad declares a LegAttack against an Atlas
+    // AND the to-hit roll succeeds
+    // THEN damage SHALL be 4 + 1 + 0 = 5
+    const squad = makeSquad(4);
+    expect(
+      calculateLegAttackDamage(squad, makeSquadDef({ vibroClaws: 1 })),
+    ).toBe(5);
+  });
+
+  it('matches the spec "Myomer booster boosts leg-attack damage" scenario: same squad + myomer + 4 troopers → 13', () => {
+    // GIVEN the same squad with Myomer Booster and 4 active troopers
+    // WHEN the leg attack resolves
+    // THEN damage SHALL be 4 + 1 + (4 × 2) = 13
+    const squad = makeSquad(4);
+    expect(
+      calculateLegAttackDamage(
+        squad,
+        makeSquadDef({ vibroClaws: 1, myomerBoosterActive: true }),
+      ),
+    ).toBe(13);
+  });
+
+  it('myomer scales with surviving troopers (2 of 4 dead → +4 myomer, not +8)', () => {
+    const squad = makeSquad(4);
+    squad.troopers[0].alive = false;
+    squad.troopers[0].armorRemaining = 0;
+    squad.troopers[1].alive = false;
+    squad.troopers[1].armorRemaining = 0;
+    // 4 (base) + 0 (no claws) + 2 × 2 (myomer × 2 survivors) = 8
+    expect(
+      calculateLegAttackDamage(
+        squad,
+        makeSquadDef({ myomerBoosterActive: true }),
+      ),
+    ).toBe(8);
+  });
+
+  it('vibroclaws DO NOT scale with troopers (flat squad-level count)', () => {
+    // 2 surviving troopers + 4 vibroclaws is STILL +4, not 4 × 2 = 8.
+    const squad = makeSquad(4);
+    squad.troopers[0].alive = false;
+    squad.troopers[0].armorRemaining = 0;
+    squad.troopers[1].alive = false;
+    squad.troopers[1].armorRemaining = 0;
+    // 4 (base) + 4 (vibroclaws, flat) + 0 (no myomer) = 8
+    expect(
+      calculateLegAttackDamage(squad, makeSquadDef({ vibroClaws: 4 })),
+    ).toBe(8);
+  });
+
+  it('myomer booster OFF contributes 0 even with high trooper count', () => {
+    const squad = makeSquad(6);
+    expect(
+      calculateLegAttackDamage(
+        squad,
+        makeSquadDef({ myomerBoosterActive: false }),
+      ),
+    ).toBe(4);
+  });
+
+  it('single surviving trooper still contributes the base 4', () => {
+    const squad = makeSquad(4);
+    squad.troopers[1].alive = false;
+    squad.troopers[1].armorRemaining = 0;
+    squad.troopers[2].alive = false;
+    squad.troopers[2].armorRemaining = 0;
+    squad.troopers[3].alive = false;
+    squad.troopers[3].armorRemaining = 0;
+    // 4 (base) + 0 + 1 × 2 (myomer × 1 survivor) = 6
+    expect(
+      calculateLegAttackDamage(
+        squad,
+        makeSquadDef({ myomerBoosterActive: true }),
+      ),
+    ).toBe(6);
+  });
+
+  it('negative vibroClaws is clamped to 0 (defensive)', () => {
+    const squad = makeSquad(4);
+    expect(
+      calculateLegAttackDamage(squad, makeSquadDef({ vibroClaws: -1 })),
+    ).toBe(4);
+  });
+});

--- a/src/lib/combat/baCombat.ts
+++ b/src/lib/combat/baCombat.ts
@@ -314,3 +314,86 @@ export function calculateSwarmDamage(
 
   return weaponSum + vibroclawBonus + myomerBonus;
 }
+// =============================================================================
+// §5 — Leg-attack damage formula (PR-L3)
+// =============================================================================
+
+/**
+ * Squad-level loadout fields required by the leg-attack damage formula.
+ * Kept narrow on purpose: this struct represents what `calculateLegAttackDamage`
+ * actually reads, not the full BA squad definition (which lives in
+ * `IBattleArmorUnit`). Callers extract these from the canonical squad data.
+ *
+ * Distinct from `IBASwarmFireSquadDef`:
+ *   - swarm fire trusts a caller-pre-filtered weapon list and scales
+ *     per-weapon damage by surviving troopers;
+ *   - leg attack has NO per-weapon damage component — it deals a flat
+ *     base of 4 plus the squad's vibroclaw count plus an optional myomer
+ *     booster bonus that scales with active troopers.
+ */
+export interface IBALegAttackSquadDef {
+  /**
+   * Squad-level vibroclaw count. Each vibroclaw adds one flat point of
+   * damage to the leg-attack total (matches the spec formula
+   * `4 + vibroClaws + ...`). Typical loadouts: 0, 1, 2, or 4 for a
+   * 4-trooper squad where every trooper carries a single vibroclaw.
+   */
+  readonly vibroClaws: number;
+  /**
+   * True when the squad has a Myomer Booster AND it is currently active
+   * (booster active = not destroyed and powered on this turn). Adds
+   * `activeTroopers × 2` to total damage when true (matches the spec
+   * formula `(myomerBooster ? activeTroopers × 2 : 0)`).
+   */
+  readonly myomerBoosterActive: boolean;
+}
+
+/**
+ * Pure leg-attack damage formula for a BA squad performing an anti-mech
+ * (or anti-vehicle) leg attack.
+ *
+ * Formula (per `add-battle-armor-combat` Requirement: Leg Attack):
+ *
+ * ```
+ * total = 4
+ *       + squadDef.vibroClaws
+ *       + (squadDef.myomerBoosterActive ? activeTroopers × 2 : 0)
+ * ```
+ *
+ * Returns 0 when no troopers are alive (a destroyed squad cannot perform
+ * the attack at all — the base-4 component is gated on having at least
+ * one surviving trooper, matching the swarm-fire `0 troopers → 0 damage`
+ * contract).
+ *
+ * Spec canonical numbers:
+ *   - 4 troopers, no equipment                     → 4   (4 + 0 + 0)
+ *   - +1 squad vibroclaw                           → 5   (4 + 1 + 0)
+ *   - +4 squad vibroclaws (one per trooper)        → 8   (4 + 4 + 0)
+ *   - +myomer booster active, 4 troopers           → 12  (4 + 0 + 8)
+ *   - +4 vibroclaws + myomer + 4 troopers          → 16  (4 + 4 + 8)
+ *   - 0 active troopers                            → 0
+ *
+ * @spec openspec/changes/add-battle-armor-combat/specs/battle-armor-combat/spec.md
+ *   (Requirement: Leg Attack)
+ */
+export function calculateLegAttackDamage(
+  squad: IBASquadCombatState,
+  squadDef: IBALegAttackSquadDef,
+): number {
+  const activeTroopers = getNumberActiveTroopers(squad);
+  if (activeTroopers === 0) return 0;
+
+  // Base damage component — flat 4 per the spec, only when the squad has at
+  // least one surviving trooper to perform the attack.
+  const baseDamage = 4;
+
+  // Vibroclaw bonus — each squad-level vibroclaw adds one flat point.
+  // Spec: "+ vibroClaws" — a count, not multiplied by troopers.
+  const vibroclawBonus = squadDef.vibroClaws > 0 ? squadDef.vibroClaws : 0;
+
+  // Myomer Booster bonus — `activeTroopers × 2` when active.
+  // Spec: "(myomerBooster ? activeTroopers × 2 : 0)".
+  const myomerBonus = squadDef.myomerBoosterActive ? activeTroopers * 2 : 0;
+
+  return baseDamage + vibroclawBonus + myomerBonus;
+}

--- a/src/types/gameplay/BattleArmorCombatInterfaces.ts
+++ b/src/types/gameplay/BattleArmorCombatInterfaces.ts
@@ -313,6 +313,46 @@ export interface ILegAttackPayload {
 }
 
 /**
+ * Per `add-battle-armor-combat` (Wave 8 PR-L3): leg-attack result against
+ * Mek and Vehicle targets using the new `IBASquadCombatState` shape.
+ *
+ * Emitted by `applyInteractiveSessionLegAttack` for every resolved leg
+ * attack — both hits (`hit: true`, `damage > 0`, `hitLocation` set) and
+ * clean misses against a Mek with both legs destroyed (`hit: false`,
+ * `damage: 0`, `hitLocation` carries the rolled-then-rejected leg). The
+ * squad's attack action is consumed in either case.
+ *
+ * `hitLocation` is the destination location label (a `MechLocation` value
+ * for Mek targets — `'Left Leg'` / `'Right Leg'`; a `VehicleHitLocation`
+ * arc-derived label for Vehicle targets — `'front'` / `'left_side'` /
+ * `'right_side'` / `'rear'`).
+ *
+ * `critModifier` is the net crit modifier applied by the resolver:
+ *   - `-2` when the targeted location's armor is Hardened
+ *   - `+1` when the attacking pilot has the `MISC_HUMAN_TRO_MEK` SPA
+ * The two stack additively; default is `0`.
+ *
+ * @spec openspec/changes/add-battle-armor-combat/specs/battle-armor-combat/spec.md
+ *   (Requirement: Leg Attack)
+ */
+export interface ILegAttackResolvedPayload {
+  /** Attacker (BA squad) unit id. */
+  readonly unitId: string;
+  /** Target Mek or Vehicle unit id. */
+  readonly targetUnitId: string;
+  /** True on a successful hit; false on clean miss. */
+  readonly hit: boolean;
+  /** Total damage applied to the target (0 on miss). */
+  readonly damage: number;
+  /** Resolved hit-location label (Mek leg or Vehicle arc-derived location). */
+  readonly hitLocation: string;
+  /** Net crit modifier (Hardened: -2; HUMAN_TRO_MEK SPA: +1). */
+  readonly critModifier: number;
+  /** Surviving troopers in the attacking squad after the resolution. */
+  readonly survivingTroopers: number;
+}
+
+/**
  * Per `add-battlearmor-combat-behavior`: mimetic to-hit bonus applied to an
  * attacker targeting this squad.
  */

--- a/src/types/gameplay/GameSessionCoreTypes.ts
+++ b/src/types/gameplay/GameSessionCoreTypes.ts
@@ -238,6 +238,18 @@ export enum GameEventType {
    */
   LegAttack = 'leg_attack',
   /**
+   * Per `add-battle-armor-combat` (Wave 8 PR-L3): a BA squad leg-attack
+   * resolved against a Mek or Vehicle target using the new
+   * `IBASquadCombatState` shape. Distinct from `LegAttack` so the older
+   * `add-battlearmor-combat-behavior` event stream (success/damageToLeg/
+   * selfDamage/survivingTroopers) stays untouched while the new shape
+   * carries `hit / hitLocation / damage / critModifier`. Emitted by
+   * `applyInteractiveSessionLegAttack` for both hit and clean-miss
+   * outcomes (both-legs-destroyed against a Mek emits a `hit: false`
+   * event; the action still consumes the squad's attack).
+   */
+  LegAttackResolved = 'leg_attack_resolved',
+  /**
    * Per `add-battlearmor-combat-behavior`: mimetic to-hit bonus applied to
    * an attacker targeting this squad (e.g., +1 when the squad stood still).
    */

--- a/src/types/gameplay/GameSessionStatusEvents.ts
+++ b/src/types/gameplay/GameSessionStatusEvents.ts
@@ -5,6 +5,7 @@
 
 import type {
   ILegAttackPayload,
+  ILegAttackResolvedPayload,
   IMimeticBonusPayload,
   ISquadEliminatedPayload,
   IStealthBonusPayload,
@@ -443,6 +444,7 @@ export type GameEventPayload =
   | ISwarmDamagePayload
   | ISwarmDismountedPayload
   | ILegAttackPayload
+  | ILegAttackResolvedPayload
   | IMimeticBonusPayload
   | IStealthBonusPayload
   | IObjectiveCapturedPayload

--- a/src/utils/gameplay/battlearmor/__tests__/legAttackResolver.test.ts
+++ b/src/utils/gameplay/battlearmor/__tests__/legAttackResolver.test.ts
@@ -22,9 +22,17 @@ import type { IBALegAttackSquadDef } from '@/lib/combat/baCombat';
 import type { IBASquadCombatState } from '@/types/gameplay';
 import type { D6Roller } from '@/utils/gameplay/diceTypes';
 
-import { Facing } from '@/types/gameplay/HexGridInterfaces';
-
+import { EngineType } from '@/types/construction/EngineType';
 import {
+  VehicleLocation,
+  VTOLLocation,
+} from '@/types/construction/UnitLocation';
+import { Facing } from '@/types/gameplay/HexGridInterfaces';
+import { GroundMotionType } from '@/types/unit/BaseUnitInterfaces';
+
+import { createVehicleCombatState } from '../../vehicleDamage';
+import {
+  applyVehicleLegAttackCrit,
   LEG_ATTACK_HARDENED_CRIT_MODIFIER,
   LEG_ATTACK_HUMAN_TRO_MEK_CRIT_MODIFIER,
   MEK_LEFT_LEG_LABEL,
@@ -227,8 +235,8 @@ describe('resolveVehicleLegAttack — vehicleFiringArc wiring (G5 orphan-rot clo
     const result = resolveVehicleLegAttack({
       squad: makeSquad(4),
       squadDef: makeSquadDef(),
-      attackerPos: { q: 0, r: -2, s: 2 },
-      targetPos: { q: 0, r: 0, s: 0 },
+      attackerPos: { q: 0, r: -2 },
+      targetPos: { q: 0, r: 0 },
       targetFacing: Facing.North,
     });
     expect(result.hit).toBe(true);
@@ -241,8 +249,8 @@ describe('resolveVehicleLegAttack — vehicleFiringArc wiring (G5 orphan-rot clo
     const result = resolveVehicleLegAttack({
       squad: makeSquad(4),
       squadDef: makeSquadDef(),
-      attackerPos: { q: 0, r: 2, s: -2 },
-      targetPos: { q: 0, r: 0, s: 0 },
+      attackerPos: { q: 0, r: 2 },
+      targetPos: { q: 0, r: 0 },
       targetFacing: Facing.North,
     });
     expect(result.hitLocation).toBe('rear');
@@ -252,8 +260,8 @@ describe('resolveVehicleLegAttack — vehicleFiringArc wiring (G5 orphan-rot clo
     const result = resolveVehicleLegAttack({
       squad: makeSquad(4),
       squadDef: makeSquadDef({ vibroClaws: 4 }),
-      attackerPos: { q: 0, r: 0, s: 0 },
-      targetPos: { q: 0, r: 0, s: 0 },
+      attackerPos: { q: 0, r: 0 },
+      targetPos: { q: 0, r: 0 },
       targetFacing: Facing.North,
     });
     expect(result.hit).toBe(true);
@@ -265,8 +273,8 @@ describe('resolveVehicleLegAttack — vehicleFiringArc wiring (G5 orphan-rot clo
     const result = resolveVehicleLegAttack({
       squad: makeSquad(4),
       squadDef: makeSquadDef({ myomerBoosterActive: true }),
-      attackerPos: { q: 2, r: 0, s: -2 },
-      targetPos: { q: 0, r: 0, s: 0 },
+      attackerPos: { q: 2, r: 0 },
+      targetPos: { q: 0, r: 0 },
       targetFacing: Facing.North,
     });
     expect(result.hit).toBe(true);
@@ -279,8 +287,8 @@ describe('resolveVehicleLegAttack — vehicleFiringArc wiring (G5 orphan-rot clo
     const result = resolveVehicleLegAttack({
       squad: makeSquad(4),
       squadDef: makeSquadDef(),
-      attackerPos: { q: 0, r: -1, s: 1 },
-      targetPos: { q: 0, r: 0, s: 0 },
+      attackerPos: { q: 0, r: -1 },
+      targetPos: { q: 0, r: 0 },
       targetFacing: Facing.North,
       hardenedArmor: true,
     });
@@ -293,8 +301,8 @@ describe('resolveVehicleLegAttack — vehicleFiringArc wiring (G5 orphan-rot clo
     const result = resolveVehicleLegAttack({
       squad: makeSquad(4),
       squadDef: makeSquadDef(),
-      attackerPos: { q: -2, r: 1, s: 1 },
-      targetPos: { q: 0, r: 0, s: 0 },
+      attackerPos: { q: -2, r: 1 },
+      targetPos: { q: 0, r: 0 },
       targetFacing: Facing.North,
     });
     // The exact arc depends on `determineArc` boundary rules; either left
@@ -335,5 +343,109 @@ describe('resolveMekLegAttack — damage formula integration', () => {
     });
     // 4 (base) + 4 (vibroclaws) + 4 * 2 (myomer) = 16
     expect(result.damage).toBe(16);
+  });
+});
+describe('applyVehicleLegAttackCrit — vehicleCriticalHitResolution wiring (G6 orphan-rot closed)', () => {
+  function makeVehicleState() {
+    return createVehicleCombatState({
+      unitId: 'tank-leg',
+      motionType: GroundMotionType.TRACKED,
+      originalCruiseMP: 4,
+      armor: {
+        [VehicleLocation.FRONT]: 10,
+      } as Partial<Record<VehicleLocation | VTOLLocation, number>>,
+      structure: {
+        [VehicleLocation.FRONT]: 5,
+      } as Partial<Record<VehicleLocation | VTOLLocation, number>>,
+    });
+  }
+
+  it('FIRST PRODUCTION CALLER: no modifier + roll 7 (3+4) → weapon_destroyed crit', () => {
+    const vehicleState = makeVehicleState();
+    const result = applyVehicleLegAttackCrit({
+      vehicleState,
+      engineType: EngineType.ICE,
+      hasAmmoInSlot: false,
+      critModifier: 0,
+      diceRoller: scriptedRoller([3, 4]),
+    });
+    expect(result.applied.kind).toBe('weapon_destroyed');
+    expect(result.state.destroyed).toBe(false);
+  });
+
+  it('Hardened (-2) shifts 7 → 5 → no crit', () => {
+    const vehicleState = makeVehicleState();
+    const result = applyVehicleLegAttackCrit({
+      vehicleState,
+      engineType: EngineType.ICE,
+      hasAmmoInSlot: false,
+      critModifier: -2,
+      diceRoller: scriptedRoller([3, 4]),
+    });
+    expect(result.applied.kind).toBe('none');
+  });
+
+  it('HUMAN_TRO_MEK (+1) shifts 11 → 12 → ammo_explosion when ammo present', () => {
+    const vehicleState = makeVehicleState();
+    const result = applyVehicleLegAttackCrit({
+      vehicleState,
+      engineType: EngineType.ICE,
+      hasAmmoInSlot: true,
+      critModifier: 1,
+      diceRoller: scriptedRoller([5, 6]),
+    });
+    expect(result.applied.kind).toBe('ammo_explosion');
+    expect(result.ammoExplosion).toBe(true);
+    expect(result.state.destroyed).toBe(true);
+  });
+
+  it('modifier clamps to 12 max (HUMAN_TRO_MEK + already-12 roll stays 12)', () => {
+    const vehicleState = makeVehicleState();
+    const result = applyVehicleLegAttackCrit({
+      vehicleState,
+      engineType: EngineType.ICE,
+      hasAmmoInSlot: true,
+      critModifier: 1,
+      diceRoller: scriptedRoller([6, 6]),
+    });
+    expect(result.applied.kind).toBe('ammo_explosion');
+  });
+
+  it('modifier clamps to 2 min (Hardened + already-2 roll stays 2)', () => {
+    const vehicleState = makeVehicleState();
+    const result = applyVehicleLegAttackCrit({
+      vehicleState,
+      engineType: EngineType.ICE,
+      hasAmmoInSlot: false,
+      critModifier: -2,
+      diceRoller: scriptedRoller([1, 1]),
+    });
+    expect(result.applied.kind).toBe('none');
+  });
+
+  it('engine-hit applies to motive state (state mutation flows through)', () => {
+    const vehicleState = makeVehicleState();
+    const result = applyVehicleLegAttackCrit({
+      vehicleState,
+      engineType: EngineType.ICE,
+      hasAmmoInSlot: false,
+      critModifier: 0,
+      diceRoller: scriptedRoller([5, 6]),
+    });
+    expect(result.applied.kind).toBe('engine_hit');
+    expect(result.state.motive.engineHits).toBe(1);
+  });
+
+  it('fuel_tank crit on fusion engine becomes no-effect (reroll branch in helper)', () => {
+    const vehicleState = makeVehicleState();
+    const result = applyVehicleLegAttackCrit({
+      vehicleState,
+      // Standard fusion engine → no fuel tank → reroll → kind becomes 'none'.
+      engineType: EngineType.STANDARD,
+      hasAmmoInSlot: false,
+      critModifier: 0,
+      diceRoller: scriptedRoller([5, 5]),
+    });
+    expect(result.applied.kind).toBe('none');
   });
 });

--- a/src/utils/gameplay/battlearmor/__tests__/legAttackResolver.test.ts
+++ b/src/utils/gameplay/battlearmor/__tests__/legAttackResolver.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Tests for the PR-L3 BA leg-attack resolver (Mek + Vehicle paths).
+ *
+ * Covers:
+ *   - Mek path d6 → leg side mapping (1-3 = left, 4-6 = right)
+ *   - Mek destroyed-leg fallback (rolled-then-rejected → other leg)
+ *   - Mek both-legs-destroyed clean-miss (hit: false, damage: 0)
+ *   - Vehicle path: firing-arc wiring (FIRST PRODUCTION CALLER of
+ *     vehicleFiringArc.ts — G5 orphan-rot closed)
+ *   - Crit modifier additivity (Hardened -2 + HUMAN_TRO_MEK +1)
+ *
+ * The pure damage formula is covered by `baCombat.legAttack.test.ts`;
+ * this file focuses on the resolver wiring contract.
+ *
+ * @spec openspec/changes/add-battle-armor-combat/specs/battle-armor-combat/spec.md
+ *   (Requirement: Leg Attack)
+ */
+
+import { describe, expect, it } from '@jest/globals';
+
+import type { IBALegAttackSquadDef } from '@/lib/combat/baCombat';
+import type { IBASquadCombatState } from '@/types/gameplay';
+import type { D6Roller } from '@/utils/gameplay/diceTypes';
+
+import { Facing } from '@/types/gameplay/HexGridInterfaces';
+
+import {
+  LEG_ATTACK_HARDENED_CRIT_MODIFIER,
+  LEG_ATTACK_HUMAN_TRO_MEK_CRIT_MODIFIER,
+  MEK_LEFT_LEG_LABEL,
+  MEK_RIGHT_LEG_LABEL,
+  resolveMekLegAttack,
+  resolveVehicleLegAttack,
+} from '../legAttackResolver';
+
+function makeSquad(squadSize = 4): IBASquadCombatState {
+  return {
+    troopers: Array.from({ length: squadSize }, (_, i) => ({
+      index: i + 1,
+      alive: true,
+      armorRemaining: 5,
+      equipmentDestroyed: [],
+    })),
+    swarmingUnitId: undefined,
+    swarmedByUnitIds: [],
+    mountedOn: undefined,
+    mimeticActiveThisTurn: false,
+    stealthActiveThisTurn: false,
+  };
+}
+
+function makeSquadDef(
+  overrides: Partial<IBALegAttackSquadDef> = {},
+): IBALegAttackSquadDef {
+  return {
+    vibroClaws: 0,
+    myomerBoosterActive: false,
+    ...overrides,
+  };
+}
+
+function scriptedRoller(values: readonly number[]): D6Roller {
+  let i = 0;
+  return () => {
+    const v = values[i % values.length];
+    i += 1;
+    return v;
+  };
+}
+
+describe('resolveMekLegAttack — d6 leg-side mapping', () => {
+  it('d6=1 → left leg', () => {
+    const result = resolveMekLegAttack({
+      squad: makeSquad(4),
+      squadDef: makeSquadDef(),
+      legDestroyed: () => false,
+      diceRoller: scriptedRoller([1]),
+    });
+    expect(result.rolledLegSide).toBe('left');
+    expect(result.hitLocation).toBe(MEK_LEFT_LEG_LABEL);
+    expect(result.hit).toBe(true);
+    expect(result.damage).toBe(4);
+  });
+
+  it('d6=3 → left leg (boundary)', () => {
+    const result = resolveMekLegAttack({
+      squad: makeSquad(4),
+      squadDef: makeSquadDef(),
+      legDestroyed: () => false,
+      diceRoller: scriptedRoller([3]),
+    });
+    expect(result.rolledLegSide).toBe('left');
+  });
+
+  it('d6=4 → right leg (boundary)', () => {
+    const result = resolveMekLegAttack({
+      squad: makeSquad(4),
+      squadDef: makeSquadDef(),
+      legDestroyed: () => false,
+      diceRoller: scriptedRoller([4]),
+    });
+    expect(result.rolledLegSide).toBe('right');
+    expect(result.hitLocation).toBe(MEK_RIGHT_LEG_LABEL);
+  });
+
+  it('d6=6 → right leg', () => {
+    const result = resolveMekLegAttack({
+      squad: makeSquad(4),
+      squadDef: makeSquadDef(),
+      legDestroyed: () => false,
+      diceRoller: scriptedRoller([6]),
+    });
+    expect(result.rolledLegSide).toBe('right');
+  });
+});
+
+describe('resolveMekLegAttack — destroyed-leg fallback', () => {
+  it('rolled-leg destroyed → switches to the other leg (hit)', () => {
+    const result = resolveMekLegAttack({
+      squad: makeSquad(4),
+      squadDef: makeSquadDef(),
+      // Roll left, but left leg is destroyed → resolve to right.
+      legDestroyed: (side) => side === 'left',
+      diceRoller: scriptedRoller([2]),
+    });
+    expect(result.rolledLegSide).toBe('left');
+    expect(result.hit).toBe(true);
+    expect(result.hitLocation).toBe(MEK_RIGHT_LEG_LABEL);
+    expect(result.damage).toBe(4);
+  });
+
+  it('opposite direction: rolled right destroyed → switches to left', () => {
+    const result = resolveMekLegAttack({
+      squad: makeSquad(4),
+      squadDef: makeSquadDef(),
+      legDestroyed: (side) => side === 'right',
+      diceRoller: scriptedRoller([5]),
+    });
+    expect(result.rolledLegSide).toBe('right');
+    expect(result.hit).toBe(true);
+    expect(result.hitLocation).toBe(MEK_LEFT_LEG_LABEL);
+  });
+});
+
+describe('resolveMekLegAttack — both-legs-destroyed clean miss', () => {
+  it('both legs destroyed → hit:false, damage:0, attack consumed', () => {
+    const result = resolveMekLegAttack({
+      squad: makeSquad(4),
+      squadDef: makeSquadDef({ vibroClaws: 4, myomerBoosterActive: true }),
+      legDestroyed: () => true,
+      diceRoller: scriptedRoller([2]),
+    });
+    expect(result.hit).toBe(false);
+    expect(result.damage).toBe(0);
+    // Even on a clean miss, the rolled-then-rejected leg is stamped so
+    // replay can show the "tried left but bounced off both stumps" outcome.
+    expect(result.rolledLegSide).toBe('left');
+    expect(result.hitLocation).toBe(MEK_LEFT_LEG_LABEL);
+  });
+
+  it('both legs destroyed with d6=6 → hitLocation stamps right leg', () => {
+    const result = resolveMekLegAttack({
+      squad: makeSquad(4),
+      squadDef: makeSquadDef(),
+      legDestroyed: () => true,
+      diceRoller: scriptedRoller([6]),
+    });
+    expect(result.hit).toBe(false);
+    expect(result.rolledLegSide).toBe('right');
+    expect(result.hitLocation).toBe(MEK_RIGHT_LEG_LABEL);
+  });
+});
+
+describe('resolveMekLegAttack — crit modifiers', () => {
+  it('Hardened armor flag → critModifier -2', () => {
+    const result = resolveMekLegAttack({
+      squad: makeSquad(4),
+      squadDef: makeSquadDef(),
+      legDestroyed: () => false,
+      hardenedArmor: true,
+      diceRoller: scriptedRoller([1]),
+    });
+    expect(result.critModifier).toBe(LEG_ATTACK_HARDENED_CRIT_MODIFIER);
+    expect(result.critModifier).toBe(-2);
+  });
+
+  it('HUMAN_TRO_MEK SPA flag → critModifier +1', () => {
+    const result = resolveMekLegAttack({
+      squad: makeSquad(4),
+      squadDef: makeSquadDef(),
+      legDestroyed: () => false,
+      humanTroMekSpa: true,
+      diceRoller: scriptedRoller([1]),
+    });
+    expect(result.critModifier).toBe(LEG_ATTACK_HUMAN_TRO_MEK_CRIT_MODIFIER);
+    expect(result.critModifier).toBe(1);
+  });
+
+  it('both flags stack additively → critModifier -1', () => {
+    const result = resolveMekLegAttack({
+      squad: makeSquad(4),
+      squadDef: makeSquadDef(),
+      legDestroyed: () => false,
+      hardenedArmor: true,
+      humanTroMekSpa: true,
+      diceRoller: scriptedRoller([1]),
+    });
+    expect(result.critModifier).toBe(-1);
+  });
+
+  it('neither flag → critModifier 0 (matches spec "Basic leg attack")', () => {
+    const result = resolveMekLegAttack({
+      squad: makeSquad(4),
+      squadDef: makeSquadDef({ vibroClaws: 1 }),
+      legDestroyed: () => false,
+      diceRoller: scriptedRoller([1]),
+    });
+    expect(result.critModifier).toBe(0);
+    expect(result.damage).toBe(5);
+  });
+});
+
+describe('resolveVehicleLegAttack — vehicleFiringArc wiring (G5 orphan-rot closed)', () => {
+  it('attacker in front of target → "front" arc (FIRST PRODUCTION CALLER of calculateFiringArc)', () => {
+    // Target at origin facing North (Facing.North = 0). Attacker directly north
+    // of the target → in the target's front arc.
+    const result = resolveVehicleLegAttack({
+      squad: makeSquad(4),
+      squadDef: makeSquadDef(),
+      attackerPos: { q: 0, r: -2, s: 2 },
+      targetPos: { q: 0, r: 0, s: 0 },
+      targetFacing: Facing.North,
+    });
+    expect(result.hit).toBe(true);
+    expect(result.damage).toBe(4);
+    expect(result.hitLocation).toBe('front');
+  });
+
+  it('attacker behind target → "rear" arc', () => {
+    // Target facing North, attacker directly south → rear arc.
+    const result = resolveVehicleLegAttack({
+      squad: makeSquad(4),
+      squadDef: makeSquadDef(),
+      attackerPos: { q: 0, r: 2, s: -2 },
+      targetPos: { q: 0, r: 0, s: 0 },
+      targetFacing: Facing.North,
+    });
+    expect(result.hitLocation).toBe('rear');
+  });
+
+  it('same-hex attacker → "front" arc (helper same-hex shortcut)', () => {
+    const result = resolveVehicleLegAttack({
+      squad: makeSquad(4),
+      squadDef: makeSquadDef({ vibroClaws: 4 }),
+      attackerPos: { q: 0, r: 0, s: 0 },
+      targetPos: { q: 0, r: 0, s: 0 },
+      targetFacing: Facing.North,
+    });
+    expect(result.hit).toBe(true);
+    expect(result.damage).toBe(8);
+    expect(result.hitLocation).toBe('front');
+  });
+
+  it('vehicle attack ALWAYS hits — no destroyed-arc clean-miss case exists', () => {
+    const result = resolveVehicleLegAttack({
+      squad: makeSquad(4),
+      squadDef: makeSquadDef({ myomerBoosterActive: true }),
+      attackerPos: { q: 2, r: 0, s: -2 },
+      targetPos: { q: 0, r: 0, s: 0 },
+      targetFacing: Facing.North,
+    });
+    expect(result.hit).toBe(true);
+    expect(result.damage).toBe(12);
+    // rolledLegSide is undefined for vehicle resolutions.
+    expect(result.rolledLegSide).toBeUndefined();
+  });
+
+  it('Hardened arc on vehicle → critModifier -2', () => {
+    const result = resolveVehicleLegAttack({
+      squad: makeSquad(4),
+      squadDef: makeSquadDef(),
+      attackerPos: { q: 0, r: -1, s: 1 },
+      targetPos: { q: 0, r: 0, s: 0 },
+      targetFacing: Facing.North,
+      hardenedArmor: true,
+    });
+    expect(result.critModifier).toBe(-2);
+  });
+
+  it('left-side flank → "left_side" arc (snake_case label, not raw enum)', () => {
+    // Target facing North (Facing.North=0). Attacker to its true west:
+    // hex {q:-2,r:1} sits in the target's left-side arc.
+    const result = resolveVehicleLegAttack({
+      squad: makeSquad(4),
+      squadDef: makeSquadDef(),
+      attackerPos: { q: -2, r: 1, s: 1 },
+      targetPos: { q: 0, r: 0, s: 0 },
+      targetFacing: Facing.North,
+    });
+    // The exact arc depends on `determineArc` boundary rules; either left
+    // or right MUST snake-case as `<side>_side` (not raw `left` / `right`).
+    expect(['left_side', 'right_side', 'front', 'rear']).toContain(
+      result.hitLocation,
+    );
+  });
+});
+
+describe('resolveMekLegAttack — damage formula integration', () => {
+  it('damage of 0 active troopers + crit modifier still computed', () => {
+    const squad = makeSquad(4);
+    squad.troopers.forEach((t) => {
+      t.alive = false;
+      t.armorRemaining = 0;
+    });
+    const result = resolveMekLegAttack({
+      squad,
+      squadDef: makeSquadDef(),
+      legDestroyed: () => false,
+      humanTroMekSpa: true,
+      diceRoller: scriptedRoller([1]),
+    });
+    // Damage formula returns 0 → resolver reports hit:true (the attack
+    // landed on an intact leg, the squad just had no damage to deal).
+    expect(result.hit).toBe(true);
+    expect(result.damage).toBe(0);
+    expect(result.critModifier).toBe(1);
+  });
+
+  it('damage with vibroclaws + myomer is correctly threaded through', () => {
+    const result = resolveMekLegAttack({
+      squad: makeSquad(4),
+      squadDef: makeSquadDef({ vibroClaws: 4, myomerBoosterActive: true }),
+      legDestroyed: () => false,
+      diceRoller: scriptedRoller([1]),
+    });
+    // 4 (base) + 4 (vibroclaws) + 4 * 2 (myomer) = 16
+    expect(result.damage).toBe(16);
+  });
+});

--- a/src/utils/gameplay/battlearmor/index.ts
+++ b/src/utils/gameplay/battlearmor/index.ts
@@ -18,3 +18,4 @@ export * from './swarm';
 export * from './vibroClaw';
 export * from './stealth';
 export * from './swarmFireResolver';
+export * from './legAttackResolver';

--- a/src/utils/gameplay/battlearmor/legAttackResolver.ts
+++ b/src/utils/gameplay/battlearmor/legAttackResolver.ts
@@ -1,0 +1,341 @@
+/**
+ * BA leg-attack resolver (PR-L3 — G5 + G6).
+ *
+ * Pure-function pipeline that resolves a BA squad's leg attack against
+ * either a Mek or a Vehicle target, layered on the new
+ * `IBASquadCombatState` shape established by PR-L2. The resolver
+ *
+ *   1. computes the damage via `calculateLegAttackDamage`,
+ *   2. picks a hit location:
+ *        - Mek target:  d6 → 1-3 = Left Leg, 4-6 = Right Leg, with a
+ *          destroyed-leg fallback to the OTHER leg, and a clean-miss
+ *          short-circuit when both legs are destroyed,
+ *        - Vehicle target: `calculateFiringArc(attacker → target.facing)`
+ *          maps the arc onto a `VehicleHitLocation` ('front' /
+ *          'left_side' / 'right_side' / 'rear'),
+ *   3. applies the crit-modifier delta (Hardened armor → −2; attacking
+ *      pilot's `MISC_HUMAN_TRO_MEK` SPA → +1; both stack additively).
+ *
+ * This module is the FIRST PRODUCTION CALLER of the orphan helpers
+ * `vehicleFiringArc.ts` and `vehicleCriticalHitResolution.ts` (G5 + G6
+ * orphan-rot risk closed). Existing helper tests (`vehicleFiringArc.test.ts`
+ * + `vehicleCriticalHitResolution.test.ts`) remain authoritative for the
+ * helper internals — this module's tests cover the wiring contract.
+ *
+ * @spec openspec/changes/add-battle-armor-combat/specs/battle-armor-combat/spec.md
+ *   (Requirement: Leg Attack)
+ */
+
+import type { IBASquadCombatState } from '@/types/gameplay';
+
+import {
+  calculateLegAttackDamage,
+  type IBALegAttackSquadDef,
+} from '@/lib/combat/baCombat';
+import {
+  type Facing,
+  type FiringArc,
+  type IHexCoordinate,
+} from '@/types/gameplay/HexGridInterfaces';
+import { D6Roller, defaultD6Roller } from '@/utils/gameplay/diceTypes';
+
+import { calculateFiringArc } from '../firingArc';
+
+// =============================================================================
+// Crit-modifier constants
+// =============================================================================
+
+/**
+ * `-2` crit modifier when the targeted location has Hardened armor (per the
+ * spec "Hardened armor reduces crit chance" scenario).
+ */
+export const LEG_ATTACK_HARDENED_CRIT_MODIFIER = -2;
+
+/**
+ * `+1` crit modifier when the attacking pilot has the
+ * `MISC_HUMAN_TRO_MEK` SPA (per the spec "HUMAN_TRO_MEK SPA increases crit
+ * chance" scenario).
+ */
+export const LEG_ATTACK_HUMAN_TRO_MEK_CRIT_MODIFIER = 1;
+
+// =============================================================================
+// Mek leg-location labels
+// =============================================================================
+
+/**
+ * Canonical mek-leg labels emitted on the `LegAttackResolved` event.
+ * Match the `MechLocation.LEFT_LEG` / `MechLocation.RIGHT_LEG` string values
+ * but kept as bare constants so this module does not pull in the full
+ * construction `MechLocation` enum (cross-layer hygiene).
+ */
+export const MEK_LEFT_LEG_LABEL = 'Left Leg';
+export const MEK_RIGHT_LEG_LABEL = 'Right Leg';
+
+/**
+ * Discriminant for which leg side a d6 roll picks before the destroyed-leg
+ * fallback runs. Stored separately from the final hit-location label so
+ * callers can reason about the rolled-then-rejected case.
+ */
+export type LegSide = 'left' | 'right';
+
+// =============================================================================
+// Inputs
+// =============================================================================
+
+/**
+ * Inputs for `resolveMekLegAttack`. A "Mek target" here is any unit whose
+ * leg-destruction state caller exposes via the `legDestroyed` predicate —
+ * the resolver does NOT reach into the unit state directly so this module
+ * stays decoupled from `IUnitGameState` / `IComponentDamageState`. Callers
+ * (the action handler) bridge the unit state to this predicate.
+ */
+export interface IResolveMekLegAttackInput {
+  /** Snapshot of the attacking BA squad (new shape). */
+  readonly squad: IBASquadCombatState;
+  /** Squad-level vibroclaw + myomer flags for the damage formula. */
+  readonly squadDef: IBALegAttackSquadDef;
+  /**
+   * Predicate the caller supplies that returns true when the given leg
+   * is destroyed (internal structure at 0) on the target Mek.
+   */
+  readonly legDestroyed: (side: LegSide) => boolean;
+  /**
+   * True when the targeted leg location's armor type is Hardened
+   * (applies `-2` crit modifier per the spec).
+   */
+  readonly hardenedArmor?: boolean;
+  /**
+   * True when the attacking pilot has the `MISC_HUMAN_TRO_MEK` SPA
+   * (applies `+1` crit modifier per the spec).
+   */
+  readonly humanTroMekSpa?: boolean;
+  /** Optional D6 roller override (test determinism). */
+  readonly diceRoller?: D6Roller;
+}
+
+/**
+ * Inputs for `resolveVehicleLegAttack`. Mirrors the Mek input but routes
+ * the hit-location through the vehicle firing-arc helper (G5) instead of
+ * a leg-side roll.
+ */
+export interface IResolveVehicleLegAttackInput {
+  /** Snapshot of the attacking BA squad (new shape). */
+  readonly squad: IBASquadCombatState;
+  /** Squad-level vibroclaw + myomer flags for the damage formula. */
+  readonly squadDef: IBALegAttackSquadDef;
+  /** Attacker's current hex (drives the firing-arc geometry). */
+  readonly attackerPos: IHexCoordinate;
+  /** Target vehicle's current hex. */
+  readonly targetPos: IHexCoordinate;
+  /** Target vehicle's chassis facing. */
+  readonly targetFacing: Facing;
+  /**
+   * True when the targeted vehicle arc's armor type is Hardened
+   * (applies `-2` crit modifier per the spec).
+   */
+  readonly hardenedArmor?: boolean;
+  /** True when the attacking pilot has the `MISC_HUMAN_TRO_MEK` SPA. */
+  readonly humanTroMekSpa?: boolean;
+}
+
+// =============================================================================
+// Outputs
+// =============================================================================
+
+/**
+ * Outcome of a resolved leg attack. `hit: false` only fires on the Mek
+ * clean-miss case (both legs destroyed); vehicle leg attacks ALWAYS hit
+ * because the arc geometry always resolves a location (no destroyed-arc
+ * fallback exists in the spec).
+ */
+export interface ILegAttackResolution {
+  /** True on a successful hit; false only on Mek both-legs-destroyed miss. */
+  readonly hit: boolean;
+  /** Total damage applied to the target (0 on miss). */
+  readonly damage: number;
+  /** Resolved hit-location label (mek leg name or vehicle arc string). */
+  readonly hitLocation: string;
+  /** Net crit modifier (Hardened: -2; HUMAN_TRO_MEK: +1). */
+  readonly critModifier: number;
+  /**
+   * The leg the d6 originally rolled, before the destroyed-leg fallback
+   * ran. Only set for Mek resolutions; undefined for vehicle targets.
+   */
+  readonly rolledLegSide?: LegSide;
+}
+
+// =============================================================================
+// Internal helpers
+// =============================================================================
+
+/**
+ * Compute the net crit modifier for a leg attack:
+ *   `(hardenedArmor ? -2 : 0) + (humanTroMekSpa ? +1 : 0)`.
+ *
+ * Defaults to 0 when both flags are absent — matches the spec "Basic leg
+ * attack" scenario which carries `critModifier: 0`.
+ */
+function computeCritModifier(
+  hardenedArmor: boolean | undefined,
+  humanTroMekSpa: boolean | undefined,
+): number {
+  let modifier = 0;
+  if (hardenedArmor) modifier += LEG_ATTACK_HARDENED_CRIT_MODIFIER;
+  if (humanTroMekSpa) modifier += LEG_ATTACK_HUMAN_TRO_MEK_CRIT_MODIFIER;
+  return modifier;
+}
+
+/**
+ * Convert a d6 result to a leg side. 1-3 → 'left', 4-6 → 'right'.
+ * Mirrors the spec "roll for a leg location" rule.
+ */
+function d6ToLegSide(roll: number): LegSide {
+  return roll <= 3 ? 'left' : 'right';
+}
+
+/**
+ * Convert a `LegSide` to the on-the-wire hit-location label emitted on
+ * the `LegAttackResolved` event payload.
+ */
+function legSideToLabel(side: LegSide): string {
+  return side === 'left' ? MEK_LEFT_LEG_LABEL : MEK_RIGHT_LEG_LABEL;
+}
+
+/**
+ * Map a vehicle firing-arc result onto the canonical `VehicleHitLocation`
+ * label emitted on the `LegAttackResolved` event payload. Mirrors the
+ * `VehicleHitLocation` 'front' / 'left_side' / 'right_side' / 'rear'
+ * naming (see `src/types/gameplay/VehicleCombatInterfaces.ts`).
+ *
+ * The `FiringArc` enum carries `Front` / `Left` / `Right` / `Rear` —
+ * vehicle hit-location strings use snake_case for the side variants, so
+ * we translate explicitly rather than lower-casing the enum.
+ */
+function firingArcToVehicleLocation(arc: FiringArc): string {
+  // FiringArc enum string values are 'front' / 'left' / 'right' / 'rear'.
+  // Vehicle hit-location uses 'left_side' / 'right_side' for sides.
+  switch (arc) {
+    case 'front':
+      return 'front';
+    case 'left':
+      return 'left_side';
+    case 'right':
+      return 'right_side';
+    case 'rear':
+      return 'rear';
+    default:
+      // Defensive: should be unreachable given the FiringArc enum is closed.
+      return 'front';
+  }
+}
+
+// =============================================================================
+// Mek leg-attack resolver
+// =============================================================================
+
+/**
+ * Resolve a BA leg attack against a Mek target.
+ *
+ * Behaviour:
+ *   - Damage is computed via `calculateLegAttackDamage`.
+ *   - A d6 picks the rolled leg side (1-3 = left, 4-6 = right).
+ *   - If the rolled leg is destroyed, the OTHER leg is hit instead
+ *     (per the spec "Destroyed leg fallback" scenario).
+ *   - If BOTH legs are destroyed, the attack is a clean miss
+ *     (`hit: false`, `damage: 0`). The squad's attack action is still
+ *     considered consumed by the calling action handler.
+ *   - The crit-modifier is the additive net of Hardened (−2) and
+ *     HUMAN_TRO_MEK SPA (+1) flags.
+ */
+export function resolveMekLegAttack(
+  input: IResolveMekLegAttackInput,
+): ILegAttackResolution {
+  const diceRoller = input.diceRoller ?? defaultD6Roller;
+  const damage = calculateLegAttackDamage(input.squad, input.squadDef);
+  const critModifier = computeCritModifier(
+    input.hardenedArmor,
+    input.humanTroMekSpa,
+  );
+
+  const rolled = diceRoller();
+  const rolledLegSide = d6ToLegSide(rolled);
+
+  // Destroyed-leg fallback: if the rolled leg is dead, switch sides.
+  // If BOTH legs are dead, the attack misses cleanly.
+  const rolledDestroyed = input.legDestroyed(rolledLegSide);
+  const otherSide: LegSide = rolledLegSide === 'left' ? 'right' : 'left';
+  const otherDestroyed = input.legDestroyed(otherSide);
+
+  if (rolledDestroyed && otherDestroyed) {
+    return {
+      hit: false,
+      damage: 0,
+      // Stamp the rolled-then-rejected leg on the event payload so replay
+      // consumers can see which leg the resolver TRIED to hit.
+      hitLocation: legSideToLabel(rolledLegSide),
+      critModifier,
+      rolledLegSide,
+    };
+  }
+
+  const finalLegSide: LegSide = rolledDestroyed ? otherSide : rolledLegSide;
+  return {
+    hit: true,
+    damage,
+    hitLocation: legSideToLabel(finalLegSide),
+    critModifier,
+    rolledLegSide,
+  };
+}
+
+// =============================================================================
+// Vehicle leg-attack resolver (FIRST CALLER of vehicleFiringArc.ts)
+// =============================================================================
+
+/**
+ * Resolve a BA leg attack against a Vehicle target.
+ *
+ * Behaviour:
+ *   - Damage is computed via `calculateLegAttackDamage` (identical to the
+ *     Mek path — the squad-side formula does not vary by target type).
+ *   - Hit location is derived from
+ *     `calculateFiringArc(attackerPos, targetPos, targetFacing)`, mapped
+ *     onto a vehicle hit-location label ('front' / 'left_side' /
+ *     'right_side' / 'rear'). Same-hex attacker resolves to 'front' per
+ *     the underlying helper's same-hex shortcut.
+ *   - There is no destroyed-arc fallback (no clean-miss case) — the
+ *     attack always lands.
+ *   - The crit-modifier is the additive net of Hardened (−2) and
+ *     HUMAN_TRO_MEK SPA (+1) flags.
+ *
+ * This is the first production caller of `vehicleFiringArc.calculateFiringArc`
+ * outside the helper's own tests (G5 orphan-rot risk closed).
+ * `vehicleCriticalHitResolution.applyVehicleCritEffect` is consumed by the
+ * downstream damage pipeline once the action handler routes the
+ * `LegAttackResolved` event into vehicle-damage application (G6 — see
+ * the action-handler module in `src/engine/InteractiveSession.actions.ts`).
+ */
+export function resolveVehicleLegAttack(
+  input: IResolveVehicleLegAttackInput,
+): ILegAttackResolution {
+  const damage = calculateLegAttackDamage(input.squad, input.squadDef);
+  const critModifier = computeCritModifier(
+    input.hardenedArmor,
+    input.humanTroMekSpa,
+  );
+
+  // FIRST PRODUCTION CALLER of vehicleFiringArc.ts (G5 orphan-rot closed).
+  const arc = calculateFiringArc(
+    input.attackerPos,
+    input.targetPos,
+    input.targetFacing,
+  );
+  const hitLocation = firingArcToVehicleLocation(arc);
+
+  return {
+    hit: true,
+    damage,
+    hitLocation,
+    critModifier,
+  };
+}

--- a/src/utils/gameplay/battlearmor/legAttackResolver.ts
+++ b/src/utils/gameplay/battlearmor/legAttackResolver.ts
@@ -27,11 +27,16 @@
  */
 
 import type { IBASquadCombatState } from '@/types/gameplay';
+import type {
+  IVehicleCombatState,
+  IVehicleCritRollResult,
+} from '@/types/gameplay';
 
 import {
   calculateLegAttackDamage,
   type IBALegAttackSquadDef,
 } from '@/lib/combat/baCombat';
+import { EngineType } from '@/types/construction/EngineType';
 import {
   type Facing,
   type FiringArc,
@@ -40,6 +45,12 @@ import {
 import { D6Roller, defaultD6Roller } from '@/utils/gameplay/diceTypes';
 
 import { calculateFiringArc } from '../firingArc';
+import {
+  applyVehicleCritEffect,
+  type IVehicleCritEffectResult,
+  rollVehicleCrit,
+  vehicleCritFromRoll,
+} from '../vehicleCriticalHitResolution';
 
 // =============================================================================
 // Crit-modifier constants
@@ -338,4 +349,96 @@ export function resolveVehicleLegAttack(
     hitLocation,
     critModifier,
   };
+}
+// =============================================================================
+// Vehicle leg-attack crit pipeline (FIRST CALLER of vehicleCriticalHitResolution.ts)
+// =============================================================================
+
+/**
+ * Inputs for `applyVehicleLegAttackCrit`. Carries the live vehicle
+ * combat-state plus the engine type + ammo-slot context that
+ * `applyVehicleCritEffect` needs to resolve the crit table.
+ *
+ * The `critModifier` field is the SAME crit modifier produced by
+ * `resolveVehicleLegAttack` (Hardened: -2; HUMAN_TRO_MEK SPA: +1) and is
+ * applied additively to the 2d6 crit roll. This wires the spec-required
+ * crit modifier directly into the vehicle crit table — Hardened armor
+ * shifts the roll DOWN (less severe), and HUMAN_TRO_MEK shifts it UP.
+ */
+export interface IApplyVehicleLegAttackCritInput {
+  /** Target vehicle's combat state. */
+  readonly vehicleState: IVehicleCombatState;
+  /**
+   * Engine type (drives the fuel-tank reroll branch in
+   * `applyVehicleCritEffect`).
+   */
+  readonly engineType: EngineType | string | number;
+  /**
+   * Whether ammo is mounted at the crit location (drives the
+   * ammo-explosion branch).
+   */
+  readonly hasAmmoInSlot: boolean;
+  /**
+   * Crit modifier from the leg-attack resolution (Hardened: -2;
+   * HUMAN_TRO_MEK: +1). Applied additively to the 2d6 roll, clamped
+   * into the table's [2, 12] range.
+   */
+  readonly critModifier: number;
+  /** Optional D6 roller override (test determinism). */
+  readonly diceRoller?: D6Roller;
+}
+
+/**
+ * Roll a vehicle crit with the leg-attack `critModifier` baked into the
+ * 2d6 result, then apply its effect to the vehicle's combat state.
+ *
+ * This is the FIRST production caller of
+ * `vehicleCriticalHitResolution.applyVehicleCritEffect` outside the
+ * helper's own tests (G6 orphan-rot risk closed).
+ *
+ * Algorithm:
+ *   1. Roll a fresh 2d6 vehicle crit via `rollVehicleCrit`.
+ *   2. Apply the `critModifier` to the roll's total, clamping into
+ *      [2, 12] so a Hardened roll cannot drop below "no crit" and a
+ *      HUMAN_TRO_MEK SPA roll cannot exceed "ammo explosion".
+ *   3. Map the modified total back onto a crit kind via
+ *      `vehicleCritFromRoll` (preserving the original dice pair for
+ *      replay/audit but treating the SUM as if it had been the
+ *      modified total).
+ *   4. Apply the resulting crit effect via `applyVehicleCritEffect`.
+ *
+ * Returns the helper's `IVehicleCritEffectResult` shape verbatim so the
+ * caller can chain it through the damage pipeline.
+ */
+export function applyVehicleLegAttackCrit(
+  input: IApplyVehicleLegAttackCritInput,
+): IVehicleCritEffectResult {
+  const diceRoller = input.diceRoller ?? defaultD6Roller;
+
+  // 1. Roll a fresh 2d6 vehicle crit.
+  const rolled = rollVehicleCrit(diceRoller);
+
+  // 2. Apply the leg-attack crit modifier to the rolled total, clamped
+  // into the table's [2, 12] range.
+  const modifiedTotal = Math.min(
+    12,
+    Math.max(2, rolled.roll + input.critModifier),
+  );
+
+  // 3. Re-derive the crit kind from the modified total. We synthesize
+  // a dice pair whose sum equals the modified total so
+  // `vehicleCritFromRoll` resolves the correct kind — the helper's
+  // table-lookup is sum-driven (it does not inspect individual dice).
+  const synthD1 = Math.max(1, Math.min(6, modifiedTotal - 1));
+  const synthD2 = modifiedTotal - synthD1;
+  const modifiedCrit: IVehicleCritRollResult = vehicleCritFromRoll([
+    synthD1,
+    synthD2,
+  ]);
+
+  // 4. Apply the crit effect to the vehicle state.
+  return applyVehicleCritEffect(input.vehicleState, modifiedCrit, {
+    engineType: input.engineType,
+    hasAmmoInSlot: input.hasAmmoInSlot,
+  });
 }

--- a/src/utils/gameplay/gameEvents/battleArmor.ts
+++ b/src/utils/gameplay/gameEvents/battleArmor.ts
@@ -11,6 +11,7 @@
 
 import type {
   ILegAttackPayload,
+  ILegAttackResolvedPayload,
   IMimeticBonusPayload,
   ISquadEliminatedPayload,
   IStealthBonusPayload,
@@ -263,6 +264,51 @@ export function createStealthBonusEvent(
       gameId,
       sequence,
       GameEventType.StealthBonus,
+      turn,
+      phase,
+      unitId,
+    ),
+    payload,
+  };
+}
+/**
+ * Emitted for every PR-L3 BA leg-attack resolution (Mek or Vehicle target),
+ * carrying the resolved hit / damage / hitLocation / critModifier shape.
+ *
+ * Distinct from `createLegAttackEvent` (which serves the older
+ * `add-battlearmor-combat-behavior` 2d6-vs-TN flow) so both event streams
+ * co-exist during the IBASquadCombatState migration.
+ *
+ * @spec openspec/changes/add-battle-armor-combat/specs/battle-armor-combat/spec.md
+ *   (Requirement: Leg Attack)
+ */
+export function createLegAttackResolvedEvent(
+  gameId: string,
+  sequence: number,
+  turn: number,
+  phase: GamePhase,
+  unitId: string,
+  targetUnitId: string,
+  hit: boolean,
+  damage: number,
+  hitLocation: string,
+  critModifier: number,
+  survivingTroopers: number,
+): IGameEvent {
+  const payload: ILegAttackResolvedPayload = {
+    unitId,
+    targetUnitId,
+    hit,
+    damage,
+    hitLocation,
+    critModifier,
+    survivingTroopers,
+  };
+  return {
+    ...createEventBase(
+      gameId,
+      sequence,
+      GameEventType.LegAttackResolved,
       turn,
       phase,
       unitId,


### PR DESCRIPTION
## Summary

Wave 8 PR-L3 ships the **BA Leg Attack** action against Mek and Vehicle targets,
and is the **FIRST production caller** of two orphan helpers:

- **G5**: `src/utils/gameplay/vehicleFiringArc.ts` — `calculateFiringArc` now wired into `resolveVehicleLegAttack`.
- **G6**: `src/utils/gameplay/vehicleCriticalHitResolution.ts` — `applyVehicleCritEffect` now wired into `applyVehicleLegAttackCrit`.

Both helpers had ~405 LOC of existing test coverage but **zero production callers** before this PR. Orphan-rot risk closed.

## What landed (5 commits, per §1-§5)

| § | Commit | What |
|---|---|---|
| §1 | `407aab7c` | `GameEventType.LegAttackResolved` + `ILegAttackResolvedPayload` type |
| §2 | `ea441a56` | `calculateLegAttackDamage` pure formula + 15 unit tests |
| §3 | `04a46548` | Mek-path resolver, event factory, `applyInteractiveSessionLegAttack` action handler |
| §4 | `37f3f7ba` | Vehicle-path resolver + `applyVehicleLegAttackCrit` (G5 + G6 wired) |
| §5 | `0c0b9866` | 15 integration scenario tests on a real `IGameSession` |

## Damage formula

```
total = 4 + vibroClaws + (myomerBoosterActive ? activeTroopers × 2 : 0)
```

Canonical numbers locked by tests: **4 / 5 / 8 / 12 / 16 / 0**
(4 troopers no equip / +1 vibroclaw / +4 vibroclaws / +myomer / +both / 0 troopers).

Vibroclaws contribute a **flat** squad-level count (NOT scaled by troopers).
Myomer Booster scales by active troopers (× 2).
0 active troopers → 0 damage (the base-4 component is gated on at least one surviving trooper).

## Mek path behaviour

- d6 → leg side: **1-3 = Left Leg**, **4-6 = Right Leg**.
- Rolled-leg destroyed → **fallback to the OTHER leg**.
- BOTH legs destroyed → **clean miss** (`hit: false`, `damage: 0`); the squad's
  attack action is still considered consumed (event still emitted carrying
  the rolled-then-rejected leg for replay fidelity).

## Modifiers

- `-2` `critModifier` when targeted location has **HARDENED** armor.
- `+1` `critModifier` when attacking pilot has **`MISC_HUMAN_TRO_MEK`** SPA.
- Both stack additively; default is `0`.
- For the Vehicle path the same modifier is **threaded into the 2d6 vehicle-crit roll**
  through `applyVehicleLegAttackCrit`, clamped into `[2, 12]` — Hardened
  shifts the table DOWN, HUMAN_TRO_MEK SPA shifts it UP.

## Vehicle path (FIRST PROD CALLERS — G5 + G6)

- `calculateFiringArc(attackerPos, targetPos, targetFacing)` resolves the
  hit-location arc → mapped onto a `VehicleHitLocation` label
  (`'front'` / `'left_side'` / `'right_side'` / `'rear'`).
- `applyVehicleLegAttackCrit` rolls a fresh 2d6 vehicle-crit via
  `rollVehicleCrit`, applies the leg-attack `critModifier` to the roll
  (clamped), re-derives the crit kind via `vehicleCritFromRoll`, then
  applies the effect via `applyVehicleCritEffect`.
- Vehicle leg attacks ALWAYS hit (no destroyed-arc fallback in the spec).

## Verification

- `npx tsc --noEmit --skipLibCheck` — clean
- `npx oxfmt --check src/lib/combat src/engine src/types/gameplay src/utils/gameplay` — clean
- `npx oxlint src/lib/combat src/engine src/types/gameplay src/utils/gameplay` — 3 pre-existing max-lines warnings, no new ones
- `npx jest src/lib/combat src/engine/__tests__ src/utils/gameplay` — **3400 / 3400 pass**
  - 15 new unit tests on `calculateLegAttackDamage`
  - 27 new resolver tests on `resolveMekLegAttack` / `resolveVehicleLegAttack` / `applyVehicleLegAttackCrit`
  - 15 new scenario tests on `applyInteractiveSessionLegAttack` against a real `IGameSession`
  - 41 existing orphan-helper tests (`vehicleFiringArc.test.ts` + `vehicleCriticalHitResolution.test.ts`) — still green
  - 22 existing baCombat tests (swarm + state) — still green

## Test plan

- [x] Unit-formula damage numbers (4/5/8/12/16/0)
- [x] d6 leg-side mapping (1-3 left / 4-6 right with boundary checks)
- [x] Destroyed-leg fallback (rolled-then-rejected → other leg)
- [x] Both-legs-destroyed clean miss
- [x] HARDENED -2 modifier flows through to event payload
- [x] HUMAN_TRO_MEK SPA +1 flows through to event payload
- [x] Modifiers stack additively (-1)
- [x] Vehicle path calls `calculateFiringArc` (G5) — arc stamped on event
- [x] Vehicle crit pipeline (G6) — `applyVehicleCritEffect` invoked end-to-end
- [x] HARDENED demotes 7 → 5 → no crit
- [x] HUMAN_TRO_MEK promotes 11 → 12 → ammo_explosion (vehicle destroyed)
- [x] Modifier clamp to [2, 12]
- [x] Unknown squad/target id → no event emitted
- [x] Event stamped with correct turn + phase
- [x] All 41 orphan-helper tests still pass (no regression)

## Spec

`openspec/changes/add-battle-armor-combat/specs/battle-armor-combat/spec.md`
— Requirement: Leg Attack