### PR TITLE
Source movement step cost badge

### DIFF
--- a/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
+++ b/docs/audits/2026-05-22-tactical-map-rules-source-matrix.md
@@ -88,6 +88,10 @@ The `source-movement-reach-badge` slice pins the normal reachable movement
 badge to that same source-backed path, so the standing MP badge now exposes
 `movement:megamek` source refs, MegaMek rule refs, and projection explanation
 metadata before hover path preview replaces it.
+The `source-movement-step-cost-badge` slice extends that provenance to the
+separate terrain/elevation step-cost marker, so visible `T+`/`E+`/`UP`/`DN`
+cost labels also identify their shared `movement:megamek` source and rule
+references.
 The `source-hover-path-preview-badge` slice keeps the hovered path MP badge on
 that same source-backed path: hovering a reachable destination now preserves
 terrain/elevation cost, heat, `movement:megamek` source refs, and MegaMek rule

--- a/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
+++ b/docs/audits/2026-05-26-tactical-map-pr-spec-coverage.md
@@ -126,6 +126,9 @@ decisions are made, not because CI is stale.
   shared projection metadata itself. The `source-movement-reach-badge` slice
   now pins the normal reachable movement badge to the shared movement
   projection source references, rule references, and explanation detail. The
+  `source-movement-step-cost-badge` slice does the same for the separate
+  terrain/elevation cost badge, so the visible `T+`/`E+`/`UP`/`DN` cost marker
+  is also pinned to `movement:megamek` evidence. The
   `source-hover-path-preview-badge` slice keeps the hovered path MP badge tied
   to that same source-backed movement badge path instead of thinning the
   displayed commit preview. Full elevated AirMek/WiGE pathing and broader

--- a/openspec/changes/source-movement-step-cost-badge/proposal.md
+++ b/openspec/changes/source-movement-step-cost-badge/proposal.md
@@ -1,0 +1,23 @@
+# Source Movement Step Cost Badge
+
+## Why
+
+Reachable movement hexes can render a separate terrain/elevation step-cost
+badge such as `T+1 E+2 UP2`. That badge explains why a destination costs more
+MP, so it should identify the same shared movement projection evidence as the
+standing movement reach badge and hover path preview.
+
+## What Changes
+
+- Add movement-channel projection source references, MegaMek rule references,
+  and projection explanation metadata to the visible step-cost badge.
+- Keep the existing terrain cost, elevation cost, elevation delta, MP cost, and
+  movement legality behavior unchanged.
+- Add component coverage proving the cost badge is tied to the shared
+  `movement:megamek` projection.
+
+## Out Of Scope
+
+- Changing terrain/elevation MP math, movement pathfinding, destination
+  legality, movement commit validation, combat projection, terrain import, LOS,
+  or isometric rendering.

--- a/openspec/changes/source-movement-step-cost-badge/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/source-movement-step-cost-badge/specs/tactical-map-interface/spec.md
@@ -1,0 +1,29 @@
+# Spec Delta: Tactical Map Interface
+
+## MODIFIED Requirements
+
+### Requirement: Rules-Backed Tactical Projection Contract
+
+The tactical map interface SHALL render movement, combat, terrain/elevation,
+fog, LOS, cover, and firing-arc highlights from shared rules projections rather
+than from view-local legality calculations.
+
+Every projection that affects action legality SHALL identify the rule source it
+is pinned to, using this source order: official BattleTech rules where citable,
+MegaMek tactical behavior as practical oracle for tactical ambiguity, MekHQ
+only for campaign/scenario context, then local OpenSpec/Jest fixtures as the
+project acceptance contract.
+
+#### Scenario: Movement step-cost badge keeps projection provenance
+
+- **GIVEN** a reachable movement destination has represented terrain or
+  elevation step costs
+- **WHEN** the tactical map renders the visible movement step-cost badge
+- **THEN** the badge SHALL expose the shared movement-channel tactical
+  projection source and MegaMek-backed rule references
+- **AND** the badge SHALL expose the projection explanation that includes the
+  represented terrain and elevation cost details
+- **AND** the badge SHALL continue to expose terrain cost, elevation delta, and
+  elevation cost metadata without relying only on color
+- **AND** exposing those details SHALL NOT change terrain/elevation MP math,
+  pathfinding, or commit legality

--- a/openspec/changes/source-movement-step-cost-badge/tasks.md
+++ b/openspec/changes/source-movement-step-cost-badge/tasks.md
@@ -1,0 +1,8 @@
+## Tasks
+
+- [x] Add an OpenSpec scenario for movement step-cost badge provenance.
+- [x] Thread movement-channel projection source/rule references into the
+      terrain/elevation step-cost badge.
+- [x] Lock the step-cost badge metadata with representative terrain and
+      elevation cost coverage.
+- [x] Run OpenSpec and focused tactical-map tests.

