### PR TITLE
Surface cliff exits on tactical map

### DIFF
--- a/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
+++ b/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
@@ -84,6 +84,11 @@ source reference so same-hex walk/run/jump options carry their reachable or
 blocked state, MP cost, terrain and elevation costs, heat, and blocked reason
 directly in `movement:megamek` projection metadata instead of only in visible
 badges/tooltips.
+The `source-hover-path-preview-badge` slice keeps the hovered path MP badge on
+that same source-backed path: hovering a reachable destination now preserves
+terrain/elevation cost, heat, `movement:megamek` source refs, and MegaMek rule
+refs on the preview badge instead of thinning the displayed commit preview to
+MP and movement type only.
 Replayable gameplay events for runtime movement state are covered by
 `apply-runtime-movement-state-events`; player-facing tactical command controls
 for represented conversion and infantry mount-state changes are covered by

--- a/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
+++ b/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
@@ -84,6 +84,10 @@ source reference so same-hex walk/run/jump options carry their reachable or
 blocked state, MP cost, terrain and elevation costs, heat, and blocked reason
 directly in `movement:megamek` projection metadata instead of only in visible
 badges/tooltips.
+The `source-movement-reach-badge` slice pins the normal reachable movement
+badge to that same source-backed path, so the standing MP badge now exposes
+`movement:megamek` source refs, MegaMek rule refs, and projection explanation
+metadata before hover path preview replaces it.
 The `source-hover-path-preview-badge` slice keeps the hovered path MP badge on
 that same source-backed path: hovering a reachable destination now preserves
 terrain/elevation cost, heat, `movement:megamek` source refs, and MegaMek rule

--- a/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
+++ b/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
@@ -88,6 +88,10 @@ The `source-movement-reach-badge` slice pins the normal reachable movement
 badge to that same source-backed path, so the standing MP badge now exposes
 `movement:megamek` source refs, MegaMek rule refs, and projection explanation
 metadata before hover path preview replaces it.
+The `source-movement-step-cost-badge` slice extends that provenance to the
+separate terrain/elevation step-cost marker, so visible `T+`/`E+`/`UP`/`DN`
+cost labels also identify their shared `movement:megamek` source and rule
+references.
 The `source-hover-path-preview-badge` slice keeps the hovered path MP badge on
 that same source-backed path: hovering a reachable destination now preserves
 terrain/elevation cost, heat, `movement:megamek` source refs, and MegaMek rule

--- a/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
+++ b/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
@@ -79,6 +79,11 @@ The follow-on `surface-cliff-exits-map-context` slice exposes represented
 `cliffTopExits` on hex metadata, terrain labels, terrain/elevation source
 details, and terrain hover context so the map explains directional cliff edges
 from imported terrain instead of hiding them inside movement-only diagnostics.
+The `surface-movement-option-source-details` slice expands the shared movement
+source reference so same-hex walk/run/jump options carry their reachable or
+blocked state, MP cost, terrain and elevation costs, heat, and blocked reason
+directly in `movement:megamek` projection metadata instead of only in visible
+badges/tooltips.
 Replayable gameplay events for runtime movement state are covered by
 `apply-runtime-movement-state-events`; player-facing tactical command controls
 for represented conversion and infantry mount-state changes are covered by

--- a/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
+++ b/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
@@ -75,6 +75,10 @@ now uses MegaMek row order to disambiguate those labels, matching
 `Board.java:1062-1063`. The verified local corpus run parsed all 2,386 boards
 under `E:\Projects\megamek\megamek\data\boards` with 0 failures, covering
 3,638,056 hex rows, 382,251 large-coordinate rows, and 5,253 `cliff_top` rows.
+The follow-on `surface-cliff-exits-map-context` slice exposes represented
+`cliffTopExits` on hex metadata, terrain labels, terrain/elevation source
+details, and terrain hover context so the map explains directional cliff edges
+from imported terrain instead of hiding them inside movement-only diagnostics.
 Replayable gameplay events for runtime movement state are covered by
 `apply-runtime-movement-state-events`; player-facing tactical command controls
 for represented conversion and infantry mount-state changes are covered by

--- a/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
+++ b/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
@@ -119,7 +119,11 @@ decisions are made, not because CI is stale.
   disambiguating labels by MegaMek row order. The
   `surface-cliff-exits-map-context` slice now carries represented cliff exit
   directions into rendered hex metadata, terrain labels, projection source
-  detail, and hover terrain context. Full elevated AirMek/WiGE pathing and
+  detail, and hover terrain context. The
+  `surface-movement-option-source-details` slice now expands movement source
+  references so same-hex walk/run/jump options carry their reachable/blocked
+  state, MP cost, terrain/elevation cost, heat, and blocked reason in the
+  shared projection metadata itself. Full elevated AirMek/WiGE pathing and
   broader takeoff/hover sequencing remain follow-up work.
   Runtime infantry mounted/dismounted height precedence is now covered; the
   replayable gameplay-event mutation path is now covered by

--- a/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
+++ b/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
@@ -123,12 +123,13 @@ decisions are made, not because CI is stale.
   `surface-movement-option-source-details` slice now expands movement source
   references so same-hex walk/run/jump options carry their reachable/blocked
   state, MP cost, terrain/elevation cost, heat, and blocked reason in the
-  shared projection metadata itself. The `source-hover-path-preview-badge`
-  slice now keeps the hovered path MP badge tied to the same movement
-  projection source references, rule references, terrain/elevation costs, and
-  heat metadata that the normal movement badge exposes. Full elevated
-  AirMek/WiGE pathing and broader takeoff/hover sequencing remain follow-up
-  work.
+  shared projection metadata itself. The `source-movement-reach-badge` slice
+  now pins the normal reachable movement badge to the shared movement
+  projection source references, rule references, and explanation detail. The
+  `source-hover-path-preview-badge` slice keeps the hovered path MP badge tied
+  to that same source-backed movement badge path instead of thinning the
+  displayed commit preview. Full elevated AirMek/WiGE pathing and broader
+  takeoff/hover sequencing remain follow-up work.
   Runtime infantry mounted/dismounted height precedence is now covered; the
   replayable gameplay-event mutation path is now covered by
   `apply-runtime-movement-state-events`, and tactical command controls are now

--- a/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
+++ b/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
@@ -123,8 +123,12 @@ decisions are made, not because CI is stale.
   `surface-movement-option-source-details` slice now expands movement source
   references so same-hex walk/run/jump options carry their reachable/blocked
   state, MP cost, terrain/elevation cost, heat, and blocked reason in the
-  shared projection metadata itself. Full elevated AirMek/WiGE pathing and
-  broader takeoff/hover sequencing remain follow-up work.
+  shared projection metadata itself. The `source-hover-path-preview-badge`
+  slice now keeps the hovered path MP badge tied to the same movement
+  projection source references, rule references, terrain/elevation costs, and
+  heat metadata that the normal movement badge exposes. Full elevated
+  AirMek/WiGE pathing and broader takeoff/hover sequencing remain follow-up
+  work.
   Runtime infantry mounted/dismounted height precedence is now covered; the
   replayable gameplay-event mutation path is now covered by
   `apply-runtime-movement-state-events`, and tactical command controls are now

--- a/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
+++ b/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
@@ -116,8 +116,11 @@ decisions are made, not because CI is stale.
   source-checks the parser against a local MegaMek board corpus; the first
   recorded run parsed 2,386 boards, 3,638,056 hex rows, 382,251
   large-coordinate rows, and 5,253 `cliff_top` rows with 0 failures after
