### PR TITLE
Auto-land short WiGE movement

### DIFF
--- a/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
+++ b/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
@@ -60,6 +60,14 @@ Imported MegaMek board cliff metadata is covered by
 `Board.java:537-602`: `.board` `cliff_top:1:<exitMask>` entries now import as
 `cliffTopExits` only for in-board 1- or 2-level drops, so real map data drives
 the same movement projection instead of relying on hand-authored fixtures.
+Large MegaMek board labels are covered by
+`import-large-megamek-board-coordinates`, source-pinned to MegaMek
+`Coords.java:510-514`, `Board.java:1062-1063`, and real
+`170x120 Fort David.board` labels such as `10412`, `10016`, and `104120`:
+the parser now splits two-or-more digit column/row components against declared
+board dimensions so large-board terrain, elevation, and cliff metadata reaches
+the same tactical projection path instead of failing the old fixed-four-digit
+guard.
 Replayable gameplay events for runtime movement state are covered by
 `apply-runtime-movement-state-events`; player-facing tactical command controls
 for represented conversion and infantry mount-state changes are covered by

--- a/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
+++ b/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
@@ -84,6 +84,11 @@ source reference so same-hex walk/run/jump options carry their reachable or
 blocked state, MP cost, terrain and elevation costs, heat, and blocked reason
 directly in `movement:megamek` projection metadata instead of only in visible
 badges/tooltips.
+The `source-hover-path-preview-badge` slice keeps the hovered path MP badge on
+that same source-backed path: hovering a reachable destination now preserves
+terrain/elevation cost, heat, `movement:megamek` source refs, and MegaMek rule
+refs on the preview badge instead of thinning the displayed commit preview to
+MP and movement type only.
 Replayable gameplay events for runtime movement state are covered by
 `apply-runtime-movement-state-events`; player-facing tactical command controls
 for represented conversion and infantry mount-state changes are covered by

--- a/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
+++ b/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
@@ -84,6 +84,10 @@ source reference so same-hex walk/run/jump options carry their reachable or
 blocked state, MP cost, terrain and elevation costs, heat, and blocked reason
 directly in `movement:megamek` projection metadata instead of only in visible
 badges/tooltips.
+The `source-movement-reach-badge` slice pins the normal reachable movement
+badge to that same source-backed path, so the standing MP badge now exposes
+`movement:megamek` source refs, MegaMek rule refs, and projection explanation
+metadata before hover path preview replaces it.
 The `source-hover-path-preview-badge` slice keeps the hovered path MP badge on
 that same source-backed path: hovering a reachable destination now preserves
 terrain/elevation cost, heat, `movement:megamek` source refs, and MegaMek rule

--- a/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
+++ b/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
@@ -39,7 +39,10 @@ Short-distance automatic WiGE landing for represented positive-altitude WiGE
 vehicles, Glider ProtoMeks, and LAM AirMeks is now covered by
 `auto-land-short-wige-movement`, source-pinned to MegaMek
 `MovePath.java:1689-1738`, and replays through the same runtime movement-state
-channel used by altitude controls.
+channel used by altitude controls. The represented already-moved distance and
+UP/HOVER-style exemptions from the same MegaMek helper are now covered by
+`pin-wige-hover-distance-exemptions`, so the map no longer shows a `LAND`
+consequence or runtime landing patch when those source guards apply.
 Replayable gameplay events for runtime movement state are covered by
 `apply-runtime-movement-state-events`; player-facing tactical command controls
 for represented conversion and infantry mount-state changes are covered by
@@ -826,8 +829,10 @@ those fall clusters destroy locations or the unit.
 clusters through the shared critical-hit resolver and emits movement-phase
 `CriticalHit`, `CriticalHitResolved`, and `ComponentDestroyed` follow-through
 events. Short-distance forced landing from represented higher WiGE elevations is
-covered by `auto-land-short-wige-movement`; finer-grained hover/takeoff
-direction state remains follow-up work.
+covered by `auto-land-short-wige-movement`; represented already-moved distance
+and hover-style exemptions are covered by
+`pin-wige-hover-distance-exemptions`; finer-grained hover/takeoff direction
+state remains follow-up work.
 
 Additional small-unit movement data pin: MegaMek `Infantry.java:560-568` and
 `BattleArmor.java:520-523` return walk MP as base run MP unless optional TacOps
@@ -1584,7 +1589,9 @@ tooltip reason rows, and same-hex option metadata via
 `surface-airborne-altitude-control-context`. Full airborne VTOL/WiGE altitude
 pathing, hover/takeoff/landing sequencing, clearance, and broad oracle sweeps
 remain follow-ups. Represented short-distance WiGE auto-landing is covered by
-`auto-land-short-wige-movement`. Basic Climb/Descend runtime
+`auto-land-short-wige-movement`, and the represented prior-distance plus
+hover-style exemptions for that auto-landing helper are covered by
+`pin-wige-hover-distance-exemptions`. Basic Climb/Descend runtime
 altitude-control commands now exist via `wire-vtol-wige-altitude-controls`, but
 full UP/DOWN MP accounting and terrain-clearance-specific gates remain pending.
 

--- a/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
+++ b/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
@@ -68,6 +68,13 @@ the parser now splits two-or-more digit column/row components against declared
 board dimensions so large-board terrain, elevation, and cliff metadata reaches
 the same tactical projection path instead of failing the old fixed-four-digit
 guard.
+The follow-on `audit-megamek-board-import-corpus` verifier now makes that import
+claim repeatable against a local MegaMek board checkout. Its first local run
+found ambiguous labels such as `10101` on `170x120 Fort David.board`; MekStation
+now uses MegaMek row order to disambiguate those labels, matching
+`Board.java:1062-1063`. The verified local corpus run parsed all 2,386 boards
+under `E:\Projects\megamek\megamek\data\boards` with 0 failures, covering
+3,638,056 hex rows, 382,251 large-coordinate rows, and 5,253 `cliff_top` rows.
 Replayable gameplay events for runtime movement state are covered by
 `apply-runtime-movement-state-events`; player-facing tactical command controls
 for represented conversion and infantry mount-state changes are covered by

--- a/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
+++ b/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
@@ -54,6 +54,12 @@ sheer-cliff movement is now covered by
 cliff-top exits add the WiGE +1 MP ascent surcharge and block represented
 tracked/wheeled/hover vehicle ascent when no pavement/road surface cancels the
 cliff effect, without inferring cliffs from ordinary elevation deltas.
+Imported MegaMek board cliff metadata is covered by
+`import-megamek-cliff-top-exits`, source-pinned to MegaMek
+`Terrain.java:103-119`, `Terrain.java:302`, `Terrains.java:147-150`, and
+`Board.java:537-602`: `.board` `cliff_top:1:<exitMask>` entries now import as
+`cliffTopExits` only for in-board 1- or 2-level drops, so real map data drives
+the same movement projection instead of relying on hand-authored fixtures.
 Replayable gameplay events for runtime movement state are covered by
 `apply-runtime-movement-state-events`; player-facing tactical command controls
 for represented conversion and infantry mount-state changes are covered by

--- a/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
+++ b/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
@@ -88,6 +88,10 @@ The `source-movement-reach-badge` slice pins the normal reachable movement
 badge to that same source-backed path, so the standing MP badge now exposes
 `movement:megamek` source refs, MegaMek rule refs, and projection explanation
 metadata before hover path preview replaces it.
+The `source-movement-step-cost-badge` slice extends that provenance to the
+separate terrain/elevation step-cost marker, so visible `T+`/`E+`/`UP`/`DN`
+cost labels also identify their shared `movement:megamek` source and rule
+references.
 The `source-hover-path-preview-badge` slice keeps the hovered path MP badge on
 that same source-backed path: hovering a reachable destination now preserves
 terrain/elevation cost, heat, `movement:megamek` source refs, and MegaMek rule

--- a/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
+++ b/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
@@ -79,6 +79,11 @@ The follow-on `surface-cliff-exits-map-context` slice exposes represented
 `cliffTopExits` on hex metadata, terrain labels, terrain/elevation source
 details, and terrain hover context so the map explains directional cliff edges
 from imported terrain instead of hiding them inside movement-only diagnostics.
+The `surface-movement-option-source-details` slice expands the shared movement
+source reference so same-hex walk/run/jump options carry their reachable or
+blocked state, MP cost, terrain and elevation costs, heat, and blocked reason
+directly in `movement:megamek` projection metadata instead of only in visible
+badges/tooltips.
 Replayable gameplay events for runtime movement state are covered by
 `apply-runtime-movement-state-events`; player-facing tactical command controls
 for represented conversion and infantry mount-state changes are covered by

--- a/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
+++ b/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
@@ -43,6 +43,12 @@ channel used by altitude controls. The represented already-moved distance and
 UP/HOVER-style exemptions from the same MegaMek helper are now covered by
 `pin-wige-hover-distance-exemptions`, so the map no longer shows a `LAND`
 consequence or runtime landing patch when those source guards apply.
+Represented WiGE building-top climb cost is now covered by
+`pin-wige-building-climb-cost`, source-pinned to MegaMek
+`MoveStep.java:2844-2864`: the shared movement-cost helper adds the +2 MP
+climb-mode surcharge when entering a higher represented building ceiling while
+leaving the separate +1 sheer-cliff surcharge as a follow-up until MekStation
+encodes directional cliff-top terrain metadata.
 Replayable gameplay events for runtime movement state are covered by
 `apply-runtime-movement-state-events`; player-facing tactical command controls
 for represented conversion and infantry mount-state changes are covered by

--- a/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
+++ b/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
@@ -47,8 +47,13 @@ Represented WiGE building-top climb cost is now covered by
 `pin-wige-building-climb-cost`, source-pinned to MegaMek
 `MoveStep.java:2844-2864`: the shared movement-cost helper adds the +2 MP
 climb-mode surcharge when entering a higher represented building ceiling while
-leaving the separate +1 sheer-cliff surcharge as a follow-up until MekStation
-encodes directional cliff-top terrain metadata.
+leaving the separate cliff behavior to explicit edge metadata. Directional
+sheer-cliff movement is now covered by
+`pin-directional-cliff-movement-metadata`, source-pinned to MegaMek
+`Hex.java:744-750` and `MoveStep.java:2858-2864` / `:3159-3178`: encoded
+cliff-top exits add the WiGE +1 MP ascent surcharge and block represented
+tracked/wheeled/hover vehicle ascent when no pavement/road surface cancels the
+cliff effect, without inferring cliffs from ordinary elevation deltas.
 Replayable gameplay events for runtime movement state are covered by
 `apply-runtime-movement-state-events`; player-facing tactical command controls
 for represented conversion and infantry mount-state changes are covered by

--- a/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
+++ b/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
@@ -75,6 +75,10 @@ now uses MegaMek row order to disambiguate those labels, matching
 `Board.java:1062-1063`. The verified local corpus run parsed all 2,386 boards
 under `E:\Projects\megamek\megamek\data\boards` with 0 failures, covering
 3,638,056 hex rows, 382,251 large-coordinate rows, and 5,253 `cliff_top` rows.
+The follow-on `surface-cliff-exits-map-context` slice exposes represented
+`cliffTopExits` on hex metadata, terrain labels, terrain/elevation source
+details, and terrain hover context so the map explains directional cliff edges
+from imported terrain instead of hiding them inside movement-only diagnostics.
 Replayable gameplay events for runtime movement state are covered by
 `apply-runtime-movement-state-events`; player-facing tactical command controls
 for represented conversion and infantry mount-state changes are covered by

--- a/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
+++ b/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
@@ -35,6 +35,11 @@ landing-control required/not-required context via
 `pin-airmek-landing-control-context`, and required damaged landings now queue a
 canonical AirMek landing PSR via `queue-airmek-landing-psr`, then resolve that
 landing check in the same movement command via `resolve-airmek-landing-psr`.
+Short-distance automatic WiGE landing for represented positive-altitude WiGE
+vehicles, Glider ProtoMeks, and LAM AirMeks is now covered by
+`auto-land-short-wige-movement`, source-pinned to MegaMek
+`MovePath.java:1689-1738`, and replays through the same runtime movement-state
+channel used by altitude controls.
 Replayable gameplay events for runtime movement state are covered by
 `apply-runtime-movement-state-events`; player-facing tactical command controls
 for represented conversion and infantry mount-state changes are covered by
@@ -790,8 +795,9 @@ altitude from ground-map elevation. MekStation now tracks represented AirMek
 WiGE elevation in `lamAirMekAltitude`, exposes Climb/Descend controls in
 AirMek mode, dispatches replayable altitude-control MP reserves, caps Climb at
 25, and marks positive-elevation AirMek ground projection as altitude-control
-owned. Full elevated AirMek/WiGE pathing, takeoff/landing sequencing, and
-automatic WiGE landing remain follow-up work.
+owned. Represented short-distance automatic WiGE landing is covered by
+`auto-land-short-wige-movement`; full hover/takeoff/landing sequencing and
+broader elevated AirMek/WiGE pathing remain follow-up work.
 
 2026-05-31 LAM AirMek landing-control context pin: MegaMek
 `LandAirMek.java:789-847` requires an AirMek landing control roll only when
@@ -819,8 +825,9 @@ those fall clusters destroy locations or the unit.
 `resolve-airmek-landing-crash-crits` now routes structure-exposing landing fall
 clusters through the shared critical-hit resolver and emits movement-phase
 `CriticalHit`, `CriticalHitResolved`, and `ComponentDestroyed` follow-through
-events. Automatic forced landing from higher WiGE elevations remains follow-up
-work.
+events. Short-distance forced landing from represented higher WiGE elevations is
+covered by `auto-land-short-wige-movement`; finer-grained hover/takeoff
+direction state remains follow-up work.
 
 Additional small-unit movement data pin: MegaMek `Infantry.java:560-568` and
 `BattleArmor.java:520-523` return walk MP as base run MP unless optional TacOps
@@ -922,8 +929,10 @@ reason. MekStation blocked VTOL/WiGE ground projections now carry
 altitude-control required, represented control mode, and represented altitude
 through top-down hex metadata, movement badges, invalid badges, accessible
 labels, tooltip reason rows, and same-hex option metadata. This is explanatory
-context only; full airborne altitude pathing, hover, takeoff, landing, and
-automatic WiGE landing remain follow-ups.
+context only; full airborne altitude pathing, VTOL landing, hover, takeoff,
+and non-represented airborne paths remain follow-ups.
+Represented short-distance WiGE auto-landing is covered separately by
+`auto-land-short-wige-movement`.
 
 2026-05-31 VTOL/WiGE altitude-control command pin: MegaMek
 `MovementDisplay.java:5268-5286` handles raise/lower controls by adding UP/DOWN
@@ -946,8 +955,9 @@ projected movement costs and remaining budget, carries the metadata through
 top-down badges/tooltips/shared projection explanations, consumes the same
 reserve during committed movement validation, and clears the reserve when the
 movement declaration replays. Full airborne pathing, hover/takeoff/landing
-sequencing, automatic WiGE landing, and advanced WiGE subtype altitude ceilings
-remain follow-ups.
+sequencing and advanced WiGE subtype altitude ceilings remain follow-ups;
+represented short-distance WiGE auto-landing is covered by
+`auto-land-short-wige-movement`.
 
 2026-05-31 altitude-control clearance gate pin: MegaMek
 `Entity.java:2433-2497` derives minimum descent altitude from water, woods
@@ -959,7 +969,8 @@ selected unit's encoded terrain, map elevation, and represented unit height to
 disable misleading altitude controls before dispatch while preserving the same
 replayable altitude-control event and MP reserve for legal commands. Remaining
 altitude-control gaps are full airborne pathing, hover/takeoff/landing
-sequencing, automatic WiGE landing, and LAM/ProtoMek-specific WiGE ceilings.
+sequencing and LAM/ProtoMek-specific WiGE ceilings; represented short-distance
+WiGE auto-landing is covered by `auto-land-short-wige-movement`.
 
 Tracked-vehicle browser update: the tactical-map browser harness now pairs the
 VTOL proof with a tracked ground-vehicle abrupt-climb scenario. The top-down map
@@ -1571,8 +1582,9 @@ projection now also surfaces represented altitude-control mode and altitude in
 top-down hex metadata, movement badges, invalid badges, accessible labels,
 tooltip reason rows, and same-hex option metadata via
 `surface-airborne-altitude-control-context`. Full airborne VTOL/WiGE altitude
-pathing, hover/takeoff/landing sequencing, clearance, automatic WiGE landing,
-and broad oracle sweeps remain follow-ups. Basic Climb/Descend runtime
+pathing, hover/takeoff/landing sequencing, clearance, and broad oracle sweeps
+remain follow-ups. Represented short-distance WiGE auto-landing is covered by
+`auto-land-short-wige-movement`. Basic Climb/Descend runtime
 altitude-control commands now exist via `wire-vtol-wige-altitude-controls`, but
 full UP/DOWN MP accounting and terrain-clearance-specific gates remain pending.
 

--- a/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
+++ b/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
@@ -109,7 +109,10 @@ decisions are made, not because CI is stale.
   `cliff_top:1:<exitMask>` import is covered by
   `import-megamek-cliff-top-exits`, including exit-mask conversion and
   MegaMek-style removal of exits that do not point to an in-board 1- or
-  2-level drop. Full elevated AirMek/WiGE pathing and broader takeoff/hover
+  2-level drop. Large-board MegaMek labels such as `10412`, `10016`, and
+  `104120` are covered by `import-large-megamek-board-coordinates`, including
+  dimension-disambiguated column/row parsing and large-coordinate cliff import
+  coverage. Full elevated AirMek/WiGE pathing and broader takeoff/hover
   sequencing remain follow-up work.
   Runtime infantry mounted/dismounted height precedence is now covered; the
   replayable gameplay-event mutation path is now covered by

--- a/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
+++ b/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
@@ -119,7 +119,11 @@ decisions are made, not because CI is stale.
   disambiguating labels by MegaMek row order. The
   `surface-cliff-exits-map-context` slice now carries represented cliff exit
   directions into rendered hex metadata, terrain labels, projection source
-  detail, and hover terrain context. Full elevated AirMek/WiGE pathing and
+  detail, and hover terrain context. The
+  `surface-movement-option-source-details` slice now expands movement source
+  references so same-hex walk/run/jump options carry their reachable/blocked
+  state, MP cost, terrain/elevation cost, heat, and blocked reason in the
+  shared projection metadata itself. Full elevated AirMek/WiGE pathing and
   broader takeoff/hover sequencing remain follow-up work.
   Runtime infantry mounted/dismounted height precedence is now covered; the
   replayable gameplay-event mutation path is now covered by

--- a/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
+++ b/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
@@ -123,12 +123,13 @@ decisions are made, not because CI is stale.
   `surface-movement-option-source-details` slice now expands movement source
   references so same-hex walk/run/jump options carry their reachable/blocked
   state, MP cost, terrain/elevation cost, heat, and blocked reason in the
-  shared projection metadata itself. The `source-hover-path-preview-badge`
-  slice now keeps the hovered path MP badge tied to the same movement
-  projection source references, rule references, terrain/elevation costs, and
-  heat metadata that the normal movement badge exposes. Full elevated
-  AirMek/WiGE pathing and broader takeoff/hover sequencing remain follow-up
-  work.
+  shared projection metadata itself. The `source-movement-reach-badge` slice
+  now pins the normal reachable movement badge to the shared movement
+  projection source references, rule references, and explanation detail. The
+  `source-hover-path-preview-badge` slice keeps the hovered path MP badge tied
+  to that same source-backed movement badge path instead of thinning the
+  displayed commit preview. Full elevated AirMek/WiGE pathing and broader
+  takeoff/hover sequencing remain follow-up work.
   Runtime infantry mounted/dismounted height precedence is now covered; the
   replayable gameplay-event mutation path is now covered by
   `apply-runtime-movement-state-events`, and tactical command controls are now

--- a/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
+++ b/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
@@ -99,8 +99,11 @@ decisions are made, not because CI is stale.
   WiGE landing is covered by `auto-land-short-wige-movement`, while
   `pin-wige-hover-distance-exemptions` keeps those landing highlights and
   runtime patches suppressed when MegaMek's represented prior-distance or
-  hover-style exemptions apply. Full elevated AirMek/WiGE pathing and broader
-  takeoff/hover sequencing remain follow-up work.
+  hover-style exemptions apply. Represented WiGE building-top climb cost is now
+  covered by `pin-wige-building-climb-cost`, including preview/commit
+  insufficient-MP agreement for the +2 MP climb-mode surcharge. Full elevated
+  AirMek/WiGE pathing, directional cliff metadata, and broader takeoff/hover
+  sequencing remain follow-up work.
   Runtime infantry mounted/dismounted height precedence is now covered; the
   replayable gameplay-event mutation path is now covered by
   `apply-runtime-movement-state-events`, and tactical command controls are now

--- a/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
+++ b/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
@@ -112,8 +112,12 @@ decisions are made, not because CI is stale.
   2-level drop. Large-board MegaMek labels such as `10412`, `10016`, and
   `104120` are covered by `import-large-megamek-board-coordinates`, including
   dimension-disambiguated column/row parsing and large-coordinate cliff import
-  coverage. Full elevated AirMek/WiGE pathing and broader takeoff/hover
-  sequencing remain follow-up work.
+  coverage. The optional `audit-megamek-board-import-corpus` verifier now
+  source-checks the parser against a local MegaMek board corpus; the first
+  recorded run parsed 2,386 boards, 3,638,056 hex rows, 382,251
+  large-coordinate rows, and 5,253 `cliff_top` rows with 0 failures after
+  disambiguating labels by MegaMek row order. Full elevated AirMek/WiGE pathing
+  and broader takeoff/hover sequencing remain follow-up work.
   Runtime infantry mounted/dismounted height precedence is now covered; the
   replayable gameplay-event mutation path is now covered by
   `apply-runtime-movement-state-events`, and tactical command controls are now

--- a/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
+++ b/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
@@ -101,9 +101,12 @@ decisions are made, not because CI is stale.
   runtime patches suppressed when MegaMek's represented prior-distance or
   hover-style exemptions apply. Represented WiGE building-top climb cost is now
   covered by `pin-wige-building-climb-cost`, including preview/commit
-  insufficient-MP agreement for the +2 MP climb-mode surcharge. Full elevated
-  AirMek/WiGE pathing, directional cliff metadata, and broader takeoff/hover
-  sequencing remain follow-up work.
+  insufficient-MP agreement for the +2 MP climb-mode surcharge. Directional
+  sheer-cliff metadata is now covered by
+  `pin-directional-cliff-movement-metadata`, including WiGE +1 MP cliff-ascent
+  cost and tracked/wheeled/hover vehicle cliff-ascent blocking when no
+  pavement/road surface cancels the cliff. Full elevated AirMek/WiGE pathing
+  and broader takeoff/hover sequencing remain follow-up work.
   Runtime infantry mounted/dismounted height precedence is now covered; the
   replayable gameplay-event mutation path is now covered by
   `apply-runtime-movement-state-events`, and tactical command controls are now

--- a/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
+++ b/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
@@ -47,10 +47,12 @@ decisions are made, not because CI is stale.
   Represented altitude-positive VTOL/WiGE units now fail closed in the ground
   projection with source-backed altitude-control reasons via
   `block-airborne-vtol-wige-ground-projection`; full airborne altitude pathing,
-  hover/takeoff/landing sequencing, and automatic WiGE landing remain
-  follow-up work. WiGE vehicle tokens now expose represented altitude in the
-  same top-down/isometric metadata and visible badge channel as VTOL tokens via
-  `show-wige-altitude-token-context`. Stale or mismatched movement capability
+  hover/takeoff/landing sequencing, and non-represented airborne cases remain
+  follow-up work. Represented short-distance WiGE automatic landing is covered
+  by `auto-land-short-wige-movement`. WiGE vehicle tokens now expose
+  represented altitude in the same top-down/isometric metadata and visible
+  badge channel as VTOL tokens via `show-wige-altitude-token-context`.
+  Stale or mismatched movement capability
   motives now fail closed from represented altitude-positive VTOL/WiGE vehicle
   combat state via `block-airborne-vehicle-state-mismatch`. Blocked
   altitude-control projections now carry represented control mode and altitude
@@ -67,10 +69,12 @@ decisions are made, not because CI is stale.
   altitude-control MP, block airborne ground projection, and cap Climb at the
   source-backed altitude 12 ceiling via
   `gate-protomek-wige-altitude-ceiling`; full multi-step airborne pathing,
-  hover/takeoff/landing sequencing, and automatic WiGE landing remain
-  follow-up work. Represented LAM AirMek altitude controls now replay
-  `lamAirMekAltitude`, reserve altitude-control MP, block elevated ground
-  projection, and cap Climb at the LandAirMek-specific WiGE +25 ceiling via
+  hover/takeoff/landing sequencing, and non-represented airborne cases remain
+  follow-up work. Represented Glider ProtoMek short-distance automatic landing
+  is covered by `auto-land-short-wige-movement`. Represented LAM AirMek
+  altitude controls now replay `lamAirMekAltitude`, reserve altitude-control
+  MP, block elevated ground projection, and cap Climb at the
+  LandAirMek-specific WiGE +25 ceiling via
   `gate-lam-airmek-wige-altitude-ceiling`. AirMek-to-Mek conversion now clears
   represented AirMek WiGE elevation through a replayable automatic-landing
   state patch via `pin-lam-airmek-mek-automatic-landing`. AirMek Descend
@@ -87,9 +91,10 @@ decisions are made, not because CI is stale.
   events via `fanout-airmek-landing-destruction`, and structure-exposing crash
   clusters now resolve movement-phase `CriticalHit`, `CriticalHitResolved`, and
   `ComponentDestroyed` follow-through via
-  `resolve-airmek-landing-crash-crits`; full elevated AirMek/WiGE pathing,
-  minimum-distance automatic WiGE landing, and takeoff/hover sequencing remain
-  follow-up work.
+  `resolve-airmek-landing-crash-crits`; represented minimum-distance automatic
+  WiGE landing is covered by `auto-land-short-wige-movement`, while full
+  elevated AirMek/WiGE pathing and takeoff/hover sequencing remain follow-up
+  work.
   Runtime infantry mounted/dismounted height precedence is now covered; the
   replayable gameplay-event mutation path is now covered by
   `apply-runtime-movement-state-events`, and tactical command controls are now

--- a/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
+++ b/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
@@ -123,8 +123,12 @@ decisions are made, not because CI is stale.
   `surface-movement-option-source-details` slice now expands movement source
   references so same-hex walk/run/jump options carry their reachable/blocked
   state, MP cost, terrain/elevation cost, heat, and blocked reason in the
-  shared projection metadata itself. Full elevated AirMek/WiGE pathing and
-  broader takeoff/hover sequencing remain follow-up work.
+  shared projection metadata itself. The `source-hover-path-preview-badge`
+  slice now keeps the hovered path MP badge tied to the same movement
+  projection source references, rule references, terrain/elevation costs, and
+  heat metadata that the normal movement badge exposes. Full elevated
+  AirMek/WiGE pathing and broader takeoff/hover sequencing remain follow-up
+  work.
   Runtime infantry mounted/dismounted height precedence is now covered; the
   replayable gameplay-event mutation path is now covered by
   `apply-runtime-movement-state-events`, and tactical command controls are now

--- a/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
+++ b/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
@@ -116,8 +116,11 @@ decisions are made, not because CI is stale.
   source-checks the parser against a local MegaMek board corpus; the first
   recorded run parsed 2,386 boards, 3,638,056 hex rows, 382,251
   large-coordinate rows, and 5,253 `cliff_top` rows with 0 failures after
-  disambiguating labels by MegaMek row order. Full elevated AirMek/WiGE pathing
-  and broader takeoff/hover sequencing remain follow-up work.
+  disambiguating labels by MegaMek row order. The
+  `surface-cliff-exits-map-context` slice now carries represented cliff exit
+  directions into rendered hex metadata, terrain labels, projection source
+  detail, and hover terrain context. Full elevated AirMek/WiGE pathing and
+  broader takeoff/hover sequencing remain follow-up work.
   Runtime infantry mounted/dismounted height precedence is now covered; the
   replayable gameplay-event mutation path is now covered by
   `apply-runtime-movement-state-events`, and tactical command controls are now

--- a/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
+++ b/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
@@ -49,7 +49,9 @@ decisions are made, not because CI is stale.
   `block-airborne-vtol-wige-ground-projection`; full airborne altitude pathing,
   hover/takeoff/landing sequencing, and non-represented airborne cases remain
   follow-up work. Represented short-distance WiGE automatic landing is covered
-  by `auto-land-short-wige-movement`. WiGE vehicle tokens now expose
+  by `auto-land-short-wige-movement`, and the MegaMek prior-distance plus
+  UP/HOVER exemptions for that helper are covered by
+  `pin-wige-hover-distance-exemptions`. WiGE vehicle tokens now expose
   represented altitude in the same top-down/isometric metadata and visible
   badge channel as VTOL tokens via `show-wige-altitude-token-context`.
   Stale or mismatched movement capability
