### PR TITLE
Source hover path preview badge

### DIFF
--- a/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
+++ b/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
@@ -84,6 +84,11 @@ source reference so same-hex walk/run/jump options carry their reachable or
 blocked state, MP cost, terrain and elevation costs, heat, and blocked reason
 directly in `movement:megamek` projection metadata instead of only in visible
 badges/tooltips.
+The `source-hover-path-preview-badge` slice keeps the hovered path MP badge on
+that same source-backed path: hovering a reachable destination now preserves
+terrain/elevation cost, heat, `movement:megamek` source refs, and MegaMek rule
+refs on the preview badge instead of thinning the displayed commit preview to
+MP and movement type only.
 Replayable gameplay events for runtime movement state are covered by
 `apply-runtime-movement-state-events`; player-facing tactical command controls
 for represented conversion and infantry mount-state changes are covered by

--- a/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
+++ b/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
@@ -84,6 +84,10 @@ source reference so same-hex walk/run/jump options carry their reachable or
 blocked state, MP cost, terrain and elevation costs, heat, and blocked reason
 directly in `movement:megamek` projection metadata instead of only in visible
 badges/tooltips.
+The `source-movement-reach-badge` slice pins the normal reachable movement
+badge to that same source-backed path, so the standing MP badge now exposes
+`movement:megamek` source refs, MegaMek rule refs, and projection explanation
+metadata before hover path preview replaces it.
 The `source-hover-path-preview-badge` slice keeps the hovered path MP badge on
 that same source-backed path: hovering a reachable destination now preserves
 terrain/elevation cost, heat, `movement:megamek` source refs, and MegaMek rule

--- a/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
+++ b/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
@@ -88,6 +88,10 @@ The `source-movement-reach-badge` slice pins the normal reachable movement
 badge to that same source-backed path, so the standing MP badge now exposes
 `movement:megamek` source refs, MegaMek rule refs, and projection explanation
 metadata before hover path preview replaces it.
+The `source-movement-step-cost-badge` slice extends that provenance to the
+separate terrain/elevation step-cost marker, so visible `T+`/`E+`/`UP`/`DN`
+cost labels also identify their shared `movement:megamek` source and rule
+references.
 The `source-hover-path-preview-badge` slice keeps the hovered path MP badge on
 that same source-backed path: hovering a reachable destination now preserves
 terrain/elevation cost, heat, `movement:megamek` source refs, and MegaMek rule

--- a/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
+++ b/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
@@ -123,12 +123,13 @@ decisions are made, not because CI is stale.
   `surface-movement-option-source-details` slice now expands movement source
   references so same-hex walk/run/jump options carry their reachable/blocked
   state, MP cost, terrain/elevation cost, heat, and blocked reason in the
-  shared projection metadata itself. The `source-hover-path-preview-badge`
-  slice now keeps the hovered path MP badge tied to the same movement
-  projection source references, rule references, terrain/elevation costs, and
-  heat metadata that the normal movement badge exposes. Full elevated
-  AirMek/WiGE pathing and broader takeoff/hover sequencing remain follow-up
-  work.
+  shared projection metadata itself. The `source-movement-reach-badge` slice
+  now pins the normal reachable movement badge to the shared movement
+  projection source references, rule references, and explanation detail. The
+  `source-hover-path-preview-badge` slice keeps the hovered path MP badge tied
+  to that same source-backed movement badge path instead of thinning the
+  displayed commit preview. Full elevated AirMek/WiGE pathing and broader
+  takeoff/hover sequencing remain follow-up work.
   Runtime infantry mounted/dismounted height precedence is now covered; the
   replayable gameplay-event mutation path is now covered by
   `apply-runtime-movement-state-events`, and tactical command controls are now

--- a/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
+++ b/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
@@ -123,8 +123,12 @@ decisions are made, not because CI is stale.
   `surface-movement-option-source-details` slice now expands movement source
   references so same-hex walk/run/jump options carry their reachable/blocked
   state, MP cost, terrain/elevation cost, heat, and blocked reason in the
-  shared projection metadata itself. Full elevated AirMek/WiGE pathing and
-  broader takeoff/hover sequencing remain follow-up work.
+  shared projection metadata itself. The `source-hover-path-preview-badge`
+  slice now keeps the hovered path MP badge tied to the same movement
+  projection source references, rule references, terrain/elevation costs, and
+  heat metadata that the normal movement badge exposes. Full elevated
+  AirMek/WiGE pathing and broader takeoff/hover sequencing remain follow-up
+  work.
   Runtime infantry mounted/dismounted height precedence is now covered; the
   replayable gameplay-event mutation path is now covered by
   `apply-runtime-movement-state-events`, and tactical command controls are now