-  disambiguating labels by MegaMek row order. Full elevated AirMek/WiGE pathing
-  and broader takeoff/hover sequencing remain follow-up work.
+  disambiguating labels by MegaMek row order. The
+  `surface-cliff-exits-map-context` slice now carries represented cliff exit
+  directions into rendered hex metadata, terrain labels, projection source
+  detail, and hover terrain context. Full elevated AirMek/WiGE pathing and
+  broader takeoff/hover sequencing remain follow-up work.
   Runtime infantry mounted/dismounted height precedence is now covered; the
   replayable gameplay-event mutation path is now covered by
   `apply-runtime-movement-state-events`, and tactical command controls are now

--- a/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
+++ b/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
@@ -126,6 +126,9 @@ decisions are made, not because CI is stale.
   shared projection metadata itself. The `source-movement-reach-badge` slice
   now pins the normal reachable movement badge to the shared movement
   projection source references, rule references, and explanation detail. The
+  `source-movement-step-cost-badge` slice does the same for the separate
+  terrain/elevation cost badge, so the visible `T+`/`E+`/`UP`/`DN` cost marker
+  is also pinned to `movement:megamek` evidence. The
   `source-hover-path-preview-badge` slice keeps the hovered path MP badge tied
   to that same source-backed movement badge path instead of thinning the
   displayed commit preview. Full elevated AirMek/WiGE pathing and broader

--- a/openspec/changes/source-hover-path-preview-badge/proposal.md
+++ b/openspec/changes/source-hover-path-preview-badge/proposal.md
@@ -1,0 +1,27 @@
+# Source Hover Path Preview Badge
+
+## Why
+
+The map's normal movement badge exposes movement type, motive mode, MP cost,
+terrain/elevation details, heat, and shared projection provenance. When the
+player hovers a reachable destination, that badge is replaced by the path
+preview MP badge. The hover badge kept the movement type visible, but it did
+not carry the same cost breakdown or `movement:megamek` source references.
+
+That weakens the tactical explanation layer at the exact moment the player is
+previewing a movement commit.
+
+## What Changes
+
+- Expand the hovered path MP badge with terrain cost, elevation delta/cost,
+  heat, movement source references, rule references, and projection
+  explanation metadata.
+- Include terrain/elevation/heat details in the hover badge accessible label.
+- Add regression coverage proving the hover path preview badge remains tied to
+  the shared rules-backed projection, including same-hex movement options.
+
+## Impact
+
+This is a display/provenance change only. It does not alter movement
+pathfinding, destination legality, commit validation, combat, LOS, terrain
+import, or parser behavior.

--- a/openspec/changes/source-hover-path-preview-badge/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/source-hover-path-preview-badge/specs/tactical-map-interface/spec.md
@@ -1,0 +1,30 @@
+# Spec Delta: Tactical Map Interface
+
+## MODIFIED Requirements
+
+### Requirement: Rules-Backed Tactical Projection Contract
+
+The tactical map interface SHALL render movement, combat, terrain/elevation,
+fog, LOS, cover, and firing-arc highlights from shared rules projections rather
+than from view-local legality calculations.
+
+Every projection that affects action legality SHALL identify the rule source it
+is pinned to, using this source order: official BattleTech rules where citable,
+MegaMek tactical behavior as practical oracle for tactical ambiguity, MekHQ
+only for campaign/scenario context, then local OpenSpec/Jest fixtures as the
+project acceptance contract.
+
+#### Scenario: Hover path badge keeps movement projection provenance
+
+- **GIVEN** a selected unit has a reachable movement destination
+- **WHEN** the player hovers that destination and the map renders the path MP
+  preview badge
+- **THEN** the badge SHALL continue to expose movement type and motive mode
+- **AND** it SHALL expose represented MP cost, terrain cost, elevation
+  delta/cost, and heat when those facts are present
+- **AND** it SHALL expose the shared `movement:megamek` projection source and
+  MegaMek rule references
+- **AND** its accessible label SHALL include the same terrain, elevation, and
+  heat context
+- **AND** exposing those details SHALL NOT change pathfinding or commit
+  legality

--- a/openspec/changes/source-hover-path-preview-badge/tasks.md
+++ b/openspec/changes/source-hover-path-preview-badge/tasks.md
@@ -1,0 +1,13 @@
+## 1. Hover Path Badge
+
+- [x] Expose terrain/elevation/heat metadata on hovered path MP badges.
+- [x] Expose shared movement projection source and MegaMek rule references on
+      hovered path MP badges.
+- [x] Include the same cost breakdown in the hover badge accessible label.
+
+## 2. Tests
+
+- [x] Update HexMapDisplay movement tests for single-option hover path badge
+      provenance.
+- [x] Update HexMapDisplay movement tests for same-hex option source metadata
+      on hover path badges.

--- a/openspec/changes/source-movement-reach-badge/proposal.md
+++ b/openspec/changes/source-movement-reach-badge/proposal.md
@@ -1,0 +1,25 @@
+# Source Movement Reach Badge
+
+## Why
+
+The tactical map's standing movement reach badge is one of the first places a
+player checks destination legality, MP cost, movement mode, heat, terrain, and
+elevation. The hover path preview now preserves shared movement projection
+source evidence, but the non-hover reach badge still exposes its costs without
+directly identifying the shared `movement:megamek` projection evidence on the
+badge itself.
+
+## What Changes
+
+- Add shared movement projection source references, rule references, and
+  explanation metadata to the normal reachable movement badge.
+- Keep the current movement costs, same-hex option summary, terrain/elevation
+  metadata, heat metadata, and command legality behavior unchanged.
+- Add component coverage proving the visible movement reach badge carries the
+  same projection provenance as the rendered hex and hover explanation layer.
+
+## Out Of Scope
+
+- Changing movement pathfinding, destination legality, MP cost math, movement
+  commit validation, combat projection, LOS, terrain import, or isometric depth
+  sorting.

--- a/openspec/changes/source-movement-reach-badge/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/source-movement-reach-badge/specs/tactical-map-interface/spec.md
@@ -1,0 +1,31 @@
+# Spec Delta: Tactical Map Interface
+
+## MODIFIED Requirements
+
+### Requirement: Rules-Backed Tactical Projection Contract
+
+The tactical map interface SHALL render movement, combat, terrain/elevation,
+fog, LOS, cover, and firing-arc highlights from shared rules projections rather
+than from view-local legality calculations.
+
+Every projection that affects action legality SHALL identify the rule source it
+is pinned to, using this source order: official BattleTech rules where citable,
+MegaMek tactical behavior as practical oracle for tactical ambiguity, MekHQ
+only for campaign/scenario context, then local OpenSpec/Jest fixtures as the
+project acceptance contract.
+
+#### Scenario: Movement reach badge keeps projection provenance
+
+- **GIVEN** a selected unit has one or more reachable movement options for a
+  destination hex
+- **WHEN** the tactical map renders the normal movement reach badge before any
+  hover path preview replaces it
+- **THEN** the badge SHALL expose the shared movement-channel tactical
+  projection source and MegaMek-backed rule references
+- **AND** the badge SHALL expose the projection explanation that includes the
+  represented movement options
+- **AND** the badge SHALL continue to expose represented MP cost, movement
+  type/mode, terrain cost, elevation delta/cost, heat, and same-hex option
+  metadata when those facts are present
+- **AND** exposing those details SHALL NOT change pathfinding or commit
+  legality

--- a/openspec/changes/source-movement-reach-badge/tasks.md
+++ b/openspec/changes/source-movement-reach-badge/tasks.md
@@ -1,0 +1,8 @@
+## Tasks
+
+- [x] Add an OpenSpec scenario for movement reach badge provenance.
+- [x] Thread movement-channel projection source/rule references into the normal
+      movement reach badge.
+- [x] Lock the badge metadata with representative Walk/Run/Jump same-hex option
+      coverage.
+- [x] Run OpenSpec and focused tactical-map tests.