@@ -71,7 +73,9 @@ decisions are made, not because CI is stale.
   `gate-protomek-wige-altitude-ceiling`; full multi-step airborne pathing,
   hover/takeoff/landing sequencing, and non-represented airborne cases remain
   follow-up work. Represented Glider ProtoMek short-distance automatic landing
-  is covered by `auto-land-short-wige-movement`. Represented LAM AirMek
+  is covered by `auto-land-short-wige-movement`, with represented hover-style
+  exemption and already-moved distance accounting covered by
+  `pin-wige-hover-distance-exemptions`. Represented LAM AirMek
   altitude controls now replay `lamAirMekAltitude`, reserve altitude-control
   MP, block elevated ground projection, and cap Climb at the
   LandAirMek-specific WiGE +25 ceiling via
@@ -92,9 +96,11 @@ decisions are made, not because CI is stale.
   clusters now resolve movement-phase `CriticalHit`, `CriticalHitResolved`, and
   `ComponentDestroyed` follow-through via
   `resolve-airmek-landing-crash-crits`; represented minimum-distance automatic
-  WiGE landing is covered by `auto-land-short-wige-movement`, while full
-  elevated AirMek/WiGE pathing and takeoff/hover sequencing remain follow-up
-  work.
+  WiGE landing is covered by `auto-land-short-wige-movement`, while
+  `pin-wige-hover-distance-exemptions` keeps those landing highlights and
+  runtime patches suppressed when MegaMek's represented prior-distance or
+  hover-style exemptions apply. Full elevated AirMek/WiGE pathing and broader
+  takeoff/hover sequencing remain follow-up work.
   Runtime infantry mounted/dismounted height precedence is now covered; the
   replayable gameplay-event mutation path is now covered by
   `apply-runtime-movement-state-events`, and tactical command controls are now

--- a/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
+++ b/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
@@ -105,8 +105,12 @@ decisions are made, not because CI is stale.
   sheer-cliff metadata is now covered by
   `pin-directional-cliff-movement-metadata`, including WiGE +1 MP cliff-ascent
   cost and tracked/wheeled/hover vehicle cliff-ascent blocking when no
-  pavement/road surface cancels the cliff. Full elevated AirMek/WiGE pathing
-  and broader takeoff/hover sequencing remain follow-up work.
+  pavement/road surface cancels the cliff. MegaMek `.board`
+  `cliff_top:1:<exitMask>` import is covered by
+  `import-megamek-cliff-top-exits`, including exit-mask conversion and
+  MegaMek-style removal of exits that do not point to an in-board 1- or
+  2-level drop. Full elevated AirMek/WiGE pathing and broader takeoff/hover
+  sequencing remain follow-up work.
   Runtime infantry mounted/dismounted height precedence is now covered; the
   replayable gameplay-event mutation path is now covered by
   `apply-runtime-movement-state-events`, and tactical command controls are now

--- a/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
+++ b/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
@@ -126,6 +126,9 @@ decisions are made, not because CI is stale.
   shared projection metadata itself. The `source-movement-reach-badge` slice
   now pins the normal reachable movement badge to the shared movement
   projection source references, rule references, and explanation detail. The
+  `source-movement-step-cost-badge` slice does the same for the separate
+  terrain/elevation cost badge, so the visible `T+`/`E+`/`UP`/`DN` cost marker
+  is also pinned to `movement:megamek` evidence. The
   `source-hover-path-preview-badge` slice keeps the hovered path MP badge tied
   to that same source-backed movement badge path instead of thinning the
   displayed commit preview. Full elevated AirMek/WiGE pathing and broader

--- a/openspec/changes/audit-megamek-board-import-corpus/proposal.md
+++ b/openspec/changes/audit-megamek-board-import-corpus/proposal.md
@@ -1,0 +1,34 @@
+# Change Proposal: Audit MegaMek Board Import Corpus
+
+## Summary
+
+Add an optional local audit command that parses a MegaMek `data/boards` corpus
+with MekStation's board parser and reports import coverage for board count,
+hex count, large-coordinate labels, and `cliff_top` metadata.
+
+## Motivation
+
+The tactical map depends on imported terrain, elevation, and edge metadata for
+rules-backed movement and visibility projection. Recent slices fixed
+`cliff_top` import and large-board labels, but the remaining source-trust gap is
+broader external oracle sweep coverage over real MegaMek boards.
+
+CI cannot assume a local MegaMek checkout, so this change adds a developer-run
+verifier that is explicit, repeatable, and documented without making the normal
+test suite depend on external files.
+
+## Scope
+
+- Add a script that scans a local MegaMek `data/boards` directory.
+- Parse every selected `.board` file through `parseMegaMekBoard`.
+- Fail on parser errors or parsed-hex count mismatches.
+- Report large-coordinate and `cliff_top` coverage.
+- Add a package script for discoverability.
+- Update tactical-map audit docs with the new verifier.
+
+## Non-Goals
+
+- Add MegaMek board files to the repository.
+- Require the corpus audit in CI.
+- Compare every terrain semantic against MegaMek runtime behavior.
+- Expand parser terrain-type support beyond the current import contract.

--- a/openspec/changes/audit-megamek-board-import-corpus/specs/megamek-board-parser/spec.md
+++ b/openspec/changes/audit-megamek-board-import-corpus/specs/megamek-board-parser/spec.md
@@ -1,0 +1,64 @@
+# Spec Delta: MegaMek Board Parser
+
+## ADDED Requirements
+
+### Requirement: Local MegaMek Board Corpus Audit
+
+MekStation SHALL provide a developer-run audit command that parses selected
+MegaMek `.board` files with the MekStation board parser and reports import
+coverage.
+
+#### Scenario: Audit parses a local MegaMek board corpus
+
+- **GIVEN** a developer has a local MegaMek checkout with `data/boards`
+- **WHEN** the developer runs the MegaMek board import audit command
+- **THEN** the command SHALL recursively scan `.board` files
+- **AND** parse each selected file with `parseMegaMekBoard`
+- **AND** report parsed board count and parsed hex count.
+
+#### Scenario: Audit reports terrain metadata coverage
+
+- **GIVEN** selected MegaMek board files contain large board-coordinate labels
+  or `cliff_top` terrain metadata
+- **WHEN** the audit completes
+- **THEN** the command SHALL report how many selected boards and hex rows used
+  large-coordinate labels
+- **AND** how many selected boards and hex rows contained `cliff_top` metadata.
+
+#### Scenario: Audit fails on parser regressions
+
+- **GIVEN** a selected MegaMek board cannot be parsed by MekStation
+- **WHEN** the audit reaches that board
+- **THEN** the command SHALL include the file and parser error in its failure
+  report
+- **AND** exit non-zero.
+
+#### Scenario: Audit fails on skipped hex rows
+
+- **GIVEN** a selected MegaMek board contains `hex` rows
+- **WHEN** parsing succeeds but the parsed hex count differs from the number of
+  `hex` rows in the source file
+- **THEN** the command SHALL report the mismatch
+- **AND** exit non-zero.
+
+#### Scenario: Audit remains optional outside local oracle environments
+
+- **GIVEN** CI or a developer machine does not have a local MegaMek checkout
+- **WHEN** normal unit tests, typecheck, lint, format, and build commands run
+- **THEN** they SHALL NOT require the corpus audit command.
+
+## MODIFIED Requirements
+
+### Requirement: Hex Coordinate Parsing
+
+The parser SHALL preserve existing explicit-coordinate parsing for unambiguous
+MegaMek board labels, and SHALL use MegaMek row order to disambiguate labels
+that can be split into multiple valid column/row pairs.
+
+#### Scenario: Disambiguate ambiguous large-board labels by row order
+
+- **GIVEN** a `.board` file declares `size 170 120`
+- **AND** the 101st `hex` row uses board label `10101`
+- **WHEN** parsing the coordinate
+- **THEN** the parser SHALL choose column `101`, row `1` from MegaMek row order
+  rather than column `10`, row `101`.

--- a/openspec/changes/audit-megamek-board-import-corpus/tasks.md
+++ b/openspec/changes/audit-megamek-board-import-corpus/tasks.md
@@ -1,0 +1,24 @@
+# Tasks: Audit MegaMek Board Import Corpus
+
+## 1. Spec contract
+
+- [x] 1.1 Author proposal/tasks/spec delta for the optional corpus audit
+- [x] 1.2 Validate the OpenSpec change strictly
+
+## 2. Implementation
+
+- [x] 2.1 Add a local script that scans MegaMek `.board` files
+- [x] 2.2 Parse each selected board through MekStation's parser
+- [x] 2.3 Report board, hex, large-coordinate, and `cliff_top` coverage
+- [x] 2.4 Fail on parse errors or parsed-hex count mismatches
+- [x] 2.5 Add a package script for the verifier
+
+## 3. Verification
+
+- [x] 3.1 Run the verifier against the local MegaMek board corpus
+- [x] 3.2 `npx.cmd openspec validate audit-megamek-board-import-corpus --strict` passes
+- [x] 3.3 `npm.cmd run typecheck` passes
+- [x] 3.4 `npm.cmd run lint` passes
+- [x] 3.5 `npm.cmd run format:check` passes
+- [x] 3.6 `npm.cmd run build` passes
+- [x] 3.7 `git diff --check` passes

--- a/openspec/changes/auto-land-short-wige-movement/proposal.md
+++ b/openspec/changes/auto-land-short-wige-movement/proposal.md
@@ -1,0 +1,31 @@
+# Auto-Land Short WiGE Movement
+
+## Why
+
+The tactical map currently fails closed for positive-altitude WiGE-style units
+instead of projecting the horizontal move and the automatic landing consequence
+MegaMek applies when they move too short a distance. That keeps the UI safe, but
+it leaves AirMek, WiGE vehicle, and Glider ProtoMek movement unexplained: a
+player can see altitude controls, yet cannot preview the source-backed
+minimum-distance landing rule from the map.
+
+## What Changes
+
+- Allow represented positive-altitude WiGE-style units to use the shared WiGE
+  movement projection instead of the prior ground-projection block.
+- Project the MegaMek short-distance automatic landing consequence on reachable
+  non-jump WiGE paths.
+- Replay automatic landing as runtime movement-state changes after the committed
+  move so later map, combat, and replay consumers agree with the engine state.
+- Preserve explicit altitude-control/takeoff and jump exemptions so a recent
+  climb or jump does not get auto-landed by this slice.
+
+## Source Notes
+
+- MegaMek `MovePath.automaticWiGELanding(...)` requires airborne WiGE movement
+  to land after moving fewer than five hexes, with Glider ProtoMeks exempt once
+  they move four hexes, unless the path jumped, took off, or used hover-style
+  movement.
+- MekStation represents altitude through `vehicleAltitude`, `protoAltitude`, and
+  `lamAirMekAltitude`; automatic landing should use the same replayable runtime
+  state channel rather than a UI-only correction.

--- a/openspec/changes/auto-land-short-wige-movement/specs/movement-system/spec.md
+++ b/openspec/changes/auto-land-short-wige-movement/specs/movement-system/spec.md
@@ -1,0 +1,30 @@
+# Spec Delta: Movement System
+
+## MODIFIED Requirements
+
+### Requirement: Movement Declaration Runtime State Agreement
+
+Committed positive-altitude WiGE-style movement SHALL replay the automatic
+landing state transition when MegaMek's short-distance landing rule applies, so
+post-movement map projection, combat modifiers, and replay state all observe
+the landed unit state.
+
+#### Scenario: Short WiGE movement commits automatic landing
+
+- **GIVEN** a positive-altitude WiGE-style unit commits a non-jump movement path
+  shorter than the source-backed minimum airborne distance
+- **AND** the unit did not use represented altitude-control/takeoff steps during
+  this movement declaration
+- **WHEN** the engine accepts the movement declaration
+- **THEN** it SHALL append a replayable runtime movement-state change that
+  clears the represented WiGE altitude after the movement declaration
+- **AND** subsequent movement projection SHALL no longer treat the unit as
+  positive-altitude airborne.
+
+#### Scenario: Glider ProtoMek uses four-hex minimum distance
+
+- **GIVEN** a positive-altitude Glider ProtoMek commits represented WiGE
+  movement
+- **WHEN** it moves four or more hexes without jumping or altitude-control
+  takeoff steps
+- **THEN** the automatic landing runtime state SHALL NOT be emitted.

--- a/openspec/changes/auto-land-short-wige-movement/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/auto-land-short-wige-movement/specs/tactical-map-interface/spec.md
@@ -1,0 +1,25 @@
+# Spec Delta: Tactical Map Interface
+
+## MODIFIED Requirements
+
+### Requirement: Movement Projection Detail Surface
+
+Positive-altitude WiGE-style movement projections SHALL expose MegaMek's
+short-distance automatic landing rule as part of the same movement highlight
+data used for MP, terrain, elevation, heat, and blocked reasons.
+
+#### Scenario: Short elevated WiGE movement previews automatic landing
+
+- **GIVEN** a selected positive-altitude WiGE-style unit has a legal non-jump
+  movement path shorter than MegaMek's minimum airborne distance
+- **WHEN** the tactical map projects that destination
+- **THEN** the destination SHALL remain reachable when its MP cost is legal
+- **AND** the projection SHALL explain that the unit will automatically land at
+  movement end instead of requiring the player to infer that consequence.
+
+#### Scenario: Exempt elevated WiGE movement does not preview automatic landing
+
+- **GIVEN** a selected positive-altitude WiGE-style unit has jumped or just used
+  represented altitude-control steps this movement phase
+- **WHEN** the tactical map projects a destination
+- **THEN** the movement projection SHALL NOT claim automatic landing will occur.

--- a/openspec/changes/auto-land-short-wige-movement/tasks.md
+++ b/openspec/changes/auto-land-short-wige-movement/tasks.md
@@ -1,0 +1,11 @@
+# Tasks: Auto-Land Short WiGE Movement
+
+- [x] 1. Add source-backed automatic WiGE landing projection metadata and shared
+  helper logic for vehicles, Glider ProtoMeks, and LAM AirMeks.
+- [x] 2. Allow positive-altitude WiGE-style units to preview and commit
+  represented horizontal WiGE movement while keeping VTOL and LAM Fighter
+  blocks intact.
+- [x] 3. Emit replayable automatic-landing runtime state after committed short
+  non-jump WiGE movement.
+- [x] 4. Add projection/commit agreement tests and update tactical-map audit
+  notes.

--- a/openspec/changes/import-large-megamek-board-coordinates/proposal.md
+++ b/openspec/changes/import-large-megamek-board-coordinates/proposal.md
@@ -1,0 +1,44 @@
+# Change Proposal: Import Large MegaMek Board Coordinates
+
+## Summary
+
+Support MegaMek `.board` hex labels whose column or row component exceeds two
+digits, such as `10016` and `104120`, so large official or community boards can
+feed tactical-map terrain, elevation, and cliff metadata instead of failing at
+parse time.
+
+## Motivation
+
+The tactical map depends on imported board terrain/elevation data as the source
+for movement and visibility projection. MegaMek saves ordinary small boards with
+labels like `0101`, but large boards are serialized by concatenating the
+1-indexed column and row with only sub-10 values zero-padded. Real MegaMek board
+data therefore includes labels such as `10412`, `10016`, and `104120`.
+
+MekStation previously required exactly four digits and rejected these large-board
+labels, which blocked real imported terrain from reaching the same map
+projection path.
+
+## Source Anchors
+
+- MegaMek `Coords.java:510-514`: `getBoardNum()` concatenates 1-indexed x/y and
+  only zero-pads components below 10.
+- MegaMek `Board.java:1062-1063`: board loading ignores the serialized label and
+  assigns coordinates by board order, confirming the label is not fixed-width.
+- MegaMek `data/boards/unofficial/Ashnods Maps/170x120 Fort David.board:2007`:
+  real large-board cliff terrain uses `hex 10412 ...`.
+- MegaMek `data/boards/unofficial/Ashnods Maps/170x120 Fort David.board:20367`:
+  real large-board labels can have three-digit row components (`hex 104120 ...`).
+
+## Scope
+
+- Parse MegaMek board labels with two-or-more digit column and row components.
+- Use declared board dimensions to disambiguate the column/row split.
+- Preserve existing four-digit small-board parsing and invalid-coordinate errors.
+- Add parser coverage for large-board labels and large-board cliff metadata.
+
+## Non-Goals
+
+- Change internal axial coordinate math.
+- Parse all MegaMek terrain types not already supported by the board parser.
+- Add a full corpus sweep over every MegaMek board file.

--- a/openspec/changes/import-large-megamek-board-coordinates/specs/megamek-board-parser/spec.md
+++ b/openspec/changes/import-large-megamek-board-coordinates/specs/megamek-board-parser/spec.md
@@ -1,0 +1,40 @@
+# Spec Delta: MegaMek Board Parser
+
+## MODIFIED Requirements
+
+### Requirement: Hex Coordinate Parsing
+
+The parser SHALL parse MegaMek board labels whose 1-indexed column and row
+components are each at least two digits after sub-10 zero padding, and SHALL
+convert the parsed offset coordinate to MekStation axial coordinates.
+
+#### Scenario: Parse large-board coordinate with three-digit column
+
+- **GIVEN** a `.board` file declares `size 170 120`
+- **AND** a hex line uses board label `10412`
+- **WHEN** parsing the coordinate
+- **THEN** the parser SHALL interpret the label as column `104`, row `12`
+- **AND** convert it to axial coordinate `q=103`, `r=-40`.
+
+#### Scenario: Parse large-board coordinate with three-digit row
+
+- **GIVEN** a `.board` file declares `size 170 120`
+- **AND** a hex line uses board label `104120`
+- **WHEN** parsing the coordinate
+- **THEN** the parser SHALL interpret the label as column `104`, row `120`
+- **AND** convert it to axial coordinate `q=103`, `r=68`.
+
+#### Scenario: Reject label outside declared board dimensions
+
+- **GIVEN** a `.board` file declares `size 2 2`
+- **AND** a hex line uses board label `9917`
+- **WHEN** parsing the coordinate
+- **THEN** the parser SHALL throw error `Invalid hex coordinate`.
+
+#### Scenario: Preserve large-board terrain metadata import
+
+- **GIVEN** a `.board` file declares `size 170 120`
+- **AND** a large-board hex label contains `cliff_top:1:<exitMask>`
+- **WHEN** the parser reads the board
+- **THEN** the parsed hex SHALL preserve valid `cliffTopExits` metadata on the
+  correct axial coordinate.

--- a/openspec/changes/import-large-megamek-board-coordinates/tasks.md
+++ b/openspec/changes/import-large-megamek-board-coordinates/tasks.md
@@ -1,0 +1,26 @@
+# Tasks: Import Large MegaMek Board Coordinates
+
+## 1. Spec contract
+
+- [x] 1.1 Author proposal/tasks/spec delta for large MegaMek board labels
+- [x] 1.2 Validate the OpenSpec change strictly
+
+## 2. Implementation
+
+- [x] 2.1 Parse two-or-more digit MegaMek column and row label components
+- [x] 2.2 Use declared board dimensions to choose the correct column/row split
+- [x] 2.3 Preserve existing small-board coordinate parsing behavior
+- [x] 2.4 Preserve invalid-coordinate failure behavior for labels that cannot fit
+      the declared board dimensions
+
+## 3. Verification
+
+- [x] 3.1 Add parser coverage for three-digit columns and rows
+- [x] 3.2 Add parser coverage proving large-board cliff metadata still imports
+- [x] 3.3 `npx.cmd openspec validate import-large-megamek-board-coordinates --strict` passes
+- [x] 3.4 Focused parser tests pass
+- [x] 3.5 `npm.cmd run typecheck` passes
+- [x] 3.6 `npm.cmd run lint` passes
+- [x] 3.7 `npm.cmd run format:check` passes
+- [x] 3.8 `npm.cmd run build` passes
+- [x] 3.9 `git diff --check` passes

--- a/openspec/changes/import-megamek-cliff-top-exits/proposal.md
+++ b/openspec/changes/import-megamek-cliff-top-exits/proposal.md
@@ -1,0 +1,25 @@
+# Import MegaMek Cliff-Top Exits
+
+## Why
+
+The movement engine now understands explicit `cliffTopExits` metadata, but
+imported MegaMek `.board` files still drop `cliff_top:1:<exits>` terrain
+entries. That leaves real maps unable to drive the source-backed cliff movement
+projection added by the prior slice.
+
+## What Changes
+
+- Parse MegaMek `cliff_top:1:<exitMask>` terrain entries from `.board` hex
+  terrain strings.
+- Convert the exit bitmask into facing directions `0..5`, matching MegaMek's
+  `1 << direction` encoding.
+- Preserve valid cliff-top exits as MekStation `cliffTopExits` terrain-feature
+  metadata.
+- Discard cliff-top exits that do not point to an in-board 1- or 2-level drop,
+  matching MegaMek's automatic-terrain correction behavior.
+
+## Source Anchor
+
+- MegaMek `Terrain.java:103-119` and `Terrain.java:302`
+- MegaMek `Terrains.java:147-150` and `Terrains.java:199`
+- MegaMek `Board.java:537-602`

--- a/openspec/changes/import-megamek-cliff-top-exits/specs/megamek-board-parser/spec.md
+++ b/openspec/changes/import-megamek-cliff-top-exits/specs/megamek-board-parser/spec.md
@@ -1,0 +1,26 @@
+# Spec Delta: MegaMek Board Parser
+
+## MODIFIED Requirements
+
+### Requirement: Terrain String Parsing
+
+The parser SHALL parse semicolon-delimited terrain feature strings and extract
+terrain type, level, and supported source metadata.
+
+#### Scenario: Parse cliff-top exit metadata
+
+- **GIVEN** a board hex terrain string contains `cliff_top:1:<exitMask>`
+- **WHEN** the parser reads the board
+- **THEN** the parser SHALL convert each active bit in `<exitMask>` into a
+  `cliffTopExits` facing direction on that hex's terrain-feature metadata
+- **AND** each active exit SHALL use MegaMek's `1 << direction` encoding for
+  directions `0..5`.
+
+#### Scenario: Correct imported cliff exits against board elevations
+
+- **GIVEN** a board hex has imported `cliff_top` exits
+- **WHEN** an exit points off board or toward a neighbor that is not exactly 1
+  or 2 elevation levels lower
+- **THEN** the parser SHALL omit that exit from `cliffTopExits`
+- **AND** the parser SHALL NOT create cliff metadata when no imported exits
+  remain valid.

--- a/openspec/changes/import-megamek-cliff-top-exits/specs/movement-system/spec.md
+++ b/openspec/changes/import-megamek-cliff-top-exits/specs/movement-system/spec.md
@@ -1,0 +1,18 @@
+# Spec Delta: Movement System
+
+## MODIFIED Requirements
+
+### Requirement: Movement Terrain And Elevation Costs
+
+Movement cost calculation SHALL apply source-backed terrain and elevation MP
+costs for represented unit movement modes while preserving preview and commit
+validation agreement.
+
+#### Scenario: Parsed board cliff metadata drives movement projection
+
+- **GIVEN** a MegaMek `.board` file imports a valid `cliff_top` exit on the high
+  side of a 1- or 2-level drop
+- **WHEN** the tactical movement projection evaluates movement across that edge
+- **THEN** the projection SHALL use the imported `cliffTopExits` metadata for
+  the same WiGE cliff-ascent cost and vehicle cliff-ascent blocking rules as
+  hand-authored terrain metadata.

--- a/openspec/changes/import-megamek-cliff-top-exits/tasks.md
+++ b/openspec/changes/import-megamek-cliff-top-exits/tasks.md
@@ -1,0 +1,25 @@
+# Tasks: Import MegaMek Cliff-Top Exits
+
+## 1. Spec contract
+
+- [x] 1.1 Author proposal/tasks/spec deltas for MegaMek cliff-top exit import
+- [x] 1.2 Validate the OpenSpec change strictly
+
+## 2. Implementation
+
+- [x] 2.1 Parse `cliff_top:1:<exitMask>` entries from MegaMek board terrain strings
+- [x] 2.2 Convert exit masks to facing-direction metadata
+- [x] 2.3 Drop cliff-top exits that do not point to a 1- or 2-level drop
+- [x] 2.4 Preserve imported cliff metadata through terrain feature encoding
+
+## 3. Verification
+
+- [x] 3.1 Add parser coverage for cliff exit masks and invalid cliff correction
+- [x] 3.2 Add movement projection coverage using parsed board cliff metadata
+- [x] 3.3 `npx.cmd openspec validate import-megamek-cliff-top-exits --strict` passes
+- [x] 3.4 Focused parser and movement tests pass
+- [x] 3.5 `npm.cmd run typecheck` passes
+- [x] 3.6 `npm.cmd run lint` passes
+- [x] 3.7 `npm.cmd run format:check` passes
+- [x] 3.8 `npm.cmd run build` passes
+- [x] 3.9 `git diff --check` passes

--- a/openspec/changes/pin-directional-cliff-movement-metadata/proposal.md
+++ b/openspec/changes/pin-directional-cliff-movement-metadata/proposal.md
@@ -1,0 +1,27 @@
+# Pin Directional Cliff Movement Metadata
+
+## Why
+
+The previous WiGE building-climb slice intentionally did not infer MegaMek's
+sheer-cliff rules from ordinary elevation deltas. MegaMek represents cliff tops
+as directional hex-edge metadata, and movement legality/cost depends on whether
+the unit crosses that encoded edge. MekStation needs the same distinction before
+the tactical map can explain cliff movement without over-blocking normal hills.
+
+## What Changes
+
+- Add explicit `cliffTopExits` terrain-feature metadata using existing facing
+  direction values.
+- Apply the source-backed WiGE +1 MP sheer-cliff ascent surcharge only when the
+  destination hex has a cliff-top exit toward the source hex and the move rises.
+- Block represented tracked/wheeled/hover vehicle ascent over an encoded sheer
+  cliff unless the destination has a pavement/road/bridge surface that cancels
+  the cliff effect for road-capable movement.
+- Keep ordinary elevation changes without cliff metadata on the existing
+  non-cliff movement path.
+
+## Source Anchor
+
+- MegaMek `Hex.java:744-750`
+- MegaMek `MoveStep.java:2858-2864`
+- MegaMek `MoveStep.java:3159-3178`

--- a/openspec/changes/pin-directional-cliff-movement-metadata/specs/movement-system/spec.md
+++ b/openspec/changes/pin-directional-cliff-movement-metadata/specs/movement-system/spec.md
@@ -1,0 +1,40 @@
+# Spec Delta: Movement System
+
+## MODIFIED Requirements
+
+### Requirement: Movement Terrain And Elevation Costs
+
+Movement cost calculation SHALL apply source-backed terrain and elevation MP
+costs for represented unit movement modes while preserving preview and commit
+validation agreement.
+
+#### Scenario: Directional cliff metadata distinguishes sheer cliffs from hills
+
+- **GIVEN** a represented map hex has terrain-feature metadata identifying
+  cliff-top exits toward one or more adjacent hexes
+- **WHEN** a unit moves across an edge not listed in that cliff-top metadata
+- **THEN** movement cost and legality SHALL follow ordinary non-cliff elevation
+  rules
+- **AND** the system SHALL NOT infer sheer-cliff behavior from elevation delta
+  alone.
+
+#### Scenario: WiGE pays the sheer-cliff ascent surcharge
+
+- **GIVEN** a represented WiGE mover crosses upward into a destination hex whose
+  cliff-top metadata exits toward the source hex
+- **WHEN** the player previews or commits that movement
+- **THEN** movement cost SHALL include the source-backed +1 MP sheer-cliff
+  ascent surcharge
+- **AND** preview/pathfinding and committed movement validation SHALL use the
+  same cost.
+
+#### Scenario: Vehicles cannot ascend an encoded sheer cliff without road cover
+
+- **GIVEN** a represented tracked, wheeled, or hover vehicle attempts to move
+  upward into a destination hex whose cliff-top metadata exits toward the source
+  hex
+- **AND** the destination does not have a pavement, paved-road, or bridge
+  surface that cancels cliff effects for road-capable movement
+- **WHEN** the player previews or commits that movement
+- **THEN** the movement SHALL be blocked with a terrain-blocked reason before
+  commit.

--- a/openspec/changes/pin-directional-cliff-movement-metadata/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/pin-directional-cliff-movement-metadata/specs/tactical-map-interface/spec.md
@@ -1,0 +1,19 @@
+# Spec Delta: Tactical Map Interface
+
+## MODIFIED Requirements
+
+### Requirement: Rules-Backed Movement Projection
+
+Movement overlays SHALL be derived from shared movement projection data and
+SHALL explain legal, blocked, and consequential movement outcomes before the
+player commits them.
+
+#### Scenario: Encoded cliff movement appears in map projection
+
+- **GIVEN** a selected represented unit previews movement across an encoded
+  directional cliff edge
+- **WHEN** the movement mode is WiGE, tracked, wheeled, or hover
+- **THEN** the destination projection SHALL expose the same added cost or
+  terrain-blocked reason that committed movement validation would apply
+- **AND** ordinary elevation changes without cliff metadata SHALL continue to
+  display as non-cliff movement.