--- a/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
+++ b/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
@@ -126,6 +126,9 @@ decisions are made, not because CI is stale.
   shared projection metadata itself. The `source-movement-reach-badge` slice
   now pins the normal reachable movement badge to the shared movement
   projection source references, rule references, and explanation detail. The
+  `source-movement-step-cost-badge` slice does the same for the separate
+  terrain/elevation cost badge, so the visible `T+`/`E+`/`UP`/`DN` cost marker
+  is also pinned to `movement:megamek` evidence. The
   `source-hover-path-preview-badge` slice keeps the hovered path MP badge tied
   to that same source-backed movement badge path instead of thinning the
   displayed commit preview. Full elevated AirMek/WiGE pathing and broader

--- a/openspec/changes/source-hover-path-preview-badge/proposal.md
+++ b/openspec/changes/source-hover-path-preview-badge/proposal.md
@@ -1,0 +1,27 @@
+# Source Hover Path Preview Badge
+
+## Why
+
+The map's normal movement badge exposes movement type, motive mode, MP cost,
+terrain/elevation details, heat, and shared projection provenance. When the
+player hovers a reachable destination, that badge is replaced by the path
+preview MP badge. The hover badge kept the movement type visible, but it did
+not carry the same cost breakdown or `movement:megamek` source references.
+
+That weakens the tactical explanation layer at the exact moment the player is
+previewing a movement commit.
+
+## What Changes
+
+- Expand the hovered path MP badge with terrain cost, elevation delta/cost,
+  heat, movement source references, rule references, and projection
+  explanation metadata.
+- Include terrain/elevation/heat details in the hover badge accessible label.
+- Add regression coverage proving the hover path preview badge remains tied to
+  the shared rules-backed projection, including same-hex movement options.
+
+## Impact
+
+This is a display/provenance change only. It does not alter movement
+pathfinding, destination legality, commit validation, combat, LOS, terrain
+import, or parser behavior.

--- a/openspec/changes/source-hover-path-preview-badge/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/source-hover-path-preview-badge/specs/tactical-map-interface/spec.md
@@ -1,0 +1,30 @@
+# Spec Delta: Tactical Map Interface
+
+## MODIFIED Requirements
+
+### Requirement: Rules-Backed Tactical Projection Contract
+
+The tactical map interface SHALL render movement, combat, terrain/elevation,
+fog, LOS, cover, and firing-arc highlights from shared rules projections rather
+than from view-local legality calculations.
+
+Every projection that affects action legality SHALL identify the rule source it
+is pinned to, using this source order: official BattleTech rules where citable,
+MegaMek tactical behavior as practical oracle for tactical ambiguity, MekHQ
+only for campaign/scenario context, then local OpenSpec/Jest fixtures as the
+project acceptance contract.
+
+#### Scenario: Hover path badge keeps movement projection provenance
+
+- **GIVEN** a selected unit has a reachable movement destination
+- **WHEN** the player hovers that destination and the map renders the path MP
+  preview badge
+- **THEN** the badge SHALL continue to expose movement type and motive mode
+- **AND** it SHALL expose represented MP cost, terrain cost, elevation
+  delta/cost, and heat when those facts are present
+- **AND** it SHALL expose the shared `movement:megamek` projection source and
+  MegaMek rule references
+- **AND** its accessible label SHALL include the same terrain, elevation, and
+  heat context
+- **AND** exposing those details SHALL NOT change pathfinding or commit
+  legality

--- a/openspec/changes/source-hover-path-preview-badge/tasks.md
+++ b/openspec/changes/source-hover-path-preview-badge/tasks.md
@@ -1,0 +1,13 @@
+## 1. Hover Path Badge
+
+- [x] Expose terrain/elevation/heat metadata on hovered path MP badges.
+- [x] Expose shared movement projection source and MegaMek rule references on
+      hovered path MP badges.
+- [x] Include the same cost breakdown in the hover badge accessible label.
+
+## 2. Tests
+
+- [x] Update HexMapDisplay movement tests for single-option hover path badge
+      provenance.
+- [x] Update HexMapDisplay movement tests for same-hex option source metadata
+      on hover path badges.