--- a/openspec/changes/source-movement-step-cost-badge/proposal.md
+++ b/openspec/changes/source-movement-step-cost-badge/proposal.md
@@ -1,0 +1,23 @@
+# Source Movement Step Cost Badge
+
+## Why
+
+Reachable movement hexes can render a separate terrain/elevation step-cost
+badge such as `T+1 E+2 UP2`. That badge explains why a destination costs more
+MP, so it should identify the same shared movement projection evidence as the
+standing movement reach badge and hover path preview.
+
+## What Changes
+
+- Add movement-channel projection source references, MegaMek rule references,
+  and projection explanation metadata to the visible step-cost badge.
+- Keep the existing terrain cost, elevation cost, elevation delta, MP cost, and
+  movement legality behavior unchanged.
+- Add component coverage proving the cost badge is tied to the shared
+  `movement:megamek` projection.
+
+## Out Of Scope
+
+- Changing terrain/elevation MP math, movement pathfinding, destination
+  legality, movement commit validation, combat projection, terrain import, LOS,
+  or isometric rendering.

--- a/openspec/changes/source-movement-step-cost-badge/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/source-movement-step-cost-badge/specs/tactical-map-interface/spec.md
@@ -1,0 +1,29 @@
+# Spec Delta: Tactical Map Interface
+
+## MODIFIED Requirements
+
+### Requirement: Rules-Backed Tactical Projection Contract
+
+The tactical map interface SHALL render movement, combat, terrain/elevation,
+fog, LOS, cover, and firing-arc highlights from shared rules projections rather
+than from view-local legality calculations.
+
+Every projection that affects action legality SHALL identify the rule source it
+is pinned to, using this source order: official BattleTech rules where citable,
+MegaMek tactical behavior as practical oracle for tactical ambiguity, MekHQ
+only for campaign/scenario context, then local OpenSpec/Jest fixtures as the
+project acceptance contract.
+
+#### Scenario: Movement step-cost badge keeps projection provenance
+
+- **GIVEN** a reachable movement destination has represented terrain or
+  elevation step costs
+- **WHEN** the tactical map renders the visible movement step-cost badge
+- **THEN** the badge SHALL expose the shared movement-channel tactical
+  projection source and MegaMek-backed rule references
+- **AND** the badge SHALL expose the projection explanation that includes the
+  represented terrain and elevation cost details
+- **AND** the badge SHALL continue to expose terrain cost, elevation delta, and
+  elevation cost metadata without relying only on color
+- **AND** exposing those details SHALL NOT change terrain/elevation MP math,
+  pathfinding, or commit legality

--- a/openspec/changes/source-movement-step-cost-badge/tasks.md
+++ b/openspec/changes/source-movement-step-cost-badge/tasks.md
@@ -1,0 +1,8 @@
+## Tasks
+
+- [x] Add an OpenSpec scenario for movement step-cost badge provenance.
+- [x] Thread movement-channel projection source/rule references into the
+      terrain/elevation step-cost badge.
+- [x] Lock the step-cost badge metadata with representative terrain and
+      elevation cost coverage.
+- [x] Run OpenSpec and focused tactical-map tests.

--- a/openspec/changes/surface-cliff-exits-map-context/proposal.md
+++ b/openspec/changes/surface-cliff-exits-map-context/proposal.md
@@ -1,0 +1,16 @@
+# Surface Cliff Exits Map Context
+
+## Why
+
+MegaMek board cliff-top exits now import into `IHexTerrain`, and movement projection uses that metadata to distinguish sheer cliffs from ordinary elevation changes. The map still needs to expose those represented directional cliff edges in the same terrain/elevation explanation surfaces players and tests inspect.
+
+## What Changes
+
+- Include represented `cliffTopExits` in terrain/elevation projection source detail when present.
+- Expose cliff exit directions on rendered hex and terrain label metadata.
+- Show cliff exit directions in terrain hover and action hover terrain context.
+
+## Out of Scope
+
+- Changing movement, combat, LOS, cover, or parser behavior.
+- Inferring cliff edges from elevation deltas when no `cliffTopExits` metadata is represented.

--- a/openspec/changes/surface-cliff-exits-map-context/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/surface-cliff-exits-map-context/specs/tactical-map-interface/spec.md
@@ -1,0 +1,18 @@
+# Spec Delta: Tactical Map Interface
+
+## MODIFIED Requirements
+
+### Requirement: Rules-Backed Tactical Projection Contract
+
+The tactical map interface SHALL render movement, combat, terrain/elevation, fog, LOS, cover, and firing-arc highlights from shared rules projections rather than from view-local legality calculations.
+
+Every projection that affects action legality SHALL identify the rule source it is pinned to, using this source order: official BattleTech rules where citable, MegaMek tactical behavior as practical oracle for tactical ambiguity, MekHQ only for campaign/scenario context, then local OpenSpec/Jest fixtures as the project acceptance contract.
+
+#### Scenario: Terrain projection exposes represented cliff exits
+
+- **GIVEN** a rendered hex has represented directional `cliffTopExits`
+- **WHEN** the hex renders and its terrain/elevation projection metadata is inspected
+- **THEN** the hex SHALL expose the cliff exit directions in machine-readable terrain metadata
+- **AND** terrain/elevation source detail SHALL include the cliff exit direction labels
+- **AND** hover terrain context SHALL show the represented cliff edge directions
+- **AND** exposing those directions SHALL NOT change movement, combat, LOS, cover, or parser behavior

--- a/openspec/changes/surface-cliff-exits-map-context/tasks.md
+++ b/openspec/changes/surface-cliff-exits-map-context/tasks.md
@@ -1,0 +1,6 @@
+## Implementation
+
+- [x] Add cliff exit directions to terrain/elevation projection source metadata.
+- [x] Expose represented cliff exits in hex DOM, terrain labels, and hover terrain context.
+- [x] Cover source metadata, rendered hex metadata, and tooltip context with focused tests.
+- [x] Validate the OpenSpec delta and focused tests.

--- a/openspec/changes/surface-movement-option-source-details/proposal.md
+++ b/openspec/changes/surface-movement-option-source-details/proposal.md
@@ -1,0 +1,26 @@
+# Surface Movement Option Source Details
+
+## Why
+
+The tactical map already renders same-hex walk/run/jump movement options in
+badges, hover rows, and projection explanations, but the shared source
+reference still compressed movement legality to a coarse `walk projection` /
+`run projection` label. That left downstream top-down and isometric surfaces
+with source metadata that did not independently explain which movement modes
+were legal, blocked, costly, or heat-generating.
+
+## What Changes
+
+- Expand the shared movement projection source detail so it includes each
+  represented same-hex movement option, its legal/blocked state, MP cost,
+  terrain/elevation cost details, heat, and blocked reason when present.
+- Keep the existing source channel and MegaMek rule references intact so UI
+  consumers can continue filtering on `movement:megamek`.
+- Add regression coverage proving mixed walk/run/jump options are represented
+  in the source reference, not only in the visible badge text.
+
+## Impact
+
+This is a tactical map explanation-layer change only. It does not alter
+movement pathfinding, movement commit validation, combat, LOS, terrain import,
+or parser behavior.