--- a/openspec/changes/pin-directional-cliff-movement-metadata/tasks.md
+++ b/openspec/changes/pin-directional-cliff-movement-metadata/tasks.md
@@ -1,0 +1,24 @@
+# Tasks: Pin Directional Cliff Movement Metadata
+
+## 1. Spec contract
+
+- [x] 1.1 Author proposal/tasks/spec deltas for directional cliff movement metadata
+- [x] 1.2 Validate the OpenSpec change strictly
+
+## 2. Implementation
+
+- [x] 2.1 Add explicit cliff-top exit metadata to terrain feature encoding
+- [x] 2.2 Add WiGE +1 MP cliff-ascent surcharge through shared movement costs
+- [x] 2.3 Block represented vehicle upward cliff movement when no pavement/road surface cancels it
+- [x] 2.4 Preserve ordinary hill/elevation movement when no cliff metadata is encoded
+
+## 3. Verification
+
+- [x] 3.1 Add focused movement projection and commit-validation coverage
+- [x] 3.2 Focused movement tests pass
+- [x] 3.3 `npx.cmd openspec validate pin-directional-cliff-movement-metadata --strict` passes
+- [x] 3.4 `npm.cmd run typecheck` passes
+- [x] 3.5 `npm.cmd run lint` passes
+- [x] 3.6 `npm.cmd run format:check` passes
+- [x] 3.7 `npm.cmd run build` passes
+- [x] 3.8 `git diff --check` passes

--- a/openspec/changes/pin-wige-building-climb-cost/proposal.md
+++ b/openspec/changes/pin-wige-building-climb-cost/proposal.md
@@ -1,0 +1,24 @@
+# Pin WiGE Building Climb Cost
+
+## Why
+
+WiGE movement projection still treated every represented terrain/elevation step
+as a flat 1 MP move. MegaMek's movement source keeps the ordinary WiGE
+terrain/elevation bypass, but charges +2 MP when a WiGE must stay in climb mode
+over a higher building-top crossing. The tactical map needs that cost before it
+can be trusted as the player's movement explanation layer.
+
+## What Changes
+
+- Add the represented WiGE +2 MP climb-mode surcharge when entering a building
+  hex whose represented ceiling is higher than the source hex ceiling.
+- Keep ordinary represented elevation, woods, and non-building terrain ignored
+  for WiGE ground projection.
+- Keep movement preview, pathfinding, and committed movement validation on the
+  same shared movement-cost helper.
+- Document the sheer-cliff +1 MP rule as a remaining source gap because
+  MekStation does not yet encode directional cliff-top terrain metadata.
+
+## Source Anchor
+
+- MegaMek `MoveStep.java:2844-2864`

--- a/openspec/changes/pin-wige-building-climb-cost/specs/movement-system/spec.md
+++ b/openspec/changes/pin-wige-building-climb-cost/specs/movement-system/spec.md
@@ -1,0 +1,38 @@
+# Spec Delta: Movement System
+
+## MODIFIED Requirements
+
+### Requirement: Movement Terrain And Elevation Costs
+
+Movement cost calculation SHALL apply source-backed terrain and elevation MP
+costs for represented unit movement modes while preserving preview and commit
+validation agreement.
+
+#### Scenario: WiGE pays climb-mode cost over a higher represented building top
+
+- **GIVEN** a represented landed WiGE mover is adjacent to a destination hex
+  that contains represented building elevation
+- **WHEN** the destination's represented ceiling is higher than the source hex's
+  represented ceiling
+- **THEN** movement cost projection SHALL add the source-backed +2 MP WiGE
+  climb-mode surcharge
+- **AND** the same cost SHALL be used by pathfinding, movement preview, and
+  committed movement validation.
+
+#### Scenario: Ordinary represented terrain and elevation remain bypassed by WiGE
+
+- **GIVEN** a represented landed WiGE mover is adjacent to woods, clear terrain,
+  water, or ordinary elevation changes without a higher represented building top
+- **WHEN** the player previews or commits movement into that destination
+- **THEN** the movement cost SHALL preserve the represented WiGE terrain and
+  elevation bypass
+- **AND** the destination SHALL NOT receive the building climb-mode surcharge.
+
+#### Scenario: Directional cliff surcharge is not implied without cliff metadata
+
+- **GIVEN** a represented WiGE mover crosses an ordinary elevation change
+- **WHEN** the map does not encode directional cliff-top terrain metadata for the
+  crossed edge
+- **THEN** the movement cost SHALL NOT infer the separate source-backed +1 MP
+  sheer-cliff surcharge from elevation delta alone
+- **AND** full cliff parity SHALL remain a separate movement-system follow-up.

--- a/openspec/changes/pin-wige-building-climb-cost/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/pin-wige-building-climb-cost/specs/tactical-map-interface/spec.md
@@ -1,0 +1,19 @@
+# Spec Delta: Tactical Map Interface
+
+## MODIFIED Requirements
+
+### Requirement: Rules-Backed Movement Projection
+
+Movement overlays SHALL be derived from shared movement projection data and
+SHALL explain legal, blocked, and consequential movement outcomes before the
+player commits them.
+
+#### Scenario: WiGE building climb costs are visible before commit
+
+- **GIVEN** a selected represented landed WiGE unit can enter a higher
+  represented building-top hex
+- **WHEN** the player previews the destination in top-down or isometric mode
+- **THEN** the map's movement projection SHALL include the +2 MP WiGE
+  climb-mode surcharge in the displayed destination cost
+- **AND** over-budget destinations caused by that surcharge SHALL be shown as
+  illegal with the same insufficient-MP reason the engine would return.

--- a/openspec/changes/pin-wige-building-climb-cost/tasks.md
+++ b/openspec/changes/pin-wige-building-climb-cost/tasks.md
@@ -1,0 +1,23 @@
+# Tasks: Pin WiGE Building Climb Cost
+
+## 1. Spec contract
+
+- [x] 1.1 Author proposal/tasks/spec deltas for represented WiGE building climb cost
+- [x] 1.2 Validate the OpenSpec change strictly
+
+## 2. Implementation
+
+- [x] 2.1 Add the represented WiGE +2 MP building climb-mode surcharge to shared movement costs
+- [x] 2.2 Preserve ordinary WiGE terrain/elevation bypass for non-building represented terrain
+- [x] 2.3 Keep movement preview and commit validation aligned through shared cost calculation
+
+## 3. Verification
+
+- [x] 3.1 Add focused movement projection and commit-validation coverage
+- [x] 3.2 Focused movement tests pass
+- [x] 3.3 `npx.cmd openspec validate pin-wige-building-climb-cost --strict` passes
+- [x] 3.4 `npm.cmd run typecheck` passes
+- [x] 3.5 `npm.cmd run lint` passes
+- [x] 3.6 `npm.cmd run format:check` passes
+- [x] 3.7 `npm.cmd run build` passes
+- [x] 3.8 `git diff --check` passes

--- a/openspec/changes/pin-wige-hover-distance-exemptions/proposal.md
+++ b/openspec/changes/pin-wige-hover-distance-exemptions/proposal.md
@@ -1,0 +1,29 @@
+# Pin WiGE Hover And Distance Exemptions
+
+## Why
+
+`auto-land-short-wige-movement` made the map and runtime replay automatic WiGE
+landing for represented positive-altitude WiGE vehicles, Glider ProtoMeks, and
+LAM AirMeks. MegaMek's `MovePath.automaticWiGELanding(...)` has two extra
+guards the projection must preserve before the map can be trusted as the
+player's explanation layer:
+
+- distance already moved this turn contributes to the minimum-distance check;
+- UP/HOVER-style represented steps exempt the automatic landing.
+
+Without this, a player could see a forced landing badge on a hover-style move
+that MegaMek would keep airborne, or see a forced landing after a short plotted
+segment even though the unit has already moved enough hexes this turn.
+
+## What Changes
+
+- Count represented `hexesMovedThisTurn` together with the currently projected
+  path when evaluating short-distance WiGE automatic landing.
+- Suppress automatic landing projection and runtime landing patches when the
+  represented movement mode is hover or when altitude-control steps are pending.
+- Keep the top-down/isometric `LAND` badge and automatic-landing tooltip
+  metadata aligned with the same source-backed helper.
+
+## Source Anchor
+
+- MegaMek `MovePath.java:1699-1743`

--- a/openspec/changes/pin-wige-hover-distance-exemptions/specs/movement-system/spec.md
+++ b/openspec/changes/pin-wige-hover-distance-exemptions/specs/movement-system/spec.md
@@ -1,0 +1,31 @@
+# Spec Delta: Movement System
+
+## MODIFIED Requirements
+
+### Requirement: Automatic WiGE Landing
+
+Represented positive-altitude WiGE movement SHALL apply MegaMek's automatic
+landing rule when a WiGE vehicle, Glider ProtoMek, or LAM AirMek moves below
+its source-backed minimum airborne distance.
+
+#### Scenario: Prior movement distance contributes to automatic WiGE landing
+
+- **GIVEN** a represented positive-altitude WiGE unit has already moved hexes
+  this turn
+- **WHEN** the player previews or commits another legal WiGE movement segment
+- **THEN** the automatic landing minimum-distance check SHALL count both the
+  represented hexes already moved this turn and the currently projected path
+- **AND** a unit whose accumulated distance reaches the source-backed minimum
+  SHALL remain airborne
+- **AND** a unit whose accumulated distance stays below the source-backed
+  minimum SHALL receive the same automatic landing projection and runtime state
+  patch as a one-segment short move.
+
+#### Scenario: Hover-style represented movement stays airborne
+
+- **GIVEN** a represented positive-altitude WiGE unit can use a hover-style
+  movement mode
+- **WHEN** the player previews or commits a legal hover-style movement segment
+- **THEN** the automatic WiGE landing helper SHALL NOT require a landing
+- **AND** the runtime movement command SHALL NOT append an automatic WiGE
+  landing state patch for that hover-style movement.

--- a/openspec/changes/pin-wige-hover-distance-exemptions/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/pin-wige-hover-distance-exemptions/specs/tactical-map-interface/spec.md
@@ -1,0 +1,21 @@
+# Spec Delta: Tactical Map Interface
+
+## MODIFIED Requirements
+
+### Requirement: Rules-Backed Movement Projection
+
+Movement overlays SHALL be derived from shared movement projection data and
+SHALL explain legal, blocked, and consequential movement outcomes before the
+player commits them.
+
+#### Scenario: WiGE hover and prior-distance exemptions match the engine
+
+- **GIVEN** a selected represented positive-altitude WiGE unit has legal
+  movement destinations in top-down or isometric mode
+- **WHEN** the projected destination uses hover-style movement or the unit's
+  accumulated movement distance already reaches the source-backed WiGE minimum
+- **THEN** the destination SHALL NOT expose automatic-landing metadata
+- **AND** the destination SHALL NOT render the automatic landing `LAND` badge
+  or automatic-landing tooltip row
+- **AND** committed movement to the same destination SHALL preserve altitude
+  rather than replaying an automatic landing patch.

--- a/openspec/changes/pin-wige-hover-distance-exemptions/tasks.md
+++ b/openspec/changes/pin-wige-hover-distance-exemptions/tasks.md
@@ -1,0 +1,23 @@
+# Tasks: Pin WiGE Hover And Distance Exemptions
+
+## 1. Spec contract
+
+- [x] 1.1 Author proposal/tasks/spec deltas for WiGE hover and prior-distance exemptions
+- [x] 1.2 Validate the OpenSpec change strictly
+
+## 2. Implementation
+
+- [x] 2.1 Count represented hexes already moved this turn in automatic WiGE landing distance
+- [x] 2.2 Exempt represented hover movement from automatic WiGE landing projection
+- [x] 2.3 Exempt represented hover movement from runtime automatic-landing state patches
+
+## 3. Verification
+
+- [x] 3.1 Add focused helper tests for hover exemption and accumulated movement distance
+- [x] 3.2 Add/extend map projection tests proving hover destinations omit landing metadata
+- [x] 3.3 Focused movement/runtime tests pass
+- [x] 3.4 `npx.cmd openspec validate pin-wige-hover-distance-exemptions --strict` passes
+- [x] 3.5 `npm.cmd run typecheck` passes
+- [x] 3.6 `npm.cmd run lint` passes
+- [x] 3.7 `npm.cmd run format:check` passes
+- [x] 3.8 `git diff --check` passes

--- a/openspec/changes/source-hover-path-preview-badge/proposal.md
+++ b/openspec/changes/source-hover-path-preview-badge/proposal.md
@@ -1,0 +1,27 @@
+# Source Hover Path Preview Badge
+
+## Why
+
+The map's normal movement badge exposes movement type, motive mode, MP cost,
+terrain/elevation details, heat, and shared projection provenance. When the
+player hovers a reachable destination, that badge is replaced by the path
+preview MP badge. The hover badge kept the movement type visible, but it did
+not carry the same cost breakdown or `movement:megamek` source references.
+
+That weakens the tactical explanation layer at the exact moment the player is
+previewing a movement commit.
+
+## What Changes
+
+- Expand the hovered path MP badge with terrain cost, elevation delta/cost,
+  heat, movement source references, rule references, and projection
+  explanation metadata.
+- Include terrain/elevation/heat details in the hover badge accessible label.
+- Add regression coverage proving the hover path preview badge remains tied to
+  the shared rules-backed projection, including same-hex movement options.
+
+## Impact
+
+This is a display/provenance change only. It does not alter movement
+pathfinding, destination legality, commit validation, combat, LOS, terrain
+import, or parser behavior.

--- a/openspec/changes/source-hover-path-preview-badge/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/source-hover-path-preview-badge/specs/tactical-map-interface/spec.md
@@ -1,0 +1,30 @@
+# Spec Delta: Tactical Map Interface
+
+## MODIFIED Requirements
+
+### Requirement: Rules-Backed Tactical Projection Contract
+
+The tactical map interface SHALL render movement, combat, terrain/elevation,
+fog, LOS, cover, and firing-arc highlights from shared rules projections rather
+than from view-local legality calculations.
+
+Every projection that affects action legality SHALL identify the rule source it
+is pinned to, using this source order: official BattleTech rules where citable,
+MegaMek tactical behavior as practical oracle for tactical ambiguity, MekHQ
+only for campaign/scenario context, then local OpenSpec/Jest fixtures as the
+project acceptance contract.
+
+#### Scenario: Hover path badge keeps movement projection provenance
+
+- **GIVEN** a selected unit has a reachable movement destination
+- **WHEN** the player hovers that destination and the map renders the path MP
+  preview badge
+- **THEN** the badge SHALL continue to expose movement type and motive mode
+- **AND** it SHALL expose represented MP cost, terrain cost, elevation
+  delta/cost, and heat when those facts are present
+- **AND** it SHALL expose the shared `movement:megamek` projection source and
+  MegaMek rule references
+- **AND** its accessible label SHALL include the same terrain, elevation, and
+  heat context
+- **AND** exposing those details SHALL NOT change pathfinding or commit
+  legality

--- a/openspec/changes/source-hover-path-preview-badge/tasks.md
+++ b/openspec/changes/source-hover-path-preview-badge/tasks.md
@@ -1,0 +1,13 @@
+## 1. Hover Path Badge
+
+- [x] Expose terrain/elevation/heat metadata on hovered path MP badges.
+- [x] Expose shared movement projection source and MegaMek rule references on
+      hovered path MP badges.
+- [x] Include the same cost breakdown in the hover badge accessible label.
+
+## 2. Tests
+
+- [x] Update HexMapDisplay movement tests for single-option hover path badge
+      provenance.
+- [x] Update HexMapDisplay movement tests for same-hex option source metadata
+      on hover path badges.

--- a/openspec/changes/source-movement-reach-badge/proposal.md
+++ b/openspec/changes/source-movement-reach-badge/proposal.md
@@ -1,0 +1,25 @@
+# Source Movement Reach Badge
+
+## Why
+
+The tactical map's standing movement reach badge is one of the first places a
+player checks destination legality, MP cost, movement mode, heat, terrain, and
+elevation. The hover path preview now preserves shared movement projection
+source evidence, but the non-hover reach badge still exposes its costs without
+directly identifying the shared `movement:megamek` projection evidence on the
+badge itself.
+
+## What Changes
+
+- Add shared movement projection source references, rule references, and
+  explanation metadata to the normal reachable movement badge.
+- Keep the current movement costs, same-hex option summary, terrain/elevation
+  metadata, heat metadata, and command legality behavior unchanged.
+- Add component coverage proving the visible movement reach badge carries the
+  same projection provenance as the rendered hex and hover explanation layer.
+
+## Out Of Scope
+
+- Changing movement pathfinding, destination legality, MP cost math, movement
+  commit validation, combat projection, LOS, terrain import, or isometric depth
+  sorting.

--- a/openspec/changes/source-movement-reach-badge/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/source-movement-reach-badge/specs/tactical-map-interface/spec.md
@@ -1,0 +1,31 @@
+# Spec Delta: Tactical Map Interface
+
+## MODIFIED Requirements
+
+### Requirement: Rules-Backed Tactical Projection Contract
+
+The tactical map interface SHALL render movement, combat, terrain/elevation,
+fog, LOS, cover, and firing-arc highlights from shared rules projections rather
+than from view-local legality calculations.
+
+Every projection that affects action legality SHALL identify the rule source it
+is pinned to, using this source order: official BattleTech rules where citable,
+MegaMek tactical behavior as practical oracle for tactical ambiguity, MekHQ
+only for campaign/scenario context, then local OpenSpec/Jest fixtures as the
+project acceptance contract.
+
+#### Scenario: Movement reach badge keeps projection provenance
+
+- **GIVEN** a selected unit has one or more reachable movement options for a
+  destination hex
+- **WHEN** the tactical map renders the normal movement reach badge before any
+  hover path preview replaces it
+- **THEN** the badge SHALL expose the shared movement-channel tactical
+  projection source and MegaMek-backed rule references
+- **AND** the badge SHALL expose the projection explanation that includes the
+  represented movement options
+- **AND** the badge SHALL continue to expose represented MP cost, movement
+  type/mode, terrain cost, elevation delta/cost, heat, and same-hex option
+  metadata when those facts are present
+- **AND** exposing those details SHALL NOT change pathfinding or commit
+  legality

--- a/openspec/changes/source-movement-reach-badge/tasks.md
+++ b/openspec/changes/source-movement-reach-badge/tasks.md
@@ -1,0 +1,8 @@
+## Tasks
+
+- [x] Add an OpenSpec scenario for movement reach badge provenance.
+- [x] Thread movement-channel projection source/rule references into the normal
+      movement reach badge.
+- [x] Lock the badge metadata with representative Walk/Run/Jump same-hex option
+      coverage.
+- [x] Run OpenSpec and focused tactical-map tests.

--- a/openspec/changes/source-movement-step-cost-badge/proposal.md
+++ b/openspec/changes/source-movement-step-cost-badge/proposal.md
@@ -1,0 +1,23 @@
+# Source Movement Step Cost Badge
+
+## Why
+
+Reachable movement hexes can render a separate terrain/elevation step-cost
+badge such as `T+1 E+2 UP2`. That badge explains why a destination costs more
+MP, so it should identify the same shared movement projection evidence as the
+standing movement reach badge and hover path preview.
+
+## What Changes
+
+- Add movement-channel projection source references, MegaMek rule references,
+  and projection explanation metadata to the visible step-cost badge.
+- Keep the existing terrain cost, elevation cost, elevation delta, MP cost, and
+  movement legality behavior unchanged.
+- Add component coverage proving the cost badge is tied to the shared
+  `movement:megamek` projection.
+
+## Out Of Scope
+
+- Changing terrain/elevation MP math, movement pathfinding, destination
+  legality, movement commit validation, combat projection, terrain import, LOS,
+  or isometric rendering.

--- a/openspec/changes/source-movement-step-cost-badge/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/source-movement-step-cost-badge/specs/tactical-map-interface/spec.md
@@ -1,0 +1,29 @@
+# Spec Delta: Tactical Map Interface
+
+## MODIFIED Requirements
+
+### Requirement: Rules-Backed Tactical Projection Contract
+
+The tactical map interface SHALL render movement, combat, terrain/elevation,
+fog, LOS, cover, and firing-arc highlights from shared rules projections rather
+than from view-local legality calculations.
+
+Every projection that affects action legality SHALL identify the rule source it
+is pinned to, using this source order: official BattleTech rules where citable,
+MegaMek tactical behavior as practical oracle for tactical ambiguity, MekHQ
+only for campaign/scenario context, then local OpenSpec/Jest fixtures as the
+project acceptance contract.
+
+#### Scenario: Movement step-cost badge keeps projection provenance
+
+- **GIVEN** a reachable movement destination has represented terrain or
+  elevation step costs
+- **WHEN** the tactical map renders the visible movement step-cost badge
+- **THEN** the badge SHALL expose the shared movement-channel tactical
+  projection source and MegaMek-backed rule references
+- **AND** the badge SHALL expose the projection explanation that includes the
+  represented terrain and elevation cost details
+- **AND** the badge SHALL continue to expose terrain cost, elevation delta, and
+  elevation cost metadata without relying only on color
+- **AND** exposing those details SHALL NOT change terrain/elevation MP math,
+  pathfinding, or commit legality

--- a/openspec/changes/source-movement-step-cost-badge/tasks.md
+++ b/openspec/changes/source-movement-step-cost-badge/tasks.md
@@ -1,0 +1,8 @@
+## Tasks
+
+- [x] Add an OpenSpec scenario for movement step-cost badge provenance.
+- [x] Thread movement-channel projection source/rule references into the
+      terrain/elevation step-cost badge.
+- [x] Lock the step-cost badge metadata with representative terrain and
+      elevation cost coverage.
+- [x] Run OpenSpec and focused tactical-map tests.

--- a/openspec/changes/surface-cliff-exits-map-context/proposal.md
+++ b/openspec/changes/surface-cliff-exits-map-context/proposal.md
@@ -1,0 +1,16 @@
+# Surface Cliff Exits Map Context
+
+## Why
+
+MegaMek board cliff-top exits now import into `IHexTerrain`, and movement projection uses that metadata to distinguish sheer cliffs from ordinary elevation changes. The map still needs to expose those represented directional cliff edges in the same terrain/elevation explanation surfaces players and tests inspect.
+
+## What Changes
+
+- Include represented `cliffTopExits` in terrain/elevation projection source detail when present.
+- Expose cliff exit directions on rendered hex and terrain label metadata.
+- Show cliff exit directions in terrain hover and action hover terrain context.
+
+## Out of Scope
+
+- Changing movement, combat, LOS, cover, or parser behavior.
+- Inferring cliff edges from elevation deltas when no `cliffTopExits` metadata is represented.

--- a/openspec/changes/surface-cliff-exits-map-context/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/surface-cliff-exits-map-context/specs/tactical-map-interface/spec.md
@@ -1,0 +1,18 @@
+# Spec Delta: Tactical Map Interface
+
+## MODIFIED Requirements
+
+### Requirement: Rules-Backed Tactical Projection Contract
+
+The tactical map interface SHALL render movement, combat, terrain/elevation, fog, LOS, cover, and firing-arc highlights from shared rules projections rather than from view-local legality calculations.
+
+Every projection that affects action legality SHALL identify the rule source it is pinned to, using this source order: official BattleTech rules where citable, MegaMek tactical behavior as practical oracle for tactical ambiguity, MekHQ only for campaign/scenario context, then local OpenSpec/Jest fixtures as the project acceptance contract.
+
+#### Scenario: Terrain projection exposes represented cliff exits
+
+- **GIVEN** a rendered hex has represented directional `cliffTopExits`
+- **WHEN** the hex renders and its terrain/elevation projection metadata is inspected
+- **THEN** the hex SHALL expose the cliff exit directions in machine-readable terrain metadata
+- **AND** terrain/elevation source detail SHALL include the cliff exit direction labels
+- **AND** hover terrain context SHALL show the represented cliff edge directions
+- **AND** exposing those directions SHALL NOT change movement, combat, LOS, cover, or parser behavior

--- a/openspec/changes/surface-cliff-exits-map-context/tasks.md
+++ b/openspec/changes/surface-cliff-exits-map-context/tasks.md
@@ -1,0 +1,6 @@
+## Implementation
+
+- [x] Add cliff exit directions to terrain/elevation projection source metadata.
+- [x] Expose represented cliff exits in hex DOM, terrain labels, and hover terrain context.
+- [x] Cover source metadata, rendered hex metadata, and tooltip context with focused tests.
+- [x] Validate the OpenSpec delta and focused tests.

--- a/openspec/changes/surface-movement-option-source-details/proposal.md
+++ b/openspec/changes/surface-movement-option-source-details/proposal.md
@@ -1,0 +1,26 @@
+# Surface Movement Option Source Details
+
+## Why
+
+The tactical map already renders same-hex walk/run/jump movement options in
+badges, hover rows, and projection explanations, but the shared source
+reference still compressed movement legality to a coarse `walk projection` /
+`run projection` label. That left downstream top-down and isometric surfaces
+with source metadata that did not independently explain which movement modes
+were legal, blocked, costly, or heat-generating.
+
+## What Changes
+
+- Expand the shared movement projection source detail so it includes each
+  represented same-hex movement option, its legal/blocked state, MP cost,
+  terrain/elevation cost details, heat, and blocked reason when present.
+- Keep the existing source channel and MegaMek rule references intact so UI
+  consumers can continue filtering on `movement:megamek`.
+- Add regression coverage proving mixed walk/run/jump options are represented
+  in the source reference, not only in the visible badge text.
+
+## Impact
+
+This is a tactical map explanation-layer change only. It does not alter
+movement pathfinding, movement commit validation, combat, LOS, terrain import,
+or parser behavior.

--- a/openspec/changes/surface-movement-option-source-details/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/surface-movement-option-source-details/specs/tactical-map-interface/spec.md
@@ -1,0 +1,30 @@
+# Spec Delta: Tactical Map Interface
+
+## MODIFIED Requirements
+
+### Requirement: Rules-Backed Tactical Projection Contract
+
+The tactical map interface SHALL render movement, combat, terrain/elevation,
+fog, LOS, cover, and firing-arc highlights from shared rules projections rather
+than from view-local legality calculations.
+
+Every projection that affects action legality SHALL identify the rule source it
+is pinned to, using this source order: official BattleTech rules where citable,
+MegaMek tactical behavior as practical oracle for tactical ambiguity, MekHQ
+only for campaign/scenario context, then local OpenSpec/Jest fixtures as the
+project acceptance contract.
+
+#### Scenario: Movement source detail explains same-hex options
+
+- **GIVEN** a rendered hex has one or more movement projection options for the
+  selected unit
+- **WHEN** the shared tactical projection source references are inspected
+- **THEN** the movement source reference SHALL include each represented
+  movement option's type or motive mode
+- **AND** it SHALL include whether that option is reachable or blocked
+- **AND** it SHALL include represented MP cost, terrain cost, elevation cost,
+  heat, and blocked reason when those facts are present
+- **AND** the source reference SHALL continue to identify MegaMek movement
+  rules as the tactical oracle
+- **AND** exposing those details SHALL NOT change movement pathfinding or
+  commit legality

--- a/openspec/changes/surface-movement-option-source-details/tasks.md
+++ b/openspec/changes/surface-movement-option-source-details/tasks.md
@@ -1,0 +1,13 @@
+## 1. Projection Source Detail
+
+- [x] Include per-option movement state, MP, terrain/elevation cost, heat, and
+      blocked detail in shared movement projection source references.
+- [x] Preserve the existing `movement:megamek` channel and rule references for
+      existing top-down/isometric consumers.
+
+## 2. Tests
+
+- [x] Update tactical map projection tests for the expanded single-option
+      source detail.
+- [x] Add mixed walk/run/jump source-reference coverage for same-hex movement
+      options.

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "validate:infantry": "npx tsx scripts/validate-infantry-bv.ts",
     "validate:aerospace": "npx tsx scripts/validate-aerospace-bv.ts",
     "validate:vehicle": "npx tsx scripts/validate-vehicle-bv.ts",
+    "audit:megamek-boards": "npx tsx scripts/audit-megamek-board-import.ts",
     "validate:refactor": "npm run test && npm run lint && npm run build",
     "analyze:files": "./scripts/monitor-file-sizes.sh",
     "analyze:files:report": "./scripts/monitor-file-sizes.sh > file-analysis-report.txt && cat file-analysis-report.txt",