--- a/openspec/changes/source-movement-reach-badge/proposal.md
+++ b/openspec/changes/source-movement-reach-badge/proposal.md
@@ -1,0 +1,25 @@
+# Source Movement Reach Badge
+
+## Why
+
+The tactical map's standing movement reach badge is one of the first places a
+player checks destination legality, MP cost, movement mode, heat, terrain, and
+elevation. The hover path preview now preserves shared movement projection
+source evidence, but the non-hover reach badge still exposes its costs without
+directly identifying the shared `movement:megamek` projection evidence on the
+badge itself.
+
+## What Changes
+
+- Add shared movement projection source references, rule references, and
+  explanation metadata to the normal reachable movement badge.
+- Keep the current movement costs, same-hex option summary, terrain/elevation
+  metadata, heat metadata, and command legality behavior unchanged.
+- Add component coverage proving the visible movement reach badge carries the
+  same projection provenance as the rendered hex and hover explanation layer.
+
+## Out Of Scope
+
+- Changing movement pathfinding, destination legality, MP cost math, movement
+  commit validation, combat projection, LOS, terrain import, or isometric depth
+  sorting.

--- a/openspec/changes/source-movement-reach-badge/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/source-movement-reach-badge/specs/tactical-map-interface/spec.md
@@ -1,0 +1,31 @@
+# Spec Delta: Tactical Map Interface
+
+## MODIFIED Requirements
+
+### Requirement: Rules-Backed Tactical Projection Contract
+
+The tactical map interface SHALL render movement, combat, terrain/elevation,
+fog, LOS, cover, and firing-arc highlights from shared rules projections rather
+than from view-local legality calculations.
+
+Every projection that affects action legality SHALL identify the rule source it
+is pinned to, using this source order: official BattleTech rules where citable,
+MegaMek tactical behavior as practical oracle for tactical ambiguity, MekHQ
+only for campaign/scenario context, then local OpenSpec/Jest fixtures as the
+project acceptance contract.
+
+#### Scenario: Movement reach badge keeps projection provenance
+
+- **GIVEN** a selected unit has one or more reachable movement options for a
+  destination hex
+- **WHEN** the tactical map renders the normal movement reach badge before any
+  hover path preview replaces it
+- **THEN** the badge SHALL expose the shared movement-channel tactical
+  projection source and MegaMek-backed rule references
+- **AND** the badge SHALL expose the projection explanation that includes the
+  represented movement options
+- **AND** the badge SHALL continue to expose represented MP cost, movement
+  type/mode, terrain cost, elevation delta/cost, heat, and same-hex option
+  metadata when those facts are present
+- **AND** exposing those details SHALL NOT change pathfinding or commit
+  legality

--- a/openspec/changes/source-movement-reach-badge/tasks.md
+++ b/openspec/changes/source-movement-reach-badge/tasks.md
@@ -1,0 +1,8 @@
+## Tasks
+
+- [x] Add an OpenSpec scenario for movement reach badge provenance.
+- [x] Thread movement-channel projection source/rule references into the normal
+      movement reach badge.
+- [x] Lock the badge metadata with representative Walk/Run/Jump same-hex option
+      coverage.
+- [x] Run OpenSpec and focused tactical-map tests.

--- a/openspec/changes/source-movement-step-cost-badge/proposal.md
+++ b/openspec/changes/source-movement-step-cost-badge/proposal.md
@@ -1,0 +1,23 @@
+# Source Movement Step Cost Badge
+
+## Why
+
+Reachable movement hexes can render a separate terrain/elevation step-cost
+badge such as `T+1 E+2 UP2`. That badge explains why a destination costs more
+MP, so it should identify the same shared movement projection evidence as the
+standing movement reach badge and hover path preview.
+
+## What Changes
+
+- Add movement-channel projection source references, MegaMek rule references,
+  and projection explanation metadata to the visible step-cost badge.
+- Keep the existing terrain cost, elevation cost, elevation delta, MP cost, and
+  movement legality behavior unchanged.
+- Add component coverage proving the cost badge is tied to the shared
+  `movement:megamek` projection.
+
+## Out Of Scope
+
+- Changing terrain/elevation MP math, movement pathfinding, destination
+  legality, movement commit validation, combat projection, terrain import, LOS,
+  or isometric rendering.