--- a/openspec/changes/surface-movement-option-source-details/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/surface-movement-option-source-details/specs/tactical-map-interface/spec.md
@@ -1,0 +1,30 @@
+# Spec Delta: Tactical Map Interface
+
+## MODIFIED Requirements
+
+### Requirement: Rules-Backed Tactical Projection Contract
+
+The tactical map interface SHALL render movement, combat, terrain/elevation,
+fog, LOS, cover, and firing-arc highlights from shared rules projections rather
+than from view-local legality calculations.
+
+Every projection that affects action legality SHALL identify the rule source it
+is pinned to, using this source order: official BattleTech rules where citable,
+MegaMek tactical behavior as practical oracle for tactical ambiguity, MekHQ
+only for campaign/scenario context, then local OpenSpec/Jest fixtures as the
+project acceptance contract.
+
+#### Scenario: Movement source detail explains same-hex options
+
+- **GIVEN** a rendered hex has one or more movement projection options for the
+  selected unit
+- **WHEN** the shared tactical projection source references are inspected
+- **THEN** the movement source reference SHALL include each represented
+  movement option's type or motive mode
+- **AND** it SHALL include whether that option is reachable or blocked
+- **AND** it SHALL include represented MP cost, terrain cost, elevation cost,
+  heat, and blocked reason when those facts are present
+- **AND** the source reference SHALL continue to identify MegaMek movement
+  rules as the tactical oracle
+- **AND** exposing those details SHALL NOT change movement pathfinding or
+  commit legality

--- a/openspec/changes/surface-movement-option-source-details/tasks.md
+++ b/openspec/changes/surface-movement-option-source-details/tasks.md
@@ -1,0 +1,13 @@
+## 1. Projection Source Detail
+
+- [x] Include per-option movement state, MP, terrain/elevation cost, heat, and
+      blocked detail in shared movement projection source references.
+- [x] Preserve the existing `movement:megamek` channel and rule references for
+      existing top-down/isometric consumers.
+
+## 2. Tests
+
+- [x] Update tactical map projection tests for the expanded single-option
+      source detail.
+- [x] Add mixed walk/run/jump source-reference coverage for same-hex movement
+      options.

--- a/src/components/gameplay/HexMapDisplay/HexCell.hoverMovementBadge.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexCell.hoverMovementBadge.tsx
@@ -1,11 +1,57 @@
 import React from 'react';
 
 import type { IHexCoordinate, IMovementRangeHex } from '@/types/gameplay';
+import type { ITacticalMapProjectionSourceReference } from '@/utils/gameplay/tacticalMapProjection';
+
+import {
+  formatTacticalProjectionRuleReferences,
+  formatTacticalProjectionSourceReferences,
+} from '@/utils/gameplay/tacticalMapProjection';
 
 import {
   formatMovementModeTitle,
   formatMovementReachBadgeLabel,
 } from './HexCell.movementBadges';