--- a/scripts/audit-megamek-board-import.ts
+++ b/scripts/audit-megamek-board-import.ts
@@ -1,0 +1,311 @@
+#!/usr/bin/env npx tsx
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { parseMegaMekBoard } from '../src/lib/parsers/megaMekBoard';
+
+const DEFAULT_MEGAMEK_ROOT = 'E:/Projects/megamek/megamek';
+
+interface AuditOptions {
+  readonly megamekRoot: string;
+  readonly boardsRoot?: string;
+  readonly filter?: string;
+  readonly limit?: number;
+  readonly requireCliff: boolean;
+  readonly json: boolean;
+  readonly help: boolean;
+}
+
+interface BoardAuditResult {
+  readonly filePath: string;
+  readonly relativePath: string;
+  readonly hexRows: number;
+  readonly parsedHexes: number;
+  readonly largeCoordinateRows: number;
+  readonly cliffTopRows: number;
+  readonly width?: number;
+  readonly height?: number;
+  readonly error?: string;
+}
+
+interface AuditSummary {
+  readonly boardsRoot: string;
+  readonly scannedBoards: number;
+  readonly parsedBoards: number;
+  readonly failedBoards: number;
+  readonly totalHexRows: number;
+  readonly parsedHexes: number;
+  readonly largeCoordinateBoards: number;
+  readonly largeCoordinateRows: number;
+  readonly cliffTopBoards: number;
+  readonly cliffTopRows: number;
+  readonly failures: readonly BoardAuditResult[];
+}
+
+function parseArgs(argv: readonly string[]): AuditOptions {
+  const options: AuditOptions = {
+    megamekRoot: process.env.MEGAMEK_ROOT ?? DEFAULT_MEGAMEK_ROOT,
+    requireCliff: false,
+    json: false,
+    help: false,
+  };
+
+  let current: AuditOptions = options;
+
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+    switch (arg) {
+      case '--megamek':
+        current = {
+          ...current,
+          megamekRoot: path.resolve(argv[++index] ?? ''),
+        };
+        break;
+      case '--boards':
+        current = {
+          ...current,
+          boardsRoot: path.resolve(argv[++index] ?? ''),
+        };
+        break;
+      case '--filter':
+        current = { ...current, filter: argv[++index] ?? '' };
+        break;
+      case '--limit':
+        current = { ...current, limit: Number(argv[++index] ?? '') };
+        break;
+      case '--require-cliff':
+        current = { ...current, requireCliff: true };
+        break;
+      case '--json':
+        current = { ...current, json: true };
+        break;
+      case '--help':
+      case '-h':
+        current = { ...current, help: true };
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return current;
+}
+
+function showHelp(): void {
+  console.log(`
+MegaMek board import audit
+
+Usage:
+  npx tsx scripts/audit-megamek-board-import.ts [options]
+
+Options:
+  --megamek <path>       MegaMek repo root. Defaults to MEGAMEK_ROOT or ${DEFAULT_MEGAMEK_ROOT}
+  --boards <path>        Board corpus root. Defaults to <megamek>/data/boards
+  --filter <text>        Only audit board paths containing this text
+  --limit <number>       Stop after auditing this many selected board files
+  --require-cliff        Fail if selected boards contain no cliff_top metadata
+  --json                 Emit machine-readable JSON summary
+  --help, -h             Show this help
+`);
+}
+
+function collectBoardFiles(root: string): string[] {
+  const files: string[] = [];
+  const entries = fs
+    .readdirSync(root, { withFileTypes: true })
+    .sort((left, right) => left.name.localeCompare(right.name));
+
+  for (const entry of entries) {
+    const fullPath = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectBoardFiles(fullPath));
+      continue;
+    }
+
+    if (entry.isFile() && entry.name.toLowerCase().endsWith('.board')) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+function countMatches(content: string, pattern: RegExp): number {
+  return content.match(pattern)?.length ?? 0;
+}
+
+function auditBoard(filePath: string, boardsRoot: string): BoardAuditResult {
+  const relativePath = path.relative(boardsRoot, filePath);
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const hexRows = countMatches(content, /^hex\s+\S+/gm);
+  const largeCoordinateRows = countMatches(content, /^hex\s+\d{5,}\s/gm);
+  const cliffTopRows = countMatches(
+    content,
+    /^hex\s+\S+\s+[-\d]+\s+"[^"]*cliff_top:/gm,
+  );
+
+  try {
+    const board = parseMegaMekBoard(content);
+    if (board.hexes.length !== hexRows) {
+      return {
+        filePath,
+        relativePath,
+        hexRows,
+        parsedHexes: board.hexes.length,
+        largeCoordinateRows,
+        cliffTopRows,
+        width: board.width,
+        height: board.height,
+        error: `Parsed ${board.hexes.length} hexes from ${hexRows} hex rows`,
+      };
+    }
+
+    return {
+      filePath,
+      relativePath,
+      hexRows,
+      parsedHexes: board.hexes.length,
+      largeCoordinateRows,
+      cliffTopRows,
+      width: board.width,
+      height: board.height,
+    };
+  } catch (error) {
+    return {
+      filePath,
+      relativePath,
+      hexRows,
+      parsedHexes: 0,
+      largeCoordinateRows,
+      cliffTopRows,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function summarize(
+  boardsRoot: string,
+  results: readonly BoardAuditResult[],
+): AuditSummary {
+  const failures = results.filter((result) => result.error);
+
+  return {
+    boardsRoot,
+    scannedBoards: results.length,
+    parsedBoards: results.length - failures.length,
+    failedBoards: failures.length,
+    totalHexRows: results.reduce((sum, result) => sum + result.hexRows, 0),
+    parsedHexes: results.reduce((sum, result) => sum + result.parsedHexes, 0),
+    largeCoordinateBoards: results.filter(
+      (result) => result.largeCoordinateRows > 0,
+    ).length,
+    largeCoordinateRows: results.reduce(
+      (sum, result) => sum + result.largeCoordinateRows,
+      0,
+    ),
+    cliffTopBoards: results.filter((result) => result.cliffTopRows > 0).length,
+    cliffTopRows: results.reduce((sum, result) => sum + result.cliffTopRows, 0),
+    failures,
+  };
+}
+
+function printSummary(summary: AuditSummary): void {
+  console.log('MegaMek board import audit');
+  console.log(`Boards root: ${summary.boardsRoot}`);
+  console.log(`Scanned boards: ${summary.scannedBoards}`);
+  console.log(`Parsed boards: ${summary.parsedBoards}`);
+  console.log(`Failed boards: ${summary.failedBoards}`);
+  console.log(`Hex rows: ${summary.totalHexRows}`);
+  console.log(`Parsed hexes: ${summary.parsedHexes}`);
+  console.log(
+    `Large-coordinate coverage: ${summary.largeCoordinateBoards} boards, ${summary.largeCoordinateRows} hex rows`,
+  );
+  console.log(
+    `cliff_top coverage: ${summary.cliffTopBoards} boards, ${summary.cliffTopRows} hex rows`,
+  );
+
+  if (summary.failures.length > 0) {
+    console.log('\nFailures:');
+    for (const failure of summary.failures.slice(0, 20)) {
+      console.log(`- ${failure.relativePath}: ${failure.error}`);
+    }
+    if (summary.failures.length > 20) {
+      console.log(`- ... ${summary.failures.length - 20} more`);
+    }
+  }
+}
+
+function main(): void {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    showHelp();
+    return;
+  }
+
+  const boardsRoot = path.resolve(
+    options.boardsRoot ?? path.join(options.megamekRoot, 'data', 'boards'),
+  );
+
+  if (!fs.existsSync(boardsRoot) || !fs.statSync(boardsRoot).isDirectory()) {
+    throw new Error(`MegaMek boards directory not found: ${boardsRoot}`);
+  }
+
+  let boardFiles = collectBoardFiles(boardsRoot);
+  if (options.filter) {
+    const normalizedFilter = options.filter.toLowerCase();
+    boardFiles = boardFiles.filter((filePath) =>
+      path
+        .relative(boardsRoot, filePath)
+        .toLowerCase()
+        .includes(normalizedFilter),
+    );
+  }
+  if (options.limit !== undefined) {
+    if (!Number.isInteger(options.limit) || options.limit < 1) {
+      throw new Error('--limit must be a positive integer');
+    }
+    boardFiles = boardFiles.slice(0, options.limit);
+  }
+
+  const results = boardFiles.map((filePath) =>
+    auditBoard(filePath, boardsRoot),
+  );
+  let summary = summarize(boardsRoot, results);
+
+  if (options.requireCliff && summary.cliffTopRows === 0) {
+    summary = {
+      ...summary,
+      failedBoards: summary.failedBoards + 1,
+      failures: [
+        ...summary.failures,
+        {
+          filePath: boardsRoot,
+          relativePath: '.',
+          hexRows: 0,
+          parsedHexes: 0,
+          largeCoordinateRows: 0,
+          cliffTopRows: 0,
+          error: 'Selected board corpus did not contain any cliff_top metadata',
+        },
+      ],
+    };
+  }
+
+  if (options.json) {
+    console.log(JSON.stringify(summary, null, 2));
+  } else {
+    printSummary(summary);
+  }
+
+  if (summary.failures.length > 0) {
+    process.exitCode = 1;
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/src/__tests__/unit/lib/parsers/megaMekBoard.test.ts
+++ b/src/__tests__/unit/lib/parsers/megaMekBoard.test.ts
@@ -87,6 +87,22 @@ end`;
       // col=3, row=3: q = 3-1 = 2, r = 3-1 - floor(2/2) = 2 - 1 = 1
       expect(result.hexes[0].coordinate).toEqual({ q: 2, r: 1 });
     });
+
+    it('should parse MegaMek large-board coordinates with three-digit columns', () => {
+      const content = `size 170 120
+hex 10412 0 "" ""
+end`;
+      const result = parseMegaMekBoard(content);
+      expect(result.hexes[0].coordinate).toEqual({ q: 103, r: -40 });
+    });
+
+    it('should parse MegaMek large-board coordinates with three-digit rows', () => {
+      const content = `size 170 120
+hex 104120 0 "" ""
+end`;
+      const result = parseMegaMekBoard(content);
+      expect(result.hexes[0].coordinate).toEqual({ q: 103, r: 68 });
+    });
   });
 
   describe('single terrain features', () => {
@@ -349,6 +365,23 @@ end`;
         cliffTopExits: [Facing.Southeast],
       });
     });
+
+    it('should parse large-board cliff_top exits from MegaMek board labels', () => {
+      const content = `size 170 120
+hex 9916 3 "" ""
+hex 10015 3 "" ""
+hex 10016 4 "cliff_top:1:33;pavement:1" ""
+end`;
+      const result = parseMegaMekBoard(content);
+      const cliffHex = result.hexes.find(
+        (hex) => hex.coordinate.q === 99 && hex.coordinate.r === -34,
+      );
+      expect(cliffHex?.features[0]).toEqual({
+        type: TerrainType.Pavement,
+        level: 1,
+        cliffTopExits: [Facing.North, Facing.Northwest],
+      });
+    });
   });
 
   describe('full board parsing', () => {
@@ -448,6 +481,15 @@ end`;
     it('should throw on invalid hex coordinate', () => {
       const content = `size 2 2
 hex XXXX 0 "" ""
+end`;
+      expect(() => parseMegaMekBoard(content)).toThrow(
+        'Invalid hex coordinate',
+      );
+    });
+
+    it('should throw on hex coordinates outside the declared board size', () => {
+      const content = `size 2 2
+hex 9917 0 "" ""
 end`;
       expect(() => parseMegaMekBoard(content)).toThrow(
         'Invalid hex coordinate',

--- a/src/__tests__/unit/lib/parsers/megaMekBoard.test.ts
+++ b/src/__tests__/unit/lib/parsers/megaMekBoard.test.ts
@@ -103,6 +103,20 @@ end`;
       const result = parseMegaMekBoard(content);
       expect(result.hexes[0].coordinate).toEqual({ q: 103, r: 68 });
     });