--- a/openspec/changes/source-movement-step-cost-badge/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/source-movement-step-cost-badge/specs/tactical-map-interface/spec.md
@@ -1,0 +1,29 @@
+# Spec Delta: Tactical Map Interface
+
+## MODIFIED Requirements
+
+### Requirement: Rules-Backed Tactical Projection Contract
+
+The tactical map interface SHALL render movement, combat, terrain/elevation,
+fog, LOS, cover, and firing-arc highlights from shared rules projections rather
+than from view-local legality calculations.
+
+Every projection that affects action legality SHALL identify the rule source it
+is pinned to, using this source order: official BattleTech rules where citable,
+MegaMek tactical behavior as practical oracle for tactical ambiguity, MekHQ
+only for campaign/scenario context, then local OpenSpec/Jest fixtures as the
+project acceptance contract.
+
+#### Scenario: Movement step-cost badge keeps projection provenance
+
+- **GIVEN** a reachable movement destination has represented terrain or
+  elevation step costs
+- **WHEN** the tactical map renders the visible movement step-cost badge
+- **THEN** the badge SHALL expose the shared movement-channel tactical
+  projection source and MegaMek-backed rule references
+- **AND** the badge SHALL expose the projection explanation that includes the
+  represented terrain and elevation cost details
+- **AND** the badge SHALL continue to expose terrain cost, elevation delta, and
+  elevation cost metadata without relying only on color
+- **AND** exposing those details SHALL NOT change terrain/elevation MP math,
+  pathfinding, or commit legality

--- a/openspec/changes/source-movement-step-cost-badge/tasks.md
+++ b/openspec/changes/source-movement-step-cost-badge/tasks.md
@@ -1,0 +1,8 @@
+## Tasks
+
+- [x] Add an OpenSpec scenario for movement step-cost badge provenance.
+- [x] Thread movement-channel projection source/rule references into the
+      terrain/elevation step-cost badge.
+- [x] Lock the step-cost badge metadata with representative terrain and
+      elevation cost coverage.
+- [x] Run OpenSpec and focused tactical-map tests.

--- a/src/components/gameplay/HexMapDisplay/HexCell.hoverMovementBadge.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexCell.hoverMovementBadge.tsx
@@ -1,11 +1,57 @@
 import React from 'react';
 
 import type { IHexCoordinate, IMovementRangeHex } from '@/types/gameplay';
+import type { ITacticalMapProjectionSourceReference } from '@/utils/gameplay/tacticalMapProjection';
+
+import {
+  formatTacticalProjectionRuleReferences,
+  formatTacticalProjectionSourceReferences,
+} from '@/utils/gameplay/tacticalMapProjection';
 
 import {
   formatMovementModeTitle,
   formatMovementReachBadgeLabel,
 } from './HexCell.movementBadges';