--- a/src/components/gameplay/HexMapDisplay/HexCell.movementBadges.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexCell.movementBadges.tsx
@@ -445,11 +445,15 @@ export function MovementStepCostBadge({
   y,
   hex,
   movementInfo,
+  projectionExplanation,
+  sourceReferences,
 }: {
   readonly x: number;
   readonly y: number;
   readonly hex: IHexCoordinate;
   readonly movementInfo?: IMovementRangeHex;
+  readonly projectionExplanation?: string;
+  readonly sourceReferences?: readonly ITacticalMapProjectionSourceReference[];
 }): React.ReactElement | null {
   if (!movementInfo?.reachable) return null;
   const label = formatMovementStepCostLabel(movementInfo);
@@ -457,14 +461,32 @@ export function MovementStepCostBadge({
 
   const title = formatMovementStepCostTitle(movementInfo);
   const width = Math.max(28, label.length * 5.4 + 8);
+  const movementSourceReferences =
+    sourceReferences?.filter((source) => source.channel === 'movement') ?? [];
+  const movementSourceRefsAttribute =
+    formatTacticalProjectionSourceReferences(movementSourceReferences) ||
+    undefined;
+  const movementRuleRefsAttribute =
+    formatTacticalProjectionRuleReferences(movementSourceReferences) ||
+    undefined;
+  const movementProjectionChannel =
+    movementSourceReferences.length > 0 ? 'movement' : undefined;
   return (
     <g
       pointerEvents="none"
       data-testid={`hex-movement-cost-badge-${hex.q}-${hex.r}`}
       aria-label={title}
+      data-tactical-projection-source={
+        movementProjectionChannel ? 'shared-tactical-map-projection' : undefined
+      }
+      data-tactical-projection-channel={movementProjectionChannel}
+      data-tactical-rules-surface={movementProjectionChannel}
       data-movement-step-terrain-cost={movementInfo.terrainCost}
       data-movement-step-elevation-cost={movementInfo.elevationCost}
       data-movement-step-elevation-delta={movementInfo.elevationDelta}
+      data-movement-step-source-refs={movementSourceRefsAttribute}
+      data-movement-step-rule-refs={movementRuleRefsAttribute}
+      data-movement-step-projection-explanation={projectionExplanation}
     >
       <title>{title}</title>
       <rect

--- a/src/components/gameplay/HexMapDisplay/HexCell.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexCell.tsx
@@ -980,6 +980,8 @@ export const HexCell = React.memo(function HexCell({
         y={y}
         hex={hex}
         movementInfo={movementInfo}
+        projectionExplanation={tacticalProjectionExplanation}
+        sourceReferences={tacticalProjectionSourceReferences}
       />
       <MovementStandUpBadge x={x} y={y} hex={hex} movementInfo={movementInfo} />
       <MovementAutomaticLandingBadge

--- a/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.test.tsx
+++ b/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.test.tsx
@@ -2718,6 +2718,32 @@ describe('HexMapDisplay tactical visual layers', () => {
       'data-movement-step-elevation-cost',
       '2',
     );
+    expect(screen.getByTestId('hex-movement-cost-badge-1-0')).toHaveAttribute(
+      'data-tactical-projection-source',
+      'shared-tactical-map-projection',
+    );
+    expect(screen.getByTestId('hex-movement-cost-badge-1-0')).toHaveAttribute(
+      'data-tactical-projection-channel',
+      'movement',
+    );
+    expect(screen.getByTestId('hex-movement-cost-badge-1-0')).toHaveAttribute(
+      'data-movement-step-source-refs',
+      expect.stringContaining(
+        'movement:megamek:MegaMek movement rules projection:walk/tracked projection: walk via tracked reachable 3 MP terrain +1 elevation delta +2 cost +2',
+      ),
+    );
+    expect(screen.getByTestId('hex-movement-cost-badge-1-0')).toHaveAttribute(
+      'data-movement-step-rule-refs',
+      expect.stringContaining(
+        'movement:megamek:MegaMek common/moves/MoveStep.java',
+      ),
+    );
+    expect(screen.getByTestId('hex-movement-cost-badge-1-0')).toHaveAttribute(
+      'data-movement-step-projection-explanation',
+      expect.stringContaining(
+        'Walk reachable 3 MP; mode tracked; terrain cost +1; elevation delta +2 cost +2',
+      ),
+    );
 
     act(() => {
       unmount();


### PR DESCRIPTION
## Summary

- Attach the terrain/elevation step-cost badge to shared movement projection provenance.
- Surface `movement:megamek` source refs, MegaMek rule refs, and projection explanation metadata directly on the visible `T+`/`E+`/`UP`/`DN` cost marker.
- Add OpenSpec and audit notes for the movement step-cost badge provenance outcome.

## Verification

- `npx.cmd openspec validate source-movement-step-cost-badge --strict`
- `npm.cmd test -- --runTestsByPath src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.test.tsx --watchAll=false`
- `npm.cmd test -- --runTestsByPath src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.combatProjection.test.tsx src/utils/gameplay/__tests__/tacticalMapProjection.test.ts --watchAll=false`
- `npm.cmd run typecheck`
- `npm.cmd run lint` (passes with existing max-lines warnings)
- `npm.cmd run format:check`
- `npm.cmd run build` (passes with existing baseline-browser-mapping and multi-lockfile warnings)
- `git diff --check`

## Notes

This is display/provenance only. It does not change terrain/elevation MP math, movement pathfinding, destination legality, movement commit validation, combat, LOS, terrain import, or isometric behavior.