+
+    it('should disambiguate large-board labels with MegaMek row order', () => {
+      const priorHexes = Array.from({ length: 100 }, (_, index) => {
+        const col = index + 1;
+        const label = `${col < 10 ? `0${col}` : col}01`;
+        return `hex ${label} 0 "" ""`;
+      });
+      const content = `size 170 120
+${priorHexes.join('\n')}
+hex 10101 0 "" ""
+end`;
+      const result = parseMegaMekBoard(content);
+      expect(result.hexes[100].coordinate).toEqual({ q: 100, r: -50 });
+    });
   });
 
   describe('single terrain features', () => {

--- a/src/__tests__/unit/lib/parsers/megaMekBoard.test.ts
+++ b/src/__tests__/unit/lib/parsers/megaMekBoard.test.ts
@@ -7,6 +7,7 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 
 import { parseMegaMekBoard } from '@/lib/parsers/megaMekBoard';
+import { Facing } from '@/types/gameplay';
 import { TerrainType } from '@/types/gameplay/TerrainTypes';
 
 describe('parseMegaMekBoard', () => {
@@ -296,6 +297,56 @@ end`;
       expect(result.hexes[0].features).toContainEqual({
         type: TerrainType.Rubble,
         level: 1,
+      });
+    });
+  });
+
+  describe('cliff-top terrain exits', () => {
+    it('should parse valid cliff_top exit masks onto the first terrain feature', () => {
+      const content = `size 2 1
+hex 0101 1 "cliff_top:1:4;pavement:1" ""
+hex 0201 0 "" ""
+end`;
+      const result = parseMegaMekBoard(content);
+      expect(result.hexes[0].features[0]).toEqual({
+        type: TerrainType.Pavement,
+        level: 1,
+        cliffTopExits: [Facing.Southeast],
+      });
+    });
+
+    it('should create a clear feature when a valid cliff_top has no mapped terrain', () => {
+      const content = `size 2 1
+hex 0101 0 "" ""
+hex 0201 1 "cliff_top:1:32" ""
+end`;
+      const result = parseMegaMekBoard(content);
+      expect(result.hexes[1].features[0]).toEqual({
+        type: TerrainType.Clear,
+        level: 0,
+        cliffTopExits: [Facing.Northwest],
+      });
+    });
+
+    it('should drop cliff_top exits that do not point to a 1- or 2-level drop', () => {
+      const content = `size 2 1
+hex 0101 1 "cliff_top:1:4" ""
+hex 0201 1 "" ""
+end`;
+      const result = parseMegaMekBoard(content);
+      expect(result.hexes[0].features).toHaveLength(0);
+    });
+
+    it('should keep only valid cliff_top bits from a mixed exit mask', () => {
+      const content = `size 2 1
+hex 0101 1 "cliff_top:1:6;pavement:1" ""
+hex 0201 0 "" ""
+end`;
+      const result = parseMegaMekBoard(content);
+      expect(result.hexes[0].features[0]).toEqual({
+        type: TerrainType.Pavement,
+        level: 1,
+        cliffTopExits: [Facing.Southeast],
       });
     });
   });

--- a/src/components/gameplay/EventLogDisplay.runtimeMovement.ts
+++ b/src/components/gameplay/EventLogDisplay.runtimeMovement.ts
@@ -8,6 +8,13 @@ export function formatRuntimeMovementStateChangedEvent(event: IGameEvent): {
   readonly unitId?: string;
 } {
   const payload = event.payload as IRuntimeMovementStateChangedPayload;
+  if (payload.source === 'automatic_wige_landing') {
+    return {
+      text: 'Automatic WiGE landing',
+      unitId: payload.unitId,
+    };
+  }
+
   if (payload.lamAirMekLandingControlRequired === undefined) {
     return {
       text: event.type.replace(/_/g, ' '),

--- a/src/components/gameplay/HexMapDisplay/HexCell.hoverMovementBadge.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexCell.hoverMovementBadge.tsx
@@ -1,11 +1,57 @@
 import React from 'react';
 
 import type { IHexCoordinate, IMovementRangeHex } from '@/types/gameplay';
+import type { ITacticalMapProjectionSourceReference } from '@/utils/gameplay/tacticalMapProjection';
+
+import {
+  formatTacticalProjectionRuleReferences,
+  formatTacticalProjectionSourceReferences,
+} from '@/utils/gameplay/tacticalMapProjection';
 
 import {
   formatMovementModeTitle,
   formatMovementReachBadgeLabel,
 } from './HexCell.movementBadges';
+
+function formatSignedCost(value: number): string {
+  return value >= 0 ? `+${value}` : `${value}`;
+}
+
+function formatPathPreviewTitle(
+  movementInfo: IMovementRangeHex | undefined,
+  hoverMpCost: number,
+): string {
+  if (!movementInfo) return `Movement path preview: ${hoverMpCost} MP`;
+
+  const details = [
+    `${formatMovementModeTitle({ ...movementInfo, mpCost: hoverMpCost })} path preview: ${hoverMpCost} MP`,
+  ];
+  if (movementInfo.terrainCost !== undefined) {
+    details.push(`terrain ${formatSignedCost(movementInfo.terrainCost)}`);
+  }
+  if (
+    movementInfo.elevationDelta !== undefined ||
+    movementInfo.elevationCost !== undefined
+  ) {
+    const elevationDetails: string[] = [];
+    if (movementInfo.elevationDelta !== undefined) {
+      elevationDetails.push(
+        `delta ${formatSignedCost(movementInfo.elevationDelta)}`,
+      );
+    }
+    if (movementInfo.elevationCost !== undefined) {
+      elevationDetails.push(
+        `cost ${formatSignedCost(movementInfo.elevationCost)}`,
+      );
+    }
+    details.push(`elevation ${elevationDetails.join(' ')}`);
+  }
+  if (movementInfo.heatGenerated !== undefined) {
+    details.push(`heat ${formatSignedCost(movementInfo.heatGenerated)}`);
+  }
+
+  return details.join('; ');
+}
 
 export function MovementHoverCostBadge({
   x,
@@ -13,12 +59,16 @@ export function MovementHoverCostBadge({
   hex,
   hoverMpCost,
   movementInfo,
+  projectionExplanation,
+  sourceReferences,
 }: {
   readonly x: number;
   readonly y: number;
   readonly hex: IHexCoordinate;
   readonly hoverMpCost?: number;
   readonly movementInfo?: IMovementRangeHex;
+  readonly projectionExplanation?: string;
+  readonly sourceReferences?: readonly ITacticalMapProjectionSourceReference[];
 }): React.ReactElement | null {
   if (hoverMpCost === undefined) return null;
 
@@ -32,20 +82,39 @@ export function MovementHoverCostBadge({
   const label = activeMovementInfo
     ? formatMovementReachBadgeLabel(activeMovementInfo)
     : `${hoverMpCost}MP`;
-  const title = activeMovementInfo
-    ? `${formatMovementModeTitle(activeMovementInfo)} path preview: ${hoverMpCost} MP`
-    : `Movement path preview: ${hoverMpCost} MP`;
+  const title = formatPathPreviewTitle(movementInfo, hoverMpCost);
   const width = Math.max(34, label.length * 5.6 + 10);
+  const movementSourceReferences =
+    sourceReferences?.filter((source) => source.channel === 'movement') ?? [];
+  const movementSourceRefsAttribute =
+    formatTacticalProjectionSourceReferences(movementSourceReferences) ||
+    undefined;
+  const movementRuleRefsAttribute =
+    formatTacticalProjectionRuleReferences(movementSourceReferences) ||
+    undefined;
+  const movementProjectionChannel =
+    movementSourceReferences.length > 0 ? 'movement' : undefined;
 
   return (
     <g
       pointerEvents="none"
       data-testid={`hex-mp-badge-${hex.q}-${hex.r}`}
       aria-label={title}
+      data-tactical-projection-source={
+        movementProjectionChannel ? 'shared-tactical-map-projection' : undefined
+      }
+      data-tactical-projection-channel={movementProjectionChannel}
+      data-tactical-rules-surface={movementProjectionChannel}
       data-hover-mp-cost={hoverMpCost}
       data-movement-badge-type={movementInfo?.movementType}
       data-movement-badge-mode={movementInfo?.movementMode}
+      data-movement-badge-terrain-cost={movementInfo?.terrainCost}
+      data-movement-badge-elevation-delta={movementInfo?.elevationDelta}
+      data-movement-badge-elevation-cost={movementInfo?.elevationCost}
       data-movement-badge-heat-generated={movementInfo?.heatGenerated}
+      data-movement-badge-source-refs={movementSourceRefsAttribute}
+      data-movement-badge-rule-refs={movementRuleRefsAttribute}
+      data-movement-badge-projection-explanation={projectionExplanation}
     >
       <title>{title}</title>
       <rect

--- a/src/components/gameplay/HexMapDisplay/HexCell.labels.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexCell.labels.tsx
@@ -20,6 +20,10 @@ import {
 } from '@/utils/gameplay/tacticalMapProjection';
 
 import { formatCombatC3Label } from './HexMapDisplay.combatC3Context';
+import {
+  terrainCliffExitDirectionsAttributeForFeatures,
+  terrainCliffExitLabelsAttributeForFeatures,
+} from './HexMapDisplay.terrainMetadata';
 
 const TERRAIN_ELEVATION_PROJECTION_CHANNEL = 'terrain-elevation';
 const SHARED_TACTICAL_PROJECTION_SOURCE = 'shared-tactical-map-projection';
@@ -48,7 +52,11 @@ export function formatTerrainFeaturesLabel(
 
 function formatTerrainFeatureReference(feature: ITerrainFeature): string {
   const label = formatTerrainLabel(feature.type);
-  return feature.level > 0 ? `${label} L${feature.level}` : label;
+  const levelLabel = feature.level > 0 ? `${label} L${feature.level}` : label;
+  const cliffExitLabels = terrainCliffExitLabelsAttributeForFeatures([feature]);
+  return cliffExitLabels
+    ? `${levelLabel} cliff edges ${cliffExitLabels}`
+    : levelLabel;
 }
 
 export function formatTerrainFeatureReferenceLabel(
@@ -467,6 +475,12 @@ export function TerrainBadge({
         displayTypes.length > 0 ? displayTypes.join(',') : 'clear'
       }
       data-terrain-feature-levels={terrainFeatureLevelsAttribute(
+        displayFeatures,
+      )}
+      data-terrain-cliff-exits={terrainCliffExitDirectionsAttributeForFeatures(
+        displayFeatures,
+      )}
+      data-terrain-cliff-exit-labels={terrainCliffExitLabelsAttributeForFeatures(
         displayFeatures,
       )}
       data-terrain-feature-count={displayTypes.length}

--- a/src/components/gameplay/HexMapDisplay/HexCell.labels.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexCell.labels.tsx
@@ -193,6 +193,17 @@ export function formatMovementLabel(movementInfo: IMovementRangeHex): string {
           : ` at altitude ${movementInfo.altitudeControlAltitude}`
       }`
     : '';
+  const automaticLandingLabel = movementInfo.automaticLandingRequired
+    ? `, automatic ${formatMovementModeLabel(
+        movementInfo.automaticLandingMode,
+      )} landing ${movementInfo.automaticLandingDistance ?? 0}/${
+        movementInfo.automaticLandingMinimumDistance ?? 0
+      } hexes${
+        movementInfo.automaticLandingReason
+          ? `: ${movementInfo.automaticLandingReason}`
+          : ''
+      }`
+    : '';
   const invalidLabel = movementInfo.movementInvalidReason
     ? `, invalid ${movementInfo.movementInvalidReason}${
         movementInfo.movementInvalidDetails
@@ -217,7 +228,7 @@ export function formatMovementLabel(movementInfo: IMovementRangeHex): string {
     movementInfo.heatGenerated !== undefined
       ? `, heat +${movementInfo.heatGenerated}`
       : ''
-  }${standLabel}${hullDownExitLabel}${altitudeControlLabel}${invalidLabel}${blockedLabel}`;
+  }${standLabel}${hullDownExitLabel}${altitudeControlLabel}${automaticLandingLabel}${invalidLabel}${blockedLabel}`;
 }
 
 function formatTerrainBadge(terrainType: string | null): string {

--- a/src/components/gameplay/HexMapDisplay/HexCell.movementBadges.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexCell.movementBadges.tsx
@@ -445,11 +445,15 @@ export function MovementStepCostBadge({
   y,
   hex,
   movementInfo,
+  projectionExplanation,
+  sourceReferences,
 }: {
   readonly x: number;
   readonly y: number;
   readonly hex: IHexCoordinate;
   readonly movementInfo?: IMovementRangeHex;
+  readonly projectionExplanation?: string;
+  readonly sourceReferences?: readonly ITacticalMapProjectionSourceReference[];
 }): React.ReactElement | null {
   if (!movementInfo?.reachable) return null;
   const label = formatMovementStepCostLabel(movementInfo);
@@ -457,14 +461,32 @@ export function MovementStepCostBadge({
 
   const title = formatMovementStepCostTitle(movementInfo);
   const width = Math.max(28, label.length * 5.4 + 8);
+  const movementSourceReferences =
+    sourceReferences?.filter((source) => source.channel === 'movement') ?? [];
+  const movementSourceRefsAttribute =
+    formatTacticalProjectionSourceReferences(movementSourceReferences) ||
+    undefined;
+  const movementRuleRefsAttribute =
+    formatTacticalProjectionRuleReferences(movementSourceReferences) ||
+    undefined;
+  const movementProjectionChannel =
+    movementSourceReferences.length > 0 ? 'movement' : undefined;
   return (
     <g
       pointerEvents="none"
       data-testid={`hex-movement-cost-badge-${hex.q}-${hex.r}`}
       aria-label={title}
+      data-tactical-projection-source={
+        movementProjectionChannel ? 'shared-tactical-map-projection' : undefined
+      }
+      data-tactical-projection-channel={movementProjectionChannel}
+      data-tactical-rules-surface={movementProjectionChannel}
       data-movement-step-terrain-cost={movementInfo.terrainCost}
       data-movement-step-elevation-cost={movementInfo.elevationCost}
       data-movement-step-elevation-delta={movementInfo.elevationDelta}
+      data-movement-step-source-refs={movementSourceRefsAttribute}
+      data-movement-step-rule-refs={movementRuleRefsAttribute}
+      data-movement-step-projection-explanation={projectionExplanation}
     >
       <title>{title}</title>
       <rect

--- a/src/components/gameplay/HexMapDisplay/HexCell.movementBadges.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexCell.movementBadges.tsx
@@ -11,6 +11,7 @@ import {
   movementOptionAltitudeControlsAttribute,
   movementOptionAltitudeControlMpCostsAttribute,
   movementOptionAltitudeControlStepCountsAttribute,
+  movementOptionAutomaticLandingsAttribute,
   movementOptionBlockedReasonsAttribute,
   movementOptionConversionMpCostsAttribute,
   movementOptionConversionStepCountsAttribute,
@@ -72,7 +73,16 @@ export function formatMovementReachBadgeTitle(
       : `; altitude control ${
           movementInfo.altitudeControlStepCount ?? 0
         } steps ${movementInfo.altitudeControlMpCost ?? 0} MP`;
-  const primary = `${formatMovementModeTitle(movementInfo)} reachable: ${movementInfo.mpCost} MP${conversion}${altitudeControl}`;
+  const automaticLanding = movementInfo.automaticLandingRequired
+    ? `; automatic ${
+        movementInfo.automaticLandingMode
+          ? formatMovementModeTitleLabel(movementInfo.automaticLandingMode)
+          : 'WiGE'
+      } landing ${movementInfo.automaticLandingDistance ?? 0}/${
+        movementInfo.automaticLandingMinimumDistance ?? 0
+      } hexes`
+    : '';
+  const primary = `${formatMovementModeTitle(movementInfo)} reachable: ${movementInfo.mpCost} MP${conversion}${altitudeControl}${automaticLanding}`;
   const options = movementInfo.movementModeOptions ?? [];
   if (options.length <= 1) return primary;
   return `${primary}; options ${options.map(formatMovementOptionTitle).join('; ')}`;
@@ -221,6 +231,18 @@ export function MovementReachBadge({
       data-movement-badge-altitude-control-altitude={
         movementInfo.altitudeControlAltitude
       }
+      data-movement-badge-automatic-landing-required={
+        movementInfo.automaticLandingRequired ? 'true' : undefined
+      }
+      data-movement-badge-automatic-landing-mode={
+        movementInfo.automaticLandingMode
+      }
+      data-movement-badge-automatic-landing-distance={
+        movementInfo.automaticLandingDistance
+      }
+      data-movement-badge-automatic-landing-minimum-distance={
+        movementInfo.automaticLandingMinimumDistance
+      }
       data-movement-badge-option-count={
         movementOptions.length > 1 ? movementOptions.length : undefined
       }
@@ -294,6 +316,11 @@ export function MovementReachBadge({
           ? movementOptionAltitudeControlsAttribute(movementOptions)
           : undefined
       }
+      data-movement-badge-option-automatic-landings={
+        movementOptions.length > 1
+          ? movementOptionAutomaticLandingsAttribute(movementOptions)
+          : undefined
+      }
     >
       <title>{title}</title>
       <rect
@@ -314,6 +341,72 @@ export function MovementReachBadge({
         fill="#ecfdf5"
       >
         {label}
+      </text>
+    </g>
+  );
+}
+
+function formatAutomaticLandingBadgeTitle(
+  movementInfo: IMovementRangeHex,
+): string {
+  const mode = movementInfo.automaticLandingMode
+    ? formatMovementModeTitleLabel(movementInfo.automaticLandingMode)
+    : 'WiGE';
+  const reason = movementInfo.automaticLandingReason
+    ? `: ${movementInfo.automaticLandingReason}`
+    : '';
+  return `Automatic ${mode} landing after ${
+    movementInfo.automaticLandingDistance ?? 0
+  }/${movementInfo.automaticLandingMinimumDistance ?? 0} hexes${reason}`;
+}
+
+export function MovementAutomaticLandingBadge({
+  x,
+  y,
+  hex,
+  movementInfo,
+}: {
+  readonly x: number;
+  readonly y: number;
+  readonly hex: IHexCoordinate;
+  readonly movementInfo?: IMovementRangeHex;
+}): React.ReactElement | null {
+  if (!movementInfo?.automaticLandingRequired) return null;
+  const title = formatAutomaticLandingBadgeTitle(movementInfo);
+  return (
+    <g
+      pointerEvents="none"
+      data-testid={`hex-automatic-landing-badge-${hex.q}-${hex.r}`}
+      aria-label={title}
+      data-automatic-landing-mode={movementInfo.automaticLandingMode}
+      data-automatic-landing-distance={movementInfo.automaticLandingDistance}
+      data-automatic-landing-minimum-distance={
+        movementInfo.automaticLandingMinimumDistance
+      }
+      data-automatic-landing-reason={movementInfo.automaticLandingReason}
+    >
+      <title>{title}</title>
+      <rect
+        x={x - 19}
+        y={y + 33}
+        width={38}
+        height={12}
+        rx={3}
+        fill="#7c2d12"
+        opacity={0.92}
+        stroke="#fed7aa"
+        strokeOpacity={0.65}
+        strokeWidth={0.7}
+      />
+      <text
+        x={x}
+        y={y + 42}
+        textAnchor="middle"
+        fontSize={8}
+        fontWeight="bold"
+        fill="#fff7ed"
+      >
+        LAND
       </text>
     </g>
   );

--- a/src/components/gameplay/HexMapDisplay/HexCell.movementBadges.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexCell.movementBadges.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 
 import type { IHexCoordinate, IMovementRangeHex } from '@/types/gameplay';
+import type { ITacticalMapProjectionSourceReference } from '@/utils/gameplay/tacticalMapProjection';
+
+import {
+  formatTacticalProjectionRuleReferences,
+  formatTacticalProjectionSourceReferences,
+} from '@/utils/gameplay/tacticalMapProjection';
 
 import {
   formatMovementModeLabel,
@@ -191,23 +197,42 @@ export function MovementReachBadge({
   y,
   hex,
   movementInfo,
+  projectionExplanation,
+  sourceReferences,
 }: {
   readonly x: number;
   readonly y: number;
   readonly hex: IHexCoordinate;
   readonly movementInfo?: IMovementRangeHex;
+  readonly projectionExplanation?: string;
+  readonly sourceReferences?: readonly ITacticalMapProjectionSourceReference[];
 }): React.ReactElement | null {
   if (!movementInfo?.reachable) return null;
   const label = formatMovementReachBadgeLabel(movementInfo);
   const title = formatMovementReachBadgeTitle(movementInfo);
   const movementOptions = movementInfo.movementModeOptions ?? [];
   const width = Math.max(34, label.length * 5.6 + 10);
+  const movementSourceReferences =
+    sourceReferences?.filter((source) => source.channel === 'movement') ?? [];
+  const movementSourceRefsAttribute =
+    formatTacticalProjectionSourceReferences(movementSourceReferences) ||
+    undefined;
+  const movementRuleRefsAttribute =
+    formatTacticalProjectionRuleReferences(movementSourceReferences) ||
+    undefined;
+  const movementProjectionChannel =
+    movementSourceReferences.length > 0 ? 'movement' : undefined;
 
   return (
     <g
       pointerEvents="none"
       data-testid={`hex-movement-badge-${hex.q}-${hex.r}`}
       aria-label={title}
+      data-tactical-projection-source={
+        movementProjectionChannel ? 'shared-tactical-map-projection' : undefined
+      }
+      data-tactical-projection-channel={movementProjectionChannel}
+      data-tactical-rules-surface={movementProjectionChannel}
       data-movement-badge-type={movementInfo.movementType}
       data-movement-badge-mode={movementInfo.movementMode}
       data-movement-badge-mp-cost={movementInfo.mpCost}
@@ -321,6 +346,9 @@ export function MovementReachBadge({
           ? movementOptionAutomaticLandingsAttribute(movementOptions)
           : undefined
       }
+      data-movement-badge-source-refs={movementSourceRefsAttribute}
+      data-movement-badge-rule-refs={movementRuleRefsAttribute}
+      data-movement-badge-projection-explanation={projectionExplanation}
     >
       <title>{title}</title>
       <rect

--- a/src/components/gameplay/HexMapDisplay/HexCell.movementOptionSummaries.ts
+++ b/src/components/gameplay/HexMapDisplay/HexCell.movementOptionSummaries.ts
@@ -111,6 +111,12 @@ function movementRangeOptionFor(
     altitudeControlRequired: movementInfo.altitudeControlRequired,
     altitudeControlMode: movementInfo.altitudeControlMode,
     altitudeControlAltitude: movementInfo.altitudeControlAltitude,
+    automaticLandingRequired: movementInfo.automaticLandingRequired,
+    automaticLandingReason: movementInfo.automaticLandingReason,
+    automaticLandingMode: movementInfo.automaticLandingMode,
+    automaticLandingDistance: movementInfo.automaticLandingDistance,
+    automaticLandingMinimumDistance:
+      movementInfo.automaticLandingMinimumDistance,
     blockedReason: movementInfo.blockedReason,
     movementInvalidReason: movementInfo.movementInvalidReason,
     movementInvalidDetails: movementInfo.movementInvalidDetails,
@@ -311,6 +317,22 @@ export function movementOptionAltitudeControlsAttribute(
   return altitudeOptions.length > 0 ? altitudeOptions.join('|') : undefined;
 }
 
+export function movementOptionAutomaticLandingsAttribute(
+  options: readonly IMovementRangeModeOption[],
+): string | undefined {
+  const automaticLandingOptions = options
+    .filter((option) => option.automaticLandingRequired)
+    .map(
+      (option) =>
+        `${option.movementType}:${option.automaticLandingMode ?? 'wige'}:${
+          option.automaticLandingDistance ?? '?'
+        }/${option.automaticLandingMinimumDistance ?? '?'}`,
+    );
+  return automaticLandingOptions.length > 0
+    ? automaticLandingOptions.join('|')
+    : undefined;
+}
+
 export function movementOptionMaxReachableHeatGenerated(
   movementInfo?: IMovementRangeHex,
 ): number | undefined {
@@ -391,6 +413,21 @@ function formatMovementOptionAltitudeControlDetail(
   return parts.length > 0 ? `, ${parts.join(', ')}` : '';
 }
 
+function formatMovementOptionAutomaticLandingDetail(
+  option: IMovementRangeModeOption,
+): string {
+  if (!option.automaticLandingRequired) return '';
+  const mode = option.automaticLandingMode
+    ? formatMovementModeTitleLabel(option.automaticLandingMode)
+    : 'WiGE';
+  const distance = option.automaticLandingDistance ?? 0;
+  const minimumDistance = option.automaticLandingMinimumDistance ?? 0;
+  const reason = option.automaticLandingReason
+    ? `: ${option.automaticLandingReason}`
+    : '';
+  return `, automatic ${mode} landing ${distance}/${minimumDistance} hexes${reason}`;
+}
+
 export function formatMovementOptionTitle(
   option: IMovementRangeModeOption,
 ): string {
@@ -402,11 +439,12 @@ export function formatMovementOptionTitle(
   const costBreakdown = formatMovementOptionCostBreakdown(option);
   const conversion = formatMovementOptionConversionDetail(option);
   const altitudeControl = formatMovementOptionAltitudeControlDetail(option);
+  const automaticLanding = formatMovementOptionAutomaticLandingDetail(option);
   const heat =
     option.heatGenerated === undefined ? '' : `, heat +${option.heatGenerated}`;
   const blockedDetail = movementOptionBlockedDetail(option);
   const blocked = option.reachable
     ? ''
     : `, blocked${blockedDetail ? `: ${blockedDetail}` : ''}`;
-  return `${option.movementType}${movementMode} ${option.reachable ? 'reachable' : 'blocked'} ${cost}${costBreakdown}${conversion}${altitudeControl}${heat}${blocked}`;
+  return `${option.movementType}${movementMode} ${option.reachable ? 'reachable' : 'blocked'} ${cost}${costBreakdown}${conversion}${altitudeControl}${automaticLanding}${heat}${blocked}`;
 }

--- a/src/components/gameplay/HexMapDisplay/HexCell.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexCell.tsx
@@ -960,7 +960,14 @@ export const HexCell = React.memo(function HexCell({
         sourceReferences={tacticalProjectionSourceReferences}
       />
       {hoverMpCost === undefined && (
-        <MovementReachBadge x={x} y={y} hex={hex} movementInfo={movementInfo} />
+        <MovementReachBadge
+          x={x}
+          y={y}
+          hex={hex}
+          movementInfo={movementInfo}
+          projectionExplanation={tacticalProjectionExplanation}
+          sourceReferences={tacticalProjectionSourceReferences}
+        />
       )}
       <MovementBlockedOptionsBadge
         x={x}

--- a/src/components/gameplay/HexMapDisplay/HexCell.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexCell.tsx
@@ -998,6 +998,8 @@ export const HexCell = React.memo(function HexCell({
         hex={hex}
         hoverMpCost={hoverMpCost}
         movementInfo={movementInfo}
+        projectionExplanation={tacticalProjectionExplanation}
+        sourceReferences={tacticalProjectionSourceReferences}
       />
       <CombatLineOfSightBlockerBadge
         x={x}

--- a/src/components/gameplay/HexMapDisplay/HexCell.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexCell.tsx
@@ -980,6 +980,8 @@ export const HexCell = React.memo(function HexCell({
         y={y}
         hex={hex}
         movementInfo={movementInfo}
+        projectionExplanation={tacticalProjectionExplanation}
+        sourceReferences={tacticalProjectionSourceReferences}
       />
       <MovementStandUpBadge x={x} y={y} hex={hex} movementInfo={movementInfo} />
       <MovementAutomaticLandingBadge

--- a/src/components/gameplay/HexMapDisplay/HexCell.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexCell.tsx
@@ -90,6 +90,8 @@ import {
   terrainBuildingConstructionFactorsAttribute,
   terrainBuildingIdsAttribute,
   terrainBuildingLevelsAttribute,
+  terrainCliffExitDirectionsAttribute,
+  terrainCliffExitLabelsAttribute,
 } from './HexMapDisplay.terrainMetadata';
 import {
   isIsometricProjection,
@@ -297,6 +299,9 @@ export const HexCell = React.memo(function HexCell({
   const terrainBuildingLevelAttribute = terrainBuildingLevelsAttribute(terrain);
   const terrainBuildingCfAttribute =
     terrainBuildingConstructionFactorsAttribute(terrain);
+  const terrainCliffExitDirections =
+    terrainCliffExitDirectionsAttribute(terrain);
+  const terrainCliffExitLabels = terrainCliffExitLabelsAttribute(terrain);
   const elevation = terrain?.elevation ?? 0;
   const elevationLabel = formatElevationLabel(elevation);
   const isIsometricTile = isIsometricProjection(projectionMode);
@@ -569,6 +574,8 @@ export const HexCell = React.memo(function HexCell({
       data-terrain-feature-levels={terrainFeatureLevelsAttribute(
         terrainFeatures,
       )}
+      data-terrain-cliff-exits={terrainCliffExitDirections}
+      data-terrain-cliff-exit-labels={terrainCliffExitLabels}
       data-terrain-building-ids={terrainBuildingIdAttribute}
       data-terrain-building-levels={terrainBuildingLevelAttribute}
       data-terrain-construction-factors={terrainBuildingCfAttribute}

--- a/src/components/gameplay/HexMapDisplay/HexCell.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexCell.tsx
@@ -60,6 +60,7 @@ import {
   terrainFeatureLevelsAttribute,
 } from './HexCell.labels';
 import {
+  MovementAutomaticLandingBadge,
   MovementPathStepBadge,
   MovementReachBadge,
   MovementStepCostBadge,
@@ -69,6 +70,7 @@ import { MovementBlockedOptionsBadge } from './HexCell.movementBlockedOptionsBad
 import {
   movementOptionAltitudeControlMpCostsAttribute,
   movementOptionAltitudeControlStepCountsAttribute,
+  movementOptionAutomaticLandingsAttribute,
   movementOptionCostsAttribute,
   movementOptionBlockedReasonsAttribute,
   movementOptionConversionMpCostsAttribute,
@@ -553,6 +555,9 @@ export const HexCell = React.memo(function HexCell({
       data-movement-option-altitude-control-mp-costs={movementOptionAltitudeControlMpCostsAttribute(
         movementOptions ?? [],
       )}
+      data-movement-option-automatic-landings={movementOptionAutomaticLandingsAttribute(
+        movementOptions ?? [],
+      )}
       data-mp-cost={movementInfo?.mpCost}
       data-terrain-cost={movementInfo?.terrainCost}
       data-heat-generated={movementInfo?.heatGenerated}
@@ -602,6 +607,19 @@ export const HexCell = React.memo(function HexCell({
       data-movement-altitude-control-mode={movementInfo?.altitudeControlMode}
       data-movement-altitude-control-altitude={
         movementInfo?.altitudeControlAltitude
+      }
+      data-movement-automatic-landing-required={
+        movementInfo?.automaticLandingRequired ? 'true' : undefined
+      }
+      data-movement-automatic-landing-mode={movementInfo?.automaticLandingMode}
+      data-movement-automatic-landing-distance={
+        movementInfo?.automaticLandingDistance
+      }
+      data-movement-automatic-landing-minimum-distance={
+        movementInfo?.automaticLandingMinimumDistance
+      }
+      data-movement-automatic-landing-reason={
+        movementInfo?.automaticLandingReason
       }
       data-path-index={pathIndex}
       data-path-step={
@@ -950,6 +968,12 @@ export const HexCell = React.memo(function HexCell({
         movementInfo={movementInfo}
       />
       <MovementStandUpBadge x={x} y={y} hex={hex} movementInfo={movementInfo} />
+      <MovementAutomaticLandingBadge
+        x={x}
+        y={y}
+        hex={hex}
+        movementInfo={movementInfo}
+      />
       <MovementPathStepBadge x={x} y={y} hex={hex} pathIndex={pathIndex} />
       <HeatBadge
         x={x}

--- a/src/components/gameplay/HexMapDisplay/HexMapDisplay.movementCostContext.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexMapDisplay.movementCostContext.tsx
@@ -8,7 +8,10 @@ import {
   formatTacticalProjectionSourceReferences,
 } from '@/utils/gameplay/tacticalMapProjection';
 
-import { formatElevationLabel } from './HexCell.labels';
+import {
+  formatElevationLabel,
+  formatMovementModeLabel,
+} from './HexCell.labels';
 import { formatMovementPathSummaryLabel } from './HexMapDisplay.tooltipFormatters';
 
 function movementSourceAttributes(
@@ -70,6 +73,8 @@ export function MovementCostContextRows({
   const hasAltitudeControlContext =
     movementInfo.altitudeControlStepCount !== undefined ||
     movementInfo.altitudeControlMpCost !== undefined;
+  const hasAutomaticLandingContext =
+    movementInfo.automaticLandingRequired === true;
   const conversionStepCount = movementInfo.conversionStepCount ?? 0;
   const conversionStepLabel =
     conversionStepCount === 1 ? '1 step' : `${conversionStepCount} steps`;
@@ -85,6 +90,7 @@ export function MovementCostContextRows({
     movementInfo.heatGenerated === undefined &&
     !hasConversionContext &&
     !hasAltitudeControlContext &&
+    !hasAutomaticLandingContext &&
     !pathSummaryLabel
   ) {
     return null;
@@ -150,6 +156,29 @@ export function MovementCostContextRows({
         >
           Altitude control: {altitudeControlStepLabel},{' '}
           {movementInfo.altitudeControlMpCost ?? 0} MP
+        </div>
+      )}
+      {hasAutomaticLandingContext && (
+        <div
+          data-testid={`${testIdPrefix}-automatic-landing`}
+          data-movement-context-kind="automatic-landing"
+          data-movement-automatic-landing-mode={
+            movementInfo.automaticLandingMode
+          }
+          data-movement-automatic-landing-distance={
+            movementInfo.automaticLandingDistance
+          }
+          data-movement-automatic-landing-minimum-distance={
+            movementInfo.automaticLandingMinimumDistance
+          }
+          data-movement-automatic-landing-reason={
+            movementInfo.automaticLandingReason
+          }
+          {...sourceAttributes}
+        >
+          Automatic {formatMovementModeLabel(movementInfo.automaticLandingMode)}{' '}
+          landing: {movementInfo.automaticLandingDistance ?? 0}/
+          {movementInfo.automaticLandingMinimumDistance ?? 0} hexes
         </div>
       )}
       {pathSummaryLabel && (

--- a/src/components/gameplay/HexMapDisplay/HexMapDisplay.movementOptionRows.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexMapDisplay.movementOptionRows.tsx
@@ -15,6 +15,7 @@ import {
   formatMovementOptionTitle,
   movementOptionAltitudeControlMpCostsAttribute,
   movementOptionAltitudeControlStepCountsAttribute,
+  movementOptionAutomaticLandingsAttribute,
   movementOptionBlockedDetail,
   movementOptionBlockedReasonsAttribute,
   movementOptionConversionMpCostsAttribute,
@@ -99,6 +100,9 @@ export function MovementModeOptionRows({
       data-movement-option-altitude-control-mp-costs={movementOptionAltitudeControlMpCostsAttribute(
         options,
       )}
+      data-movement-option-automatic-landings={movementOptionAutomaticLandingsAttribute(
+        options,
+      )}
       data-movement-option-blocked-reasons={movementOptionBlockedReasonsAttribute(
         options,
       )}
@@ -144,6 +148,21 @@ export function MovementModeOptionRows({
             }
             data-movement-option-altitude-control-mp-cost={
               option.altitudeControlMpCost
+            }
+            data-movement-option-automatic-landing-required={
+              option.automaticLandingRequired ? 'true' : undefined
+            }
+            data-movement-option-automatic-landing-mode={
+              option.automaticLandingMode
+            }
+            data-movement-option-automatic-landing-distance={
+              option.automaticLandingDistance
+            }
+            data-movement-option-automatic-landing-minimum-distance={
+              option.automaticLandingMinimumDistance
+            }
+            data-movement-option-automatic-landing-reason={
+              option.automaticLandingReason
             }
             data-movement-option-blocked-reason={blockedDetail}
             data-movement-option-invalid-reason={option.movementInvalidReason}

--- a/src/components/gameplay/HexMapDisplay/HexMapDisplay.terrainMetadata.ts
+++ b/src/components/gameplay/HexMapDisplay/HexMapDisplay.terrainMetadata.ts
@@ -1,6 +1,10 @@
 import type { IHexTerrain } from '@/types/gameplay';
 
-import { TerrainType } from '@/types/gameplay';
+import { Facing, TerrainType } from '@/types/gameplay';
+import {
+  getFacingAbbreviation,
+  getFacingName,
+} from '@/utils/gameplay/unitPosition';
 
 type TerrainFeature = IHexTerrain['features'][number];
 
@@ -70,4 +74,76 @@ export function terrainBuildingDetailLabel(
     formatTerrainBuildingDetail,
   );
   return details.length > 0 ? details.join('; ') : undefined;
+}
+
+function isFacing(value: number): value is Facing {
+  return (
+    Number.isInteger(value) &&
+    value >= Facing.North &&
+    value <= Facing.Northwest
+  );
+}
+
+export function terrainCliffExitDirectionsForFeatures(
+  features: readonly TerrainFeature[],
+): readonly Facing[] {
+  const directions = new Set<Facing>();
+  for (const feature of features) {
+    for (const direction of feature.cliffTopExits ?? []) {
+      if (isFacing(direction)) {
+        directions.add(direction);
+      }
+    }
+  }
+
+  return Array.from(directions).sort((a, b) => a - b);
+}
+
+export function terrainCliffExitDirectionsAttributeForFeatures(
+  features: readonly TerrainFeature[],
+): string | undefined {
+  const directions = terrainCliffExitDirectionsForFeatures(features);
+  return directions.length > 0 ? directions.join(',') : undefined;
+}
+
+export function terrainCliffExitLabelsAttributeForFeatures(
+  features: readonly TerrainFeature[],
+): string | undefined {
+  const directions = terrainCliffExitDirectionsForFeatures(features);
+  return directions.length > 0
+    ? directions.map(getFacingAbbreviation).join(',')
+    : undefined;
+}
+
+export function terrainCliffExitDetailLabelForFeatures(
+  features: readonly TerrainFeature[],
+): string | undefined {
+  const directions = terrainCliffExitDirectionsForFeatures(features);
+  return directions.length > 0
+    ? `Cliff edges: ${directions.map(getFacingName).join(', ')}`
+    : undefined;
+}
+
+export function terrainCliffExitDirectionsAttribute(
+  terrain: IHexTerrain | undefined,
+): string | undefined {
+  return terrain
+    ? terrainCliffExitDirectionsAttributeForFeatures(terrain.features)
+    : undefined;
+}
+
+export function terrainCliffExitLabelsAttribute(
+  terrain: IHexTerrain | undefined,
+): string | undefined {
+  return terrain
+    ? terrainCliffExitLabelsAttributeForFeatures(terrain.features)
+    : undefined;
+}
+
+export function terrainCliffExitDetailLabel(
+  terrain: IHexTerrain | undefined,
+): string | undefined {
+  return terrain
+    ? terrainCliffExitDetailLabelForFeatures(terrain.features)
+    : undefined;
 }

--- a/src/components/gameplay/HexMapDisplay/HexMapDisplay.terrainTooltip.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexMapDisplay.terrainTooltip.tsx
@@ -22,6 +22,9 @@ import {
 } from './HexCell.labels';
 import { ProjectionContextRows } from './HexMapDisplay.projectionTooltipRows';
 import {
+  terrainCliffExitDetailLabel,
+  terrainCliffExitDirectionsAttribute,
+  terrainCliffExitLabelsAttribute,
   terrainBuildingConstructionFactorsAttribute,
   terrainBuildingDetailLabel,
   terrainBuildingIdsAttribute,
@@ -55,6 +58,8 @@ function terrainElevationSourceAttributes(
     sourceReferences.length > 0
       ? TERRAIN_ELEVATION_PROJECTION_CHANNEL
       : undefined;
+  const cliffExitDirections = terrainCliffExitDirectionsAttribute(terrain);
+  const cliffExitLabels = terrainCliffExitLabelsAttribute(terrain);
 
   return {
     'data-tactical-projection-source': projectionChannel
@@ -70,6 +75,8 @@ function terrainElevationSourceAttributes(
     'data-terrain-feature-levels': terrainFeatureLevelsAttribute(
       terrain.features,
     ),
+    'data-terrain-cliff-exits': cliffExitDirections,
+    'data-terrain-cliff-exit-labels': cliffExitLabels,
     'data-elevation': terrain.elevation,
     'data-terrain-source-refs': sourceRefsAttribute,
     'data-terrain-rule-refs': ruleRefsAttribute,
@@ -137,6 +144,7 @@ export function TerrainHoverTooltip({
   const buildingCfAttribute =
     terrainBuildingConstructionFactorsAttribute(terrain);
   const buildingDetailLabel = terrainBuildingDetailLabel(terrain);
+  const cliffExitDetailLabel = terrainCliffExitDetailLabel(terrain);
   const blocksLos = terrain.features.some(
     (feature) => TERRAIN_PROPERTIES[feature.type].blocksLOS,
   );
@@ -177,6 +185,14 @@ export function TerrainHoverTooltip({
           {...sourceAttributes}
         >
           Building: {buildingDetailLabel}
+        </div>
+      )}
+      {cliffExitDetailLabel && (
+        <div
+          data-testid="hex-terrain-tooltip-cliff-exits"
+          {...sourceAttributes}
+        >
+          {cliffExitDetailLabel}
         </div>
       )}
       <div data-testid="hex-terrain-tooltip-cover">
@@ -226,6 +242,7 @@ export function TerrainContextRows({
   const buildingCfAttribute =
     terrainBuildingConstructionFactorsAttribute(terrain);
   const buildingDetailLabel = terrainBuildingDetailLabel(terrain);
+  const cliffExitDetailLabel = terrainCliffExitDetailLabel(terrain);
   const sourceAttributes = terrainElevationSourceAttributes(
     terrain,
     projection,
@@ -254,6 +271,14 @@ export function TerrainContextRows({
           {...sourceAttributes}
         >
           Building: {buildingDetailLabel}
+        </div>
+      )}
+      {cliffExitDetailLabel && (
+        <div
+          data-testid={`${testIdPrefix}-cliff-exits-context`}
+          {...sourceAttributes}
+        >
+          {cliffExitDetailLabel}
         </div>
       )}
     </div>

--- a/src/components/gameplay/HexMapDisplay/MovementCostOverlay.projection.ts
+++ b/src/components/gameplay/HexMapDisplay/MovementCostOverlay.projection.ts
@@ -4,6 +4,7 @@ import { formatMovementModeTitle } from './HexCell.movementBadges';
 import {
   movementOptionAltitudeControlMpCostsAttribute,
   movementOptionAltitudeControlStepCountsAttribute,
+  movementOptionAutomaticLandingsAttribute,
   movementOptionBlockedReasonsAttribute,
   movementOptionConversionMpCostsAttribute,
   movementOptionConversionStepCountsAttribute,
@@ -63,6 +64,13 @@ function formatMovementProjectionTitle(
       } MP`,
     );
   }
+  if (movementInfo.automaticLandingRequired) {
+    details.push(
+      `automatic ${movementInfo.automaticLandingMode ?? 'wige'} landing ${
+        movementInfo.automaticLandingDistance ?? 0
+      }/${movementInfo.automaticLandingMinimumDistance ?? 0} hexes`,
+    );
+  }
   const blockedReason =
     movementInfo.movementInvalidDetails ??
     movementInfo.blockedReason ??
@@ -115,6 +123,14 @@ export function movementProjectionOverlayAttributes(
       movementInfo?.altitudeControlStepCount,
     'data-movement-projection-altitude-control-mp-cost':
       movementInfo?.altitudeControlMpCost,
+    'data-movement-projection-automatic-landing-required':
+      movementInfo?.automaticLandingRequired ? 'true' : undefined,
+    'data-movement-projection-automatic-landing-mode':
+      movementInfo?.automaticLandingMode,
+    'data-movement-projection-automatic-landing-distance':
+      movementInfo?.automaticLandingDistance,
+    'data-movement-projection-automatic-landing-minimum-distance':
+      movementInfo?.automaticLandingMinimumDistance,
     'data-movement-projection-blocked-reason': movementInfo?.blockedReason,
     'data-movement-projection-invalid-reason':
       movementInfo?.movementInvalidReason,
@@ -149,6 +165,9 @@ export function movementProjectionOverlayAttributes(
       hasMultipleOptions
         ? movementOptionAltitudeControlMpCostsAttribute(movementOptions)
         : undefined,
+    'data-movement-projection-option-automatic-landings': hasMultipleOptions
+      ? movementOptionAutomaticLandingsAttribute(movementOptions)
+      : undefined,
     'data-movement-projection-option-blocked-reasons': hasMultipleOptions
       ? movementOptionBlockedReasonsAttribute(movementOptions)
       : undefined,

--- a/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.test.tsx
+++ b/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.test.tsx
@@ -2971,6 +2971,86 @@ describe('HexMapDisplay tactical visual layers', () => {
     });
   });
 
+  it('surfaces automatic WiGE landing consequences on reachable movement hexes', () => {
+    const reason =
+      'MegaMek automatic WiGE landing: unit moved below the minimum airborne distance';
+    const { unmount } = render(
+      <HexMapDisplay
+        mapId="map-1"
+        radius={1}
+        tokens={[]}
+        selectedHex={null}
+        movementRange={[
+          {
+            hex: { q: 1, r: 0 },
+            mpCost: 1,
+            terrainCost: 0,
+            elevationDelta: 2,
+            elevationCost: 0,
+            movementMode: 'wige',
+            reachable: true,
+            movementType: MovementType.Walk,
+            automaticLandingRequired: true,
+            automaticLandingMode: 'wige',
+            automaticLandingDistance: 1,
+            automaticLandingMinimumDistance: 5,
+            automaticLandingReason: reason,
+          },
+        ]}
+      />,
+    );
+
+    const wigeHex = screen.getByTestId('hex-1-0');
+    expect(wigeHex).toHaveAttribute(
+      'data-movement-automatic-landing-required',
+      'true',
+    );
+    expect(wigeHex).toHaveAttribute(
+      'data-movement-automatic-landing-mode',
+      'wige',
+    );
+    expect(wigeHex).toHaveAttribute(
+      'data-movement-automatic-landing-distance',
+      '1',
+    );
+    expect(wigeHex).toHaveAttribute(
+      'data-movement-automatic-landing-minimum-distance',
+      '5',
+    );
+    expect(wigeHex).toHaveAttribute(
+      'aria-label',
+      expect.stringContaining('automatic WiGE landing 1/5 hexes'),
+    );
+
+    const movementBadge = screen.getByTestId('hex-movement-badge-1-0');
+    expect(movementBadge).toHaveAttribute(
+      'aria-label',
+      expect.stringContaining('automatic WiGE landing 1/5 hexes'),
+    );
+    expect(movementBadge).toHaveAttribute(
+      'data-movement-badge-automatic-landing-required',
+      'true',
+    );
+    expect(
+      screen.getByTestId('hex-automatic-landing-badge-1-0'),
+    ).toHaveAccessibleName(`Automatic WiGE landing after 1/5 hexes: ${reason}`);
+    expect(
+      screen.getByTestId('hex-automatic-landing-badge-1-0'),
+    ).toHaveTextContent('LAND');
+
+    fireEvent.mouseEnter(wigeHex);
+    expect(
+      screen.getByTestId('hex-movement-tooltip-automatic-landing'),
+    ).toHaveTextContent('Automatic WiGE landing: 1/5 hexes');
+    expect(
+      screen.getByTestId('hex-movement-tooltip-automatic-landing'),
+    ).toHaveAttribute('data-movement-context-kind', 'automatic-landing');
+
+    act(() => {
+      unmount();
+    });
+  });
+
   it('renders jump heat impact as map metadata and a visible badge', () => {
     const { unmount } = render(
       <HexMapDisplay

--- a/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.test.tsx
+++ b/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.test.tsx
@@ -1683,7 +1683,7 @@ describe('HexMapDisplay tactical visual layers', () => {
     );
     expect(screen.getByTestId('hex-mp-badge-1-0')).toHaveAttribute(
       'aria-label',
-      'run via hover path preview: 4 MP',
+      'run via hover path preview: 4 MP; terrain +1; elevation delta +1 cost +1; heat +2',
     );
     expect(screen.getByTestId('hex-mp-badge-1-0')).toHaveAttribute(
       'data-hover-mp-cost',
@@ -1698,9 +1698,41 @@ describe('HexMapDisplay tactical visual layers', () => {
       'hover',
     );
     expect(screen.getByTestId('hex-mp-badge-1-0')).toHaveAttribute(
+      'data-movement-badge-terrain-cost',
+      '1',
+    );
+    expect(screen.getByTestId('hex-mp-badge-1-0')).toHaveAttribute(
+      'data-movement-badge-elevation-delta',
+      '1',
+    );
+    expect(screen.getByTestId('hex-mp-badge-1-0')).toHaveAttribute(
+      'data-movement-badge-elevation-cost',
+      '1',
+    );
+    expect(screen.getByTestId('hex-mp-badge-1-0')).toHaveAttribute(
       'data-movement-badge-heat-generated',
       '2',
     );
+    expect(screen.getByTestId('hex-mp-badge-1-0')).toHaveAttribute(
+      'data-tactical-projection-source',
+      'shared-tactical-map-projection',
+    );
+    expect(screen.getByTestId('hex-mp-badge-1-0')).toHaveAttribute(
+      'data-tactical-projection-channel',
+      'movement',
+    );
+    expect(
+      screen
+        .getByTestId('hex-mp-badge-1-0')
+        .getAttribute('data-movement-badge-source-refs'),
+    ).toContain(
+      'movement:megamek:MegaMek movement rules projection:run/hover projection: run via hover reachable 4 MP terrain +1 elevation delta +1 cost +1 heat +2',
+    );
+    expect(
+      screen
+        .getByTestId('hex-mp-badge-1-0')
+        .getAttribute('data-movement-badge-rule-refs'),
+    ).toContain('movement:megamek:MegaMek common/moves/MoveStep.java');
 
     act(() => {
       unmount();
@@ -1765,7 +1797,7 @@ describe('HexMapDisplay tactical visual layers', () => {
     );
     expect(screen.getByTestId('hex-mp-badge-1-0')).toHaveAttribute(
       'aria-label',
-      'run via tracked path preview: 5 MP',
+      'run via tracked path preview: 5 MP; terrain +2; elevation delta +1 cost +1; heat +2',
     );
     expect(screen.getByTestId('hex-mp-badge-1-0')).toHaveAttribute(
       'data-hover-mp-cost',
@@ -1778,6 +1810,13 @@ describe('HexMapDisplay tactical visual layers', () => {
     expect(screen.getByTestId('hex-mp-badge-1-0')).toHaveAttribute(
       'data-movement-badge-mode',
       'tracked',
+    );
+    expect(
+      screen
+        .getByTestId('hex-mp-badge-1-0')
+        .getAttribute('data-movement-badge-source-refs'),
+    ).toContain(
+      'run/tracked,walk/tracked projection: run via tracked reachable 5 MP terrain +2 elevation delta +1 cost +1 heat +2, walk via tracked reachable 3 MP terrain +2 elevation delta +1 cost +1 heat +1',
     );
 
     act(() => {

--- a/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.test.tsx
+++ b/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.test.tsx
@@ -1296,6 +1296,33 @@ describe('HexMapDisplay tactical visual layers', () => {
       'data-movement-badge-option-heats',
       'walk:0|run:2|jump:1',
     );
+    expect(badge).toHaveAttribute(
+      'data-tactical-projection-source',
+      'shared-tactical-map-projection',
+    );
+    expect(badge).toHaveAttribute(
+      'data-tactical-projection-channel',
+      'movement',
+    );
+    expect(badge).toHaveAttribute('data-tactical-rules-surface', 'movement');
+    expect(badge).toHaveAttribute(
+      'data-movement-badge-source-refs',
+      expect.stringContaining(
+        'movement:megamek:MegaMek movement rules projection:walk/tracked,run/tracked,jump projection: walk via tracked reachable 3 MP terrain +1 elevation delta +1 cost +1 heat +0, run via tracked reachable 3 MP terrain +2 elevation delta +1 cost +1 heat +2, jump reachable 1 MP terrain +0 elevation delta +2 cost +0 heat +1',
+      ),
+    );
+    expect(badge).toHaveAttribute(
+      'data-movement-badge-rule-refs',
+      expect.stringContaining(
+        'movement:megamek:MegaMek common/moves/MoveStep.java',
+      ),
+    );
+    expect(badge).toHaveAttribute(
+      'data-movement-badge-projection-explanation',
+      expect.stringContaining(
+        'movement options walk via tracked reachable 3 MP terrain +1 elevation delta +1 cost +1 heat +0',
+      ),
+    );
     expect(screen.getByTestId('hex-heat-badge-1-0')).toHaveTextContent('+2H');
     expect(screen.getByTestId('hex-heat-badge-1-0')).toHaveAttribute(
       'data-movement-option-heats',

--- a/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.test.tsx
+++ b/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.test.tsx
@@ -2718,6 +2718,32 @@ describe('HexMapDisplay tactical visual layers', () => {
       'data-movement-step-elevation-cost',
       '2',
     );
+    expect(screen.getByTestId('hex-movement-cost-badge-1-0')).toHaveAttribute(
+      'data-tactical-projection-source',
+      'shared-tactical-map-projection',
+    );
+    expect(screen.getByTestId('hex-movement-cost-badge-1-0')).toHaveAttribute(
+      'data-tactical-projection-channel',
+      'movement',
+    );
+    expect(screen.getByTestId('hex-movement-cost-badge-1-0')).toHaveAttribute(
+      'data-movement-step-source-refs',
+      expect.stringContaining(
+        'movement:megamek:MegaMek movement rules projection:walk/tracked projection: walk via tracked reachable 3 MP terrain +1 elevation delta +2 cost +2',
+      ),
+    );
+    expect(screen.getByTestId('hex-movement-cost-badge-1-0')).toHaveAttribute(
+      'data-movement-step-rule-refs',
+      expect.stringContaining(
+        'movement:megamek:MegaMek common/moves/MoveStep.java',
+      ),
+    );
+    expect(screen.getByTestId('hex-movement-cost-badge-1-0')).toHaveAttribute(
+      'data-movement-step-projection-explanation',
+      expect.stringContaining(
+        'Walk reachable 3 MP; mode tracked; terrain cost +1; elevation delta +2 cost +2',
+      ),
+    );
 
     act(() => {
       unmount();

--- a/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.terrainLabels.test.tsx
+++ b/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.terrainLabels.test.tsx
@@ -405,6 +405,73 @@ describe('HexMapDisplay terrain and elevation labels', () => {
     });
   });
 
+  it('surfaces represented cliff exits in hex labels and terrain hover context', () => {
+    const cliffTerrain: IHexTerrain = {
+      coordinate: { q: 1, r: 0 },
+      elevation: 2,
+      features: [
+        {
+          type: TerrainType.Rough,
+          level: 1,
+          cliffTopExits: [Facing.North, Facing.Southeast],
+        },
+      ],
+    };
+
+    const { unmount } = render(
+      <HexMapDisplay
+        mapId="cliff-exit-terrain-labels"
+        radius={1}
+        tokens={[]}
+        selectedHex={null}
+        hexTerrain={[cliffTerrain]}
+      />,
+    );
+
+    const cliffHex = screen.getByTestId('hex-1-0');
+    expect(cliffHex).toHaveAttribute(
+      'aria-label',
+      expect.stringContaining('terrain rough L1 cliff edges N,SE'),
+    );
+    expect(cliffHex).toHaveAttribute('data-terrain-cliff-exits', '0,2');
+    expect(cliffHex).toHaveAttribute('data-terrain-cliff-exit-labels', 'N,SE');
+    expect(cliffHex).toHaveAttribute(
+      'data-tactical-projection-sources',
+      expect.stringContaining(
+        'terrain-elevation:mekstation:Rendered map terrain/elevation grid:rough level 1 cliff edges N/SE elevation 2',
+      ),
+    );
+
+    const terrainBadge = screen.getByTestId('hex-terrain-label-1-0');
+    expect(terrainBadge).toHaveAttribute(
+      'aria-label',
+      expect.stringContaining('Terrain rough L1 cliff edges N,SE'),
+    );
+    expect(terrainBadge).toHaveAttribute('data-terrain-cliff-exits', '0,2');
+    expect(terrainBadge).toHaveAttribute(
+      'data-terrain-cliff-exit-labels',
+      'N,SE',
+    );
+
+    fireEvent.mouseEnter(cliffHex);
+
+    const cliffContext = screen.getByTestId('hex-terrain-tooltip-cliff-exits');
+    expect(cliffContext).toHaveTextContent('Cliff edges: North, Southeast');
+    expect(cliffContext).toHaveAttribute('data-terrain-cliff-exits', '0,2');
+    expect(cliffContext).toHaveAttribute(
+      'data-terrain-cliff-exit-labels',
+      'N,SE',
+    );
+    expect(cliffContext).toHaveAttribute(
+      'data-terrain-source-refs',
+      expect.stringContaining('rough level 1 cliff edges N/SE elevation 2'),
+    );
+
+    act(() => {
+      unmount();
+    });
+  });
+
   it('renders represented building levels as isometric stack layers on flat terrain', () => {
     const flatBuilding: IHexTerrain = {
       coordinate: { q: 1, r: 0 },

--- a/src/engine/InteractiveSession.actions.ts
+++ b/src/engine/InteractiveSession.actions.ts
@@ -96,6 +96,7 @@ import {
   validateCommittedMovement,
 } from '@/utils/gameplay/movement';
 import { pendingAltitudeControlMovementCost } from '@/utils/gameplay/movement/altitudeControlAccounting';
+import { automaticWigeLandingRuntimePatch } from '@/utils/gameplay/movement/automaticWigeLanding';
 import { pendingConversionMovementCost } from '@/utils/gameplay/movement/conversionAccounting';
 import { getWeaponRangeBracket } from '@/utils/gameplay/range';
 import {
@@ -370,6 +371,24 @@ export function applyInteractiveSessionMovement(
       altitudeControlMpCost: pendingAltitudeControl.mpCost,
     },
   );
+  const automaticLandingPatch = automaticWigeLandingRuntimePatch(
+    unit,
+    input.movementType,
+    validation.path,
+    input.to,
+  );
+  if (automaticLandingPatch) {
+    session = appendEvent(
+      session,
+      createRuntimeMovementStateChangedEvent(
+        session.id,
+        session.events.length,
+        session.currentState.turn,
+        input.unitId,
+        automaticLandingPatch,
+      ),
+    );
+  }
   session = lockMovement(session, input.unitId);
   return session;
 }

--- a/src/engine/InteractiveSession.actions.ts
+++ b/src/engine/InteractiveSession.actions.ts
@@ -376,6 +376,7 @@ export function applyInteractiveSessionMovement(
     input.movementType,
     validation.path,
     input.to,
+    { movementMode: movementCapability?.movementMode },
   );
   if (automaticLandingPatch) {
     session = appendEvent(

--- a/src/engine/__tests__/InteractiveSession.movement.scenario.test.ts
+++ b/src/engine/__tests__/InteractiveSession.movement.scenario.test.ts
@@ -20,9 +20,12 @@ import {
   type IGameUnit,
   type IMovementDeclaredPayload,
   type IMovementInvalidPayload,
+  type IRuntimeMovementStateChangedPayload,
   type IUnitStoodPayload,
 } from '@/types/gameplay';
 import { TerrainType } from '@/types/gameplay/TerrainTypes';
+import { GroundMotionType } from '@/types/unit/BaseUnitInterfaces';
+import { UnitType } from '@/types/unit/BattleMechInterfaces';
 import {
   advancePhase,
   createGameSession,
@@ -56,7 +59,11 @@ function makeGrid(): IHexGrid {
   return { config: { radius: 6 }, hexes };
 }
 
-function makeUnit(id: string, side: GameSide): IGameUnit {
+function makeUnit(
+  id: string,
+  side: GameSide,
+  overrides: Partial<IGameUnit> = {},
+): IGameUnit {
   return {
     id,
     name: id,
@@ -65,10 +72,13 @@ function makeUnit(id: string, side: GameSide): IGameUnit {
     pilotRef: `${id}-pilot`,
     gunnery: 4,
     piloting: 5,
+    ...overrides,
   };
 }
 
-function setupSessionAtMovement(): IGameSession {
+function setupSessionAtMovement(
+  m1Overrides: Partial<IGameUnit> = {},
+): IGameSession {
   let session = createGameSession(
     {
       mapRadius: 6,
@@ -76,7 +86,10 @@ function setupSessionAtMovement(): IGameSession {
       victoryConditions: ['elimination'],
       optionalRules: [],
     } as never,
-    [makeUnit('m1', GameSide.Player), makeUnit('blocker', GameSide.Opponent)],
+    [
+      makeUnit('m1', GameSide.Player, m1Overrides),
+      makeUnit('blocker', GameSide.Opponent),
+    ],
   );
   session = startGame(session, GameSide.Player);
   session = advancePhase(session);
@@ -110,6 +123,55 @@ function fixed2d6(total: number) {
 }
 
 describe('applyInteractiveSessionMovement', () => {
+  it('auto-lands short positive-altitude WiGE movement after declaration', () => {
+    const session = setupSessionAtMovement({
+      unitType: UnitType.VEHICLE,
+      movementMode: 'wige',
+      vehicleInit: {
+        motionType: GroundMotionType.WIGE,
+        originalCruiseMP: 4,
+        armor: {},
+        structure: {},
+        altitude: 2,
+      },
+    });
+    const result = applyInteractiveSessionMovement({
+      session,
+      grid: makeGrid(),
+      movementByUnit: capability({ walkMP: 4, runMP: 6, movementMode: 'wige' }),
+      unitId: 'm1',
+      to: { q: 0, r: 1 },
+      facing: Facing.Northeast,
+      movementType: MovementType.Walk,
+      path: [
+        { q: 0, r: 0 },
+        { q: 0, r: 1 },
+      ],
+    });
+
+    const appended = result.events.slice(session.events.length);
+    expect(appended.map((event) => event.type)).toEqual([
+      GameEventType.MovementDeclared,
+      GameEventType.RuntimeMovementStateChanged,
+      GameEventType.MovementLocked,
+    ]);
+    expect(
+      appended[1].payload as IRuntimeMovementStateChangedPayload,
+    ).toMatchObject({
+      unitId: 'm1',
+      source: 'automatic_wige_landing',
+      vehicleAltitude: 0,
+    });
+    expect(result.currentState.units.m1).toMatchObject({
+      position: { q: 0, r: 1 },
+      lockState: LockState.Locked,
+      combatState: {
+        kind: 'vehicle',
+        state: { altitude: 0, motionType: GroundMotionType.WIGE },
+      },
+    });
+  });
+
   it('rejects an occupied destination before declaring or locking movement', () => {
     const session = setupSessionAtMovement();
     const result = applyInteractiveSessionMovement({

--- a/src/lib/parsers/megaMekBoard.ts
+++ b/src/lib/parsers/megaMekBoard.ts
@@ -51,6 +51,7 @@ function parseMegaMekBoardCoordinate(
   coordStr: string,
   width: number,
   height: number,
+  hexIndex: number,
 ): { col: number; row: number } {
   if (!/^\d{4,}$/.test(coordStr)) {
     throw new Error('Invalid hex coordinate');
@@ -76,11 +77,25 @@ function parseMegaMekBoardCoordinate(
     candidates.push({ col, row });
   }
 
-  if (candidates.length !== 1) {
-    throw new Error('Invalid hex coordinate');
+  if (candidates.length === 1) {
+    return candidates[0];
   }
 
-  return candidates[0];
+  const rowOrderCoordinate = {
+    col: (hexIndex % width) + 1,
+    row: Math.floor(hexIndex / width) + 1,
+  };
+  const rowOrderCandidate = candidates.find(
+    (candidate) =>
+      candidate.col === rowOrderCoordinate.col &&
+      candidate.row === rowOrderCoordinate.row,
+  );
+
+  if (rowOrderCandidate) {
+    return rowOrderCandidate;
+  }
+
+  throw new Error('Invalid hex coordinate');
 }
 
 function parseTerrainString(terrainStr: string): {
@@ -252,7 +267,12 @@ export function parseMegaMekBoard(content: string): ParsedBoard {
       const elevationStr = parts[1];
       const terrainStr = parts.slice(2).join(' ');
 
-      const { col, row } = parseMegaMekBoardCoordinate(coordStr, width, height);
+      const { col, row } = parseMegaMekBoardCoordinate(
+        coordStr,
+        width,
+        height,
+        hexes.length,
+      );
       const elevation = parseInt(elevationStr, 10);
 
       if (isNaN(elevation)) {

--- a/src/lib/parsers/megaMekBoard.ts
+++ b/src/lib/parsers/megaMekBoard.ts
@@ -43,6 +43,46 @@ function convertOffsetToAxial(
   return { q, r };
 }
 
+function formatMegaMekBoardCoordinatePart(value: number): string {
+  return value < 10 ? `0${value}` : `${value}`;
+}
+
+function parseMegaMekBoardCoordinate(
+  coordStr: string,
+  width: number,
+  height: number,
+): { col: number; row: number } {
+  if (!/^\d{4,}$/.test(coordStr)) {
+    throw new Error('Invalid hex coordinate');
+  }
+
+  const candidates: Array<{ col: number; row: number }> = [];
+
+  for (let splitIndex = 2; splitIndex <= coordStr.length - 2; splitIndex++) {
+    const col = parseInt(coordStr.slice(0, splitIndex), 10);
+    const row = parseInt(coordStr.slice(splitIndex), 10);
+
+    if (
+      col < 1 ||
+      col > width ||
+      row < 1 ||
+      row > height ||
+      `${formatMegaMekBoardCoordinatePart(col)}${formatMegaMekBoardCoordinatePart(row)}` !==
+        coordStr
+    ) {
+      continue;
+    }
+
+    candidates.push({ col, row });
+  }
+
+  if (candidates.length !== 1) {
+    throw new Error('Invalid hex coordinate');
+  }
+
+  return candidates[0];
+}
+
 function parseTerrainString(terrainStr: string): {
   features: ITerrainFeature[];
   buildingCF?: number;
@@ -212,12 +252,7 @@ export function parseMegaMekBoard(content: string): ParsedBoard {
       const elevationStr = parts[1];
       const terrainStr = parts.slice(2).join(' ');
 
-      if (!/^\d{4}$/.test(coordStr)) {
-        throw new Error('Invalid hex coordinate');
-      }
-
-      const col = parseInt(coordStr.substring(0, 2), 10);
-      const row = parseInt(coordStr.substring(2, 4), 10);
+      const { col, row } = parseMegaMekBoardCoordinate(coordStr, width, height);
       const elevation = parseInt(elevationStr, 10);
 
       if (isNaN(elevation)) {

--- a/src/lib/parsers/megaMekBoard.ts
+++ b/src/lib/parsers/megaMekBoard.ts
@@ -3,12 +3,17 @@ import type {
   ITerrainFeature,
 } from '@/types/gameplay/TerrainTypes';
 
+import { AXIAL_DIRECTION_DELTAS } from '@/types/gameplay';
 import { TerrainType } from '@/types/gameplay/TerrainTypes';
 
 export interface ParsedBoard {
   width: number;
   height: number;
   hexes: IHexTerrain[];
+}
+
+interface ParsedHexTerrain extends IHexTerrain {
+  readonly cliffTopExitMask?: number;
 }
 
 const TERRAIN_MAP: Record<string, (level: number) => TerrainType | null> = {
@@ -27,6 +32,8 @@ const TERRAIN_MAP: Record<string, (level: number) => TerrainType | null> = {
   swamp: () => TerrainType.Swamp,
 };
 
+const CLIFF_TOP_TERRAIN = 'cliff_top';
+
 function convertOffsetToAxial(
   col: number,
   row: number,
@@ -39,12 +46,14 @@ function convertOffsetToAxial(
 function parseTerrainString(terrainStr: string): {
   features: ITerrainFeature[];
   buildingCF?: number;
+  cliffTopExitMask?: number;
 } {
   if (!terrainStr || terrainStr === '""' || terrainStr === '') {
     return { features: [] };
   }
 
-  const cleaned = terrainStr.replace(/^"|"$/g, '');
+  const cleaned =
+    terrainStr.match(/^"([^"]*)"/)?.[1] ?? terrainStr.replace(/^"|"$/g, '');
   if (!cleaned) {
     return { features: [] };
   }
@@ -52,12 +61,21 @@ function parseTerrainString(terrainStr: string): {
   const parts = cleaned.split(';');
   const features: ITerrainFeature[] = [];
   let buildingCF: number | undefined;
+  let cliffTopExitMask: number | undefined;
 
   for (const part of parts) {
-    const [terrainType, levelStr] = part.split(':');
+    const [terrainType, levelStr, exitMaskStr] = part.split(':');
 
     if (terrainType === 'bldg_cf') {
       buildingCF = parseInt(levelStr, 10);
+      continue;
+    }
+
+    if (terrainType === CLIFF_TOP_TERRAIN) {
+      const parsedExitMask = parseInt(exitMaskStr ?? '', 10);
+      if (!isNaN(parsedExitMask)) {
+        cliffTopExitMask = parsedExitMask;
+      }
       continue;
     }
 
@@ -79,7 +97,75 @@ function parseTerrainString(terrainStr: string): {
     features.push({ type, level });
   }
 
-  return { features, buildingCF };
+  return { features, buildingCF, cliffTopExitMask };
+}
+
+function coordinateKey(coordinate: { q: number; r: number }): string {
+  return `${coordinate.q},${coordinate.r}`;
+}
+
+function exitMaskToDirections(exitMask: number): number[] {
+  const directions: number[] = [];
+  for (
+    let direction = 0;
+    direction < AXIAL_DIRECTION_DELTAS.length;
+    direction++
+  ) {
+    if ((exitMask & (1 << direction)) !== 0) {
+      directions.push(direction);
+    }
+  }
+  return directions;
+}
+
+function validCliffTopDirections(
+  hex: ParsedHexTerrain,
+  byCoordinate: ReadonlyMap<string, ParsedHexTerrain>,
+): readonly number[] {
+  if (!hex.cliffTopExitMask) return [];
+
+  return exitMaskToDirections(hex.cliffTopExitMask).filter((direction) => {
+    const delta = AXIAL_DIRECTION_DELTAS[direction];
+    const neighbor = byCoordinate.get(
+      coordinateKey({
+        q: hex.coordinate.q + delta.q,
+        r: hex.coordinate.r + delta.r,
+      }),
+    );
+    if (!neighbor) return false;
+
+    const elevationDrop = hex.elevation - neighbor.elevation;
+    return elevationDrop === 1 || elevationDrop === 2;
+  });
+}
+
+function applyCliffTopExits(hexes: readonly ParsedHexTerrain[]): IHexTerrain[] {
+  const byCoordinate = new Map<string, ParsedHexTerrain>(
+    hexes.map((hex) => [coordinateKey(hex.coordinate), hex]),
+  );
+
+  return hexes.map((hex) => {
+    const cliffTopExits = validCliffTopDirections(hex, byCoordinate);
+    if (cliffTopExits.length === 0) {
+      return {
+        coordinate: hex.coordinate,
+        elevation: hex.elevation,
+        features: hex.features,
+      };
+    }
+
+    const [firstFeature, ...remainingFeatures] = hex.features;
+    const featureWithCliffExits: ITerrainFeature = {
+      ...(firstFeature ?? { type: TerrainType.Clear, level: 0 }),
+      cliffTopExits,
+    };
+
+    return {
+      coordinate: hex.coordinate,
+      elevation: hex.elevation,
+      features: [featureWithCliffExits, ...remainingFeatures],
+    };
+  });
 }
 
 export function parseMegaMekBoard(content: string): ParsedBoard {
@@ -87,7 +173,7 @@ export function parseMegaMekBoard(content: string): ParsedBoard {
 
   let width = 0;
   let height = 0;
-  const hexes: IHexTerrain[] = [];
+  const hexes: ParsedHexTerrain[] = [];
   let foundSize = false;
 
   for (const line of lines) {
@@ -139,7 +225,8 @@ export function parseMegaMekBoard(content: string): ParsedBoard {
       }
 
       const coordinate = convertOffsetToAxial(col, row);
-      const { features, buildingCF } = parseTerrainString(terrainStr);
+      const { features, buildingCF, cliffTopExitMask } =
+        parseTerrainString(terrainStr);
 
       if (buildingCF !== undefined) {
         const buildingFeature = features.find(
@@ -158,6 +245,7 @@ export function parseMegaMekBoard(content: string): ParsedBoard {
         coordinate,
         elevation,
         features,
+        cliffTopExitMask,
       });
     }
   }
@@ -166,5 +254,5 @@ export function parseMegaMekBoard(content: string): ParsedBoard {
     throw new Error('Missing size declaration');
   }
 
-  return { width, height, hexes };
+  return { width, height, hexes: applyCliffTopExits(hexes) };
 }

--- a/src/types/gameplay/GameSessionMovementEvents.ts
+++ b/src/types/gameplay/GameSessionMovementEvents.ts
@@ -307,6 +307,7 @@ export interface IRuntimeMovementStateChangedPayload {
   readonly source:
     | 'conversion_action'
     | 'altitude_control_action'
+    | 'automatic_wige_landing'
     | 'infantry_mount_action'
     | 'scenario_setup'
     | 'rules_correction';

--- a/src/types/gameplay/GameplayUIInterfaces.ts
+++ b/src/types/gameplay/GameplayUIInterfaces.ts
@@ -471,6 +471,16 @@ export interface IMovementRangeModeOption {
   readonly altitudeControlMode?: 'vtol' | 'wige';
   /** Represented altitude that triggered altitude-control ownership. */
   readonly altitudeControlAltitude?: number;
+  /** True when source-backed WiGE rules will force a landing after this move. */
+  readonly automaticLandingRequired?: boolean;
+  /** Player-facing reason for the automatic landing consequence. */
+  readonly automaticLandingReason?: string;
+  /** Motive mode whose automatic landing rule owns this consequence. */
+  readonly automaticLandingMode?: 'wige';
+  /** Hexes moved for the automatic landing minimum-distance check. */
+  readonly automaticLandingDistance?: number;
+  /** Minimum hex distance needed to remain airborne for this unit. */
+  readonly automaticLandingMinimumDistance?: number;
   /** True when a hull-down unit must leave hull-down before this option. */
   readonly hullDownExitRequired?: boolean;
   /** MP reserved for leaving hull-down before entering this option's path. */
@@ -518,6 +528,16 @@ export interface IMovementRangeHex {
   readonly altitudeControlMode?: 'vtol' | 'wige';
   /** Represented altitude that triggered altitude-control ownership. */
   readonly altitudeControlAltitude?: number;
+  /** True when source-backed WiGE rules will force a landing after this move. */
+  readonly automaticLandingRequired?: boolean;
+  /** Player-facing reason for the automatic landing consequence. */
+  readonly automaticLandingReason?: string;
+  /** Motive mode whose automatic landing rule owns this consequence. */
+  readonly automaticLandingMode?: 'wige';
+  /** Hexes moved for the automatic landing minimum-distance check. */
+  readonly automaticLandingDistance?: number;
+  /** Minimum hex distance needed to remain airborne for this unit. */
+  readonly automaticLandingMinimumDistance?: number;
   /** True when a hull-down unit must leave hull-down before this movement can resolve. */
   readonly hullDownExitRequired?: boolean;
   /** MP reserved for leaving hull-down before entering the projected path. */

--- a/src/types/gameplay/TerrainTypes.ts
+++ b/src/types/gameplay/TerrainTypes.ts
@@ -68,6 +68,12 @@ export interface ITerrainFeature {
 
   /** Whether water/ice is frozen */
   readonly isFrozen?: boolean;
+
+  /**
+   * For MegaMek-style cliff-top edge metadata: Facing numeric directions
+   * from this hex toward adjacent lower hexes where the cliff edge exists.
+   */
+  readonly cliffTopExits?: readonly number[];
 }
 
 /**

--- a/src/utils/gameplay/__tests__/tacticalMapProjection.test.ts
+++ b/src/utils/gameplay/__tests__/tacticalMapProjection.test.ts
@@ -162,7 +162,8 @@ describe('tacticalMapProjection', () => {
         channel: 'movement',
         kind: 'megamek',
         label: 'MegaMek movement rules projection',
-        detail: 'walk projection',
+        detail:
+          'walk projection: walk reachable 2 MP terrain +1 elevation delta +1 cost +1',
         ruleReferences: MOVEMENT_RULE_REFERENCES,
       },
       {
@@ -176,7 +177,7 @@ describe('tacticalMapProjection', () => {
     expect(
       formatTacticalProjectionSourceReferences(projection.sourceReferences),
     ).toBe(
-      'terrain-elevation:mekstation:Rendered map terrain/elevation grid:rough level 1 elevation 2|movement:megamek:MegaMek movement rules projection:walk projection|combat:megamek:MegaMek combat target projection:target short 1 hexes LOS clear',
+      'terrain-elevation:mekstation:Rendered map terrain/elevation grid:rough level 1 elevation 2|movement:megamek:MegaMek movement rules projection:walk projection: walk reachable 2 MP terrain +1 elevation delta +1 cost +1|combat:megamek:MegaMek combat target projection:target short 1 hexes LOS clear',
     );
     expect(
       formatTacticalProjectionRuleReferences(projection.sourceReferences),
@@ -406,6 +407,20 @@ describe('tacticalMapProjection', () => {
     );
     expect(projection.explanation).toContain(
       'blocked Jump elevation rise of 4 exceeds jump MP 3; TerrainBlocked',
+    );
+    expect(projection.sourceReferences).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          channel: 'movement',
+          detail:
+            'walk/tracked,run/tracked,jump projection: walk via tracked reachable 3 MP heat +0, run via tracked reachable 3 MP heat +2, jump blocked 4 MP heat +1: Jump elevation rise of 4 exceeds jump MP 3',
+        }),
+      ]),
+    );
+    expect(
+      formatTacticalProjectionSourceReferences(projection.sourceReferences),
+    ).toContain(
+      'movement:megamek:MegaMek movement rules projection:walk/tracked,run/tracked,jump projection: walk via tracked reachable 3 MP heat +0, run via tracked reachable 3 MP heat +2, jump blocked 4 MP heat +1: Jump elevation rise of 4 exceeds jump MP 3',
     );
   });
 

--- a/src/utils/gameplay/gameState/__tests__/runtimeMovementState.test.ts
+++ b/src/utils/gameplay/gameState/__tests__/runtimeMovementState.test.ts
@@ -26,7 +26,6 @@ import { validateCommittedMovement } from '@/utils/gameplay/movement/commitValid
 import { deriveMovementRangeHexForDestination } from '@/utils/gameplay/movement/reachable';
 import {
   AIRBORNE_LAM_AIRMEK_GROUND_MOVEMENT_BLOCKED_REASON,
-  AIRBORNE_WIGE_GROUND_MOVEMENT_BLOCKED_REASON,
   runtimeMovementAltitudeControlContext,
   runtimeMovementProjectionBlockedReason,
 } from '@/utils/gameplay/movement/runtimeCapability';
@@ -188,7 +187,7 @@ describe('runtime movement state events', () => {
 
     expect(
       runtimeMovementProjectionBlockedReason(unit, capability, 'wige'),
-    ).toBe(AIRBORNE_WIGE_GROUND_MOVEMENT_BLOCKED_REASON);
+    ).toBeUndefined();
     expect(runtimeMovementAltitudeControlContext(unit)).toMatchObject({
       altitudeControlMode: 'wige',
       altitudeControlAltitude: 1,
@@ -289,7 +288,7 @@ describe('runtime movement state events', () => {
 
     expect(
       runtimeMovementProjectionBlockedReason(unit, capability, 'wige'),
-    ).toBe(AIRBORNE_WIGE_GROUND_MOVEMENT_BLOCKED_REASON);
+    ).toBeUndefined();
     expect(runtimeMovementAltitudeControlContext(unit)).toMatchObject({
       altitudeControlMode: 'wige',
       altitudeControlAltitude: 1,
@@ -352,7 +351,7 @@ describe('runtime movement state events', () => {
 
     expect(
       runtimeMovementProjectionBlockedReason(unit, capability, 'wige'),
-    ).toBe(AIRBORNE_LAM_AIRMEK_GROUND_MOVEMENT_BLOCKED_REASON);
+    ).toBeUndefined();
     expect(runtimeMovementAltitudeControlContext(unit)).toMatchObject({
       altitudeControlMode: 'wige',
       altitudeControlAltitude: 1,

--- a/src/utils/gameplay/movement/__tests__/automaticWigeLanding.test.ts
+++ b/src/utils/gameplay/movement/__tests__/automaticWigeLanding.test.ts
@@ -110,6 +110,91 @@ describe('automatic WiGE landing', () => {
     ).toBeUndefined();
   });
 
+  it('counts represented hexes already moved this turn', () => {
+    const unit = unitState({
+      hexesMovedThisTurn: 3,
+      combatState: {
+        kind: 'vehicle',
+        state: createVehicleCombatState({
+          unitId: 'unit',
+          motionType: GroundMotionType.WIGE,
+          originalCruiseMP: 5,
+          armor: {},
+          structure: {},
+          altitude: 2,
+        }),
+      },
+    });
+    const twoHexPath = [
+      { q: 0, r: 0 },
+      { q: 1, r: 0 },
+      { q: 2, r: 0 },
+    ];
+
+    expect(
+      automaticWigeLandingContext(unit, MovementType.Walk, twoHexPath, {
+        q: 2,
+        r: 0,
+      }),
+    ).toBeUndefined();
+    expect(
+      automaticWigeLandingContext(
+        { ...unit, hexesMovedThisTurn: 2 },
+        MovementType.Walk,
+        twoHexPath,
+        { q: 2, r: 0 },
+      ),
+    ).toMatchObject({
+      automaticLandingDistance: 4,
+      automaticLandingMinimumDistance: 5,
+    });
+  });
+
+  it('preserves represented hover movement exemptions', () => {
+    const unit = unitState({
+      combatState: {
+        kind: 'proto',
+        state: createProtoMechCombatState({
+          unitId: 'unit',
+          chassisType: ProtoChassis.GLIDER,
+          hasMainGun: false,
+          armorByLocation: {},
+          structureByLocation: {},
+          altitude: 1,
+        }),
+      },
+    });
+    const destination = { q: 1, r: 0 };
+
+    expect(
+      automaticWigeLandingContext(
+        unit,
+        MovementType.Walk,
+        undefined,
+        destination,
+        { movementMode: 'hover' },
+      ),
+    ).toBeUndefined();
+    expect(
+      automaticWigeLandingRuntimePatch(
+        unit,
+        MovementType.Walk,
+        undefined,
+        destination,
+        { movementMode: 'hover' },
+      ),
+    ).toBeUndefined();
+    expect(
+      automaticWigeLandingRuntimePatch(
+        unit,
+        MovementType.Walk,
+        undefined,
+        destination,
+        { movementMode: 'wige' },
+      ),
+    ).toEqual({ source: 'automatic_wige_landing', protoAltitude: 0 });
+  });
+
   it('preserves jump and represented altitude-control exemptions', () => {
     const unit = unitState({
       pendingAltitudeControlStepCount: 1,

--- a/src/utils/gameplay/movement/__tests__/automaticWigeLanding.test.ts
+++ b/src/utils/gameplay/movement/__tests__/automaticWigeLanding.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from '@jest/globals';
+
+import {
+  Facing,
+  GameSide,
+  LockState,
+  MovementType,
+  type IUnitGameState,
+} from '@/types/gameplay';
+import { GroundMotionType } from '@/types/unit/BaseUnitInterfaces';
+import { ProtoChassis } from '@/types/unit/ProtoMechInterfaces';
+import {
+  automaticWigeLandingContext,
+  automaticWigeLandingRuntimePatch,
+} from '@/utils/gameplay/movement/automaticWigeLanding';
+import { createProtoMechCombatState } from '@/utils/gameplay/protomech/state';
+import { createVehicleCombatState } from '@/utils/gameplay/vehicleDamage';
+
+function unitState(overrides: Partial<IUnitGameState> = {}): IUnitGameState {
+  return {
+    id: 'unit',
+    side: GameSide.Player,
+    position: { q: 0, r: 0 },
+    facing: Facing.North,
+    heat: 0,
+    movementThisTurn: MovementType.Stationary,
+    hexesMovedThisTurn: 0,
+    armor: {},
+    structure: {},
+    destroyedLocations: [],
+    destroyedEquipment: [],
+    ammo: {},
+    pilotWounds: 0,
+    pilotConscious: true,
+    destroyed: false,
+    lockState: LockState.Pending,
+    ...overrides,
+  };
+}
+
+describe('automatic WiGE landing', () => {
+  it('projects and patches short positive-altitude WiGE vehicle movement', () => {
+    const unit = unitState({
+      combatState: {
+        kind: 'vehicle',
+        state: createVehicleCombatState({
+          unitId: 'unit',
+          motionType: GroundMotionType.WIGE,
+          originalCruiseMP: 5,
+          armor: {},
+          structure: {},
+          altitude: 2,
+        }),
+      },
+    });
+    const path = [
+      { q: 0, r: 0 },
+      { q: 1, r: 0 },
+      { q: 2, r: 0 },
+    ];
+
+    expect(
+      automaticWigeLandingContext(unit, MovementType.Walk, path, {
+        q: 2,
+        r: 0,
+      }),
+    ).toMatchObject({
+      automaticLandingRequired: true,
+      automaticLandingMode: 'wige',
+      automaticLandingDistance: 2,
+      automaticLandingMinimumDistance: 5,
+    });
+    expect(
+      automaticWigeLandingRuntimePatch(unit, MovementType.Walk, path, {
+        q: 2,
+        r: 0,
+      }),
+    ).toEqual({ source: 'automatic_wige_landing', vehicleAltitude: 0 });
+  });
+
+  it('uses the Glider ProtoMek four-hex threshold', () => {
+    const unit = unitState({
+      combatState: {
+        kind: 'proto',
+        state: createProtoMechCombatState({
+          unitId: 'unit',
+          chassisType: ProtoChassis.GLIDER,
+          hasMainGun: false,
+          armorByLocation: {},
+          structureByLocation: {},
+          altitude: 1,
+        }),
+      },
+    });
+
+    expect(
+      automaticWigeLandingContext(unit, MovementType.Walk, undefined, {
+        q: 3,
+        r: 0,
+      }),
+    ).toMatchObject({
+      automaticLandingDistance: 3,
+      automaticLandingMinimumDistance: 4,
+    });
+    expect(
+      automaticWigeLandingContext(unit, MovementType.Walk, undefined, {
+        q: 4,
+        r: 0,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('preserves jump and represented altitude-control exemptions', () => {
+    const unit = unitState({
+      pendingAltitudeControlStepCount: 1,
+      combatState: {
+        kind: 'vehicle',
+        state: createVehicleCombatState({
+          unitId: 'unit',
+          motionType: GroundMotionType.WIGE,
+          originalCruiseMP: 5,
+          armor: {},
+          structure: {},
+          altitude: 1,
+        }),
+      },
+    });
+    const destination = { q: 1, r: 0 };
+
+    expect(
+      automaticWigeLandingContext(
+        { ...unit, pendingAltitudeControlStepCount: undefined },
+        MovementType.Jump,
+        undefined,
+        destination,
+      ),
+    ).toBeUndefined();
+    expect(
+      automaticWigeLandingContext(
+        unit,
+        MovementType.Walk,
+        undefined,
+        destination,
+      ),
+    ).toBeUndefined();
+  });
+
+  it('patches represented LAM AirMek WiGE elevation', () => {
+    const unit = unitState({
+      conversionMode: 'airmek',
+      lamAirMekAltitude: 2,
+    });
+
+    expect(
+      automaticWigeLandingRuntimePatch(unit, MovementType.Walk, undefined, {
+        q: 1,
+        r: 0,
+      }),
+    ).toEqual({ source: 'automatic_wige_landing', lamAirMekAltitude: 0 });
+  });
+});

--- a/src/utils/gameplay/movement/__tests__/reachable.test.ts
+++ b/src/utils/gameplay/movement/__tests__/reachable.test.ts
@@ -2182,6 +2182,136 @@ describe('deriveReachableHexes', () => {
     });
   });
 
+  it('uses explicit directional cliff metadata for WiGE and vehicle ascent projection', () => {
+    let grid = createHexGrid({ radius: 3 });
+    grid = setHex(grid, { q: 0, r: 0 }, TerrainType.Clear, 0);
+    grid = setHex(grid, { q: -1, r: 0 }, TerrainType.Clear, 1);
+    grid = setHex(
+      grid,
+      { q: 1, r: 0 },
+      terrainStringFromFeatures([
+        {
+          type: TerrainType.Clear,
+          level: 0,
+          cliffTopExits: [
+            Facing.North,
+            Facing.Northeast,
+            Facing.Southeast,
+            Facing.South,
+            Facing.Southwest,
+            Facing.Northwest,
+          ],
+        },
+      ]),
+      1,
+    );
+    const unit = makeUnitAtOrigin();
+
+    const ordinaryTrackedRise = deriveMovementRangeHexForDestination(
+      unit,
+      MovementType.Walk,
+      grid,
+      {
+        walkMP: 4,
+        runMP: 6,
+        jumpMP: 0,
+        movementMode: 'tracked',
+      },
+      { q: -1, r: 0 },
+    );
+    expect(ordinaryTrackedRise).toMatchObject({
+      mpCost: 3,
+      movementMode: 'tracked',
+      elevationDelta: 1,
+      elevationCost: 2,
+      reachable: true,
+    });
+
+    const wigeCapability: IMovementCapability = {
+      walkMP: 2,
+      runMP: 3,
+      jumpMP: 0,
+      movementMode: 'wige',
+    };
+    const wigePreview = deriveReachableHexes(
+      unit,
+      MovementType.Walk,
+      grid,
+      wigeCapability,
+    ).find((r) => r.hex.q === 1 && r.hex.r === 0);
+    expect(wigePreview).toMatchObject({
+      mpCost: 2,
+      terrainCost: 1,
+      elevationDelta: 1,
+      elevationCost: 0,
+      movementMode: 'wige',
+      reachable: true,
+    });
+
+    const wigeCommit = validateCommittedMovement({
+      grid,
+      unit,
+      to: { q: 1, r: 0 },
+      facing: Facing.Southeast,
+      movementType: MovementType.Walk,
+      capability: wigeCapability,
+      path: [
+        { q: 0, r: 0 },
+        { q: 1, r: 0 },
+      ],
+    });
+    expect(wigeCommit).toMatchObject({
+      valid: true,
+      mpCost: 2,
+      heatGenerated: 0,
+    });
+
+    const trackedPreview = deriveMovementRangeHexForDestination(
+      unit,
+      MovementType.Walk,
+      grid,
+      {
+        walkMP: 4,
+        runMP: 6,
+        jumpMP: 0,
+        movementMode: 'tracked',
+      },
+      { q: 1, r: 0 },
+    );
+    expect(trackedPreview).toMatchObject({
+      mpCost: Infinity,
+      movementMode: 'tracked',
+      reachable: false,
+      movementInvalidReason: 'TerrainBlocked',
+      movementInvalidDetails: 'Tracked movement cannot ascend a sheer cliff',
+    });
+
+    const trackedCommit = validateCommittedMovement({
+      grid,
+      unit,
+      to: { q: 1, r: 0 },
+      facing: Facing.Southeast,
+      movementType: MovementType.Walk,
+      capability: {
+        walkMP: 4,
+        runMP: 6,
+        jumpMP: 0,
+        movementMode: 'tracked',
+      },
+      path: [
+        { q: 0, r: 0 },
+        { q: 1, r: 0 },
+      ],
+    });
+    expect(trackedCommit).toMatchObject({
+      valid: false,
+      reason: 'TerrainBlocked',
+      details: 'Tracked movement cannot ascend a sheer cliff',
+      mpCost: Infinity,
+      heatGenerated: 0,
+    });
+  });
+
   it.each([
     {
       label: 'VTOL',

--- a/src/utils/gameplay/movement/__tests__/reachable.test.ts
+++ b/src/utils/gameplay/movement/__tests__/reachable.test.ts
@@ -2092,6 +2092,96 @@ describe('deriveReachableHexes', () => {
     });
   });
 
+  it('charges WiGE climb-mode MP when entering a higher represented building top', () => {
+    let grid = createHexGrid({ radius: 3 });
+    grid = setHex(grid, { q: 0, r: 0 }, TerrainType.Clear, 0);
+    grid = setHex(
+      grid,
+      { q: 1, r: 0 },
+      terrainStringFromFeatures([{ type: TerrainType.Building, level: 3 }]),
+      0,
+    );
+    const unit = makeUnitAtOrigin();
+    const capability: IMovementCapability = {
+      walkMP: 3,
+      runMP: 5,
+      jumpMP: 0,
+      movementMode: 'wige',
+    };
+
+    const preview = deriveReachableHexes(
+      unit,
+      MovementType.Walk,
+      grid,
+      capability,
+    ).find((r) => r.hex.q === 1 && r.hex.r === 0);
+    expect(preview).toMatchObject({
+      mpCost: 3,
+      terrainCost: 2,
+      elevationDelta: 0,
+      elevationCost: 0,
+      movementMode: 'wige',
+      reachable: true,
+      movementType: MovementType.Walk,
+    });
+
+    const commit = validateCommittedMovement({
+      grid,
+      unit,
+      to: { q: 1, r: 0 },
+      facing: Facing.Southeast,
+      movementType: MovementType.Walk,
+      capability,
+      path: [
+        { q: 0, r: 0 },
+        { q: 1, r: 0 },
+      ],
+    });
+    expect(commit).toMatchObject({
+      valid: true,
+      mpCost: 3,
+      heatGenerated: 0,
+    });
+
+    const insufficientCapability: IMovementCapability = {
+      ...capability,
+      walkMP: 2,
+    };
+    const overBudgetPreview = deriveMovementRangeHexForDestination(
+      unit,
+      MovementType.Walk,
+      grid,
+      insufficientCapability,
+      { q: 1, r: 0 },
+    );
+    expect(overBudgetPreview).toMatchObject({
+      mpCost: 3,
+      terrainCost: 2,
+      movementMode: 'wige',
+      reachable: false,
+      movementInvalidReason: 'InsufficientMP',
+    });
+
+    const overBudgetCommit = validateCommittedMovement({
+      grid,
+      unit,
+      to: { q: 1, r: 0 },
+      facing: Facing.Southeast,
+      movementType: MovementType.Walk,
+      capability: insufficientCapability,
+      path: [
+        { q: 0, r: 0 },
+        { q: 1, r: 0 },
+      ],
+    });
+    expect(overBudgetCommit).toMatchObject({
+      valid: false,
+      reason: 'InsufficientMP',
+      mpCost: 3,
+      heatGenerated: 0,
+    });
+  });
+
   it.each([
     {
       label: 'VTOL',

--- a/src/utils/gameplay/movement/__tests__/reachable.test.ts
+++ b/src/utils/gameplay/movement/__tests__/reachable.test.ts
@@ -2144,19 +2144,35 @@ describe('deriveReachableHexes', () => {
         capability,
         { q: 1, r: 0 },
       );
-      expect(airbornePreview).toMatchObject({
-        mpCost: Infinity,
-        heatGenerated: 0,
-        movementMode,
-        reachable: false,
-        movementType: MovementType.Walk,
-        blockedReason: reason,
-        movementInvalidReason: 'InvalidDestination',
-        movementInvalidDetails: reason,
-        altitudeControlRequired: true,
-        altitudeControlMode: movementMode,
-        altitudeControlAltitude: 2,
-      });
+      if (movementMode === 'wige') {
+        expect(airbornePreview).toMatchObject({
+          mpCost: 1,
+          terrainCost: 0,
+          elevationDelta: 4,
+          elevationCost: 0,
+          movementMode,
+          reachable: true,
+          movementType: MovementType.Walk,
+          automaticLandingRequired: true,
+          automaticLandingMode: 'wige',
+          automaticLandingDistance: 1,
+          automaticLandingMinimumDistance: 5,
+        });
+      } else {
+        expect(airbornePreview).toMatchObject({
+          mpCost: Infinity,
+          heatGenerated: 0,
+          movementMode,
+          reachable: false,
+          movementType: MovementType.Walk,
+          blockedReason: reason,
+          movementInvalidReason: 'InvalidDestination',
+          movementInvalidDetails: reason,
+          altitudeControlRequired: true,
+          altitudeControlMode: movementMode,
+          altitudeControlAltitude: 2,
+        });
+      }
 
       const commit = validateCommittedMovement({
         grid,
@@ -2170,13 +2186,21 @@ describe('deriveReachableHexes', () => {
           { q: 1, r: 0 },
         ],
       });
-      expect(commit).toMatchObject({
-        valid: false,
-        reason: 'InvalidDestination',
-        details: reason,
-        mpCost: Infinity,
-        heatGenerated: 0,
-      });
+      if (movementMode === 'wige') {
+        expect(commit).toMatchObject({
+          valid: true,
+          mpCost: 1,
+          heatGenerated: 0,
+        });
+      } else {
+        expect(commit).toMatchObject({
+          valid: false,
+          reason: 'InvalidDestination',
+          details: reason,
+          mpCost: Infinity,
+          heatGenerated: 0,
+        });
+      }
 
       const landedPreview = deriveMovementRangeHexForDestination(
         landedUnit,

--- a/src/utils/gameplay/movement/__tests__/reachable.test.ts
+++ b/src/utils/gameplay/movement/__tests__/reachable.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, expect, it } from '@jest/globals';
 
+import { parseMegaMekBoard } from '@/lib/parsers/megaMekBoard';
 import { GyroType } from '@/types/construction/GyroType';
 import {
   Facing,
@@ -15,6 +16,7 @@ import {
   MovementType,
   TerrainType,
   type IComponentDamageState,
+  type IHex,
   type IMovementCapability,
   type IHexCoordinate,
   type IHexGrid,
@@ -86,6 +88,25 @@ function setHex(
   const hexes = new Map(grid.hexes);
   hexes.set(key, { ...hex, terrain, elevation });
   return { ...grid, hexes };
+}
+
+function gridFromParsedBoard(content: string): IHexGrid {
+  const parsedBoard = parseMegaMekBoard(content);
+  const hexes = new Map<string, IHex>();
+
+  for (const parsedHex of parsedBoard.hexes) {
+    hexes.set(coordToKey(parsedHex.coordinate), {
+      coord: parsedHex.coordinate,
+      occupantId: null,
+      terrain: terrainStringFromFeatures(parsedHex.features),
+      elevation: parsedHex.elevation,
+    });
+  }
+
+  return {
+    config: { radius: Math.max(parsedBoard.width, parsedBoard.height) },
+    hexes,
+  };
 }
 
 function setOccupant(
@@ -2309,6 +2330,54 @@ describe('deriveReachableHexes', () => {
       details: 'Tracked movement cannot ascend a sheer cliff',
       mpCost: Infinity,
       heatGenerated: 0,
+    });
+  });
+
+  it('uses parsed MegaMek cliff_top exits for movement projection', () => {
+    const grid = gridFromParsedBoard(`size 2 1
+hex 0101 0 "" ""
+hex 0201 1 "cliff_top:1:32" ""
+end`);
+    const unit = makeUnitAtOrigin();
+
+    const wigePreview = deriveMovementRangeHexForDestination(
+      unit,
+      MovementType.Walk,
+      grid,
+      {
+        walkMP: 2,
+        runMP: 3,
+        jumpMP: 0,
+        movementMode: 'wige',
+      },
+      { q: 1, r: 0 },
+    );
+    expect(wigePreview).toMatchObject({
+      mpCost: 2,
+      terrainCost: 1,
+      elevationDelta: 1,
+      movementMode: 'wige',
+      reachable: true,
+    });
+
+    const trackedPreview = deriveMovementRangeHexForDestination(
+      unit,
+      MovementType.Walk,
+      grid,
+      {
+        walkMP: 4,
+        runMP: 6,
+        jumpMP: 0,
+        movementMode: 'tracked',
+      },
+      { q: 1, r: 0 },
+    );
+    expect(trackedPreview).toMatchObject({
+      mpCost: Infinity,
+      movementMode: 'tracked',
+      reachable: false,
+      movementInvalidReason: 'TerrainBlocked',
+      movementInvalidDetails: 'Tracked movement cannot ascend a sheer cliff',
     });
   });
 

--- a/src/utils/gameplay/movement/__tests__/reachable.test.ts
+++ b/src/utils/gameplay/movement/__tests__/reachable.test.ts
@@ -2266,6 +2266,83 @@ describe('deriveReachableHexes', () => {
     },
   );
 
+  it('counts prior WiGE movement before showing automatic landing metadata', () => {
+    let grid = createHexGrid({ radius: 5 });
+    grid = setHex(grid, { q: 0, r: 0 }, TerrainType.Clear, 0);
+    grid = setHex(grid, { q: 1, r: 0 }, TerrainType.Clear, 0);
+    const capability: IMovementCapability = {
+      walkMP: 5,
+      runMP: 7,
+      jumpMP: 0,
+      movementMode: 'wige',
+    };
+    const unit = {
+      ...makeUnitAtOrigin(),
+      hexesMovedThisTurn: 4,
+      combatState: {
+        kind: 'vehicle' as const,
+        state: createVehicleCombatState({
+          unitId: 'u1',
+          motionType: GroundMotionType.WIGE,
+          originalCruiseMP: 5,
+          armor: {},
+          structure: {},
+          altitude: 2,
+        }),
+      },
+    };
+
+    const preview = deriveMovementRangeHexForDestination(
+      unit,
+      MovementType.Walk,
+      grid,
+      capability,
+      { q: 1, r: 0 },
+    );
+
+    expect(preview).toMatchObject({
+      mpCost: 1,
+      movementMode: 'wige',
+      reachable: true,
+      movementType: MovementType.Walk,
+    });
+    expect(preview?.automaticLandingRequired).toBeUndefined();
+    expect(preview?.automaticLandingDistance).toBeUndefined();
+  });
+
+  it('does not show automatic landing metadata for represented hover-style WiGE movement', () => {
+    let grid = createHexGrid({ radius: 3 });
+    grid = setHex(grid, { q: 0, r: 0 }, TerrainType.Clear, 0);
+    grid = setHex(grid, { q: 1, r: 0 }, TerrainType.Clear, 0);
+    const unit = {
+      ...makeUnitAtOrigin(),
+      conversionMode: 'airmek' as const,
+      lamAirMekAltitude: 2,
+    };
+
+    const preview = deriveMovementRangeHexForDestination(
+      unit,
+      MovementType.Walk,
+      grid,
+      {
+        walkMP: 3,
+        runMP: 5,
+        jumpMP: 0,
+        movementMode: 'hover',
+      },
+      { q: 1, r: 0 },
+    );
+
+    expect(preview).toMatchObject({
+      mpCost: 1,
+      movementMode: 'hover',
+      reachable: true,
+      movementType: MovementType.Walk,
+    });
+    expect(preview?.automaticLandingRequired).toBeUndefined();
+    expect(preview?.automaticLandingDistance).toBeUndefined();
+  });
+
   it('reserves represented WiGE altitude-control MP before landed ground movement', () => {
     const grid = createHexGrid({ radius: 3 });
     const unit = {

--- a/src/utils/gameplay/movement/__tests__/runtimeCapability.test.ts
+++ b/src/utils/gameplay/movement/__tests__/runtimeCapability.test.ts
@@ -252,7 +252,7 @@ describe('runtime movement capability', () => {
         capability,
         'wige',
       ),
-    ).toBe(AIRBORNE_LAM_AIRMEK_GROUND_MOVEMENT_BLOCKED_REASON);
+    ).toBeUndefined();
     expect(runtimeMovementAltitudeControlContext(elevatedAirMek)).toMatchObject(
       {
         altitudeControlRequired: true,
@@ -327,7 +327,7 @@ describe('runtime movement capability', () => {
           capability,
           movementMode,
         ),
-      ).toBe(reason);
+      ).toBe(movementMode === 'wige' ? undefined : reason);
       expect(
         runtimeMovementAltitudeControlContext(airborneVehicle),
       ).toMatchObject({
@@ -402,7 +402,7 @@ describe('runtime movement capability', () => {
         capability,
         'wige',
       ),
-    ).toBe(AIRBORNE_WIGE_GROUND_MOVEMENT_BLOCKED_REASON);
+    ).toBeUndefined();
     expect(runtimeMovementAltitudeControlContext(airborneGlider)).toMatchObject(
       {
         altitudeControlRequired: true,

--- a/src/utils/gameplay/movement/automaticWigeLanding.ts
+++ b/src/utils/gameplay/movement/automaticWigeLanding.ts
@@ -27,6 +27,10 @@ export interface IAutomaticWigeLandingContext {
   readonly automaticLandingMinimumDistance: number;
 }
 
+interface IAutomaticWigeLandingOptions {
+  readonly movementMode?: string;
+}
+
 function normalizedAltitude(value: number | undefined): number {
   return value === undefined || !Number.isFinite(value)
     ? 0
@@ -83,18 +87,34 @@ function pathHexesMoved(
   return hexDistance(origin, destination);
 }
 
+function hexesMovedThisTurn(
+  unit: Pick<IUnitGameState, 'hexesMovedThisTurn'>,
+): number {
+  const moved = unit.hexesMovedThisTurn;
+  return moved === undefined || !Number.isFinite(moved)
+    ? 0
+    : Math.max(0, Math.floor(moved));
+}
+
+function isHoverExemptMovement(options: IAutomaticWigeLandingOptions): boolean {
+  return options.movementMode === 'hover';
+}
+
 export function automaticWigeLandingContext(
   unit: IUnitGameState,
   movementType: MovementType,
   path: readonly IHexCoordinate[] | undefined,
   destination: IHexCoordinate,
+  options: IAutomaticWigeLandingOptions = {},
 ): IAutomaticWigeLandingContext | undefined {
   const owner = automaticWigeLandingOwner(unit);
   if (!owner) return undefined;
   if (movementType === MovementType.Jump) return undefined;
+  if (isHoverExemptMovement(options)) return undefined;
   if (normalizedAltitudeControlSteps(unit) > 0) return undefined;
 
-  const distance = pathHexesMoved(unit.position, destination, path);
+  const distance =
+    hexesMovedThisTurn(unit) + pathHexesMoved(unit.position, destination, path);
   if (distance >= owner.minimumDistance) return undefined;
 
   return {
@@ -116,6 +136,7 @@ export function withAutomaticWigeLandingProjection(
     movementHex.movementType,
     movementHex.path,
     movementHex.hex,
+    { movementMode: movementHex.movementMode },
   );
   return context ? { ...movementHex, ...context } : movementHex;
 }
@@ -125,6 +146,7 @@ export function automaticWigeLandingRuntimePatch(
   movementType: MovementType,
   path: readonly IHexCoordinate[] | undefined,
   destination: IHexCoordinate,
+  options: IAutomaticWigeLandingOptions = {},
 ): Omit<IRuntimeMovementStateChangedPayload, 'unitId'> | undefined {
   const owner = automaticWigeLandingOwner(unit);
   const context = automaticWigeLandingContext(
@@ -132,6 +154,7 @@ export function automaticWigeLandingRuntimePatch(
     movementType,
     path,
     destination,
+    options,
   );
   if (!owner || !context) return undefined;
 

--- a/src/utils/gameplay/movement/automaticWigeLanding.ts
+++ b/src/utils/gameplay/movement/automaticWigeLanding.ts
@@ -1,0 +1,155 @@
+import type {
+  IHexCoordinate,
+  IMovementRangeHex,
+  IUnitGameState,
+} from '@/types/gameplay';
+import type { IRuntimeMovementStateChangedPayload } from '@/types/gameplay/GameSessionMovementEvents';
+
+import { MovementType } from '@/types/gameplay';
+import { GroundMotionType } from '@/types/unit/BaseUnitInterfaces';
+import { ProtoChassis } from '@/types/unit/ProtoMechInterfaces';
+import { hexDistance } from '@/utils/gameplay/hexMath';
+
+export const AUTOMATIC_WIGE_LANDING_REASON =
+  'MegaMek automatic WiGE landing: unit moved below the minimum airborne distance';
+
+interface IAutomaticWigeLandingOwner {
+  readonly kind: 'vehicle' | 'proto' | 'lam';
+  readonly altitude: number;
+  readonly minimumDistance: number;
+}
+
+export interface IAutomaticWigeLandingContext {
+  readonly automaticLandingRequired: true;
+  readonly automaticLandingReason: string;
+  readonly automaticLandingMode: 'wige';
+  readonly automaticLandingDistance: number;
+  readonly automaticLandingMinimumDistance: number;
+}
+
+function normalizedAltitude(value: number | undefined): number {
+  return value === undefined || !Number.isFinite(value)
+    ? 0
+    : Math.max(0, Math.floor(value));
+}
+
+function isLamAirMekMode(unit: IUnitGameState): boolean {
+  return (
+    unit.conversionMode === 1 ||
+    unit.conversionMode === 'airmek' ||
+    unit.conversionMode === 'airmech'
+  );
+}
+
+function automaticWigeLandingOwner(
+  unit: IUnitGameState,
+): IAutomaticWigeLandingOwner | undefined {
+  if (
+    unit.combatState?.kind === 'vehicle' &&
+    unit.combatState.state.motionType === GroundMotionType.WIGE
+  ) {
+    const altitude = normalizedAltitude(unit.combatState.state.altitude);
+    return altitude > 0
+      ? { kind: 'vehicle', altitude, minimumDistance: 5 }
+      : undefined;
+  }
+
+  if (
+    unit.combatState?.kind === 'proto' &&
+    unit.combatState.state.chassisType === ProtoChassis.GLIDER
+  ) {
+    const altitude = normalizedAltitude(unit.combatState.state.altitude);
+    return altitude > 0
+      ? { kind: 'proto', altitude, minimumDistance: 4 }
+      : undefined;
+  }
+
+  if (isLamAirMekMode(unit)) {
+    const altitude = normalizedAltitude(unit.lamAirMekAltitude);
+    return altitude > 0
+      ? { kind: 'lam', altitude, minimumDistance: 5 }
+      : undefined;
+  }
+
+  return undefined;
+}
+
+function pathHexesMoved(
+  origin: IHexCoordinate,
+  destination: IHexCoordinate,
+  path: readonly IHexCoordinate[] | undefined,
+): number {
+  if (path && path.length > 1) return path.length - 1;
+  return hexDistance(origin, destination);
+}
+
+export function automaticWigeLandingContext(
+  unit: IUnitGameState,
+  movementType: MovementType,
+  path: readonly IHexCoordinate[] | undefined,
+  destination: IHexCoordinate,
+): IAutomaticWigeLandingContext | undefined {
+  const owner = automaticWigeLandingOwner(unit);
+  if (!owner) return undefined;
+  if (movementType === MovementType.Jump) return undefined;
+  if (normalizedAltitudeControlSteps(unit) > 0) return undefined;
+
+  const distance = pathHexesMoved(unit.position, destination, path);
+  if (distance >= owner.minimumDistance) return undefined;
+
+  return {
+    automaticLandingRequired: true,
+    automaticLandingReason: AUTOMATIC_WIGE_LANDING_REASON,
+    automaticLandingMode: 'wige',
+    automaticLandingDistance: distance,
+    automaticLandingMinimumDistance: owner.minimumDistance,
+  };
+}
+
+export function withAutomaticWigeLandingProjection(
+  movementHex: IMovementRangeHex,
+  unit: IUnitGameState,
+): IMovementRangeHex {
+  if (!movementHex.reachable) return movementHex;
+  const context = automaticWigeLandingContext(
+    unit,
+    movementHex.movementType,
+    movementHex.path,
+    movementHex.hex,
+  );
+  return context ? { ...movementHex, ...context } : movementHex;
+}
+
+export function automaticWigeLandingRuntimePatch(
+  unit: IUnitGameState,
+  movementType: MovementType,
+  path: readonly IHexCoordinate[] | undefined,
+  destination: IHexCoordinate,
+): Omit<IRuntimeMovementStateChangedPayload, 'unitId'> | undefined {
+  const owner = automaticWigeLandingOwner(unit);
+  const context = automaticWigeLandingContext(
+    unit,
+    movementType,
+    path,
+    destination,
+  );
+  if (!owner || !context) return undefined;
+
+  switch (owner.kind) {
+    case 'vehicle':
+      return { source: 'automatic_wige_landing', vehicleAltitude: 0 };
+    case 'proto':
+      return { source: 'automatic_wige_landing', protoAltitude: 0 };
+    case 'lam':
+      return { source: 'automatic_wige_landing', lamAirMekAltitude: 0 };
+  }
+}
+
+function normalizedAltitudeControlSteps(
+  unit: Pick<IUnitGameState, 'pendingAltitudeControlStepCount'>,
+): number {
+  const steps = unit.pendingAltitudeControlStepCount;
+  return steps === undefined || !Number.isFinite(steps)
+    ? 0
+    : Math.max(0, Math.floor(steps));
+}

--- a/src/utils/gameplay/movement/calculations.ts
+++ b/src/utils/gameplay/movement/calculations.ts
@@ -21,6 +21,10 @@ import type { UnitMovementType } from './types';
 import { getHex } from '../hexGrid';
 import { hexDistance, hexLine } from '../hexMath';
 import {
+  directionalCliffBlockedReason,
+  wigeSheerCliffAscentCost,
+} from './cliffTerrain';
+import {
   movementCostContextForStep,
   type IMovementCostContext,
 } from './costContext';
@@ -313,6 +317,26 @@ export function getMovementStepCostBreakdown(
     if (fromHex) {
       elevationDelta = hex.elevation - fromHex.elevation;
       const elevationChange = Math.abs(elevationDelta);
+      const cliffBlockedReason = directionalCliffBlockedReason({
+        movementType,
+        toTerrainFeatures: terrainFeatures,
+        fromCoord,
+        toCoord: coord,
+        elevationDelta,
+        hasPavementSurfaceFeature,
+        movementModeLabel: formatMovementModeForReason(movementType),
+      });
+      if (cliffBlockedReason) {
+        return {
+          mpCost: Infinity,
+          baseCost,
+          terrainCost,
+          elevationCost: 0,
+          elevationDelta,
+          blockedReason: cliffBlockedReason,
+        };
+      }
+
       if (elevationChange > 0 && paysElevationCost(movementType)) {
         elevationCost =
           elevationChange * elevationCostMultiplier(movementType, context);
@@ -339,6 +363,14 @@ export function getMovementStepCostBreakdown(
           };
         }
       }
+      terrainCost += wigeSheerCliffAscentCost({
+        grid,
+        fromCoord,
+        toCoord: coord,
+        toTerrainFeatures: terrainFeatures,
+        movementType,
+        elevationDelta,
+      });
       terrainCost += wigeBuildingClimbModeCost({
         grid,
         fromCoord,

--- a/src/utils/gameplay/movement/calculations.ts
+++ b/src/utils/gameplay/movement/calculations.ts
@@ -37,6 +37,7 @@ import {
   requiresWaterTerrain,
   waterMovementCostModifier,
 } from './terrainRules';
+import { wigeBuildingClimbModeCost } from './wigeClimbModeCost';
 
 export const PAVEMENT_ROAD_BONUS_MP = 1;
 
@@ -338,6 +339,14 @@ export function getMovementStepCostBreakdown(
           };
         }
       }
+      terrainCost += wigeBuildingClimbModeCost({
+        grid,
+        fromCoord,
+        toCoord: coord,
+        toElevation: hex.elevation,
+        toTerrainFeatures: terrainFeatures,
+        movementType,
+      });
     }
   }
 

--- a/src/utils/gameplay/movement/cliffTerrain.ts
+++ b/src/utils/gameplay/movement/cliffTerrain.ts
@@ -1,0 +1,99 @@
+import type { IHexCoordinate, IHexGrid } from '@/types/gameplay';
+import type { ITerrainFeature } from '@/types/gameplay/TerrainTypes';
+
+import { AXIAL_DIRECTION_DELTAS } from '@/types/gameplay';
+
+import type { UnitMovementType } from './types';
+
+import { getHex } from '../hexGrid';
+
+export const WIGE_SHEER_CLIFF_ASCENT_SURCHARGE_MP = 1;
+
+function directionFromTo(
+  from: IHexCoordinate,
+  to: IHexCoordinate,
+): number | null {
+  const delta = { q: to.q - from.q, r: to.r - from.r };
+  const direction = AXIAL_DIRECTION_DELTAS.findIndex(
+    (candidate) => candidate.q === delta.q && candidate.r === delta.r,
+  );
+  return direction >= 0 ? direction : null;
+}
+
+function featureHasCliffExitToward(
+  feature: ITerrainFeature,
+  direction: number,
+): boolean {
+  return feature.cliffTopExits?.includes(direction) ?? false;
+}
+
+export function hasDirectionalCliffTopTowards(
+  terrainFeatures: readonly ITerrainFeature[],
+  from: IHexCoordinate,
+  toward: IHexCoordinate,
+): boolean {
+  const direction = directionFromTo(from, toward);
+  if (direction === null) return false;
+  return terrainFeatures.some((feature) =>
+    featureHasCliffExitToward(feature, direction),
+  );
+}
+
+function isVehicleCliffBlockedMovement(
+  movementType: UnitMovementType,
+): boolean {
+  return (
+    movementType === 'tracked' ||
+    movementType === 'wheeled' ||
+    movementType === 'hover'
+  );
+}
+
+export function directionalCliffBlockedReason(input: {
+  readonly movementType: UnitMovementType;
+  readonly toTerrainFeatures: readonly ITerrainFeature[];
+  readonly fromCoord: IHexCoordinate;
+  readonly toCoord: IHexCoordinate;
+  readonly elevationDelta: number;
+  readonly hasPavementSurfaceFeature: boolean;
+  readonly movementModeLabel: string;
+}): string | null {
+  if (!isVehicleCliffBlockedMovement(input.movementType)) return null;
+  if (input.hasPavementSurfaceFeature) return null;
+  if (input.elevationDelta !== 1 && input.elevationDelta !== 2) return null;
+  if (
+    !hasDirectionalCliffTopTowards(
+      input.toTerrainFeatures,
+      input.toCoord,
+      input.fromCoord,
+    )
+  ) {
+    return null;
+  }
+
+  return `${input.movementModeLabel} movement cannot ascend a sheer cliff`;
+}
+
+export function wigeSheerCliffAscentCost(input: {
+  readonly grid: IHexGrid;
+  readonly fromCoord: IHexCoordinate;
+  readonly toCoord: IHexCoordinate;
+  readonly toTerrainFeatures: readonly ITerrainFeature[];
+  readonly movementType: UnitMovementType;
+  readonly elevationDelta: number;
+}): number {
+  if (input.movementType !== 'wige') return 0;
+  if (input.elevationDelta <= 0) return 0;
+  if (!getHex(input.grid, input.fromCoord)) return 0;
+  if (
+    !hasDirectionalCliffTopTowards(
+      input.toTerrainFeatures,
+      input.toCoord,
+      input.fromCoord,
+    )
+  ) {
+    return 0;
+  }
+
+  return WIGE_SHEER_CLIFF_ASCENT_SURCHARGE_MP;
+}

--- a/src/utils/gameplay/movement/index.ts
+++ b/src/utils/gameplay/movement/index.ts
@@ -46,5 +46,11 @@ export {
 } from './modifiers';
 export { findPath } from './pathfinding';
 export { deriveReachableHexes } from './reachable';
+export {
+  AUTOMATIC_WIGE_LANDING_REASON,
+  automaticWigeLandingContext,
+  automaticWigeLandingRuntimePatch,
+  withAutomaticWigeLandingProjection,
+} from './automaticWigeLanding';
 export { gridWithUnitOccupants } from './occupancy';
 export { movementDeclarationLockInvalidState } from './declarationEligibility';

--- a/src/utils/gameplay/movement/reachable.ts
+++ b/src/utils/gameplay/movement/reachable.ts
@@ -47,6 +47,7 @@ import {
   withPendingAltitudeControlProjection,
   type IPendingAltitudeControlMovementCost,
 } from './altitudeControlAccounting';
+import { withAutomaticWigeLandingProjection } from './automaticWigeLanding';
 import {
   calculatePathMovementCost,
   getJumpClearanceBlockedReason,
@@ -681,18 +682,23 @@ export function deriveMovementRangeHexForDestination(
       });
     }
 
-    return withReservedProjection({
-      hex,
-      mpCost: dist + reservedCost,
-      elevationDelta,
-      elevationCost: 0,
-      terrainCost: 0,
-      path: [origin, hex],
-      heatGenerated,
-      movementMode,
-      reachable: true,
-      movementType: MovementType.Jump,
-    });
+    return withReservedProjection(
+      withAutomaticWigeLandingProjection(
+        {
+          hex,
+          mpCost: dist + reservedCost,
+          elevationDelta,
+          elevationCost: 0,
+          terrainCost: 0,
+          path: [origin, hex],
+          heatGenerated,
+          movementMode,
+          reachable: true,
+          movementType: MovementType.Jump,
+        },
+        unit,
+      ),
+    );
   }
 
   const path =
@@ -795,18 +801,23 @@ export function deriveMovementRangeHexForDestination(
   }
   const finalStep = finalStepCost(grid, path, movementMode, costContext);
 
-  return withReservedProjection({
-    hex,
-    mpCost: cost,
-    terrainCost: finalStep?.terrainCost,
-    elevationDelta: finalStep?.elevationDelta,
-    elevationCost: finalStep?.elevationCost,
-    path,
-    heatGenerated,
-    movementMode,
-    reachable: true,
-    movementType: mpType,
-    ...standUpProjection,
-    ...hullDownExitProjection,
-  });
+  return withReservedProjection(
+    withAutomaticWigeLandingProjection(
+      {
+        hex,
+        mpCost: cost,
+        terrainCost: finalStep?.terrainCost,
+        elevationDelta: finalStep?.elevationDelta,
+        elevationCost: finalStep?.elevationCost,
+        path,
+        heatGenerated,
+        movementMode,
+        reachable: true,
+        movementType: mpType,
+        ...standUpProjection,
+        ...hullDownExitProjection,
+      },
+      unit,
+    ),
+  );
 }

--- a/src/utils/gameplay/movement/runtimeCapability.ts
+++ b/src/utils/gameplay/movement/runtimeCapability.ts
@@ -193,10 +193,13 @@ function airborneVtolOrWigeGroundMovementBlockedReason(
 ): string | undefined {
   if (!isAltitudeTrackedAirborneState(unit)) return undefined;
   const altitudeContext = runtimeMovementAltitudeControlContext(unit);
-  if (altitudeContext) return altitudeContext.blockedReason;
   if (movementMode === 'vtol') {
     return AIRBORNE_VTOL_GROUND_MOVEMENT_BLOCKED_REASON;
   }
+  if (altitudeContext?.altitudeControlMode === 'wige') {
+    return movementMode === 'wige' ? undefined : altitudeContext.blockedReason;
+  }
+  if (altitudeContext) return altitudeContext.blockedReason;
   if (movementMode === 'wige') {
     return AIRBORNE_WIGE_GROUND_MOVEMENT_BLOCKED_REASON;
   }
@@ -258,7 +261,8 @@ export function runtimeMovementProjectionBlockedReason(
   if (
     profile &&
     isLamAirMekMode(unit, profile) &&
-    normalizedLamAirMekAltitude(unit) > 0
+    normalizedLamAirMekAltitude(unit) > 0 &&
+    movementMode !== 'wige'
   ) {
     return AIRBORNE_LAM_AIRMEK_GROUND_MOVEMENT_BLOCKED_REASON;
   }

--- a/src/utils/gameplay/movement/wigeClimbModeCost.ts
+++ b/src/utils/gameplay/movement/wigeClimbModeCost.ts
@@ -1,0 +1,68 @@
+import type { IHexCoordinate, IHexGrid } from '@/types/gameplay';
+
+import {
+  TerrainType,
+  TERRAIN_PROPERTIES,
+  type ITerrainFeature,
+} from '@/types/gameplay/TerrainTypes';
+import { terrainFeaturesFromString } from '@/utils/gameplay/terrainEncoding';
+
+import type { UnitMovementType } from './types';
+
+import { getHex } from '../hexGrid';
+import { hexDistance } from '../hexMath';
+
+const WIGE_CLIMB_MODE_SURCHARGE_MP = 2;
+
+function representedFeatureCeiling(feature: ITerrainFeature): number {
+  if (feature.type === TerrainType.Building && feature.level > 0) {
+    return feature.level;
+  }
+
+  return TERRAIN_PROPERTIES[feature.type]?.losBlockHeight ?? 0;
+}
+
+function representedHexCeiling(
+  surfaceElevation: number,
+  terrainFeatures: readonly ITerrainFeature[],
+): number {
+  return (
+    surfaceElevation +
+    Math.max(
+      0,
+      ...terrainFeatures.map((feature) => representedFeatureCeiling(feature)),
+    )
+  );
+}
+
+export function wigeBuildingClimbModeCost(input: {
+  readonly grid: IHexGrid;
+  readonly fromCoord: IHexCoordinate;
+  readonly toCoord: IHexCoordinate;
+  readonly toElevation: number;
+  readonly toTerrainFeatures: readonly ITerrainFeature[];
+  readonly movementType: UnitMovementType;
+}): number {
+  if (input.movementType !== 'wige') return 0;
+  if (hexDistance(input.fromCoord, input.toCoord) <= 0) return 0;
+  if (
+    !input.toTerrainFeatures.some(
+      (feature) => feature.type === TerrainType.Building && feature.level > 0,
+    )
+  ) {
+    return 0;
+  }
+
+  const fromHex = getHex(input.grid, input.fromCoord);
+  if (!fromHex) return 0;
+
+  const fromCeiling = representedHexCeiling(
+    fromHex.elevation,
+    terrainFeaturesFromString(fromHex.terrain),
+  );
+  const toCeiling = representedHexCeiling(
+    input.toElevation,
+    input.toTerrainFeatures,
+  );
+  return toCeiling > fromCeiling ? WIGE_CLIMB_MODE_SURCHARGE_MP : 0;
+}

--- a/src/utils/gameplay/tacticalMapProjection.ts
+++ b/src/utils/gameplay/tacticalMapProjection.ts
@@ -631,7 +631,9 @@ function formatMovementSourceDetail(movement: IMovementRangeHex): string {
       ),
     ),
   );
-  return `${modes.join(',')} projection`;
+  return `${modes.join(',')} projection: ${options
+    .map(formatMovementOption)
+    .join(', ')}`;
 }
 
 function movementHasStandUpContext(movement: IMovementRangeHex): boolean {

--- a/src/utils/gameplay/tacticalMapProjection.ts
+++ b/src/utils/gameplay/tacticalMapProjection.ts
@@ -451,6 +451,11 @@ function movementOptionsForProjection(
       altitudeControlRequired: movement.altitudeControlRequired,
       altitudeControlMode: movement.altitudeControlMode,
       altitudeControlAltitude: movement.altitudeControlAltitude,
+      automaticLandingRequired: movement.automaticLandingRequired,
+      automaticLandingReason: movement.automaticLandingReason,
+      automaticLandingMode: movement.automaticLandingMode,
+      automaticLandingDistance: movement.automaticLandingDistance,
+      automaticLandingMinimumDistance: movement.automaticLandingMinimumDistance,
       blockedReason: movement.blockedReason,
       movementInvalidReason: movement.movementInvalidReason,
       movementInvalidDetails: movement.movementInvalidDetails,
@@ -867,6 +872,18 @@ function formatProjectionExplanation({
         } MP`,
       );
     }
+    if (movement.automaticLandingRequired) {
+      parts.push(
+        `automatic landing ${movement.automaticLandingDistance ?? 0}/${
+          movement.automaticLandingMinimumDistance ?? 0
+        } hexes`,
+      );
+      if (movement.automaticLandingReason) {
+        parts.push(
+          `automatic landing reason ${movement.automaticLandingReason}`,
+        );
+      }
+    }
     if (movement.movementModeOptions?.length) {
       parts.push(
         `movement options ${movement.movementModeOptions
@@ -1067,11 +1084,16 @@ function formatMovementOption(option: IMovementRangeModeOption): string {
       : ` altitude control ${option.altitudeControlStepCount ?? 0} steps ${
           option.altitudeControlMpCost ?? 0
         } MP`;
+  const automaticLanding = option.automaticLandingRequired
+    ? ` automatic landing ${option.automaticLandingDistance ?? 0}/${
+        option.automaticLandingMinimumDistance ?? 0
+      } hexes`
+    : '';
   const blockedDetail = movementOptionBlockedDetail(option);
   const blocked = blockedDetail ? `: ${blockedDetail}` : '';
   return `${option.movementType}${mode} ${
     option.reachable ? 'reachable' : 'blocked'
-  } ${option.mpCost} MP${terrain}${elevation}${heat}${conversion}${altitudeControl}${option.reachable ? '' : blocked}`;
+  } ${option.mpCost} MP${terrain}${elevation}${heat}${conversion}${altitudeControl}${automaticLanding}${option.reachable ? '' : blocked}`;
 }
 
 function formatMovementOptionElevation(

--- a/src/utils/gameplay/tacticalMapProjection.ts
+++ b/src/utils/gameplay/tacticalMapProjection.ts
@@ -8,9 +8,10 @@ import type {
   IMovementRangeModeOption,
 } from '@/types/gameplay';
 
-import { TerrainType } from '@/types/gameplay';
+import { Facing, TerrainType } from '@/types/gameplay';
 
 import { coordToKey, hexEquals } from './hexMath';
+import { getFacingAbbreviation } from './unitPosition';
 
 export type TacticalMapHexProjectionIntent =
   | 'terrain'
@@ -585,7 +586,23 @@ function formatTerrainFeatureSourceDetail(
   if (feature.constructionFactor !== undefined) {
     parts.push(`CF ${feature.constructionFactor}`);
   }
+  const cliffExits = Array.from(
+    new Set(feature.cliffTopExits?.filter(isFacing) ?? []),
+  ).sort((a, b) => a - b);
+  if (cliffExits.length > 0) {
+    parts.push(
+      `cliff edges ${cliffExits.map(getFacingAbbreviation).join('/')}`,
+    );
+  }
   return parts.join(' ');
+}
+
+function isFacing(value: number): value is Facing {
+  return (
+    Number.isInteger(value) &&
+    value >= Facing.North &&
+    value <= Facing.Northwest
+  );
 }
 
 function formatTerrainFeatureLevelSourceDetail(

--- a/src/utils/gameplay/terrainEncoding.ts
+++ b/src/utils/gameplay/terrainEncoding.ts
@@ -8,7 +8,8 @@ function hasFeatureMetadata(feature: ITerrainFeature): boolean {
     feature.constructionFactor !== undefined ||
     feature.buildingId !== undefined ||
     feature.isOnFire !== undefined ||
-    feature.isFrozen !== undefined
+    feature.isFrozen !== undefined ||
+    feature.cliffTopExits !== undefined
   );
 }
 


### PR DESCRIPTION
## Summary
- Allows represented positive-altitude WiGE-style movement to project and commit horizontal WiGE movement instead of failing closed as ground projection.
- Adds source-backed short-distance automatic landing metadata for WiGE vehicles, Glider ProtoMeks, and LAM AirMeks, including visible map badge/ARIA/tooltip/detail attributes.
- Replays accepted short WiGE moves through RuntimeMovementStateChanged with source automatic_wige_landing so post-move map/combat/replay state agrees.
- Adds OpenSpec change auto-land-short-wige-movement and updates tactical-map audit coverage.

## Source Truth
- MegaMek MovePath.automaticWiGELanding: WiGE-style units land when moving below the minimum airborne distance, with five-hex WiGE and four-hex Glider ProtoMek thresholds.
- Preserves Jump and represented altitude-control/takeoff-style exemptions for this slice.

## Verification
- npx openspec validate auto-land-short-wige-movement --strict
- git diff --check
- npm run format:check
- npm run typecheck
- npm run lint (warnings only: existing max-lines warnings)
- npm test -- --runTestsByPath src/utils/gameplay/movement/__tests__/automaticWigeLanding.test.ts src/utils/gameplay/movement/__tests__/runtimeCapability.test.ts src/utils/gameplay/movement/__tests__/reachable.test.ts src/utils/gameplay/gameState/__tests__/runtimeMovementState.test.ts src/engine/__tests__/InteractiveSession.movement.scenario.test.ts src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.test.tsx --watchAll=false
- npm test -- --watchAll=false
- npm run build

## Notes
- Draft because this is stacked on #773 and should merge after the AirMek landing crash-critical stack lands.
- Not browser-visual-QAed live; Jest covers the new visible LAND badge and tooltip metadata.