+
+function formatSignedCost(value: number): string {
+  return value >= 0 ? `+${value}` : `${value}`;
+}
+
+function formatPathPreviewTitle(
+  movementInfo: IMovementRangeHex | undefined,
+  hoverMpCost: number,
+): string {
+  if (!movementInfo) return `Movement path preview: ${hoverMpCost} MP`;
+
+  const details = [
+    `${formatMovementModeTitle({ ...movementInfo, mpCost: hoverMpCost })} path preview: ${hoverMpCost} MP`,
+  ];
+  if (movementInfo.terrainCost !== undefined) {
+    details.push(`terrain ${formatSignedCost(movementInfo.terrainCost)}`);
+  }
+  if (
+    movementInfo.elevationDelta !== undefined ||
+    movementInfo.elevationCost !== undefined
+  ) {
+    const elevationDetails: string[] = [];
+    if (movementInfo.elevationDelta !== undefined) {
+      elevationDetails.push(
+        `delta ${formatSignedCost(movementInfo.elevationDelta)}`,
+      );
+    }
+    if (movementInfo.elevationCost !== undefined) {
+      elevationDetails.push(
+        `cost ${formatSignedCost(movementInfo.elevationCost)}`,
+      );
+    }
+    details.push(`elevation ${elevationDetails.join(' ')}`);
+  }
+  if (movementInfo.heatGenerated !== undefined) {
+    details.push(`heat ${formatSignedCost(movementInfo.heatGenerated)}`);
+  }
+
+  return details.join('; ');
+}
 
 export function MovementHoverCostBadge({
   x,
@@ -13,12 +59,16 @@ export function MovementHoverCostBadge({
   hex,
   hoverMpCost,
   movementInfo,
+  projectionExplanation,
+  sourceReferences,
 }: {
   readonly x: number;
   readonly y: number;
   readonly hex: IHexCoordinate;
   readonly hoverMpCost?: number;
   readonly movementInfo?: IMovementRangeHex;
+  readonly projectionExplanation?: string;
+  readonly sourceReferences?: readonly ITacticalMapProjectionSourceReference[];
 }): React.ReactElement | null {
   if (hoverMpCost === undefined) return null;
 
@@ -32,20 +82,39 @@ export function MovementHoverCostBadge({
   const label = activeMovementInfo
     ? formatMovementReachBadgeLabel(activeMovementInfo)
     : `${hoverMpCost}MP`;
-  const title = activeMovementInfo
-    ? `${formatMovementModeTitle(activeMovementInfo)} path preview: ${hoverMpCost} MP`
-    : `Movement path preview: ${hoverMpCost} MP`;
+  const title = formatPathPreviewTitle(movementInfo, hoverMpCost);
   const width = Math.max(34, label.length * 5.6 + 10);
+  const movementSourceReferences =
+    sourceReferences?.filter((source) => source.channel === 'movement') ?? [];
+  const movementSourceRefsAttribute =
+    formatTacticalProjectionSourceReferences(movementSourceReferences) ||
+    undefined;
+  const movementRuleRefsAttribute =
+    formatTacticalProjectionRuleReferences(movementSourceReferences) ||
+    undefined;
+  const movementProjectionChannel =
+    movementSourceReferences.length > 0 ? 'movement' : undefined;
 
   return (
     <g
       pointerEvents="none"
       data-testid={`hex-mp-badge-${hex.q}-${hex.r}`}
       aria-label={title}
+      data-tactical-projection-source={
+        movementProjectionChannel ? 'shared-tactical-map-projection' : undefined
+      }
+      data-tactical-projection-channel={movementProjectionChannel}
+      data-tactical-rules-surface={movementProjectionChannel}
       data-hover-mp-cost={hoverMpCost}
       data-movement-badge-type={movementInfo?.movementType}
       data-movement-badge-mode={movementInfo?.movementMode}
+      data-movement-badge-terrain-cost={movementInfo?.terrainCost}
+      data-movement-badge-elevation-delta={movementInfo?.elevationDelta}
+      data-movement-badge-elevation-cost={movementInfo?.elevationCost}
       data-movement-badge-heat-generated={movementInfo?.heatGenerated}
+      data-movement-badge-source-refs={movementSourceRefsAttribute}
+      data-movement-badge-rule-refs={movementRuleRefsAttribute}
+      data-movement-badge-projection-explanation={projectionExplanation}
     >
       <title>{title}</title>
       <rect

--- a/src/components/gameplay/HexMapDisplay/HexCell.movementBadges.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexCell.movementBadges.tsx
@@ -445,11 +445,15 @@ export function MovementStepCostBadge({
   y,
   hex,
   movementInfo,
+  projectionExplanation,
+  sourceReferences,
 }: {
   readonly x: number;
   readonly y: number;
   readonly hex: IHexCoordinate;
   readonly movementInfo?: IMovementRangeHex;
+  readonly projectionExplanation?: string;
+  readonly sourceReferences?: readonly ITacticalMapProjectionSourceReference[];
 }): React.ReactElement | null {
   if (!movementInfo?.reachable) return null;
   const label = formatMovementStepCostLabel(movementInfo);
@@ -457,14 +461,32 @@ export function MovementStepCostBadge({
 
   const title = formatMovementStepCostTitle(movementInfo);
   const width = Math.max(28, label.length * 5.4 + 8);
+  const movementSourceReferences =
+    sourceReferences?.filter((source) => source.channel === 'movement') ?? [];
+  const movementSourceRefsAttribute =
+    formatTacticalProjectionSourceReferences(movementSourceReferences) ||
+    undefined;
+  const movementRuleRefsAttribute =
+    formatTacticalProjectionRuleReferences(movementSourceReferences) ||
+    undefined;
+  const movementProjectionChannel =
+    movementSourceReferences.length > 0 ? 'movement' : undefined;
   return (
     <g
       pointerEvents="none"
       data-testid={`hex-movement-cost-badge-${hex.q}-${hex.r}`}
       aria-label={title}
+      data-tactical-projection-source={
+        movementProjectionChannel ? 'shared-tactical-map-projection' : undefined
+      }
+      data-tactical-projection-channel={movementProjectionChannel}
+      data-tactical-rules-surface={movementProjectionChannel}
       data-movement-step-terrain-cost={movementInfo.terrainCost}
       data-movement-step-elevation-cost={movementInfo.elevationCost}
       data-movement-step-elevation-delta={movementInfo.elevationDelta}
+      data-movement-step-source-refs={movementSourceRefsAttribute}
+      data-movement-step-rule-refs={movementRuleRefsAttribute}
+      data-movement-step-projection-explanation={projectionExplanation}
     >
       <title>{title}</title>
       <rect

--- a/src/components/gameplay/HexMapDisplay/HexCell.movementBadges.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexCell.movementBadges.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 
 import type { IHexCoordinate, IMovementRangeHex } from '@/types/gameplay';
+import type { ITacticalMapProjectionSourceReference } from '@/utils/gameplay/tacticalMapProjection';
+
+import {
+  formatTacticalProjectionRuleReferences,
+  formatTacticalProjectionSourceReferences,
+} from '@/utils/gameplay/tacticalMapProjection';
 
 import {
   formatMovementModeLabel,
@@ -191,23 +197,42 @@ export function MovementReachBadge({
   y,
   hex,
   movementInfo,
+  projectionExplanation,
+  sourceReferences,
 }: {
   readonly x: number;
   readonly y: number;
   readonly hex: IHexCoordinate;
   readonly movementInfo?: IMovementRangeHex;
+  readonly projectionExplanation?: string;
+  readonly sourceReferences?: readonly ITacticalMapProjectionSourceReference[];
 }): React.ReactElement | null {
   if (!movementInfo?.reachable) return null;
   const label = formatMovementReachBadgeLabel(movementInfo);
   const title = formatMovementReachBadgeTitle(movementInfo);
   const movementOptions = movementInfo.movementModeOptions ?? [];
   const width = Math.max(34, label.length * 5.6 + 10);
+  const movementSourceReferences =
+    sourceReferences?.filter((source) => source.channel === 'movement') ?? [];
+  const movementSourceRefsAttribute =
+    formatTacticalProjectionSourceReferences(movementSourceReferences) ||
+    undefined;
+  const movementRuleRefsAttribute =
+    formatTacticalProjectionRuleReferences(movementSourceReferences) ||
+    undefined;
+  const movementProjectionChannel =
+    movementSourceReferences.length > 0 ? 'movement' : undefined;
 
   return (
     <g
       pointerEvents="none"
       data-testid={`hex-movement-badge-${hex.q}-${hex.r}`}
       aria-label={title}
+      data-tactical-projection-source={
+        movementProjectionChannel ? 'shared-tactical-map-projection' : undefined
+      }
+      data-tactical-projection-channel={movementProjectionChannel}
+      data-tactical-rules-surface={movementProjectionChannel}
       data-movement-badge-type={movementInfo.movementType}
       data-movement-badge-mode={movementInfo.movementMode}
       data-movement-badge-mp-cost={movementInfo.mpCost}
@@ -321,6 +346,9 @@ export function MovementReachBadge({
           ? movementOptionAutomaticLandingsAttribute(movementOptions)
           : undefined
       }
+      data-movement-badge-source-refs={movementSourceRefsAttribute}
+      data-movement-badge-rule-refs={movementRuleRefsAttribute}
+      data-movement-badge-projection-explanation={projectionExplanation}
     >
       <title>{title}</title>
       <rect

--- a/src/components/gameplay/HexMapDisplay/HexCell.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexCell.tsx
@@ -960,7 +960,14 @@ export const HexCell = React.memo(function HexCell({
         sourceReferences={tacticalProjectionSourceReferences}
       />
       {hoverMpCost === undefined && (
-        <MovementReachBadge x={x} y={y} hex={hex} movementInfo={movementInfo} />
+        <MovementReachBadge
+          x={x}
+          y={y}
+          hex={hex}
+          movementInfo={movementInfo}
+          projectionExplanation={tacticalProjectionExplanation}
+          sourceReferences={tacticalProjectionSourceReferences}
+        />
       )}
       <MovementBlockedOptionsBadge
         x={x}

--- a/src/components/gameplay/HexMapDisplay/HexCell.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexCell.tsx
@@ -998,6 +998,8 @@ export const HexCell = React.memo(function HexCell({
         hex={hex}
         hoverMpCost={hoverMpCost}
         movementInfo={movementInfo}
+        projectionExplanation={tacticalProjectionExplanation}
+        sourceReferences={tacticalProjectionSourceReferences}
       />
       <CombatLineOfSightBlockerBadge
         x={x}

--- a/src/components/gameplay/HexMapDisplay/HexCell.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexCell.tsx
@@ -980,6 +980,8 @@ export const HexCell = React.memo(function HexCell({
         y={y}
         hex={hex}
         movementInfo={movementInfo}
+        projectionExplanation={tacticalProjectionExplanation}
+        sourceReferences={tacticalProjectionSourceReferences}
       />
       <MovementStandUpBadge x={x} y={y} hex={hex} movementInfo={movementInfo} />
       <MovementAutomaticLandingBadge

--- a/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.test.tsx
+++ b/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.test.tsx
@@ -1683,7 +1683,7 @@ describe('HexMapDisplay tactical visual layers', () => {
     );
     expect(screen.getByTestId('hex-mp-badge-1-0')).toHaveAttribute(
       'aria-label',
-      'run via hover path preview: 4 MP',
+      'run via hover path preview: 4 MP; terrain +1; elevation delta +1 cost +1; heat +2',
     );
     expect(screen.getByTestId('hex-mp-badge-1-0')).toHaveAttribute(
       'data-hover-mp-cost',
@@ -1698,9 +1698,41 @@ describe('HexMapDisplay tactical visual layers', () => {
       'hover',
     );
     expect(screen.getByTestId('hex-mp-badge-1-0')).toHaveAttribute(
+      'data-movement-badge-terrain-cost',
+      '1',
+    );
+    expect(screen.getByTestId('hex-mp-badge-1-0')).toHaveAttribute(
+      'data-movement-badge-elevation-delta',
+      '1',
+    );
+    expect(screen.getByTestId('hex-mp-badge-1-0')).toHaveAttribute(
+      'data-movement-badge-elevation-cost',
+      '1',
+    );
+    expect(screen.getByTestId('hex-mp-badge-1-0')).toHaveAttribute(
       'data-movement-badge-heat-generated',
       '2',
     );
+    expect(screen.getByTestId('hex-mp-badge-1-0')).toHaveAttribute(
+      'data-tactical-projection-source',
+      'shared-tactical-map-projection',
+    );
+    expect(screen.getByTestId('hex-mp-badge-1-0')).toHaveAttribute(
+      'data-tactical-projection-channel',
+      'movement',
+    );
+    expect(
+      screen
+        .getByTestId('hex-mp-badge-1-0')
+        .getAttribute('data-movement-badge-source-refs'),
+    ).toContain(
+      'movement:megamek:MegaMek movement rules projection:run/hover projection: run via hover reachable 4 MP terrain +1 elevation delta +1 cost +1 heat +2',
+    );
+    expect(
+      screen
+        .getByTestId('hex-mp-badge-1-0')
+        .getAttribute('data-movement-badge-rule-refs'),
+    ).toContain('movement:megamek:MegaMek common/moves/MoveStep.java');
 
     act(() => {
       unmount();
@@ -1765,7 +1797,7 @@ describe('HexMapDisplay tactical visual layers', () => {
     );
     expect(screen.getByTestId('hex-mp-badge-1-0')).toHaveAttribute(
       'aria-label',
-      'run via tracked path preview: 5 MP',
+      'run via tracked path preview: 5 MP; terrain +2; elevation delta +1 cost +1; heat +2',
     );
     expect(screen.getByTestId('hex-mp-badge-1-0')).toHaveAttribute(
       'data-hover-mp-cost',
@@ -1778,6 +1810,13 @@ describe('HexMapDisplay tactical visual layers', () => {
     expect(screen.getByTestId('hex-mp-badge-1-0')).toHaveAttribute(
       'data-movement-badge-mode',
       'tracked',
+    );
+    expect(
+      screen
+        .getByTestId('hex-mp-badge-1-0')
+        .getAttribute('data-movement-badge-source-refs'),
+    ).toContain(
+      'run/tracked,walk/tracked projection: run via tracked reachable 5 MP terrain +2 elevation delta +1 cost +1 heat +2, walk via tracked reachable 3 MP terrain +2 elevation delta +1 cost +1 heat +1',
     );
 
     act(() => {

--- a/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.test.tsx
+++ b/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.test.tsx
@@ -1296,6 +1296,33 @@ describe('HexMapDisplay tactical visual layers', () => {
       'data-movement-badge-option-heats',
       'walk:0|run:2|jump:1',
     );
+    expect(badge).toHaveAttribute(
+      'data-tactical-projection-source',
+      'shared-tactical-map-projection',
+    );
+    expect(badge).toHaveAttribute(
+      'data-tactical-projection-channel',
+      'movement',
+    );
+    expect(badge).toHaveAttribute('data-tactical-rules-surface', 'movement');
+    expect(badge).toHaveAttribute(
+      'data-movement-badge-source-refs',
+      expect.stringContaining(
+        'movement:megamek:MegaMek movement rules projection:walk/tracked,run/tracked,jump projection: walk via tracked reachable 3 MP terrain +1 elevation delta +1 cost +1 heat +0, run via tracked reachable 3 MP terrain +2 elevation delta +1 cost +1 heat +2, jump reachable 1 MP terrain +0 elevation delta +2 cost +0 heat +1',
+      ),
+    );
+    expect(badge).toHaveAttribute(
+      'data-movement-badge-rule-refs',
+      expect.stringContaining(
+        'movement:megamek:MegaMek common/moves/MoveStep.java',
+      ),
+    );
+    expect(badge).toHaveAttribute(
+      'data-movement-badge-projection-explanation',
+      expect.stringContaining(
+        'movement options walk via tracked reachable 3 MP terrain +1 elevation delta +1 cost +1 heat +0',
+      ),
+    );
     expect(screen.getByTestId('hex-heat-badge-1-0')).toHaveTextContent('+2H');
     expect(screen.getByTestId('hex-heat-badge-1-0')).toHaveAttribute(
       'data-movement-option-heats',

--- a/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.test.tsx
+++ b/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.test.tsx
@@ -2718,6 +2718,32 @@ describe('HexMapDisplay tactical visual layers', () => {
       'data-movement-step-elevation-cost',
       '2',
     );
+    expect(screen.getByTestId('hex-movement-cost-badge-1-0')).toHaveAttribute(
+      'data-tactical-projection-source',
+      'shared-tactical-map-projection',
+    );
+    expect(screen.getByTestId('hex-movement-cost-badge-1-0')).toHaveAttribute(
+      'data-tactical-projection-channel',
+      'movement',
+    );
+    expect(screen.getByTestId('hex-movement-cost-badge-1-0')).toHaveAttribute(
+      'data-movement-step-source-refs',
+      expect.stringContaining(
+        'movement:megamek:MegaMek movement rules projection:walk/tracked projection: walk via tracked reachable 3 MP terrain +1 elevation delta +2 cost +2',
+      ),
+    );
+    expect(screen.getByTestId('hex-movement-cost-badge-1-0')).toHaveAttribute(
+      'data-movement-step-rule-refs',
+      expect.stringContaining(
+        'movement:megamek:MegaMek common/moves/MoveStep.java',
+      ),
+    );
+    expect(screen.getByTestId('hex-movement-cost-badge-1-0')).toHaveAttribute(
+      'data-movement-step-projection-explanation',
+      expect.stringContaining(
+        'Walk reachable 3 MP; mode tracked; terrain cost +1; elevation delta +2 cost +2',
+      ),
+    );
 
     act(() => {
       unmount();


### PR DESCRIPTION
## Summary

- Keep hovered path MP badges tied to the same shared movement projection source metadata as normal movement badges.
- Surface terrain cost, elevation delta/cost, heat, `movement:megamek` source refs, and MegaMek rule refs directly on the hover preview badge.
- Add OpenSpec and audit notes for the hover path preview provenance outcome.

## Verification

- `npx.cmd openspec validate source-hover-path-preview-badge --strict`
- `npm.cmd test -- --runTestsByPath src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.test.tsx --watchAll=false`
- `npm.cmd test -- --runTestsByPath src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.combatProjection.test.tsx src/utils/gameplay/__tests__/tacticalMapProjection.test.ts --watchAll=false`
- `npm.cmd run typecheck`
- `npm.cmd run lint` (passes with existing max-lines warnings)
- `npm.cmd run format:check`
- `npm.cmd run build` (passes with existing baseline-browser-mapping and multi-lockfile warnings)
- `git diff --check`

## Notes

This is display/provenance only. It does not change movement pathfinding, destination legality, movement commit validation, combat, LOS, terrain import, or parser behavior.