+
+function formatSignedCost(value: number): string {
+  return value >= 0 ? `+${value}` : `${value}`;
+}
+
+function formatPathPreviewTitle(
+  movementInfo: IMovementRangeHex | undefined,
+  hoverMpCost: number,
+): string {
+  if (!movementInfo) return `Movement path preview: ${hoverMpCost} MP`;
+
+  const details = [
+    `${formatMovementModeTitle({ ...movementInfo, mpCost: hoverMpCost })} path preview: ${hoverMpCost} MP`,
+  ];
+  if (movementInfo.terrainCost !== undefined) {
+    details.push(`terrain ${formatSignedCost(movementInfo.terrainCost)}`);
+  }
+  if (
+    movementInfo.elevationDelta !== undefined ||
+    movementInfo.elevationCost !== undefined
+  ) {
+    const elevationDetails: string[] = [];
+    if (movementInfo.elevationDelta !== undefined) {
+      elevationDetails.push(
+        `delta ${formatSignedCost(movementInfo.elevationDelta)}`,
+      );
+    }
+    if (movementInfo.elevationCost !== undefined) {
+      elevationDetails.push(
+        `cost ${formatSignedCost(movementInfo.elevationCost)}`,
+      );
+    }
+    details.push(`elevation ${elevationDetails.join(' ')}`);
+  }
+  if (movementInfo.heatGenerated !== undefined) {
+    details.push(`heat ${formatSignedCost(movementInfo.heatGenerated)}`);
+  }
+
+  return details.join('; ');
+}
 
 export function MovementHoverCostBadge({
   x,
@@ -13,12 +59,16 @@ export function MovementHoverCostBadge({
   hex,
   hoverMpCost,
   movementInfo,
+  projectionExplanation,
+  sourceReferences,
 }: {
   readonly x: number;
   readonly y: number;
   readonly hex: IHexCoordinate;
   readonly hoverMpCost?: number;
   readonly movementInfo?: IMovementRangeHex;
+  readonly projectionExplanation?: string;
+  readonly sourceReferences?: readonly ITacticalMapProjectionSourceReference[];
 }): React.ReactElement | null {
   if (hoverMpCost === undefined) return null;
 
@@ -32,20 +82,39 @@ export function MovementHoverCostBadge({
   const label = activeMovementInfo
     ? formatMovementReachBadgeLabel(activeMovementInfo)
     : `${hoverMpCost}MP`;
-  const title = activeMovementInfo
-    ? `${formatMovementModeTitle(activeMovementInfo)} path preview: ${hoverMpCost} MP`
-    : `Movement path preview: ${hoverMpCost} MP`;
+  const title = formatPathPreviewTitle(movementInfo, hoverMpCost);
   const width = Math.max(34, label.length * 5.6 + 10);
+  const movementSourceReferences =
+    sourceReferences?.filter((source) => source.channel === 'movement') ?? [];
+  const movementSourceRefsAttribute =
+    formatTacticalProjectionSourceReferences(movementSourceReferences) ||
+    undefined;
+  const movementRuleRefsAttribute =
+    formatTacticalProjectionRuleReferences(movementSourceReferences) ||
+    undefined;
+  const movementProjectionChannel =
+    movementSourceReferences.length > 0 ? 'movement' : undefined;
 
   return (
     <g
       pointerEvents="none"
       data-testid={`hex-mp-badge-${hex.q}-${hex.r}`}
       aria-label={title}
+      data-tactical-projection-source={
+        movementProjectionChannel ? 'shared-tactical-map-projection' : undefined
+      }
+      data-tactical-projection-channel={movementProjectionChannel}
+      data-tactical-rules-surface={movementProjectionChannel}
       data-hover-mp-cost={hoverMpCost}
       data-movement-badge-type={movementInfo?.movementType}
       data-movement-badge-mode={movementInfo?.movementMode}
+      data-movement-badge-terrain-cost={movementInfo?.terrainCost}
+      data-movement-badge-elevation-delta={movementInfo?.elevationDelta}
+      data-movement-badge-elevation-cost={movementInfo?.elevationCost}
       data-movement-badge-heat-generated={movementInfo?.heatGenerated}
+      data-movement-badge-source-refs={movementSourceRefsAttribute}
+      data-movement-badge-rule-refs={movementRuleRefsAttribute}
+      data-movement-badge-projection-explanation={projectionExplanation}
     >
       <title>{title}</title>
       <rect

--- a/src/components/gameplay/HexMapDisplay/HexCell.labels.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexCell.labels.tsx
@@ -20,6 +20,10 @@ import {
 } from '@/utils/gameplay/tacticalMapProjection';
 
 import { formatCombatC3Label } from './HexMapDisplay.combatC3Context';
+import {
+  terrainCliffExitDirectionsAttributeForFeatures,
+  terrainCliffExitLabelsAttributeForFeatures,
+} from './HexMapDisplay.terrainMetadata';
 
 const TERRAIN_ELEVATION_PROJECTION_CHANNEL = 'terrain-elevation';
 const SHARED_TACTICAL_PROJECTION_SOURCE = 'shared-tactical-map-projection';
@@ -48,7 +52,11 @@ export function formatTerrainFeaturesLabel(
 
 function formatTerrainFeatureReference(feature: ITerrainFeature): string {
   const label = formatTerrainLabel(feature.type);
-  return feature.level > 0 ? `${label} L${feature.level}` : label;
+  const levelLabel = feature.level > 0 ? `${label} L${feature.level}` : label;
+  const cliffExitLabels = terrainCliffExitLabelsAttributeForFeatures([feature]);
+  return cliffExitLabels
+    ? `${levelLabel} cliff edges ${cliffExitLabels}`
+    : levelLabel;
 }
 
 export function formatTerrainFeatureReferenceLabel(
@@ -467,6 +475,12 @@ export function TerrainBadge({
         displayTypes.length > 0 ? displayTypes.join(',') : 'clear'
       }
       data-terrain-feature-levels={terrainFeatureLevelsAttribute(
+        displayFeatures,
+      )}
+      data-terrain-cliff-exits={terrainCliffExitDirectionsAttributeForFeatures(
+        displayFeatures,
+      )}
+      data-terrain-cliff-exit-labels={terrainCliffExitLabelsAttributeForFeatures(
         displayFeatures,
       )}
       data-terrain-feature-count={displayTypes.length}

--- a/src/components/gameplay/HexMapDisplay/HexCell.movementBadges.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexCell.movementBadges.tsx
@@ -445,11 +445,15 @@ export function MovementStepCostBadge({
   y,
   hex,
   movementInfo,
+  projectionExplanation,
+  sourceReferences,
 }: {
   readonly x: number;
   readonly y: number;
   readonly hex: IHexCoordinate;
   readonly movementInfo?: IMovementRangeHex;
+  readonly projectionExplanation?: string;
+  readonly sourceReferences?: readonly ITacticalMapProjectionSourceReference[];
 }): React.ReactElement | null {
   if (!movementInfo?.reachable) return null;
   const label = formatMovementStepCostLabel(movementInfo);
@@ -457,14 +461,32 @@ export function MovementStepCostBadge({
 
   const title = formatMovementStepCostTitle(movementInfo);
   const width = Math.max(28, label.length * 5.4 + 8);
+  const movementSourceReferences =
+    sourceReferences?.filter((source) => source.channel === 'movement') ?? [];
+  const movementSourceRefsAttribute =
+    formatTacticalProjectionSourceReferences(movementSourceReferences) ||
+    undefined;
+  const movementRuleRefsAttribute =
+    formatTacticalProjectionRuleReferences(movementSourceReferences) ||
+    undefined;
+  const movementProjectionChannel =
+    movementSourceReferences.length > 0 ? 'movement' : undefined;
   return (
     <g
       pointerEvents="none"
       data-testid={`hex-movement-cost-badge-${hex.q}-${hex.r}`}
       aria-label={title}
+      data-tactical-projection-source={
+        movementProjectionChannel ? 'shared-tactical-map-projection' : undefined
+      }
+      data-tactical-projection-channel={movementProjectionChannel}
+      data-tactical-rules-surface={movementProjectionChannel}
       data-movement-step-terrain-cost={movementInfo.terrainCost}
       data-movement-step-elevation-cost={movementInfo.elevationCost}
       data-movement-step-elevation-delta={movementInfo.elevationDelta}
+      data-movement-step-source-refs={movementSourceRefsAttribute}
+      data-movement-step-rule-refs={movementRuleRefsAttribute}
+      data-movement-step-projection-explanation={projectionExplanation}
     >
       <title>{title}</title>
       <rect

--- a/src/components/gameplay/HexMapDisplay/HexCell.movementBadges.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexCell.movementBadges.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 
 import type { IHexCoordinate, IMovementRangeHex } from '@/types/gameplay';
+import type { ITacticalMapProjectionSourceReference } from '@/utils/gameplay/tacticalMapProjection';
+
+import {
+  formatTacticalProjectionRuleReferences,
+  formatTacticalProjectionSourceReferences,
+} from '@/utils/gameplay/tacticalMapProjection';
 
 import {
   formatMovementModeLabel,
@@ -191,23 +197,42 @@ export function MovementReachBadge({
   y,
   hex,
   movementInfo,
+  projectionExplanation,
+  sourceReferences,
 }: {
   readonly x: number;
   readonly y: number;
   readonly hex: IHexCoordinate;
   readonly movementInfo?: IMovementRangeHex;
+  readonly projectionExplanation?: string;
+  readonly sourceReferences?: readonly ITacticalMapProjectionSourceReference[];
 }): React.ReactElement | null {
   if (!movementInfo?.reachable) return null;
   const label = formatMovementReachBadgeLabel(movementInfo);
   const title = formatMovementReachBadgeTitle(movementInfo);
   const movementOptions = movementInfo.movementModeOptions ?? [];
   const width = Math.max(34, label.length * 5.6 + 10);
+  const movementSourceReferences =
+    sourceReferences?.filter((source) => source.channel === 'movement') ?? [];
+  const movementSourceRefsAttribute =
+    formatTacticalProjectionSourceReferences(movementSourceReferences) ||
+    undefined;
+  const movementRuleRefsAttribute =
+    formatTacticalProjectionRuleReferences(movementSourceReferences) ||
+    undefined;
+  const movementProjectionChannel =
+    movementSourceReferences.length > 0 ? 'movement' : undefined;
 
   return (
     <g
       pointerEvents="none"
       data-testid={`hex-movement-badge-${hex.q}-${hex.r}`}
       aria-label={title}
+      data-tactical-projection-source={
+        movementProjectionChannel ? 'shared-tactical-map-projection' : undefined
+      }
+      data-tactical-projection-channel={movementProjectionChannel}
+      data-tactical-rules-surface={movementProjectionChannel}
       data-movement-badge-type={movementInfo.movementType}
       data-movement-badge-mode={movementInfo.movementMode}
       data-movement-badge-mp-cost={movementInfo.mpCost}
@@ -321,6 +346,9 @@ export function MovementReachBadge({
           ? movementOptionAutomaticLandingsAttribute(movementOptions)
           : undefined
       }
+      data-movement-badge-source-refs={movementSourceRefsAttribute}
+      data-movement-badge-rule-refs={movementRuleRefsAttribute}
+      data-movement-badge-projection-explanation={projectionExplanation}
     >
       <title>{title}</title>
       <rect

--- a/src/components/gameplay/HexMapDisplay/HexCell.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexCell.tsx
@@ -960,7 +960,14 @@ export const HexCell = React.memo(function HexCell({
         sourceReferences={tacticalProjectionSourceReferences}
       />
       {hoverMpCost === undefined && (
-        <MovementReachBadge x={x} y={y} hex={hex} movementInfo={movementInfo} />
+        <MovementReachBadge
+          x={x}
+          y={y}
+          hex={hex}
+          movementInfo={movementInfo}
+          projectionExplanation={tacticalProjectionExplanation}
+          sourceReferences={tacticalProjectionSourceReferences}
+        />
       )}
       <MovementBlockedOptionsBadge
         x={x}

--- a/src/components/gameplay/HexMapDisplay/HexCell.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexCell.tsx
@@ -998,6 +998,8 @@ export const HexCell = React.memo(function HexCell({
         hex={hex}
         hoverMpCost={hoverMpCost}
         movementInfo={movementInfo}
+        projectionExplanation={tacticalProjectionExplanation}
+        sourceReferences={tacticalProjectionSourceReferences}
       />
       <CombatLineOfSightBlockerBadge
         x={x}

--- a/src/components/gameplay/HexMapDisplay/HexCell.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexCell.tsx
@@ -980,6 +980,8 @@ export const HexCell = React.memo(function HexCell({
         y={y}
         hex={hex}
         movementInfo={movementInfo}
+        projectionExplanation={tacticalProjectionExplanation}
+        sourceReferences={tacticalProjectionSourceReferences}
       />
       <MovementStandUpBadge x={x} y={y} hex={hex} movementInfo={movementInfo} />
       <MovementAutomaticLandingBadge

--- a/src/components/gameplay/HexMapDisplay/HexCell.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexCell.tsx
@@ -90,6 +90,8 @@ import {
   terrainBuildingConstructionFactorsAttribute,
   terrainBuildingIdsAttribute,
   terrainBuildingLevelsAttribute,
+  terrainCliffExitDirectionsAttribute,
+  terrainCliffExitLabelsAttribute,
 } from './HexMapDisplay.terrainMetadata';
 import {
   isIsometricProjection,
@@ -297,6 +299,9 @@ export const HexCell = React.memo(function HexCell({
   const terrainBuildingLevelAttribute = terrainBuildingLevelsAttribute(terrain);
   const terrainBuildingCfAttribute =
     terrainBuildingConstructionFactorsAttribute(terrain);
+  const terrainCliffExitDirections =
+    terrainCliffExitDirectionsAttribute(terrain);
+  const terrainCliffExitLabels = terrainCliffExitLabelsAttribute(terrain);
   const elevation = terrain?.elevation ?? 0;
   const elevationLabel = formatElevationLabel(elevation);
   const isIsometricTile = isIsometricProjection(projectionMode);
@@ -569,6 +574,8 @@ export const HexCell = React.memo(function HexCell({
       data-terrain-feature-levels={terrainFeatureLevelsAttribute(
         terrainFeatures,
       )}
+      data-terrain-cliff-exits={terrainCliffExitDirections}
+      data-terrain-cliff-exit-labels={terrainCliffExitLabels}
       data-terrain-building-ids={terrainBuildingIdAttribute}
       data-terrain-building-levels={terrainBuildingLevelAttribute}
       data-terrain-construction-factors={terrainBuildingCfAttribute}

--- a/src/components/gameplay/HexMapDisplay/HexMapDisplay.terrainMetadata.ts
+++ b/src/components/gameplay/HexMapDisplay/HexMapDisplay.terrainMetadata.ts
@@ -1,6 +1,10 @@
 import type { IHexTerrain } from '@/types/gameplay';
 
-import { TerrainType } from '@/types/gameplay';
+import { Facing, TerrainType } from '@/types/gameplay';
+import {
+  getFacingAbbreviation,
+  getFacingName,
+} from '@/utils/gameplay/unitPosition';
 
 type TerrainFeature = IHexTerrain['features'][number];
 
@@ -70,4 +74,76 @@ export function terrainBuildingDetailLabel(
     formatTerrainBuildingDetail,
   );
   return details.length > 0 ? details.join('; ') : undefined;
+}
+
+function isFacing(value: number): value is Facing {
+  return (
+    Number.isInteger(value) &&
+    value >= Facing.North &&
+    value <= Facing.Northwest
+  );
+}
+
+export function terrainCliffExitDirectionsForFeatures(
+  features: readonly TerrainFeature[],
+): readonly Facing[] {
+  const directions = new Set<Facing>();
+  for (const feature of features) {
+    for (const direction of feature.cliffTopExits ?? []) {
+      if (isFacing(direction)) {
+        directions.add(direction);
+      }
+    }
+  }
+
+  return Array.from(directions).sort((a, b) => a - b);
+}
+
+export function terrainCliffExitDirectionsAttributeForFeatures(
+  features: readonly TerrainFeature[],
+): string | undefined {
+  const directions = terrainCliffExitDirectionsForFeatures(features);
+  return directions.length > 0 ? directions.join(',') : undefined;
+}
+
+export function terrainCliffExitLabelsAttributeForFeatures(
+  features: readonly TerrainFeature[],
+): string | undefined {
+  const directions = terrainCliffExitDirectionsForFeatures(features);
+  return directions.length > 0
+    ? directions.map(getFacingAbbreviation).join(',')
+    : undefined;
+}
+
+export function terrainCliffExitDetailLabelForFeatures(
+  features: readonly TerrainFeature[],
+): string | undefined {
+  const directions = terrainCliffExitDirectionsForFeatures(features);
+  return directions.length > 0
+    ? `Cliff edges: ${directions.map(getFacingName).join(', ')}`
+    : undefined;
+}
+
+export function terrainCliffExitDirectionsAttribute(
+  terrain: IHexTerrain | undefined,
+): string | undefined {
+  return terrain
+    ? terrainCliffExitDirectionsAttributeForFeatures(terrain.features)
+    : undefined;
+}
+
+export function terrainCliffExitLabelsAttribute(
+  terrain: IHexTerrain | undefined,
+): string | undefined {
+  return terrain
+    ? terrainCliffExitLabelsAttributeForFeatures(terrain.features)
+    : undefined;
+}
+
+export function terrainCliffExitDetailLabel(
+  terrain: IHexTerrain | undefined,
+): string | undefined {
+  return terrain
+    ? terrainCliffExitDetailLabelForFeatures(terrain.features)
+    : undefined;
 }

--- a/src/components/gameplay/HexMapDisplay/HexMapDisplay.terrainTooltip.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexMapDisplay.terrainTooltip.tsx
@@ -22,6 +22,9 @@ import {
 } from './HexCell.labels';
 import { ProjectionContextRows } from './HexMapDisplay.projectionTooltipRows';
 import {
+  terrainCliffExitDetailLabel,
+  terrainCliffExitDirectionsAttribute,
+  terrainCliffExitLabelsAttribute,
   terrainBuildingConstructionFactorsAttribute,
   terrainBuildingDetailLabel,
   terrainBuildingIdsAttribute,
@@ -55,6 +58,8 @@ function terrainElevationSourceAttributes(
     sourceReferences.length > 0
       ? TERRAIN_ELEVATION_PROJECTION_CHANNEL
       : undefined;
+  const cliffExitDirections = terrainCliffExitDirectionsAttribute(terrain);
+  const cliffExitLabels = terrainCliffExitLabelsAttribute(terrain);
 
   return {
     'data-tactical-projection-source': projectionChannel
@@ -70,6 +75,8 @@ function terrainElevationSourceAttributes(
     'data-terrain-feature-levels': terrainFeatureLevelsAttribute(
       terrain.features,
     ),
+    'data-terrain-cliff-exits': cliffExitDirections,
+    'data-terrain-cliff-exit-labels': cliffExitLabels,
     'data-elevation': terrain.elevation,
     'data-terrain-source-refs': sourceRefsAttribute,
     'data-terrain-rule-refs': ruleRefsAttribute,
@@ -137,6 +144,7 @@ export function TerrainHoverTooltip({
   const buildingCfAttribute =
     terrainBuildingConstructionFactorsAttribute(terrain);
   const buildingDetailLabel = terrainBuildingDetailLabel(terrain);
+  const cliffExitDetailLabel = terrainCliffExitDetailLabel(terrain);
   const blocksLos = terrain.features.some(
     (feature) => TERRAIN_PROPERTIES[feature.type].blocksLOS,
   );
@@ -177,6 +185,14 @@ export function TerrainHoverTooltip({
           {...sourceAttributes}
         >
           Building: {buildingDetailLabel}
+        </div>
+      )}
+      {cliffExitDetailLabel && (
+        <div
+          data-testid="hex-terrain-tooltip-cliff-exits"
+          {...sourceAttributes}
+        >
+          {cliffExitDetailLabel}
         </div>
       )}
       <div data-testid="hex-terrain-tooltip-cover">
@@ -226,6 +242,7 @@ export function TerrainContextRows({
   const buildingCfAttribute =
     terrainBuildingConstructionFactorsAttribute(terrain);
   const buildingDetailLabel = terrainBuildingDetailLabel(terrain);
+  const cliffExitDetailLabel = terrainCliffExitDetailLabel(terrain);
   const sourceAttributes = terrainElevationSourceAttributes(
     terrain,
     projection,
@@ -254,6 +271,14 @@ export function TerrainContextRows({
           {...sourceAttributes}
         >
           Building: {buildingDetailLabel}
+        </div>
+      )}
+      {cliffExitDetailLabel && (
+        <div
+          data-testid={`${testIdPrefix}-cliff-exits-context`}
+          {...sourceAttributes}
+        >
+          {cliffExitDetailLabel}
         </div>
       )}
     </div>

--- a/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.test.tsx
+++ b/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.test.tsx
@@ -1683,7 +1683,7 @@ describe('HexMapDisplay tactical visual layers', () => {
     );
     expect(screen.getByTestId('hex-mp-badge-1-0')).toHaveAttribute(
       'aria-label',
-      'run via hover path preview: 4 MP',
+      'run via hover path preview: 4 MP; terrain +1; elevation delta +1 cost +1; heat +2',
     );
     expect(screen.getByTestId('hex-mp-badge-1-0')).toHaveAttribute(
       'data-hover-mp-cost',
@@ -1698,9 +1698,41 @@ describe('HexMapDisplay tactical visual layers', () => {
       'hover',
     );
     expect(screen.getByTestId('hex-mp-badge-1-0')).toHaveAttribute(
+      'data-movement-badge-terrain-cost',
+      '1',
+    );
+    expect(screen.getByTestId('hex-mp-badge-1-0')).toHaveAttribute(
+      'data-movement-badge-elevation-delta',
+      '1',
+    );
+    expect(screen.getByTestId('hex-mp-badge-1-0')).toHaveAttribute(
+      'data-movement-badge-elevation-cost',
+      '1',
+    );
+    expect(screen.getByTestId('hex-mp-badge-1-0')).toHaveAttribute(
       'data-movement-badge-heat-generated',
       '2',
     );
+    expect(screen.getByTestId('hex-mp-badge-1-0')).toHaveAttribute(
+      'data-tactical-projection-source',
+      'shared-tactical-map-projection',
+    );
+    expect(screen.getByTestId('hex-mp-badge-1-0')).toHaveAttribute(
+      'data-tactical-projection-channel',
+      'movement',
+    );
+    expect(
+      screen
+        .getByTestId('hex-mp-badge-1-0')
+        .getAttribute('data-movement-badge-source-refs'),
+    ).toContain(
+      'movement:megamek:MegaMek movement rules projection:run/hover projection: run via hover reachable 4 MP terrain +1 elevation delta +1 cost +1 heat +2',
+    );
+    expect(
+      screen
+        .getByTestId('hex-mp-badge-1-0')
+        .getAttribute('data-movement-badge-rule-refs'),
+    ).toContain('movement:megamek:MegaMek common/moves/MoveStep.java');
 
     act(() => {
       unmount();
@@ -1765,7 +1797,7 @@ describe('HexMapDisplay tactical visual layers', () => {
     );
     expect(screen.getByTestId('hex-mp-badge-1-0')).toHaveAttribute(
       'aria-label',
-      'run via tracked path preview: 5 MP',
+      'run via tracked path preview: 5 MP; terrain +2; elevation delta +1 cost +1; heat +2',
     );
     expect(screen.getByTestId('hex-mp-badge-1-0')).toHaveAttribute(
       'data-hover-mp-cost',
@@ -1778,6 +1810,13 @@ describe('HexMapDisplay tactical visual layers', () => {
     expect(screen.getByTestId('hex-mp-badge-1-0')).toHaveAttribute(
       'data-movement-badge-mode',
       'tracked',
+    );
+    expect(
+      screen
+        .getByTestId('hex-mp-badge-1-0')
+        .getAttribute('data-movement-badge-source-refs'),
+    ).toContain(
+      'run/tracked,walk/tracked projection: run via tracked reachable 5 MP terrain +2 elevation delta +1 cost +1 heat +2, walk via tracked reachable 3 MP terrain +2 elevation delta +1 cost +1 heat +1',
     );
 
     act(() => {

--- a/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.test.tsx
+++ b/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.test.tsx
@@ -1296,6 +1296,33 @@ describe('HexMapDisplay tactical visual layers', () => {
       'data-movement-badge-option-heats',
       'walk:0|run:2|jump:1',
     );
+    expect(badge).toHaveAttribute(
+      'data-tactical-projection-source',
+      'shared-tactical-map-projection',
+    );
+    expect(badge).toHaveAttribute(
+      'data-tactical-projection-channel',
+      'movement',
+    );
+    expect(badge).toHaveAttribute('data-tactical-rules-surface', 'movement');
+    expect(badge).toHaveAttribute(
+      'data-movement-badge-source-refs',
+      expect.stringContaining(
+        'movement:megamek:MegaMek movement rules projection:walk/tracked,run/tracked,jump projection: walk via tracked reachable 3 MP terrain +1 elevation delta +1 cost +1 heat +0, run via tracked reachable 3 MP terrain +2 elevation delta +1 cost +1 heat +2, jump reachable 1 MP terrain +0 elevation delta +2 cost +0 heat +1',
+      ),
+    );
+    expect(badge).toHaveAttribute(
+      'data-movement-badge-rule-refs',
+      expect.stringContaining(
+        'movement:megamek:MegaMek common/moves/MoveStep.java',
+      ),
+    );
+    expect(badge).toHaveAttribute(
+      'data-movement-badge-projection-explanation',
+      expect.stringContaining(
+        'movement options walk via tracked reachable 3 MP terrain +1 elevation delta +1 cost +1 heat +0',
+      ),
+    );
     expect(screen.getByTestId('hex-heat-badge-1-0')).toHaveTextContent('+2H');
     expect(screen.getByTestId('hex-heat-badge-1-0')).toHaveAttribute(
       'data-movement-option-heats',

--- a/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.test.tsx
+++ b/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.test.tsx
@@ -2718,6 +2718,32 @@ describe('HexMapDisplay tactical visual layers', () => {
       'data-movement-step-elevation-cost',
       '2',
     );
+    expect(screen.getByTestId('hex-movement-cost-badge-1-0')).toHaveAttribute(
+      'data-tactical-projection-source',
+      'shared-tactical-map-projection',
+    );
+    expect(screen.getByTestId('hex-movement-cost-badge-1-0')).toHaveAttribute(
+      'data-tactical-projection-channel',
+      'movement',
+    );
+    expect(screen.getByTestId('hex-movement-cost-badge-1-0')).toHaveAttribute(
+      'data-movement-step-source-refs',
+      expect.stringContaining(
+        'movement:megamek:MegaMek movement rules projection:walk/tracked projection: walk via tracked reachable 3 MP terrain +1 elevation delta +2 cost +2',
+      ),
+    );
+    expect(screen.getByTestId('hex-movement-cost-badge-1-0')).toHaveAttribute(
+      'data-movement-step-rule-refs',
+      expect.stringContaining(
+        'movement:megamek:MegaMek common/moves/MoveStep.java',
+      ),
+    );
+    expect(screen.getByTestId('hex-movement-cost-badge-1-0')).toHaveAttribute(
+      'data-movement-step-projection-explanation',
+      expect.stringContaining(
+        'Walk reachable 3 MP; mode tracked; terrain cost +1; elevation delta +2 cost +2',
+      ),
+    );
 
     act(() => {
       unmount();

--- a/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.terrainLabels.test.tsx
+++ b/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.terrainLabels.test.tsx
@@ -405,6 +405,73 @@ describe('HexMapDisplay terrain and elevation labels', () => {
     });
   });
 
+  it('surfaces represented cliff exits in hex labels and terrain hover context', () => {
+    const cliffTerrain: IHexTerrain = {
+      coordinate: { q: 1, r: 0 },
+      elevation: 2,
+      features: [
+        {
+          type: TerrainType.Rough,
+          level: 1,
+          cliffTopExits: [Facing.North, Facing.Southeast],
+        },
+      ],
+    };
+
+    const { unmount } = render(
+      <HexMapDisplay
+        mapId="cliff-exit-terrain-labels"
+        radius={1}
+        tokens={[]}
+        selectedHex={null}
+        hexTerrain={[cliffTerrain]}
+      />,
+    );
+
+    const cliffHex = screen.getByTestId('hex-1-0');
+    expect(cliffHex).toHaveAttribute(
+      'aria-label',
+      expect.stringContaining('terrain rough L1 cliff edges N,SE'),
+    );
+    expect(cliffHex).toHaveAttribute('data-terrain-cliff-exits', '0,2');
+    expect(cliffHex).toHaveAttribute('data-terrain-cliff-exit-labels', 'N,SE');
+    expect(cliffHex).toHaveAttribute(
+      'data-tactical-projection-sources',
+      expect.stringContaining(
+        'terrain-elevation:mekstation:Rendered map terrain/elevation grid:rough level 1 cliff edges N/SE elevation 2',
+      ),
+    );
+
+    const terrainBadge = screen.getByTestId('hex-terrain-label-1-0');
+    expect(terrainBadge).toHaveAttribute(
+      'aria-label',
+      expect.stringContaining('Terrain rough L1 cliff edges N,SE'),
+    );
+    expect(terrainBadge).toHaveAttribute('data-terrain-cliff-exits', '0,2');
+    expect(terrainBadge).toHaveAttribute(
+      'data-terrain-cliff-exit-labels',
+      'N,SE',
+    );
+
+    fireEvent.mouseEnter(cliffHex);
+
+    const cliffContext = screen.getByTestId('hex-terrain-tooltip-cliff-exits');
+    expect(cliffContext).toHaveTextContent('Cliff edges: North, Southeast');
+    expect(cliffContext).toHaveAttribute('data-terrain-cliff-exits', '0,2');
+    expect(cliffContext).toHaveAttribute(
+      'data-terrain-cliff-exit-labels',
+      'N,SE',
+    );
+    expect(cliffContext).toHaveAttribute(
+      'data-terrain-source-refs',
+      expect.stringContaining('rough level 1 cliff edges N/SE elevation 2'),
+    );
+
+    act(() => {
+      unmount();
+    });
+  });
+
   it('renders represented building levels as isometric stack layers on flat terrain', () => {
     const flatBuilding: IHexTerrain = {
       coordinate: { q: 1, r: 0 },

--- a/src/utils/gameplay/__tests__/tacticalMapProjection.test.ts
+++ b/src/utils/gameplay/__tests__/tacticalMapProjection.test.ts
@@ -162,7 +162,8 @@ describe('tacticalMapProjection', () => {
         channel: 'movement',
         kind: 'megamek',
         label: 'MegaMek movement rules projection',
-        detail: 'walk projection',
+        detail:
+          'walk projection: walk reachable 2 MP terrain +1 elevation delta +1 cost +1',
         ruleReferences: MOVEMENT_RULE_REFERENCES,
       },
       {
@@ -176,7 +177,7 @@ describe('tacticalMapProjection', () => {
     expect(
       formatTacticalProjectionSourceReferences(projection.sourceReferences),
     ).toBe(
-      'terrain-elevation:mekstation:Rendered map terrain/elevation grid:rough level 1 elevation 2|movement:megamek:MegaMek movement rules projection:walk projection|combat:megamek:MegaMek combat target projection:target short 1 hexes LOS clear',
+      'terrain-elevation:mekstation:Rendered map terrain/elevation grid:rough level 1 elevation 2|movement:megamek:MegaMek movement rules projection:walk projection: walk reachable 2 MP terrain +1 elevation delta +1 cost +1|combat:megamek:MegaMek combat target projection:target short 1 hexes LOS clear',
     );
     expect(
       formatTacticalProjectionRuleReferences(projection.sourceReferences),
@@ -406,6 +407,20 @@ describe('tacticalMapProjection', () => {
     );
     expect(projection.explanation).toContain(
       'blocked Jump elevation rise of 4 exceeds jump MP 3; TerrainBlocked',
+    );
+    expect(projection.sourceReferences).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          channel: 'movement',
+          detail:
+            'walk/tracked,run/tracked,jump projection: walk via tracked reachable 3 MP heat +0, run via tracked reachable 3 MP heat +2, jump blocked 4 MP heat +1: Jump elevation rise of 4 exceeds jump MP 3',
+        }),
+      ]),
+    );
+    expect(
+      formatTacticalProjectionSourceReferences(projection.sourceReferences),
+    ).toContain(
+      'movement:megamek:MegaMek movement rules projection:walk/tracked,run/tracked,jump projection: walk via tracked reachable 3 MP heat +0, run via tracked reachable 3 MP heat +2, jump blocked 4 MP heat +1: Jump elevation rise of 4 exceeds jump MP 3',
     );
   });
 

--- a/src/utils/gameplay/tacticalMapProjection.ts
+++ b/src/utils/gameplay/tacticalMapProjection.ts
@@ -631,7 +631,9 @@ function formatMovementSourceDetail(movement: IMovementRangeHex): string {
       ),
     ),
   );
-  return `${modes.join(',')} projection`;
+  return `${modes.join(',')} projection: ${options
+    .map(formatMovementOption)
+    .join(', ')}`;
 }
 
 function movementHasStandUpContext(movement: IMovementRangeHex): boolean {

--- a/src/utils/gameplay/tacticalMapProjection.ts
+++ b/src/utils/gameplay/tacticalMapProjection.ts
@@ -8,9 +8,10 @@ import type {
   IMovementRangeModeOption,
 } from '@/types/gameplay';
 
-import { TerrainType } from '@/types/gameplay';
+import { Facing, TerrainType } from '@/types/gameplay';
 
 import { coordToKey, hexEquals } from './hexMath';
+import { getFacingAbbreviation } from './unitPosition';
 
 export type TacticalMapHexProjectionIntent =
   | 'terrain'
@@ -585,7 +586,23 @@ function formatTerrainFeatureSourceDetail(
   if (feature.constructionFactor !== undefined) {
     parts.push(`CF ${feature.constructionFactor}`);
   }
+  const cliffExits = Array.from(
+    new Set(feature.cliffTopExits?.filter(isFacing) ?? []),
+  ).sort((a, b) => a - b);
+  if (cliffExits.length > 0) {
+    parts.push(
+      `cliff edges ${cliffExits.map(getFacingAbbreviation).join('/')}`,
+    );
+  }
   return parts.join(' ');
+}
+
+function isFacing(value: number): value is Facing {
+  return (
+    Number.isInteger(value) &&
+    value >= Facing.North &&
+    value <= Facing.Northwest
+  );
 }
 
 function formatTerrainFeatureLevelSourceDetail(


### PR DESCRIPTION
## Summary

- Surface represented `cliffTopExits` from terrain metadata on rendered hexes, terrain badges, terrain/elevation source details, and terrain hover/action context.
- Add stable facing labels/attributes (`N,SE`, `0,2`) so directional cliff edges are inspectable before a player commits movement.
- Add OpenSpec and audit notes for the new map explanation surface.

## Verification

- `npx.cmd openspec validate surface-cliff-exits-map-context --strict`
- `npm.cmd test -- --runTestsByPath src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.terrainLabels.test.tsx --watchAll=false`
- `npm.cmd run typecheck`
- `npm.cmd run lint` (passes with existing max-lines warnings)
- `npm.cmd run format:check`
- `npm.cmd run build` (passes with existing baseline-browser-mapping and multi-lockfile warnings)
- `git diff --check`

## Notes

This does not change movement, combat, LOS, cover, or parser behavior. It only exposes already-represented cliff edge metadata in the player-facing tactical map explanation layer.