### PR TITLE
fix: wire campaign engine subsystems and persistence (audit W3)

### DIFF
--- a/docs/audits/2026-06-09-remediation-tracker.md
+++ b/docs/audits/2026-06-09-remediation-tracker.md
@@ -52,7 +52,7 @@ reconciliation merge `7f22e4f22` · audited main `442f90855`.
 
 | Task | Finding   | Scope                                                                                                     | Status  |
 | ---- | --------- | --------------------------------------------------------------------------------------------------------- | ------- |
-| W3.1 | D-1       | Persistence stops wiping unit battle damage + loan ledger on reload                                       | pending |
+| W3.1 | D-1       | Persistence stops wiping unit battle damage + loan ledger on reload                                       | done    |
 | W3.2 | D-2       | Register financial/turnover/factionStanding/vocationalTraining processors                                 | pending |
 | W3.3 | D-3, D-4  | applyPreset wired into creation; reconcileCoopBattle invoked                                              | pending |
 | W3.4 | D-5..D-10 | XP double-apply guard; processedBattleIds; market offers; kill counters; combatTeams; seeded campaign RNG | pending |

--- a/docs/audits/2026-06-09-remediation-tracker.md
+++ b/docs/audits/2026-06-09-remediation-tracker.md
@@ -50,12 +50,12 @@ reconciliation merge `7f22e4f22` · audited main `442f90855`.
 
 ## W3 — Campaign engine (cluster D)
 
-| Task | Finding   | Scope                                                                                                     | Status  |
-| ---- | --------- | --------------------------------------------------------------------------------------------------------- | ------- |
-| W3.1 | D-1       | Persistence stops wiping unit battle damage + loan ledger on reload                                       | done    |
-| W3.2 | D-2       | Register financial/turnover/factionStanding/vocationalTraining processors                                 | done    |
-| W3.3 | D-3, D-4  | applyPreset wired into creation; reconcileCoopBattle invoked                                              | pending |
-| W3.4 | D-5..D-10 | XP double-apply guard; processedBattleIds; market offers; kill counters; combatTeams; seeded campaign RNG | pending |
+| Task | Finding   | Scope                                                                                                                                                                                                                            | Status  |
+| ---- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| W3.1 | D-1       | Persistence stops wiping unit battle damage + loan ledger on reload                                                                                                                                                              | done    |
+| W3.2 | D-2       | Register financial/turnover/factionStanding/vocationalTraining processors                                                                                                                                                        | done    |
+| W3.3 | D-3, D-4  | applyPreset wired into creation; reconcileCoopBattle invoked at the combat-outcome enqueue seam (coopHostRegistry gate; live CampaignMatchHost registration still has no production owner — Wave 6.2 CO1 transport never landed) | done    |
+| W3.4 | D-5..D-10 | XP double-apply guard; processedBattleIds; market offers; kill counters; combatTeams; seeded campaign RNG                                                                                                                        | pending |
 
 ## W4 — CI/test enforcement (cluster E)
 

--- a/docs/audits/2026-06-09-remediation-tracker.md
+++ b/docs/audits/2026-06-09-remediation-tracker.md
@@ -50,12 +50,12 @@ reconciliation merge `7f22e4f22` · audited main `442f90855`.
 
 ## W3 — Campaign engine (cluster D)
 
-| Task | Finding   | Scope                                                                                                                                                                                                                            | Status  |
-| ---- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| W3.1 | D-1       | Persistence stops wiping unit battle damage + loan ledger on reload                                                                                                                                                              | done    |
-| W3.2 | D-2       | Register financial/turnover/factionStanding/vocationalTraining processors                                                                                                                                                        | done    |
-| W3.3 | D-3, D-4  | applyPreset wired into creation; reconcileCoopBattle invoked at the combat-outcome enqueue seam (coopHostRegistry gate; live CampaignMatchHost registration still has no production owner — Wave 6.2 CO1 transport never landed) | done    |
-| W3.4 | D-5..D-10 | XP double-apply guard; processedBattleIds; market offers; kill counters; combatTeams; seeded campaign RNG                                                                                                                        | pending |
+| Task | Finding   | Scope                                                                                                                                                                                                                            | Status |
+| ---- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| W3.1 | D-1       | Persistence stops wiping unit battle damage + loan ledger on reload                                                                                                                                                              | done   |
+| W3.2 | D-2       | Register financial/turnover/factionStanding/vocationalTraining processors                                                                                                                                                        | done   |
+| W3.3 | D-3, D-4  | applyPreset wired into creation; reconcileCoopBattle invoked at the combat-outcome enqueue seam (coopHostRegistry gate; live CampaignMatchHost registration still has no production owner — Wave 6.2 CO1 transport never landed) | done   |
+| W3.4 | D-5..D-10 | XP double-apply guard; processedBattleIds; market offers; kill counters; combatTeams; seeded campaign RNG                                                                                                                        | done   |
 
 ## W4 — CI/test enforcement (cluster E)
 

--- a/docs/audits/2026-06-09-remediation-tracker.md
+++ b/docs/audits/2026-06-09-remediation-tracker.md
@@ -53,7 +53,7 @@ reconciliation merge `7f22e4f22` · audited main `442f90855`.
 | Task | Finding   | Scope                                                                                                     | Status  |
 | ---- | --------- | --------------------------------------------------------------------------------------------------------- | ------- |
 | W3.1 | D-1       | Persistence stops wiping unit battle damage + loan ledger on reload                                       | done    |
-| W3.2 | D-2       | Register financial/turnover/factionStanding/vocationalTraining processors                                 | pending |
+| W3.2 | D-2       | Register financial/turnover/factionStanding/vocationalTraining processors                                 | done    |
 | W3.3 | D-3, D-4  | applyPreset wired into creation; reconcileCoopBattle invoked                                              | pending |
 | W3.4 | D-5..D-10 | XP double-apply guard; processedBattleIds; market offers; kill counters; combatTeams; seeded campaign RNG | pending |
 

--- a/src/components/gameplay/pages/campaigns/create/CreateCampaignPage.tsx
+++ b/src/components/gameplay/pages/campaigns/create/CreateCampaignPage.tsx
@@ -6,6 +6,7 @@ import type { IRosterUnitProjection } from '@/types/campaign/RosterUnitProjectio
 
 import { useToast } from '@/components/shared/Toast';
 import { PageLayout, Button } from '@/components/ui';
+import { applyPreset } from '@/lib/campaign/presetService';
 import { UNIT_TEMPLATES } from '@/simulation/generator';
 import { useCampaignRosterStore } from '@/stores/campaign/useCampaignRosterStore';
 import { useCampaignStore } from '@/stores/campaign/useCampaignStore';
@@ -115,9 +116,16 @@ export default function CreateCampaignPage(): React.ReactElement {
     setIsSubmitting(true);
 
     try {
+      // D-3 remediation (2026-06-09 audit): the preset picked on the
+      // wizard's Preset step must actually configure the campaign.
+      // `applyPreset` layers the preset's overrides + campaign-type
+      // defaults over the option defaults; threading the result through
+      // `createCampaign`'s options seam is what makes the selection
+      // real instead of cosmetic.
+      const presetOptions = applyPreset(selectedPreset, campaignType);
       const campaignId = store
         .getState()
-        .createCampaign(name.trim(), campaignType);
+        .createCampaign(name.trim(), campaignType, presetOptions);
 
       if (campaignId) {
         if (description.trim()) {
@@ -206,6 +214,7 @@ export default function CreateCampaignPage(): React.ReactElement {
     pilotAssignments,
     router,
     selectedPilots,
+    selectedPreset,
     selectedUnits,
     setLocalError,
     showToast,

--- a/src/components/gameplay/pages/campaigns/create/__tests__/CreateCampaignPage.preset.test.tsx
+++ b/src/components/gameplay/pages/campaigns/create/__tests__/CreateCampaignPage.preset.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * D-3 wiring seam test (2026-06-09 audit, W3.3): the preset selected on
+ * the wizard's Preset step must actually configure the created campaign.
+ *
+ * Before the fix, `handleSubmit` called `createCampaign(name, type)`
+ * without an options argument, so `applyPreset` had no production caller
+ * and every campaign silently got bare defaults regardless of the card
+ * the user clicked — the preset step was cosmetic.
+ *
+ * These tests exercise the WIRING (wizard UI -> campaign store), not the
+ * preset module in isolation: they walk the real wizard, click a real
+ * preset card, submit, and read the resulting options off the REAL
+ * campaign store.
+ */
+
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+// =============================================================================
+// Mocks — router + toast only. The campaign/roster stores are REAL so the
+// test proves the production seam, not a mocked stand-in.
+// =============================================================================
+
+const mockRouterPush = jest.fn();
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    push: mockRouterPush,
+    query: {},
+    pathname: '/gameplay/campaigns/create',
+  }),
+}));
+
+const mockShowToast = jest.fn();
+jest.mock('@/components/shared/Toast', () => {
+  const actual = jest.requireActual('@/components/shared/Toast');
+  return {
+    ...actual,
+    useToast: () => ({ showToast: mockShowToast }),
+  };
+});
+
+import CreateCampaignPage from '@/components/gameplay/pages/campaigns/create/CreateCampaignPage';
+import {
+  resetCampaignStore,
+  useCampaignStore,
+} from '@/stores/campaign/useCampaignStore';
+import { clientSafeStorage } from '@/stores/utils/clientSafeStorage';
+import { CampaignPreset } from '@/types/campaign/CampaignPreset';
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * Walk the 5-step wizard to submission: name -> type (default Mercenary)
+ * -> preset (click the given card) -> roster (empty) -> review -> submit.
+ */
+async function createCampaignViaWizard(preset?: CampaignPreset): Promise<void> {
+  fireEvent.change(screen.getByTestId('campaign-name-input'), {
+    target: { value: 'Preset Seam Co.' },
+  });
+  fireEvent.click(screen.getByTestId('wizard-next-btn')); // -> Type
+  fireEvent.click(screen.getByTestId('wizard-next-btn')); // -> Preset
+  if (preset) {
+    // PresetCard stamps `data-testid="template-<presetId>"`.
+    fireEvent.click(screen.getByTestId(`template-${preset}`));
+  }
+  fireEvent.click(screen.getByTestId('wizard-next-btn')); // -> Roster
+  fireEvent.click(screen.getByTestId('wizard-next-btn')); // -> Review
+  await act(async () => {
+    fireEvent.click(screen.getByTestId('wizard-submit-btn'));
+  });
+}
+
+function resetWorld(): void {
+  resetCampaignStore();
+  clientSafeStorage.removeItem('campaign-store');
+  mockRouterPush.mockClear();
+  mockShowToast.mockClear();
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('CreateCampaignPage — preset selection configures the campaign (D-3)', () => {
+  beforeEach(resetWorld);
+  afterEach(resetWorld);
+
+  it('creating a campaign with the Casual preset applies the Casual overrides', async () => {
+    render(<CreateCampaignPage />);
+    await createCampaignViaWizard(CampaignPreset.CASUAL);
+
+    const campaign = useCampaignStore().getState().getCampaign();
+    expect(campaign).not.toBeNull();
+    // PRESET_CASUAL overrides — each differs from the bare defaults
+    // (healing 1.0, maintenanceCycleDays 7, payForMaintenance true,
+    // useTaxes true), so all four fail when the preset is cosmetic.
+    expect(campaign?.options.healingRateMultiplier).toBe(2.0);
+    expect(campaign?.options.maintenanceCycleDays).toBe(0);
+    expect(campaign?.options.payForMaintenance).toBe(false);
+    expect(campaign?.options.useTaxes).toBe(false);
+    expect(campaign?.options.useTurnover).toBe(false);
+  });
+
+  it('the default Standard preset applies the Standard overrides (not bare defaults)', async () => {
+    render(<CreateCampaignPage />);
+    // No preset click — STANDARD is the wizard's initial selection.
+    await createCampaignViaWizard();
+
+    const campaign = useCampaignStore().getState().getCampaign();
+    expect(campaign).not.toBeNull();
+    // PRESET_STANDARD overrides that differ from bare defaults:
+    // useRoleBasedSalaries default false, useTaxes default true.
+    expect(campaign?.options.useRoleBasedSalaries).toBe(true);
+    expect(campaign?.options.useTaxes).toBe(false);
+    expect(campaign?.options.useTurnover).toBe(true);
+  });
+});

--- a/src/lib/campaign/coop/coopHostRegistry.ts
+++ b/src/lib/campaign/coop/coopHostRegistry.ts
@@ -1,0 +1,132 @@
+/**
+ * Active co-op host registry + post-battle reconciliation gate.
+ *
+ * D-4 remediation (2026-06-09 audit, W3.3): `reconcileCoopBattle` (CO2)
+ * shipped with ZERO production callers — the co-op post-battle path was
+ * dead code. The production seam where a battle "completes" for campaign
+ * purposes is the combat-outcome bus -> `useCampaignStore.enqueueOutcome`
+ * flow, so that is where `reconcileCoopOutcomeForCampaign` is invoked
+ * (see `useCampaignStore.outcomes.ts#enqueueCampaignOutcome`).
+ *
+ * Reconciliation needs the campaign's authoritative `CampaignMatchHost`
+ * (CO1). Production code does NOT yet instantiate one anywhere — the
+ * Wave 6.1 co-op route surfaces shipped with stub transports and the
+ * planned "Wave 6.2 live CO1 transport" replacement never landed
+ * (`CampaignMatchHost` / `CampaignSyncSession` are constructed only in
+ * tests). This registry is therefore the SINGLE point the future
+ * session-lifecycle wiring must call (`registerActiveCoopHost`) when it
+ * opens a hosted co-op session. Until that wiring exists,
+ * `getActiveCoopHost` returns undefined in a live app and the gate
+ * below resolves null — a documented no-op, not a silent throw.
+ *
+ * @module lib/campaign/coop/coopHostRegistry
+ */
+
+import type { CampaignMatchHost } from '@/lib/multiplayer/server/CampaignMatchHost';
+import type { ICampaign } from '@/types/campaign/Campaign';
+import type { ICombatOutcome } from '@/types/combat/CombatOutcome';
+
+import { GameSide } from '@/types/gameplay/GameSessionCoreTypes';
+
+import type { ICoopReconciliationResult } from './reconcileCoopBattle';
+
+import {
+  deriveCoopBattleConsequences,
+  reconcileCoopBattle,
+} from './reconcileCoopBattle';
+
+// =============================================================================
+// Registry
+// =============================================================================
+
+/**
+ * The live hosts, keyed by campaign id. A module-level map (not a store)
+ * because `CampaignMatchHost` instances are runtime session objects —
+ * they must never be serialized or rendered, only looked up by the
+ * post-battle seam.
+ */
+const activeHosts = new Map<string, CampaignMatchHost>();
+
+/**
+ * Register the authoritative host for its campaign. Returns an
+ * unregister function (mirrors `subscribeToCombatOutcome`'s contract);
+ * the unregister is a no-op if a NEWER host has replaced this one, so a
+ * stale teardown can't evict a live session.
+ */
+export function registerActiveCoopHost(host: CampaignMatchHost): () => void {
+  activeHosts.set(host.campaignId, host);
+  return () => {
+    if (activeHosts.get(host.campaignId) === host) {
+      activeHosts.delete(host.campaignId);
+    }
+  };
+}
+
+/** Look up the live host for a campaign, if one is registered. */
+export function getActiveCoopHost(
+  campaignId: string,
+): CampaignMatchHost | undefined {
+  return activeHosts.get(campaignId);
+}
+
+/** Test-only helper: drop every registered host. */
+export function _resetActiveCoopHosts(): void {
+  activeHosts.clear();
+}
+
+// =============================================================================
+// Post-battle reconciliation gate
+// =============================================================================
+
+/**
+ * Reconcile a freshly-landed combat outcome into the shared co-op
+ * campaign, when (and only when) this client HOSTS a co-op session for
+ * the outcome's campaign.
+ *
+ * Resolves null (no-op) when:
+ *  - the campaign is not a co-op campaign, or this client is a guest —
+ *    the host is CO1's single writer; a guest mirror receives the
+ *    resulting events over the wire instead of reconciling locally;
+ *  - no live `CampaignMatchHost` is registered for the campaign (the
+ *    production state today — see the module docstring).
+ *
+ * Never throws: the caller is a synchronous store action firing this as
+ * fire-and-forget, so a reconciliation failure is folded into the
+ * result instead of surfacing as an unhandled rejection.
+ */
+export async function reconcileCoopOutcomeForCampaign(
+  campaign: Pick<ICampaign, 'id' | 'coopSession'> | null,
+  outcome: ICombatOutcome,
+  designations: Readonly<Record<string, string>> = {},
+): Promise<ICoopReconciliationResult | null> {
+  if (!campaign?.coopSession || campaign.coopSession.mode !== 'host') {
+    return null;
+  }
+  const host = getActiveCoopHost(campaign.id);
+  if (!host) {
+    return null;
+  }
+  try {
+    const consequences = deriveCoopBattleConsequences({
+      outcome,
+      campaignId: campaign.id,
+      // The local player's units fight on GameSide.Player in every
+      // campaign-launched encounter (co-op composition puts BOTH
+      // players' forces on the shared player side per design D1).
+      playerSide: GameSide.Player,
+      // The mission payout flows through the single-player post-battle
+      // pipeline (contract fulfillment) — this seam only reconciles the
+      // facts readable from the combat outcome itself, per the
+      // `deriveCoopBattleConsequences` contract.
+      missionPayout: 0,
+      designations,
+    });
+    return await reconcileCoopBattle(host, consequences);
+  } catch (err) {
+    return {
+      ok: false,
+      events: [],
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/src/lib/campaign/persistence/serializeCampaign.ts
+++ b/src/lib/campaign/persistence/serializeCampaign.ts
@@ -110,6 +110,8 @@ export function serializeCampaign(campaign: ICampaign): SerializedCampaignBody {
     // a campaign-extension field; every `ICampaignLoan` field is already
     // a JSON-safe scalar so it serializes directly. Omitted when absent.
     loans: (campaign as ICampaignWithCommand).loans,
+    // Audit D-10 (W3.4): the replayability seed travels with the body.
+    rngSeed: campaign.rngSeed,
   };
 }
 
@@ -148,5 +150,8 @@ export function deserializeCampaignBody(
     // Restore the loan ledger (design D4). Absent on pre-CP2b snapshots,
     // in which case the campaign simply carries no `loans` field.
     ...(body.loans !== undefined ? { loans: body.loans } : {}),
+    // Audit D-10 (W3.4): restore the replayability seed. Absent on
+    // pre-fix snapshots — daily RNG falls back to an id-derived seed.
+    ...(body.rngSeed !== undefined ? { rngSeed: body.rngSeed } : {}),
   } as ICampaign;
 }

--- a/src/lib/campaign/processors/__tests__/dailyRngDeterminism.test.ts
+++ b/src/lib/campaign/processors/__tests__/dailyRngDeterminism.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Seam tests for audit finding D-10 (2026-06-09 audit, remediation W3.4).
+ *
+ * Campaign days must be replayable: the campaign carries a persisted
+ * `rngSeed` (stamped at creation, survives serialize → deserialize), and
+ * daily processors draw their outcome rolls from a seeded stream derived
+ * from (campaign seed, day, processor id) instead of raw `Math.random`.
+ *
+ * Red proof pre-fix: two healing runs from byte-identical state produced
+ * different 2d6 medical-check outcomes because the rolls were unseeded.
+ */
+import { describe, it, expect, afterEach } from '@jest/globals';
+
+import type { ICampaign } from '@/types/campaign/Campaign';
+import type { ICampaignRosterEntry } from '@/types/campaign/CampaignRosterEntry';
+import type { IInjury } from '@/types/campaign/Person';
+
+import { useCampaignRosterStore } from '@/stores/campaign/useCampaignRosterStore';
+import {
+  deserializeCampaign,
+  serializeCampaign,
+} from '@/stores/campaign/useCampaignStore.persistence';
+import { usePilotStore } from '@/stores/usePilotStore';
+import {
+  createCampaign,
+  createDefaultCampaignOptions,
+} from '@/types/campaign/Campaign';
+import { CampaignPilotStatus } from '@/types/campaign/CampaignInterfaces.types';
+import { CampaignType } from '@/types/campaign/CampaignType';
+import { CampaignPersonnelRole } from '@/types/campaign/enums/CampaignPersonnelRole';
+import { Money } from '@/types/campaign/Money';
+
+import { healingProcessor } from '../healingProcessor';
+
+/** Widened view of the campaign carrying the (new) persisted seed. */
+type ISeededCampaign = ICampaign & { readonly rngSeed?: number };
+
+/** Builds the fixed campaign the healing runs replay against. */
+function makeCampaign(rngSeed: number): ICampaign {
+  return {
+    id: 'camp-rng',
+    name: 'Determinism Co.',
+    currentDate: new Date('3025-06-15T00:00:00Z'),
+    factionId: 'mercenary',
+    forces: new Map(),
+    rootForceId: 'root',
+    missions: new Map(),
+    finances: { transactions: [], balance: new Money(0) },
+    factionStandings: {},
+    shoppingList: { items: [] },
+    options: createDefaultCampaignOptions(),
+    campaignType: CampaignType.MERCENARY,
+    createdAt: '3024-12-01T00:00:00Z',
+    updatedAt: '3025-06-14T00:00:00Z',
+    unitCombatStates: {},
+    rngSeed,
+  } as ISeededCampaign;
+}
+
+/** One healable injury — the 2d6 medical check decides heal vs no-change. */
+function makeInjury(id: string): IInjury {
+  return {
+    id,
+    type: 'Broken Bone',
+    location: 'Left Arm',
+    severity: 2,
+    daysToHeal: 30,
+    permanent: false,
+    acquired: new Date('3025-06-01T00:00:00Z'),
+  };
+}
+
+/** Builds a wounded patient whose healing outcome is roll-dependent. */
+function makePatient(id: string): ICampaignRosterEntry {
+  return {
+    pilotId: id,
+    pilotName: `Patient ${id}`,
+    status: CampaignPilotStatus.Wounded,
+    wounds: 2,
+    recoveryTime: 10,
+    xp: 0,
+    campaignXpEarned: 0,
+    campaignKills: 0,
+    campaignMissions: 0,
+    primaryRole: CampaignPersonnelRole.PILOT,
+    rankIndex: 0,
+    hireDate: new Date('3025-01-01'),
+    injuries: [makeInjury(`inj-${id}`)],
+  };
+}
+
+/** Builds the doctor whose presence routes patients onto the 2d6 check. */
+function makeDoctor(): ICampaignRosterEntry {
+  return {
+    pilotId: 'doc-1',
+    pilotName: 'Doc Holliday',
+    status: CampaignPilotStatus.Active,
+    wounds: 0,
+    recoveryTime: 0,
+    xp: 0,
+    campaignXpEarned: 0,
+    campaignKills: 0,
+    campaignMissions: 0,
+    primaryRole: CampaignPersonnelRole.DOCTOR,
+    rankIndex: 0,
+    hireDate: new Date('3025-01-01'),
+    injuries: [],
+  };
+}
+
+/** Seeds 16 wounded patients + 1 doctor — a 16-way roll-outcome vector. */
+function seedRoster(): void {
+  const patients = Array.from({ length: 16 }, (_, i) =>
+    makePatient(`p${i + 1}`),
+  );
+  useCampaignRosterStore.setState({
+    campaignId: 'camp-rng',
+    units: [],
+    pilots: [...patients, makeDoctor()],
+    missions: [],
+    activeMissionId: null,
+    missionCount: 0,
+  });
+  usePilotStore.setState({ pilots: [] });
+}
+
+/** Snapshots the roll-dependent healing outputs per patient. */
+function snapshotHealingState(): ReadonlyArray<{
+  pilotId: string;
+  daysToHeal: number[];
+}> {
+  return useCampaignRosterStore
+    .getState()
+    .pilots.filter((p) => p.pilotId !== 'doc-1')
+    .map((p) => ({
+      pilotId: p.pilotId,
+      daysToHeal: (p.injuries ?? []).map((i) => i.daysToHeal),
+    }));
+}
+
+/** Resets both stores between runs. */
+function clearStores(): void {
+  useCampaignRosterStore.setState({
+    campaignId: null,
+    units: [],
+    pilots: [],
+    missions: [],
+    activeMissionId: null,
+    missionCount: 0,
+  });
+  usePilotStore.setState({ pilots: [] });
+}
+
+describe('seeded campaign RNG (D-10)', () => {
+  afterEach(() => clearStores());
+
+  it('createCampaign stamps an rngSeed that survives the persistence round trip', () => {
+    const campaign = createCampaign('Seeded Co.', 'mercenary');
+    const seed = (campaign as ISeededCampaign).rngSeed;
+    expect(typeof seed).toBe('number');
+
+    const serialized = serializeCampaign(campaign);
+    const reloaded = deserializeCampaign(serialized, new Map(), new Map());
+    expect((reloaded as ISeededCampaign).rngSeed).toBe(seed);
+  });
+
+  it('same campaign state + same seed → identical healing outcomes twice', () => {
+    const campaign = makeCampaign(123456789);
+    const date = campaign.currentDate;
+
+    seedRoster();
+    healingProcessor.process(campaign, date);
+    const firstRun = snapshotHealingState();
+
+    clearStores();
+    seedRoster();
+    healingProcessor.process(campaign, date);
+    const secondRun = snapshotHealingState();
+
+    expect(secondRun).toEqual(firstRun);
+  });
+
+  it('different campaign seeds produce different healing outcomes', () => {
+    const date = new Date('3025-06-15T00:00:00Z');
+
+    seedRoster();
+    healingProcessor.process(makeCampaign(1), date);
+    const seedOneRun = snapshotHealingState();
+
+    clearStores();
+    seedRoster();
+    healingProcessor.process(makeCampaign(987654321), date);
+    const seedTwoRun = snapshotHealingState();
+
+    expect(seedTwoRun).not.toEqual(seedOneRun);
+  });
+});

--- a/src/lib/campaign/processors/__tests__/financialProcessor.test.ts
+++ b/src/lib/campaign/processors/__tests__/financialProcessor.test.ts
@@ -531,6 +531,45 @@ describe('dailyCostsProcessor gate - double-deduction prevention', () => {
     expect(result.campaign).toBe(campaign);
   });
 
+  it('financialProcessor should return early (no-op) when useRoleBasedSalaries is false', () => {
+    // Per audit finding D-2 (2026-06-09): mirror gate. Now that the
+    // financial processor is registered in production alongside
+    // dailyCosts, it must no-op in legacy (flat-rate) mode or a
+    // default-options campaign would be double-charged for salaries
+    // and maintenance.
+    seedRoster();
+    const forces = new Map();
+    forces.set('force-root', {
+      id: 'force-root',
+      name: 'Root Force',
+      parentForceId: undefined,
+      subForceIds: [],
+      unitIds: ['unit-001'],
+      forceType: 'standard',
+      formationLevel: 'lance',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    });
+
+    const campaign = createTestCampaign({
+      forces,
+      options: {
+        ...createDefaultCampaignOptions(),
+        useRoleBasedSalaries: false,
+        payForSalaries: true,
+        payForMaintenance: true,
+      },
+    });
+
+    // First of month — every monthly financial step would fire if the
+    // gate were missing.
+    const firstOfMonth = new Date('3025-01-01T00:00:00Z');
+    const result = financialProcessor.process(campaign, firstOfMonth);
+
+    expect(result.events.length).toBe(0);
+    expect(result.campaign).toBe(campaign);
+  });
+
   it('should still work normally when useRoleBasedSalaries is false', () => {
     const forces = new Map();
     forces.set('force-root', {

--- a/src/lib/campaign/processors/__tests__/marketProcessors.test.ts
+++ b/src/lib/campaign/processors/__tests__/marketProcessors.test.ts
@@ -1,10 +1,18 @@
+import type { ICampaignWithCommand } from '@/types/campaign/CampaignCommandExtensions';
+import type { IUnitMarketOffer } from '@/types/campaign/markets/marketTypes';
+
 import {
   ICampaign,
   createDefaultCampaignOptions,
 } from '@/types/campaign/Campaign';
 import { CampaignType } from '@/types/campaign/CampaignType';
+import { CampaignPersonnelRole } from '@/types/campaign/enums/CampaignPersonnelRole';
 import { IForce } from '@/types/campaign/Force';
-import { PersonnelMarketStyle } from '@/types/campaign/markets/marketTypes';
+import {
+  MarketExperienceLevel,
+  PersonnelMarketStyle,
+  type IPersonnelMarketOffer,
+} from '@/types/campaign/markets/marketTypes';
 import { IMission } from '@/types/campaign/Mission';
 import { Money } from '@/types/campaign/Money';
 
@@ -237,5 +245,107 @@ describe('contractMarketProcessor', () => {
     expect(result.events[0].type).toBe('market_refresh');
     expect(result.events[0].severity).toBe('info');
     expect(result.events[0].description).toContain('Contract market refreshed');
+  });
+});
+
+// =============================================================================
+// D-7 (2026-06-09 audit, W3.4): generated offers must be STORED on the
+// campaign where the command UI reads them (CampaignCommandExtensions),
+// not discarded while the day report claims a refresh happened.
+// =============================================================================
+
+/** Widened campaign view carrying the command-tier market fields. */
+type IMarketCampaign = ICampaignWithCommand & {
+  readonly unitMarket?: readonly IUnitMarketOffer[];
+};
+
+/** Builds a personnel offer with a controllable expiration date. */
+function makePersonnelOffer(
+  id: string,
+  expirationDate: string,
+): IPersonnelMarketOffer {
+  return {
+    id,
+    name: `Recruit ${id}`,
+    role: CampaignPersonnelRole.PILOT,
+    experienceLevel: MarketExperienceLevel.REGULAR,
+    skills: { gunnery: 4, piloting: 5 },
+    hireCost: 50000,
+    expirationDate,
+  };
+}
+
+describe('market offers stored on campaign state (D-7)', () => {
+  it('unit market refresh stores the generated offers on campaign.unitMarket', () => {
+    const campaign = createTestCampaign({
+      currentDate: new Date('3025-01-01T00:00:00Z'),
+      options: {
+        ...createDefaultCampaignOptions(),
+        unitMarketMethod: 'atb_monthly',
+      },
+    });
+
+    const result = unitMarketProcessor.process(campaign, campaign.currentDate);
+
+    const next = result.campaign as IMarketCampaign;
+    const reportedCount = result.events[0].data?.offerCount as number;
+    expect(next.unitMarket).toBeDefined();
+    expect(next.unitMarket).toHaveLength(reportedCount);
+  });
+
+  it('personnel market refresh appends the day offers and prunes expired ones', () => {
+    const keep = makePersonnelOffer('pmo-keep', '3025-12-31');
+    const expired = makePersonnelOffer('pmo-expired', '3025-06-01');
+    const campaign = createTestCampaign({
+      currentDate: new Date('3025-06-15T00:00:00Z'),
+      options: {
+        ...createDefaultCampaignOptions(),
+        personnelMarketStyle: PersonnelMarketStyle.MEKHQ,
+      },
+      personnelMarket: [keep, expired],
+    } as Partial<ICampaign>);
+
+    const result = personnelMarketProcessor.process(
+      campaign,
+      campaign.currentDate,
+    );
+
+    const next = result.campaign as IMarketCampaign;
+    const reportedCount = result.events[0].data?.offerCount as number;
+    const pool = next.personnelMarket ?? [];
+    // Non-expired carry-over offer survives the daily refresh…
+    expect(pool.some((o) => o.id === 'pmo-keep')).toBe(true);
+    // …the expired one is pruned…
+    expect(pool.some((o) => o.id === 'pmo-expired')).toBe(false);
+    // …and the day's generated offers land in the pool.
+    expect(pool).toHaveLength(1 + reportedCount);
+  });
+
+  it('contract market refresh replaces offers and clears declined ids', () => {
+    const campaign = createTestCampaign({
+      currentDate: new Date('3025-01-01T00:00:00Z'),
+      options: {
+        ...createDefaultCampaignOptions(),
+        contractMarketMethod: 'atb_monthly',
+      },
+      contractMarket: {
+        offers: [],
+        declinedOfferIds: ['stale-declined-id'],
+      },
+    } as Partial<ICampaign>);
+
+    const result = contractMarketProcessor.process(
+      campaign,
+      campaign.currentDate,
+    );
+
+    const next = result.campaign as IMarketCampaign;
+    const reportedCount = result.events[0].data?.contractCount as number;
+    expect(next.contractMarket).toBeDefined();
+    expect(next.contractMarket?.offers).toHaveLength(reportedCount);
+    // A refresh starts a new market cycle — declined ids reset (the
+    // ICampaignContractMarket contract: declined offers stay hidden
+    // "until the next contractMarketProcessor refresh").
+    expect(next.contractMarket?.declinedOfferIds).toEqual([]);
   });
 });

--- a/src/lib/campaign/processors/__tests__/postBattleProcessor.retryIdempotency.test.ts
+++ b/src/lib/campaign/processors/__tests__/postBattleProcessor.retryIdempotency.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Seam tests for audit findings D-5 + D-8 (2026-06-09 audit, remediation W3.4).
+ *
+ * D-5: a partial failure while applying a battle outcome must NOT leave
+ * pilot XP/wound side effects behind — the outcome stays queued for retry,
+ * and the retry must apply effects exactly once. The pre-fix code committed
+ * roster patches BEFORE the contract/prestige steps, so a throw in either
+ * left committed XP plus a queued outcome → retry double-applied.
+ *
+ * D-8: an applied outcome must increment the pilot's campaignMissions by 1
+ * and campaignKills by the after-action report's per-unit kill count so
+ * kill/mission auto-awards can ever fire.
+ */
+import type { ICampaignRosterEntry } from '@/types/campaign/CampaignRosterEntry';
+import type {
+  ICombatOutcome,
+  IUnitCombatDelta,
+} from '@/types/combat/CombatOutcome';
+import type {
+  IPostBattleReport,
+  IUnitReport,
+} from '@/utils/gameplay/postBattleReport';
+
+import { useCampaignRosterStore } from '@/stores/campaign/useCampaignRosterStore';
+import { usePilotStore } from '@/stores/usePilotStore';
+import { createDefaultCampaignOptions } from '@/types/campaign/Campaign';
+import { CampaignPilotStatus } from '@/types/campaign/CampaignInterfaces.types';
+import { CampaignType } from '@/types/campaign/CampaignType';
+import { CampaignPersonnelRole } from '@/types/campaign/enums/CampaignPersonnelRole';
+import { Money } from '@/types/campaign/Money';
+import {
+  CombatEndReason,
+  COMBAT_OUTCOME_VERSION,
+  PilotFinalStatus,
+  UnitFinalStatus,
+} from '@/types/combat/CombatOutcome';
+import { GameSide } from '@/types/gameplay/GameSessionInterfaces';
+import { PilotType, PilotStatus } from '@/types/pilot/PilotInterfaces';
+
+import { applyOutcomePrestige } from '../../prestige/applyOutcomePrestige';
+import {
+  applyPostBattle,
+  postBattleProcessor,
+  type ICampaignWithBattleState,
+} from '../postBattleProcessor';
+
+// The prestige step runs AFTER pilot patches in the pre-fix ordering, so
+// mocking it to throw once reproduces the audit's "partial failure" shape:
+// downstream computation explodes after upstream side effects committed.
+jest.mock('../../prestige/applyOutcomePrestige', () => {
+  const actual = jest.requireActual(
+    '../../prestige/applyOutcomePrestige',
+  ) as typeof import('../../prestige/applyOutcomePrestige');
+  return {
+    __esModule: true,
+    applyOutcomePrestige: jest.fn(actual.applyOutcomePrestige),
+  };
+});
+
+const prestigeMock = applyOutcomePrestige as jest.MockedFunction<
+  typeof applyOutcomePrestige
+>;
+
+// ----------------------------------------------------------------------------
+// Fixtures (mirrors postBattleProcessor.test.ts)
+// ----------------------------------------------------------------------------
+
+/** Builds a minimal campaign carrying the battle-state extension fields. */
+function createTestCampaign(
+  overrides: Partial<ICampaignWithBattleState> = {},
+): ICampaignWithBattleState {
+  return {
+    id: 'camp-1',
+    name: 'Test Campaign',
+    currentDate: new Date('3025-06-15T00:00:00Z'),
+    factionId: 'mercenary',
+    forces: new Map(),
+    rootForceId: 'root',
+    missions: new Map(),
+    finances: { transactions: [], balance: new Money(0) },
+    factionStandings: {},
+    shoppingList: { items: [] },
+    options: createDefaultCampaignOptions(),
+    campaignType: CampaignType.MERCENARY,
+    createdAt: '3024-12-01T00:00:00Z',
+    updatedAt: '3025-06-14T00:00:00Z',
+    unitCombatStates: {},
+    ...overrides,
+  };
+}
+
+/** Builds the after-action report with optional per-unit rows (D-8 kills). */
+function createTestReport(
+  matchId: string,
+  units: readonly IUnitReport[] = [],
+): IPostBattleReport {
+  return {
+    version: 1,
+    matchId,
+    winner: GameSide.Player,
+    reason: 'destruction',
+    turnCount: 5,
+    units,
+    mvpUnitId: null,
+    log: [],
+  };
+}
+
+/** Builds a player-side unit delta whose pilot survives unharmed. */
+function createDelta(
+  unitId: string,
+  overrides: Partial<IUnitCombatDelta> = {},
+): IUnitCombatDelta {
+  return {
+    unitId,
+    side: GameSide.Player,
+    destroyed: false,
+    finalStatus: UnitFinalStatus.Damaged,
+    armorRemaining: { CT: 20 },
+    internalsRemaining: { CT: 10 },
+    destroyedLocations: [],
+    destroyedComponents: [],
+    heatEnd: 0,
+    ammoRemaining: {},
+    pilotState: {
+      conscious: true,
+      wounds: 0,
+      killed: false,
+      finalStatus: PilotFinalStatus.Active,
+    },
+    ...overrides,
+  };
+}
+
+/** Builds an outcome carrying one player delta + report kill rows. */
+function createOutcome(
+  matchId: string,
+  units: readonly IUnitReport[] = [],
+): ICombatOutcome {
+  return {
+    version: COMBAT_OUTCOME_VERSION,
+    matchId,
+    contractId: null,
+    scenarioId: null,
+    endReason: CombatEndReason.Destruction,
+    report: createTestReport(matchId, units),
+    unitDeltas: [createDelta('unit-A')],
+    capturedAt: '3025-06-15T12:00:00Z',
+  };
+}
+
+/** Builds a unit report row so kill attribution flows from the report. */
+function makeUnitReport(unitId: string, kills: number): IUnitReport {
+  return {
+    unitId,
+    side: GameSide.Player,
+    designation: `Unit ${unitId}`,
+    damageDealt: 25,
+    damageReceived: 5,
+    kills,
+    heatProblems: 0,
+    physicalAttacks: 0,
+    xpPending: true,
+  };
+}
+
+/** Roster entry factory — fresh zeroed counters per test. */
+function makeRosterEntry(id: string): ICampaignRosterEntry {
+  return {
+    pilotId: id,
+    pilotName: `Pilot ${id}`,
+    status: CampaignPilotStatus.Active,
+    wounds: 0,
+    recoveryTime: 0,
+    xp: 0,
+    campaignXpEarned: 0,
+    campaignKills: 0,
+    campaignMissions: 0,
+    primaryRole: CampaignPersonnelRole.PILOT,
+    rankIndex: 0,
+    hireDate: new Date('3025-01-01'),
+    injuries: [],
+  };
+}
+
+/** Seeds roster + vault so the XP path is live (entry + pilot non-null). */
+function seedRosterEntry(pilotId: string): void {
+  useCampaignRosterStore.setState({
+    campaignId: 'camp-1',
+    units: [],
+    pilots: [makeRosterEntry(pilotId)],
+    missions: [],
+    activeMissionId: null,
+    missionCount: 0,
+  });
+  usePilotStore.setState({
+    pilots: [
+      {
+        id: pilotId,
+        name: `Pilot ${pilotId}`,
+        type: PilotType.Persistent,
+        status: PilotStatus.Active,
+        skills: { gunnery: 4, piloting: 5 },
+        wounds: 0,
+        abilities: [],
+        createdAt: '3025-01-01T00:00:00Z',
+        updatedAt: '3025-01-01T00:00:00Z',
+      },
+    ],
+  });
+}
+
+/** Resets both Zustand stores to empty state. */
+function clearStores(): void {
+  useCampaignRosterStore.setState({
+    campaignId: null,
+    units: [],
+    pilots: [],
+    missions: [],
+    activeMissionId: null,
+    missionCount: 0,
+  });
+  usePilotStore.setState({ pilots: [] });
+}
+
+/** Reads the live roster entry for assertions. */
+function rosterEntry(pilotId: string): ICampaignRosterEntry {
+  const entry = useCampaignRosterStore
+    .getState()
+    .pilots.find((p) => p.pilotId === pilotId);
+  if (!entry) throw new Error(`roster entry ${pilotId} missing`);
+  return entry;
+}
+
+// ----------------------------------------------------------------------------
+// D-5 — retry after partial failure must not double-apply pilot effects
+// ----------------------------------------------------------------------------
+
+describe('postBattleProcessor retry idempotency (D-5)', () => {
+  afterEach(() => {
+    clearStores();
+    prestigeMock.mockClear();
+  });
+
+  it('a failed apply leaves no pilot XP behind and the retry applies exactly once', () => {
+    // Control: a clean single apply with default options awards
+    // scenarioXP(1) + killXP(1) = 2 to the player-side winning pilot.
+    seedRosterEntry('unit-A');
+    const controlOutcome = createOutcome('match-control');
+    postBattleProcessor.process(
+      createTestCampaign({ pendingBattleOutcomes: [controlOutcome] }),
+      new Date('3025-06-15T00:00:00Z'),
+    );
+    const controlXp = rosterEntry('unit-A').xp;
+    expect(controlXp).toBeGreaterThan(0);
+    clearStores();
+
+    // Day 1: prestige step throws → outcome must stay queued AND the
+    // roster must be untouched (no committed XP from the failed apply).
+    seedRosterEntry('unit-A');
+    const outcome = createOutcome('match-retry');
+    const campaign = createTestCampaign({ pendingBattleOutcomes: [outcome] });
+    prestigeMock.mockImplementationOnce(() => {
+      throw new Error('induced mid-apply failure');
+    });
+
+    const day1 = postBattleProcessor.process(
+      campaign,
+      new Date('3025-06-15T00:00:00Z'),
+    );
+    const day1Campaign = day1.campaign as ICampaignWithBattleState;
+
+    expect(day1.events.some((e) => e.type === 'post_battle_apply_failed')).toBe(
+      true,
+    );
+    expect(day1Campaign.pendingBattleOutcomes ?? [outcome]).toHaveLength(1);
+    // The failed apply must be side-effect free.
+    expect(rosterEntry('unit-A').xp).toBe(0);
+
+    // Day 2: retry succeeds → effects applied exactly once.
+    const day2 = postBattleProcessor.process(
+      day1Campaign,
+      new Date('3025-06-16T00:00:00Z'),
+    );
+    const day2Campaign = day2.campaign as ICampaignWithBattleState;
+
+    expect(day2Campaign.processedBattleIds ?? []).toContain('match-retry');
+    expect(rosterEntry('unit-A').xp).toBe(controlXp);
+  });
+});
+
+// ----------------------------------------------------------------------------
+// D-8 — kill / mission counters increment from battle outcomes
+// ----------------------------------------------------------------------------
+
+describe('campaign kill/mission counters (D-8)', () => {
+  afterEach(() => {
+    clearStores();
+    prestigeMock.mockClear();
+  });
+
+  it('post-battle with 2 kills increments campaignKills by 2 and campaignMissions by 1', () => {
+    seedRosterEntry('unit-A');
+    const outcome = createOutcome('match-kills', [makeUnitReport('unit-A', 2)]);
+
+    const { summary } = applyPostBattle(outcome, createTestCampaign());
+
+    expect(summary.skippedDuplicate).toBe(false);
+    const entry = rosterEntry('unit-A');
+    expect(entry.campaignKills).toBe(2);
+    expect(entry.campaignMissions).toBe(1);
+  });
+
+  it('a unit with no report row still counts the mission with zero kills', () => {
+    seedRosterEntry('unit-A');
+    const outcome = createOutcome('match-no-kills', []);
+
+    applyPostBattle(outcome, createTestCampaign());
+
+    const entry = rosterEntry('unit-A');
+    expect(entry.campaignKills).toBe(0);
+    expect(entry.campaignMissions).toBe(1);
+  });
+});

--- a/src/lib/campaign/processors/__tests__/processorRegistration.seam.test.ts
+++ b/src/lib/campaign/processors/__tests__/processorRegistration.seam.test.ts
@@ -1,0 +1,377 @@
+/**
+ * D-2 seam tests — production registration of the financial, turnover,
+ * faction-standing, and vocational-training day processors.
+ *
+ * The 2026-06-09 audit (finding D-2) showed these four processors were
+ * shipped and unit-tested but never registered by
+ * `registerBuiltinProcessors()` — the only registration path production
+ * uses (`useCampaignStore.advanceDay`). Per-module unit tests call the
+ * processors directly, so the wiring gap was invisible to them.
+ *
+ * These tests exercise the WIRING: they register the builtins exactly the
+ * way production does and drive a full `processDay`, asserting each
+ * processor's observable day-advance effect (salary posted on payday,
+ * departure applied on a failed turnover roll, regard decayed, vocational
+ * timer advanced) — not the module logic in isolation.
+ */
+import { useCampaignRosterStore } from '@/stores/campaign/useCampaignRosterStore';
+import { usePilotStore } from '@/stores/usePilotStore';
+import {
+  ICampaign,
+  createDefaultCampaignOptions,
+} from '@/types/campaign/Campaign';
+import { CampaignPilotStatus } from '@/types/campaign/CampaignInterfaces.types';
+import { ICampaignRosterEntry } from '@/types/campaign/CampaignRosterEntry';
+import { CampaignType } from '@/types/campaign/CampaignType';
+import {
+  CampaignPersonnelRole,
+  ForceRole,
+  FormationLevel,
+} from '@/types/campaign/enums';
+import { TransactionType } from '@/types/campaign/enums/TransactionType';
+import { FactionStandingLevel } from '@/types/campaign/factionStanding/IFactionStanding';
+import { IForce } from '@/types/campaign/Force';
+import { Money } from '@/types/campaign/Money';
+import { IPilot, PilotStatus, PilotType } from '@/types/pilot/PilotInterfaces';
+
+import { getDayPipeline, _resetDayPipeline } from '../../dayPipeline';
+import {
+  registerBuiltinProcessors,
+  _resetBuiltinRegistration,
+} from '../processorRegistration';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/** Minimal roster entry for store seeding (mirrors processors.test.ts). */
+function makeRosterEntry(
+  id: string,
+  overrides: Partial<ICampaignRosterEntry> = {},
+): ICampaignRosterEntry {
+  return {
+    pilotId: id,
+    pilotName: `Pilot ${id}`,
+    status: CampaignPilotStatus.Active,
+    wounds: 0,
+    recoveryTime: 0,
+    xp: 100,
+    campaignXpEarned: 0,
+    campaignKills: 0,
+    campaignMissions: 0,
+    primaryRole: CampaignPersonnelRole.PILOT,
+    rankIndex: 0,
+    hireDate: new Date('3020-01-01'),
+    injuries: [],
+    ...overrides,
+  };
+}
+
+/** Minimal vault pilot so the processors' NPC-null guards pass. */
+function makeVaultPilot(id: string): IPilot {
+  return {
+    id,
+    name: `Pilot ${id}`,
+    type: PilotType.Persistent,
+    status: PilotStatus.Active,
+    skills: { gunnery: 4, piloting: 5 },
+    wounds: 0,
+    abilities: [],
+    awards: [],
+    createdAt: '3000-01-01T00:00:00Z',
+    updatedAt: '3025-06-15T00:00:00Z',
+  };
+}
+
+function makeForce(id: string, unitIds: string[] = []): IForce {
+  return {
+    id,
+    name: `Force ${id}`,
+    parentForceId: undefined,
+    subForceIds: [],
+    unitIds,
+    forceType: ForceRole.STANDARD,
+    formationLevel: FormationLevel.LANCE,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+  };
+}
+
+function makeCampaign(overrides: Partial<ICampaign> = {}): ICampaign {
+  return {
+    id: 'campaign-seam-1',
+    name: 'Seam Test Campaign',
+    currentDate: new Date('3025-07-15T00:00:00Z'),
+    factionId: 'mercenary',
+    forces: new Map<string, IForce>(),
+    rootForceId: 'force-root',
+    missions: new Map(),
+    finances: { transactions: [], balance: new Money(1_000_000) },
+    factionStandings: {},
+    shoppingList: { items: [] },
+    options: createDefaultCampaignOptions(),
+    campaignType: CampaignType.MERCENARY,
+    createdAt: '3020-01-01T00:00:00Z',
+    updatedAt: '3025-06-15T00:00:00Z',
+    ...overrides,
+    // Per canonicalize-unit-combat-state PR-A: required ICampaign field.
+    unitCombatStates: overrides.unitCombatStates ?? {},
+  };
+}
+
+/** Seeds roster + vault stores with matched entries so lookups resolve. */
+function seedStores(entries: ICampaignRosterEntry[]): void {
+  useCampaignRosterStore.setState({
+    campaignId: 'campaign-seam-1',
+    units: [],
+    pilots: entries,
+    missions: [],
+    activeMissionId: null,
+    missionCount: 0,
+  });
+  usePilotStore.setState({
+    pilots: entries.map((e) => makeVaultPilot(e.pilotId)),
+  });
+}
+
+function clearStores(): void {
+  useCampaignRosterStore.setState({
+    campaignId: null,
+    units: [],
+    pilots: [],
+    missions: [],
+    activeMissionId: null,
+    missionCount: 0,
+  });
+  usePilotStore.setState({ pilots: [] });
+}
+
+// Payday: 1st of month fires the monthly financial block + monthly turnover.
+const PAYDAY = new Date('3025-07-01T00:00:00Z');
+// Mid-month: only the daily paths (regard decay, vocational timer) fire.
+const MID_MONTH = new Date('3025-07-15T00:00:00Z');
+
+const D2_PROCESSOR_IDS = [
+  'financial',
+  'turnover',
+  'faction-standing',
+  'vocational-training',
+] as const;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('D-2 seam — production registration of financial/turnover/faction-standing/vocational-training', () => {
+  beforeEach(() => {
+    _resetDayPipeline();
+    _resetBuiltinRegistration();
+    clearStores();
+  });
+
+  afterEach(() => {
+    _resetDayPipeline();
+    _resetBuiltinRegistration();
+    clearStores();
+    jest.restoreAllMocks();
+  });
+
+  it('registerBuiltinProcessors registers all four D-2 processors', () => {
+    registerBuiltinProcessors();
+    const ids = getDayPipeline()
+      .getProcessors()
+      .map((p) => p.id);
+
+    expect(ids).toEqual(expect.arrayContaining([...D2_PROCESSOR_IDS]));
+  });
+
+  it('payday seam: a day-advance on the 1st posts a role-based salary transaction and reduces the balance', () => {
+    // Force every 2d6 roll high so turnover passes (no departure noise)
+    // and the assertion isolates the financial processor's effect.
+    jest.spyOn(Math, 'random').mockReturnValue(0.99);
+
+    seedStores([makeRosterEntry('p1')]);
+    const campaign = makeCampaign({
+      currentDate: PAYDAY,
+      options: {
+        ...createDefaultCampaignOptions(),
+        // Role-based finance path active; legacy dailyCosts no-ops.
+        useRoleBasedSalaries: true,
+        // Taxes off so the balance delta traces to salary/overhead only.
+        useTaxes: false,
+      },
+    });
+
+    registerBuiltinProcessors();
+    const result = getDayPipeline().processDay(campaign);
+
+    // The financial processor ran exactly once and posted monthly salary.
+    expect(
+      result.processorsRun.filter((id) => id === 'financial'),
+    ).toHaveLength(1);
+    const salaryTxs = result.campaign.finances.transactions.filter(
+      (t) => t.type === TransactionType.Salary,
+    );
+    expect(salaryTxs).toHaveLength(1);
+    expect(result.campaign.finances.balance.amount).toBeLessThan(1_000_000);
+  });
+
+  it('turnover seam: a failed monthly check on the 1st departs the pilot via roster patch and emits turnover_departure', () => {
+    // Force every 2d6 roll to snake-eyes (roll = 2) so the check fails
+    // against the default base target of 3 (+1 skill desirability) and
+    // the departure lands as "retired" (2 >= target - 4).
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+
+    seedStores([makeRosterEntry('t1')]);
+    const campaign = makeCampaign({ currentDate: PAYDAY });
+
+    registerBuiltinProcessors();
+    const result = getDayPipeline().processDay(campaign);
+
+    expect(result.processorsRun.filter((id) => id === 'turnover')).toHaveLength(
+      1,
+    );
+
+    // The departure was applied to the roster store (wiring proof: the
+    // processor's store side effect happened during the day-advance).
+    const entry = useCampaignRosterStore
+      .getState()
+      .pilots.find((p) => p.pilotId === 't1');
+    expect(entry?.departureReason).toBe('retired');
+
+    // The day surfaced the departure event and the retirement payout.
+    expect(result.events.some((e) => e.type === 'turnover_departure')).toBe(
+      true,
+    );
+    expect(
+      result.campaign.finances.transactions.some((t) =>
+        t.description.startsWith('Retirement payout'),
+      ),
+    ).toBe(true);
+  });
+
+  it('faction-standing seam: a mid-month day-advance decays nonzero regard toward zero', () => {
+    const campaign = makeCampaign({
+      currentDate: MID_MONTH,
+      factionStandings: {
+        'faction-pos': {
+          factionId: 'faction-pos',
+          regard: 30,
+          level: FactionStandingLevel.LEVEL_2,
+          accoladeLevel: 0,
+          censureLevel: 0,
+          history: [],
+        },
+        'faction-neg': {
+          factionId: 'faction-neg',
+          regard: -20,
+          level: FactionStandingLevel.LEVEL_5,
+          accoladeLevel: 0,
+          censureLevel: 0,
+          history: [],
+        },
+      },
+    });
+
+    registerBuiltinProcessors();
+    const result = getDayPipeline().processDay(campaign);
+
+    expect(
+      result.processorsRun.filter((id) => id === 'faction-standing'),
+    ).toHaveLength(1);
+    expect(result.campaign.factionStandings['faction-pos'].regard).toBeLessThan(
+      30,
+    );
+    expect(
+      result.campaign.factionStandings['faction-neg'].regard,
+    ).toBeGreaterThan(-20);
+  });
+
+  it('vocational seam: a day-advance increments the timer, and the 30th day awards XP on a successful roll', () => {
+    // High roll (12 >= TN 7) so the 30th-day check succeeds.
+    jest.spyOn(Math, 'random').mockReturnValue(0.99);
+
+    seedStores([
+      // Fresh pilot — timer should advance 0 → 1.
+      makeRosterEntry('v1'),
+      // Pilot one day from the 30-day check — XP awarded, timer reset.
+      makeRosterEntry('v2', {
+        traits: { vocationalXPTimer: 29 },
+      }),
+    ]);
+    const campaign = makeCampaign({ currentDate: MID_MONTH });
+
+    registerBuiltinProcessors();
+    const result = getDayPipeline().processDay(campaign);
+
+    expect(
+      result.processorsRun.filter((id) => id === 'vocational-training'),
+    ).toHaveLength(1);
+
+    const pilots = useCampaignRosterStore.getState().pilots;
+    const v1 = pilots.find((p) => p.pilotId === 'v1');
+    const v2 = pilots.find((p) => p.pilotId === 'v2');
+
+    expect(v1?.traits?.vocationalXPTimer).toBe(1);
+    expect(v1?.xp).toBe(100);
+
+    expect(v2?.traits?.vocationalXPTimer).toBe(0);
+    expect(v2?.xp).toBe(101);
+    expect(v2?.campaignXpEarned).toBe(1);
+  });
+
+  it('idempotency: double registration does not duplicate, and one day-advance runs each D-2 processor exactly once', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.99);
+
+    seedStores([makeRosterEntry('p1')]);
+    const campaign = makeCampaign({ currentDate: PAYDAY });
+
+    registerBuiltinProcessors();
+    registerBuiltinProcessors();
+
+    const ids = getDayPipeline()
+      .getProcessors()
+      .map((p) => p.id);
+    for (const id of D2_PROCESSOR_IDS) {
+      expect(ids.filter((i) => i === id)).toHaveLength(1);
+    }
+
+    const result = getDayPipeline().processDay(campaign);
+    for (const id of D2_PROCESSOR_IDS) {
+      expect(result.processorsRun.filter((i) => i === id)).toHaveLength(1);
+    }
+  });
+
+  it('double-deduction guard: with useRoleBasedSalaries=false the legacy dailyCosts path owns finances and the financial processor no-ops', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.99);
+
+    seedStores([makeRosterEntry('p1')]);
+    const forces = new Map<string, IForce>();
+    forces.set('force-root', makeForce('force-root', ['unit-1']));
+    // Default options: useRoleBasedSalaries=false, payForMaintenance=true.
+    const campaign = makeCampaign({ currentDate: PAYDAY, forces });
+
+    registerBuiltinProcessors();
+    const result = getDayPipeline().processDay(campaign);
+
+    const txs = result.campaign.finances.transactions;
+
+    // Exactly ONE maintenance charge — from dailyCosts. A second one
+    // would mean the financial processor double-charged maintenance.
+    expect(
+      txs.filter((t) => t.type === TransactionType.Maintenance),
+    ).toHaveLength(1);
+
+    // No role-based monthly salary — the financial block must not fire
+    // in legacy mode even on the 1st.
+    expect(txs.filter((t) => t.type === TransactionType.Salary)).toHaveLength(
+      0,
+    );
+
+    // Sanity: the legacy daily salary (Expense) DID post, so finances
+    // were processed exactly once by the legacy path.
+    expect(txs.some((t) => t.description.startsWith('Daily salaries'))).toBe(
+      true,
+    );
+  });
+});

--- a/src/lib/campaign/processors/__tests__/processorRegistration.seam.test.ts
+++ b/src/lib/campaign/processors/__tests__/processorRegistration.seam.test.ts
@@ -40,6 +40,20 @@ import {
   _resetBuiltinRegistration,
 } from '../processorRegistration';
 
+// D-10 (W3.4) made daily processor rolls come from the campaign's seeded
+// streams instead of Math.random. This suite steers roll OUTCOMES
+// (departure vs stay, vocational XP success) via jest.spyOn(Math,
+// 'random') — keep that lever by routing the seeded stream back through
+// Math.random here. RNG provenance/determinism has its own seam suite
+// (dailyRngDeterminism.test.ts); THIS suite only proves registration.
+jest.mock('@/lib/campaign/utils/campaignRng', () => {
+  const actual = jest.requireActual('@/lib/campaign/utils/campaignRng');
+  return {
+    ...actual,
+    createDailyRandom: () => () => Math.random(),
+  };
+});
+
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------

--- a/src/lib/campaign/processors/__tests__/processors.test.ts
+++ b/src/lib/campaign/processors/__tests__/processors.test.ts
@@ -254,17 +254,19 @@ describe('registerBuiltinProcessors', () => {
     _resetBuiltinRegistration();
   });
 
-  it('should register all seventeen builtin processors', () => {
+  it('should register all twenty-one builtin processors', () => {
     registerBuiltinProcessors();
     const processors = getDayPipeline().getProcessors();
 
-    // 17 = 15 prior + refit and morale
-    // (add-campaign-refit-and-prestige, Wave 4 CP3).
-    expect(processors).toHaveLength(17);
+    // 21 = 17 prior + financial, turnover, faction-standing, and
+    // vocational-training (audit finding D-2, 2026-06-09 — these four
+    // were shipped and unit-tested but never registered in production).
+    expect(processors).toHaveLength(21);
     expect(processors.map((p) => p.id).sort()).toEqual(
       [
         'healing',
         'auto-awards',
+        'turnover',
         'unit-market',
         'personnel-market',
         'contract-market',
@@ -273,9 +275,12 @@ describe('registerBuiltinProcessors', () => {
         'contracts',
         'repair-queue-builder',
         'dailyCosts',
+        'financial',
         'acquisition',
         'random-events',
+        'vocational-training',
         'scenario-generation',
+        'faction-standing',
         'scenario-encounter-bridge',
         'inventory-projection',
         'refit',
@@ -289,7 +294,7 @@ describe('registerBuiltinProcessors', () => {
     registerBuiltinProcessors();
 
     const processors = getDayPipeline().getProcessors();
-    expect(processors).toHaveLength(17);
+    expect(processors).toHaveLength(21);
   });
 
   it('should register processors in correct phase order', () => {
@@ -304,26 +309,34 @@ describe('registerBuiltinProcessors', () => {
     // scenario-encounter-bridge (EVENTS+10=810), inventory-projection
     // (CLEANUP=900). add-campaign-refit-and-prestige (Wave 4 CP3) adds
     // the refit processor (UNITS=500) and the morale processor
-    // (EVENTS=800). Expected order:
-    //   PERSONNEL × 2, MARKETS × 3, post-battle, salvage, repair,
-    //   contracts, refit (UNITS), FINANCES, EVENTS × 4, EVENTS+10,
+    // (EVENTS=800). Audit finding D-2 (2026-06-09) wires the four
+    // shipped-but-unregistered processors: turnover (PERSONNEL=100,
+    // after healing/auto-awards), financial (FINANCES=700, after
+    // dailyCosts), vocational-training (EVENTS=800), faction-standing
+    // (EVENTS=800, last EVENTS step per MekHQ). Expected order:
+    //   PERSONNEL × 3, MARKETS × 3, post-battle, salvage, repair,
+    //   contracts, refit (UNITS), FINANCES × 2, EVENTS × 6, EVENTS+10,
     //   CLEANUP.
     expect(processors[0].phase).toBe(DayPhase.PERSONNEL);
     expect(processors[1].phase).toBe(DayPhase.PERSONNEL);
-    expect(processors[2].phase).toBe(DayPhase.MARKETS);
+    expect(processors[2].phase).toBe(DayPhase.PERSONNEL); // turnover (D-2)
     expect(processors[3].phase).toBe(DayPhase.MARKETS);
     expect(processors[4].phase).toBe(DayPhase.MARKETS);
-    expect(processors[5].phase).toBe(DayPhase.MISSIONS - 50); // post-battle
-    expect(processors[6].phase).toBe(DayPhase.MISSIONS - 25); // salvage
-    expect(processors[7].phase).toBe(DayPhase.MISSIONS - 10); // repair
-    expect(processors[8].phase).toBe(DayPhase.MISSIONS); // contracts
-    expect(processors[9].phase).toBe(DayPhase.UNITS); // refit
-    expect(processors[10].phase).toBe(DayPhase.FINANCES);
-    expect(processors[11].phase).toBe(DayPhase.EVENTS);
-    expect(processors[12].phase).toBe(DayPhase.EVENTS);
+    expect(processors[5].phase).toBe(DayPhase.MARKETS);
+    expect(processors[6].phase).toBe(DayPhase.MISSIONS - 50); // post-battle
+    expect(processors[7].phase).toBe(DayPhase.MISSIONS - 25); // salvage
+    expect(processors[8].phase).toBe(DayPhase.MISSIONS - 10); // repair
+    expect(processors[9].phase).toBe(DayPhase.MISSIONS); // contracts
+    expect(processors[10].phase).toBe(DayPhase.UNITS); // refit
+    expect(processors[11].phase).toBe(DayPhase.FINANCES); // dailyCosts
+    expect(processors[12].phase).toBe(DayPhase.FINANCES); // financial (D-2)
     expect(processors[13].phase).toBe(DayPhase.EVENTS);
     expect(processors[14].phase).toBe(DayPhase.EVENTS);
-    expect(processors[15].phase).toBe(DayPhase.EVENTS + 10); // bridge
-    expect(processors[16].phase).toBe(DayPhase.CLEANUP); // inventory
+    expect(processors[15].phase).toBe(DayPhase.EVENTS); // vocational (D-2)
+    expect(processors[16].phase).toBe(DayPhase.EVENTS);
+    expect(processors[17].phase).toBe(DayPhase.EVENTS);
+    expect(processors[18].phase).toBe(DayPhase.EVENTS); // faction-standing (D-2)
+    expect(processors[19].phase).toBe(DayPhase.EVENTS + 10); // bridge
+    expect(processors[20].phase).toBe(DayPhase.CLEANUP); // inventory
   });
 });

--- a/src/lib/campaign/processors/__tests__/scenarioGenerationProcessor.test.ts
+++ b/src/lib/campaign/processors/__tests__/scenarioGenerationProcessor.test.ts
@@ -16,7 +16,9 @@ import {
   createDefaultCampaignOptions,
 } from '@/types/campaign/Campaign';
 import { CampaignType } from '@/types/campaign/CampaignType';
+import { ForceRole, FormationLevel } from '@/types/campaign/enums';
 import { MissionStatus } from '@/types/campaign/enums/MissionStatus';
+import { IForce } from '@/types/campaign/Force';
 import { IContract } from '@/types/campaign/Mission';
 import { Money } from '@/types/campaign/Money';
 import {
@@ -844,6 +846,106 @@ describe('scenarioGenerationProcessor', () => {
       );
       expect(result.campaign).toBeDefined();
       expect(result.campaign.id).toBe(campaign.id);
+    });
+  });
+
+  // ===========================================================================
+  // D-9 (2026-06-09 audit, W3.4): with no explicit campaign.combatTeams,
+  // teams must derive from the force structure so AtB generation is
+  // reachable on real campaigns (production never populates combatTeams).
+  // Derivation mirrors MekHQ CombatTeam.recalculateCombatTeams: every
+  // STANDARD-type force with assigned units forms one team; the
+  // CombatTeam ctor's default role is FRONTLINE.
+  // ===========================================================================
+  describe('combat team derivation from force structure (D-9)', () => {
+    /** Builds a unit-bearing lance force eligible for team derivation. */
+    function makeLanceForce(overrides?: Partial<IForce>): IForce {
+      return {
+        id: 'force-lance-1',
+        name: 'Alpha Lance',
+        parentForceId: 'force-root',
+        subForceIds: [],
+        unitIds: ['u1', 'u2', 'u3', 'u4'],
+        forceType: ForceRole.STANDARD,
+        formationLevel: FormationLevel.LANCE,
+        createdAt: '2025-01-01T00:00:00Z',
+        updatedAt: '2025-01-01T00:00:00Z',
+        ...overrides,
+      };
+    }
+
+    it('generates a scenario for a unit-bearing STANDARD force when combatTeams is absent', () => {
+      const force = makeLanceForce();
+      const campaign = createMockCampaign({
+        currentDate: new Date('2025-01-27'), // Monday
+        options: { ...createMockCampaign().options, useAtBScenarios: true },
+        combatTeams: undefined,
+        forces: new Map([[force.id, force]]),
+        missions: new Map([['contract-001', createMockContract()]]),
+      });
+      // random()=0 → d100 roll of 1 → battle for FRONTLINE (20% chance).
+      const processor = createScenarioGenerationProcessor(
+        createConstantRandom(0),
+      );
+
+      const result = processor.process(campaign, campaign.currentDate);
+
+      const generated = result.events.filter(
+        (e) => e.type === 'scenario_generated',
+      );
+      expect(generated).toHaveLength(1);
+      expect(generated[0].data?.teamId).toBe('force-lance-1');
+    });
+
+    it('skips unit-less and non-STANDARD forces during derivation', () => {
+      const emptyForce = makeLanceForce({ id: 'force-empty', unitIds: [] });
+      const supportForce = makeLanceForce({
+        id: 'force-support',
+        forceType: ForceRole.SUPPORT,
+      });
+      const campaign = createMockCampaign({
+        currentDate: new Date('2025-01-27'), // Monday
+        options: { ...createMockCampaign().options, useAtBScenarios: true },
+        combatTeams: undefined,
+        forces: new Map([
+          [emptyForce.id, emptyForce],
+          [supportForce.id, supportForce],
+        ]),
+        missions: new Map([['contract-001', createMockContract()]]),
+      });
+      const processor = createScenarioGenerationProcessor(
+        createConstantRandom(0),
+      );
+
+      const result = processor.process(campaign, campaign.currentDate);
+
+      expect(
+        result.events.filter((e) => e.type === 'scenario_generated'),
+      ).toHaveLength(0);
+    });
+
+    it('prefers explicit campaign.combatTeams over derivation', () => {
+      const force = makeLanceForce();
+      const campaign = createMockCampaign({
+        currentDate: new Date('2025-01-27'), // Monday
+        options: { ...createMockCampaign().options, useAtBScenarios: true },
+        combatTeams: [
+          createMockTeam({ forceId: 'explicit-team', role: CombatRole.PATROL }),
+        ],
+        forces: new Map([[force.id, force]]),
+        missions: new Map([['contract-001', createMockContract()]]),
+      });
+      const processor = createScenarioGenerationProcessor(
+        createConstantRandom(0),
+      );
+
+      const result = processor.process(campaign, campaign.currentDate);
+
+      const generated = result.events.filter(
+        (e) => e.type === 'scenario_generated',
+      );
+      expect(generated).toHaveLength(1);
+      expect(generated[0].data?.teamId).toBe('explicit-team');
     });
   });
 });

--- a/src/lib/campaign/processors/acquisitionProcessor.ts
+++ b/src/lib/campaign/processors/acquisitionProcessor.ts
@@ -4,6 +4,8 @@ import type {
 } from '@/types/campaign/acquisition/acquisitionTypes';
 import type { ICampaign } from '@/types/campaign/Campaign';
 
+import { createDailyRandom } from '@/lib/campaign/utils/campaignRng';
+
 import {
   performAcquisitionRoll,
   type RandomFn,
@@ -161,11 +163,15 @@ export const acquisitionProcessor: IDayProcessor & {
   process(
     campaign: ICampaign,
     date: Date,
-    random: RandomFn = Math.random,
+    // D-10 (2026-06-09 audit, W3.4): the production default is the
+    // campaign's seeded daily stream; tests can still inject their own.
+    random?: RandomFn,
   ): IDayProcessorResult {
     if (!campaign.options.useAcquisitionSystem) {
       return { events: [], campaign };
     }
+    const rolls: RandomFn =
+      random ?? createDailyRandom(campaign, date, processorId);
 
     const shoppingList = campaign.shoppingList;
     // oxlint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -181,7 +187,7 @@ export const acquisitionProcessor: IDayProcessor & {
     // oxlint-disable-next-line @typescript-eslint/no-unsafe-assignment
     let updatedList = shoppingList;
 
-    const pendingResult = processPendingAcquisitions(updatedList, date, random);
+    const pendingResult = processPendingAcquisitions(updatedList, date, rolls);
     updatedList = pendingResult.updatedList;
     allEvents.push(...pendingResult.events);
 

--- a/src/lib/campaign/processors/financialProcessor.ts
+++ b/src/lib/campaign/processors/financialProcessor.ts
@@ -336,6 +336,17 @@ export const financialProcessor: IDayProcessor = {
   displayName: 'Financial Processing',
 
   process(campaign: ICampaign, date: Date): IDayProcessorResult {
+    // Per audit finding D-2 (2026-06-09): mirror of dailyCostsProcessor's
+    // double-deduction gate. The role-based financial processor and the
+    // legacy flat-rate dailyCosts processor are mutually exclusive
+    // finance paths — dailyCosts no-ops when `useRoleBasedSalaries` is
+    // true, this processor no-ops when it is false — so a default-options
+    // campaign is never double-charged for salaries or maintenance now
+    // that both are registered in production.
+    if (!campaign.options.useRoleBasedSalaries) {
+      return { events: [], campaign };
+    }
+
     const events: IDayEvent[] = [];
     let updatedCampaign = campaign;
 

--- a/src/lib/campaign/processors/healingProcessor.ts
+++ b/src/lib/campaign/processors/healingProcessor.ts
@@ -25,6 +25,7 @@ import type { ICampaignRosterEntry } from '@/types/campaign/CampaignRosterEntry'
 import type { IInjury } from '@/types/campaign/Person';
 import type { IPilot } from '@/types/pilot/PilotInterfaces';
 
+import { createDailyRandom } from '@/lib/campaign/utils/campaignRng';
 import { buildPilotLookup } from '@/lib/campaign/utils/pilotLookup';
 import { useCampaignRosterStore } from '@/stores/campaign/useCampaignRosterStore';
 import { usePilotStore } from '@/stores/usePilotStore';
@@ -71,6 +72,7 @@ function processEntryHealing(
   pilotsByPilotId: ReadonlyMap<string, IPilot>,
   system: MedicalSystem,
   campaign: ICampaign,
+  random: () => number,
 ): {
   updatedInjuries: IInjury[];
   healedInjuryIds: string[];
@@ -106,7 +108,9 @@ function processEntryHealing(
       doctorEntry,
       doctorPilot,
       campaign.options,
-      Math.random,
+      // D-10 (2026-06-09 audit, W3.4): the 2d6 medical check draws from
+      // the campaign's seeded daily stream so days are replayable.
+      random,
     );
 
     const daysReduced = medResult.healingDaysReduced;
@@ -143,7 +147,7 @@ export const healingProcessor: IDayProcessor = {
   phase: DayPhase.PERSONNEL,
   displayName: 'Personnel Healing',
 
-  process(campaign: ICampaign): IDayProcessorResult {
+  process(campaign: ICampaign, date: Date): IDayProcessorResult {
     // Pre-join vault once per run (O(N) build, O(1) lookups).
     // Per PR4: roster store is the canonical entry source.
     const rosterEntries = useCampaignRosterStore.getState().pilots;
@@ -151,6 +155,10 @@ export const healingProcessor: IDayProcessor = {
     const pilotsByPilotId = buildPilotLookup(vault);
 
     const system = campaign.options.medicalSystem ?? MedicalSystem.STANDARD;
+    // D-10 (2026-06-09 audit, W3.4): one seeded stream per (campaign,
+    // day, processor) replaces raw Math.random — identical campaign
+    // state replays to identical healing outcomes.
+    const random = createDailyRandom(campaign, date, 'healing');
 
     const events: IDayEvent[] = [];
     // Per PR4: collect roster patches and commit once via applyPilotPatches.
@@ -173,6 +181,7 @@ export const healingProcessor: IDayProcessor = {
         pilotsByPilotId,
         system,
         campaign,
+        random,
       );
 
       // Commit when ANY field changes — recoveryTime decrements even

--- a/src/lib/campaign/processors/marketProcessors.ts
+++ b/src/lib/campaign/processors/marketProcessors.ts
@@ -8,13 +8,28 @@
  *
  * Each processor checks its corresponding campaign option before running.
  *
+ * Per audit finding D-7 (2026-06-09, remediation W3.4): generated offers
+ * are STORED on the campaign's command-extension fields (`unitMarket`,
+ * `personnelMarket`, `contractMarket`) — the surfaces the command UI
+ * pages read — instead of being discarded while the day report claimed a
+ * refresh happened.
+ *
+ * Per audit finding D-10 (same wave): offer rolls draw from the
+ * campaign's seeded daily streams (`createDailyRandom`) instead of raw
+ * `Math.random`, so market refreshes are replayable.
+ *
  * @module lib/campaign/processors/marketProcessors
  */
 
 import { generateAtBContracts } from '@/lib/campaign/contractMarket';
-import { generatePersonnelForDay } from '@/lib/campaign/markets/personnelMarket';
+import {
+  generatePersonnelForDay,
+  removeExpiredOffers,
+} from '@/lib/campaign/markets/personnelMarket';
 import { generateUnitOffers } from '@/lib/campaign/markets/unitMarket';
+import { createDailyRandom } from '@/lib/campaign/utils/campaignRng';
 import { ICampaign } from '@/types/campaign/Campaign';
+import { ICampaignWithCommand } from '@/types/campaign/CampaignCommandExtensions';
 
 import {
   IDayProcessor,
@@ -33,6 +48,8 @@ import {
  *
  * Checks `campaign.options.unitMarketMethod` — skips if 'none' or undefined.
  * Only generates offers on the first day of the month using `isFirstOfMonth`.
+ * The refresh REPLACES the previous pool (old offers expire at end of the
+ * previous month by construction) and stores it on `campaign.unitMarket`.
  */
 export const unitMarketProcessor: IDayProcessor = {
   id: 'unit-market',
@@ -49,7 +66,11 @@ export const unitMarketProcessor: IDayProcessor = {
       return { events: [], campaign };
     }
 
-    const offers = generateUnitOffers(campaign, Math.random);
+    // D-10: seeded per-(campaign, day, processor) stream, not Math.random.
+    const offers = generateUnitOffers(
+      campaign,
+      createDailyRandom(campaign, date, 'unit-market'),
+    );
     const events: IDayEvent[] = [
       {
         type: 'market_refresh',
@@ -59,7 +80,10 @@ export const unitMarketProcessor: IDayProcessor = {
       },
     ];
 
-    return { events, campaign };
+    // D-7: store the generated pool where consumers (and persistence)
+    // read it — a refresh replaces last month's expired offers wholesale.
+    const updated: ICampaignWithCommand = { ...campaign, unitMarket: offers };
+    return { events, campaign: updated };
   },
 };
 
@@ -70,21 +94,28 @@ export const unitMarketProcessor: IDayProcessor = {
 /**
  * Generates daily personnel market offers.
  *
- * Checks `campaign.options.personnelMarketStyle` — skips if 'disabled' or undefined.
- * Runs every day (personnel market refreshes daily).
+ * Checks `campaign.options.personnelMarketStyle` — skips if 'disabled' or
+ * undefined. Runs every day (personnel market refreshes daily). The day's
+ * new candidates JOIN the existing pool on `campaign.personnelMarket`
+ * (the surface the Personnel & Hiring page reads, CP2b design D2) after
+ * offers past their expiration date are pruned via `removeExpiredOffers`.
  */
 export const personnelMarketProcessor: IDayProcessor = {
   id: 'personnel-market',
   phase: DayPhase.MARKETS,
   displayName: 'Personnel Market Refresh',
 
-  process(campaign: ICampaign): IDayProcessorResult {
+  process(campaign: ICampaign, date: Date): IDayProcessorResult {
     const style = campaign.options.personnelMarketStyle;
     if (!style || style === 'disabled') {
       return { events: [], campaign };
     }
 
-    const offers = generatePersonnelForDay(campaign, Math.random);
+    // D-10: seeded per-(campaign, day, processor) stream, not Math.random.
+    const offers = generatePersonnelForDay(
+      campaign,
+      createDailyRandom(campaign, date, 'personnel-market'),
+    );
     const events: IDayEvent[] = [
       {
         type: 'market_refresh',
@@ -94,7 +125,19 @@ export const personnelMarketProcessor: IDayProcessor = {
       },
     ];
 
-    return { events, campaign };
+    // D-7: prune expired carry-over offers, then append the day's new
+    // candidates to the pool the hiring page reads.
+    const extended = campaign as ICampaignWithCommand;
+    const currentDateKey = campaign.currentDate.toISOString().split('T')[0];
+    const retained = removeExpiredOffers(
+      extended.personnelMarket ?? [],
+      currentDateKey,
+    );
+    const updated: ICampaignWithCommand = {
+      ...campaign,
+      personnelMarket: [...retained, ...offers],
+    };
+    return { events, campaign: updated };
   },
 };
 
@@ -105,8 +148,12 @@ export const personnelMarketProcessor: IDayProcessor = {
 /**
  * Refreshes the contract market on the first of each month.
  *
- * Checks `campaign.options.contractMarketMethod` — skips if 'none' or undefined.
- * Only generates contracts on the first day of the month using `isFirstOfMonth`.
+ * Checks `campaign.options.contractMarketMethod` — skips if 'none' or
+ * undefined. Only generates contracts on the first day of the month using
+ * `isFirstOfMonth`. The refresh REPLACES `campaign.contractMarket.offers`
+ * and clears `declinedOfferIds` — per the `ICampaignContractMarket`
+ * contract, declined offers stay hidden only "until the next
+ * contractMarketProcessor refresh replaces the offers list".
  */
 export const contractMarketProcessor: IDayProcessor = {
   id: 'contract-market',
@@ -123,7 +170,15 @@ export const contractMarketProcessor: IDayProcessor = {
       return { events: [], campaign };
     }
 
-    const contracts = generateAtBContracts(campaign);
+    // D-10: seeded stream threaded through the generator's trailing
+    // RandomFn parameter (count/negotiator/standing keep their defaults).
+    const contracts = generateAtBContracts(
+      campaign,
+      undefined,
+      undefined,
+      undefined,
+      createDailyRandom(campaign, date, 'contract-market'),
+    );
     const events: IDayEvent[] = [
       {
         type: 'market_refresh',
@@ -133,6 +188,12 @@ export const contractMarketProcessor: IDayProcessor = {
       },
     ];
 
-    return { events, campaign };
+    // D-7: a refresh starts a new market cycle — offers replaced,
+    // declined ids reset so previously-hidden offers can reappear.
+    const updated: ICampaignWithCommand = {
+      ...campaign,
+      contractMarket: { offers: contracts, declinedOfferIds: [] },
+    };
+    return { events, campaign: updated };
   },
 };

--- a/src/lib/campaign/processors/postBattleProcessor.helpers.ts
+++ b/src/lib/campaign/processors/postBattleProcessor.helpers.ts
@@ -72,6 +72,12 @@ function pilotFinalToRosterStatus(
  * NPC rule: XP helpers (awardScenarioXP / awardKillXP) return null when
  * `pilot === null` â€” NPCs don't earn XP.
  *
+ * Per audit finding D-8 (2026-06-09, W3.4): the patch also increments
+ * `campaignMissions` (every applied outcome counts as one mission for
+ * the pilot) and `campaignKills` by `killCount` â€” the unit's kill total
+ * from the after-action report â€” so kill/mission auto-awards
+ * (`awards/categoryCheckers.ts`) can ever fire.
+ *
  * Returns `null` when the pilot id can't be resolved to a roster entry â€”
  * non-fatal; the rest of the outcome continues processing.
  */
@@ -82,6 +88,7 @@ export function applyPilotDelta(
   outcomeWonByPlayer: boolean,
   entry: ICampaignRosterEntry | null,
   pilot: IPilot | null,
+  killCount: number = 0,
 ): { patch: Partial<ICampaignRosterEntry>; xpAwarded: number } | null {
   if (!entry) {
     logger.warn(
@@ -131,6 +138,11 @@ export function applyPilotDelta(
     status: newStatus,
     xp: entry.xp + xpDelta,
     campaignXpEarned: entry.campaignXpEarned + campaignXpDelta,
+    // D-8: lifetime counters the auto-award checkers threshold against.
+    // Participation in an applied outcome is one mission; kills come from
+    // the after-action report's attribution for this unit.
+    campaignKills: entry.campaignKills + Math.max(0, killCount),
+    campaignMissions: entry.campaignMissions + 1,
     recoveryTime: isWounded
       ? Math.max(entry.recoveryTime, newWounds * 7)
       : entry.recoveryTime,

--- a/src/lib/campaign/processors/postBattleProcessor.ts
+++ b/src/lib/campaign/processors/postBattleProcessor.ts
@@ -72,6 +72,11 @@ function applyOutcome(
   const vault = usePilotStore.getState().pilots;
   const pilotsByPilotId = buildPilotLookup(vault);
   const entriesByPilotId = new Map(rosterEntries.map((e) => [e.pilotId, e]));
+  // D-8 remediation (2026-06-09 audit): kill attribution comes from the
+  // after-action report's per-unit rows so campaignKills can increment.
+  const reportUnitsById = new Map(
+    outcome.report.units.map((u) => [u.unitId, u]),
+  );
   const pilotPatches = new Map<string, Partial<ICampaignRosterEntry>>();
   for (const delta of outcome.unitDeltas) {
     const entry = entriesByPilotId.get(delta.unitId) ?? null;
@@ -83,6 +88,7 @@ function applyOutcome(
       wonByPlayer,
       entry,
       pilot,
+      reportUnitsById.get(delta.unitId)?.kills ?? 0,
     );
     if (pilotResult) {
       pilotPatches.set(delta.unitId, pilotResult.patch);
@@ -106,9 +112,13 @@ function applyOutcome(
       );
     }
   }
-  if (pilotPatches.size > 0) {
-    useCampaignRosterStore.getState().applyPilotPatches(pilotPatches);
-  }
+  // D-5 remediation (2026-06-09 audit): pilot patches are NOT committed
+  // here. Every step that can throw (contract delta, prestige) must run
+  // first — the roster-store commit happens at the very end of this
+  // function so a partial failure leaves zero side effects and the
+  // outcome retained in the retry queue can be re-applied safely. The
+  // matchId dedup against processedBattleIds (above) stays the
+  // apply-once guard; this ordering makes it sound.
   const contractDelta = applyContractDelta(campaign, missions, outcome);
   const updatedContract = contractDelta?.contract ?? null;
   const remainingQueue = (campaign.pendingBattleOutcomes ?? []).filter(
@@ -131,15 +141,6 @@ function applyOutcome(
   const nextFulfilled = contractDelta?.flippedToTerminal
     ? [...previousFulfilled, contractDelta.contract.id]
     : previousFulfilled;
-  if (contractDelta?.flippedToTerminal) {
-    publishContractFulfilled({
-      contractId: contractDelta.contract.id,
-      newStatus: contractDelta.contract.status,
-      matchId: outcome.matchId,
-      playerWon: playerWon(outcome),
-      publishedAt: nowIso,
-    });
-  }
   // Per `add-campaign-refit-and-prestige` design D7: the prestige-update
   // step runs when a battle outcome is applied, so per-unit prestige
   // tracks combat results deterministically. The post-battle processor's
@@ -189,6 +190,25 @@ function applyOutcome(
         matchId: outcome.matchId,
       },
     });
+  }
+  // --- Commit point (D-5) ---------------------------------------------
+  // Every throwing computation is complete. The side effects below are
+  // non-throwing by contract: the fulfillment bus isolates listener
+  // errors, and the roster patch commit is a plain zustand state write.
+  // Committing here means a throw anywhere above leaves the roster (and
+  // the campaign) untouched while the outcome stays queued for retry —
+  // the apply is all-or-nothing from the caller's perspective.
+  if (contractDelta?.flippedToTerminal) {
+    publishContractFulfilled({
+      contractId: contractDelta.contract.id,
+      newStatus: contractDelta.contract.status,
+      matchId: outcome.matchId,
+      playerWon: playerWon(outcome),
+      publishedAt: nowIso,
+    });
+  }
+  if (pilotPatches.size > 0) {
+    useCampaignRosterStore.getState().applyPilotPatches(pilotPatches);
   }
   return {
     campaign: updatedCampaign,

--- a/src/lib/campaign/processors/processorRegistration.ts
+++ b/src/lib/campaign/processors/processorRegistration.ts
@@ -3,6 +3,8 @@ import { registerAcquisitionProcessor } from './acquisitionProcessor';
 import { autoAwardsProcessor } from './autoAwardsProcessor';
 import { contractProcessor } from './contractProcessor';
 import { dailyCostsProcessor } from './dailyCostsProcessor';
+import { factionStandingProcessor } from './factionStandingProcessor';
+import { financialProcessor } from './financialProcessor';
 import { healingProcessor } from './healingProcessor';
 import { inventoryProjectionProcessor } from './inventoryProjectionProcessor';
 import {
@@ -18,6 +20,8 @@ import { repairQueueBuilderProcessor } from './repairQueueBuilderProcessor';
 import { salvageProcessor } from './salvageProcessor';
 import { scenarioEncounterBridgeProcessor } from './scenarioEncounterBridgeProcessor';
 import { scenarioGenerationProcessor } from './scenarioGenerationProcessor';
+import { turnoverProcessor } from './turnoverProcessor';
+import { vocationalTrainingProcessor } from './vocationalTrainingProcessor';
 
 let registered = false;
 
@@ -45,6 +49,14 @@ let registered = false;
  * which violated the spec's ordering invariant (it must run before
  * contracts). Wave 5 promotes it into the battle-effects block via
  * `MISSIONS - 10`.
+ *
+ * Per audit finding D-2 (2026-06-09) this registry also wires the four
+ * processors that were shipped but never registered in production:
+ * turnover (PERSONNEL = 100, after healing/auto-awards), financial
+ * (FINANCES = 700, role-based counterpart to dailyCosts), vocational
+ * training (EVENTS = 800, independent roster bookkeeping), and faction
+ * standing (EVENTS = 800, last EVENTS step per MekHQ's end-of-day
+ * `performFactionStandingChecks`).
  */
 export function registerBuiltinProcessors(): void {
   if (registered) return;
@@ -56,7 +68,22 @@ export function registerBuiltinProcessors(): void {
   pipeline.register(healingProcessor);
   pipeline.register(contractProcessor);
   pipeline.register(dailyCostsProcessor);
+  // Per audit finding D-2 (2026-06-09): the role-based financial
+  // processor (phase FINANCES, same as dailyCosts) was shipped and
+  // unit-tested but never registered here. The two finance processors
+  // are mutually exclusive via `options.useRoleBasedSalaries` —
+  // dailyCosts no-ops when the flag is true, financial no-ops when it
+  // is false — so registering both never double-charges. This mirrors
+  // MekHQ's `finances.newDay` running after personnel/markets/units.
+  pipeline.register(financialProcessor);
   pipeline.register(autoAwardsProcessor);
+  // Per audit finding D-2: turnover (phase PERSONNEL) registers after
+  // healing and auto-awards so departures are evaluated against the
+  // day's settled personnel state — MekHQ runs retirement/turnover
+  // bookkeeping inside personnel processing after per-person medical
+  // work, and turnover payouts must debit the balance before the
+  // FINANCES phase settles the day's books.
+  pipeline.register(turnoverProcessor);
   registerAcquisitionProcessor();
   // Per `add-campaign-refit-and-prestige` design D5/D9: the refit
   // processor runs in DayPhase.UNITS (alongside maintenance/repair work);
@@ -65,6 +92,11 @@ export function registerBuiltinProcessors(): void {
   // signals are settled before morale is evaluated.
   pipeline.register(refitProcessor);
   pipeline.register(moraleProcessor);
+  // Per audit finding D-2: vocational training (phase EVENTS per the
+  // module's own contract) registers after morale — it is independent
+  // personnel-progression bookkeeping (roster-store timer/XP patches)
+  // with no dependency on the day's other EVENTS processors.
+  pipeline.register(vocationalTrainingProcessor);
   pipeline.register(randomEventsProcessor);
   pipeline.register(unitMarketProcessor);
   pipeline.register(personnelMarketProcessor);
@@ -75,6 +107,12 @@ export function registerBuiltinProcessors(): void {
   // so the campaign combat loop is wired by default. The inventory
   // projection (phase CLEANUP) runs last, after the battle-effects block.
   pipeline.register(scenarioGenerationProcessor);
+  // Per audit finding D-2: faction standing (phase EVENTS) registers
+  // last among EVENTS-phase processors, mirroring MekHQ where
+  // `performFactionStandingChecks` is the final processing step of the
+  // day (after random events and finances). The bridge (EVENTS + 10)
+  // and inventory projection (CLEANUP) still sort after it by phase.
+  pipeline.register(factionStandingProcessor);
   pipeline.register(scenarioEncounterBridgeProcessor);
   pipeline.register(inventoryProjectionProcessor);
 

--- a/src/lib/campaign/processors/randomEventsProcessor.ts
+++ b/src/lib/campaign/processors/randomEventsProcessor.ts
@@ -7,6 +7,7 @@ import {
   processPrisonerEvents,
   countPrisoners,
 } from '@/lib/campaign/events/prisonerEvents';
+import { createDailyRandom } from '@/lib/campaign/utils/campaignRng';
 import { buildPilotLookup } from '@/lib/campaign/utils/pilotLookup';
 import { useCampaignRosterStore } from '@/stores/campaign/useCampaignRosterStore';
 import { usePilotStore } from '@/stores/usePilotStore';
@@ -43,7 +44,13 @@ export const randomEventsProcessor: IDayProcessor = {
     }
 
     const dateStr = date.toISOString();
-    const random: () => number = Math.random;
+    // D-10 (2026-06-09 audit, W3.4): life/prisoner event rolls draw from
+    // the campaign's seeded daily stream so days are replayable.
+    const random: () => number = createDailyRandom(
+      campaign,
+      date,
+      'random-events',
+    );
     const allRandomEvents: IRandomEvent[] = [];
 
     // Read entries directly from roster store (canonical source per PR4

--- a/src/lib/campaign/processors/scenarioGenerationProcessor.ts
+++ b/src/lib/campaign/processors/scenarioGenerationProcessor.ts
@@ -14,6 +14,21 @@
  *    - If battle: selects scenario type, calculates OpFor BV, generates conditions
  *    - Emits event with scenario details
  *
+ * Per audit finding D-9 (2026-06-09, remediation W3.4): production never
+ * populates `campaign.combatTeams`, which made generation unreachable.
+ * When no explicit teams exist, teams are now DERIVED from the force
+ * structure — every STANDARD-type force with assigned units forms one
+ * combat team. This mirrors MekHQ `CombatTeam.recalculateCombatTeams`
+ * (walks the TO&E creating a team per eligible standard force) and the
+ * `CombatTeam` constructor's role default (FRONTLINE when the force
+ * carries no explicit combat role — MekStation forces don't, yet).
+ * Explicit `campaign.combatTeams` (persisted via the D-1 sweep) takes
+ * precedence as the override surface.
+ *
+ * Per audit finding D-10 (same wave): the production processor draws its
+ * rolls from the campaign's seeded daily stream instead of `Math.random`
+ * so Monday scenario generation is replayable.
+ *
  * @module campaign/processors/scenarioGenerationProcessor
  */
 
@@ -25,16 +40,20 @@ import {
   isMonday,
 } from '@/lib/campaign/dayPipeline';
 import {
+  BASE_BATTLE_CHANCE,
   checkForBattle,
   type RandomFn,
 } from '@/lib/campaign/scenario/battleChance';
 import { calculateOpForBV } from '@/lib/campaign/scenario/opForGeneration';
 import { generateRandomConditions } from '@/lib/campaign/scenario/scenarioConditions';
 import { selectScenarioType } from '@/lib/campaign/scenario/scenarioTypeSelection';
+import { createDailyRandom } from '@/lib/campaign/utils/campaignRng';
 import { ICampaign } from '@/types/campaign/Campaign';
+import { ForceRole } from '@/types/campaign/enums';
 import { IContract, isContract } from '@/types/campaign/Mission';
 import {
   AtBMoraleLevel,
+  CombatRole,
   type ICombatTeam,
   type IScenarioConditions,
 } from '@/types/campaign/scenario/scenarioTypes';
@@ -73,11 +92,51 @@ function getActiveContracts(campaign: ICampaign): readonly IContract[] {
 }
 
 /**
+ * Derive combat teams from the campaign's force structure (audit D-9).
+ *
+ * Minimal honest derivation per MekHQ `CombatTeam.recalculateCombatTeams`
+ * + `isEligible`: every STANDARD-type force that has units assigned forms
+ * one combat team. The role defaults to FRONTLINE (the MekHQ `CombatTeam`
+ * constructor's fallback when a force has no explicit combat role —
+ * MekStation forces carry no role field yet) with the role's base battle
+ * chance. Lance-size/weight eligibility limits are NOT modelled here —
+ * they gate on options MekStation doesn't expose yet.
+ *
+ * @param campaign - The campaign whose force tree is walked
+ * @returns One derived team per unit-bearing STANDARD force
+ */
+function deriveCombatTeamsFromForces(
+  campaign: ICampaign,
+): readonly ICombatTeam[] {
+  const teams: ICombatTeam[] = [];
+  // Array.from instead of direct Map-iterator for..of — the tsconfig
+  // target predates ES2015 iterator protocols (same pattern as
+  // getActiveContracts above).
+  for (const force of Array.from(campaign.forces.values())) {
+    // Non-combat force types (support, convoy, …) never field teams —
+    // mirrors MekHQ isEligible's STANDARD force-type gate.
+    if (force.forceType !== ForceRole.STANDARD) continue;
+    // A force with no units assigned has nothing to deploy.
+    if (force.unitIds.length === 0) continue;
+    teams.push({
+      forceId: force.id,
+      role: CombatRole.FRONTLINE,
+      battleChance: BASE_BATTLE_CHANCE[CombatRole.FRONTLINE],
+    });
+  }
+  return teams;
+}
+
+/**
  * Get combat teams for a contract.
  *
- * Returns the combat teams assigned to this contract, or empty array if none.
+ * Explicit `campaign.combatTeams` wins when present (the persisted
+ * override surface); otherwise teams are derived from the force tree so
+ * generation is reachable on real campaigns (audit D-9). All teams apply
+ * to every contract for now — per-contract team assignment is a future
+ * enhancement.
  *
- * @param campaign - The campaign (contains combat teams)
+ * @param campaign - The campaign (contains combat teams / forces)
  * @param contract - The contract to get teams for
  * @returns Array of combat teams for this contract
  */
@@ -85,9 +144,11 @@ function getCombatTeamsForContract(
   campaign: ICampaign,
   _contract: IContract,
 ): readonly ICombatTeam[] {
-  // For now, return all combat teams in the campaign
-  // In a full implementation, contracts would have their own team assignments
-  return campaign.combatTeams ?? [];
+  const explicit = campaign.combatTeams ?? [];
+  if (explicit.length > 0) {
+    return explicit;
+  }
+  return deriveCombatTeamsFromForces(campaign);
 }
 
 /**
@@ -158,6 +219,92 @@ function createScenarioEventData(
 }
 
 // =============================================================================
+// Shared Core
+// =============================================================================
+
+/**
+ * Run one day of scenario generation against an injected random stream.
+ *
+ * Single implementation shared by the production processor (seeded daily
+ * stream) and the test factory (injected random) — the two previously
+ * duplicated bodies had already started to drift, and the D-9 team
+ * derivation must behave identically in both.
+ *
+ * @param campaign - The campaign being processed
+ * @param date - The day being processed
+ * @param random - Roll source (seeded in production, injected in tests)
+ */
+function runScenarioGeneration(
+  campaign: ICampaign,
+  date: Date,
+  random: RandomFn,
+): IDayProcessorResult {
+  const events: IDayEvent[] = [];
+
+  // Gate 1: Only run on Mondays
+  if (!isMonday(date)) {
+    return { events, campaign };
+  }
+
+  // Gate 2: Only run if AtB scenarios are enabled
+  if (!campaign.options?.useAtBScenarios) {
+    return { events, campaign };
+  }
+
+  // Process each active contract
+  const activeContracts = getActiveContracts(campaign);
+  for (const contract of activeContracts) {
+    // Get combat teams for this contract (explicit or force-derived, D-9)
+    const teams = getCombatTeamsForContract(campaign, contract);
+
+    // Check each team for battle
+    for (const team of teams) {
+      // Check if battle occurs for this team
+      if (!checkForBattle(team, contract, random)) {
+        continue;
+      }
+
+      // Battle occurs! Generate scenario
+      const morale = contract.moraleLevel ?? AtBMoraleLevel.STALEMATE;
+      const scenarioResult = selectScenarioType(team.role, morale, random);
+
+      // Calculate OpFor BV
+      const playerBV = calculatePlayerBV(team);
+      const difficulty = campaign.options?.difficultyMultiplier ?? 1.0;
+      const opForBV = calculateOpForBV(playerBV, difficulty, random);
+
+      // Generate conditions
+      const conditions = generateRandomConditions(random);
+
+      // Wave 5 §8.1: stamp the scenario with a stable id so the
+      // resulting encounter / session can record it for round-trip
+      // attribution back to the contract.
+      const scenarioId = buildScenarioId(contract, team, date);
+
+      const eventData = createScenarioEventData(
+        scenarioResult.scenarioType,
+        scenarioResult.isAttacker,
+        opForBV,
+        conditions,
+        contract,
+        team,
+        scenarioId,
+      );
+
+      // Emit event
+      events.push({
+        type: 'scenario_generated',
+        description: `Scenario generated for ${contract.name}: ${scenarioResult.scenarioType}`,
+        severity: 'info',
+        data: eventData,
+      });
+    }
+  }
+
+  return { events, campaign };
+}
+
+// =============================================================================
 // Processor Implementation
 // =============================================================================
 
@@ -165,7 +312,8 @@ function createScenarioEventData(
  * Scenario Generation Day Processor
  *
  * Implements IDayProcessor interface for weekly scenario generation.
- * Runs only on Mondays when useAtBScenarios option is enabled.
+ * Runs only on Mondays when useAtBScenarios option is enabled. Rolls come
+ * from the campaign's seeded daily stream (audit D-10).
  */
 export const scenarioGenerationProcessor: IDayProcessor = {
   id: 'scenario-generation',
@@ -173,72 +321,11 @@ export const scenarioGenerationProcessor: IDayProcessor = {
   displayName: 'Scenario Generation (AtB)',
 
   process(campaign: ICampaign, date: Date): IDayProcessorResult {
-    const events: IDayEvent[] = [];
-
-    // Gate 1: Only run on Mondays
-    if (!isMonday(date)) {
-      return { events, campaign };
-    }
-
-    // Gate 2: Only run if AtB scenarios are enabled
-    if (!campaign.options?.useAtBScenarios) {
-      return { events, campaign };
-    }
-
-    // Get the random function (injectable for testing)
-    const random: RandomFn = () => Math.random();
-
-    // Process each active contract
-    const activeContracts = getActiveContracts(campaign);
-    for (const contract of activeContracts) {
-      // Get combat teams for this contract
-      const teams = getCombatTeamsForContract(campaign, contract);
-
-      // Check each team for battle
-      for (const team of teams) {
-        // Check if battle occurs for this team
-        if (!checkForBattle(team, contract, random)) {
-          continue;
-        }
-
-        // Battle occurs! Generate scenario
-        const morale = contract.moraleLevel ?? AtBMoraleLevel.STALEMATE;
-        const scenarioResult = selectScenarioType(team.role, morale, random);
-
-        // Calculate OpFor BV
-        const playerBV = calculatePlayerBV(team);
-        const difficulty = campaign.options?.difficultyMultiplier ?? 1.0;
-        const opForBV = calculateOpForBV(playerBV, difficulty, random);
-
-        // Generate conditions
-        const conditions = generateRandomConditions(random);
-
-        // Wave 5 §8.1: stamp the scenario with a stable id so the
-        // resulting encounter / session can record it for round-trip
-        // attribution back to the contract.
-        const scenarioId = buildScenarioId(contract, team, date);
-
-        const eventData = createScenarioEventData(
-          scenarioResult.scenarioType,
-          scenarioResult.isAttacker,
-          opForBV,
-          conditions,
-          contract,
-          team,
-          scenarioId,
-        );
-
-        // Emit event
-        events.push({
-          type: 'scenario_generated',
-          description: `Scenario generated for ${contract.name}: ${scenarioResult.scenarioType}`,
-          severity: 'info',
-          data: eventData,
-        });
-      }
-    }
-
-    return { events, campaign };
+    return runScenarioGeneration(
+      campaign,
+      date,
+      createDailyRandom(campaign, date, 'scenario-generation'),
+    );
   },
 };
 
@@ -259,67 +346,7 @@ export function createScenarioGenerationProcessor(
     displayName: 'Scenario Generation (AtB)',
 
     process(campaign: ICampaign, date: Date): IDayProcessorResult {
-      const events: IDayEvent[] = [];
-
-      // Gate 1: Only run on Mondays
-      if (!isMonday(date)) {
-        return { events, campaign };
-      }
-
-      // Gate 2: Only run if AtB scenarios are enabled
-      if (!campaign.options?.useAtBScenarios) {
-        return { events, campaign };
-      }
-
-      // Process each active contract
-      const activeContracts = getActiveContracts(campaign);
-      for (const contract of activeContracts) {
-        // Get combat teams for this contract
-        const teams = getCombatTeamsForContract(campaign, contract);
-
-        // Check each team for battle
-        for (const team of teams) {
-          // Check if battle occurs for this team
-          if (!checkForBattle(team, contract, random)) {
-            continue;
-          }
-
-          // Battle occurs! Generate scenario
-          const morale = contract.moraleLevel ?? AtBMoraleLevel.STALEMATE;
-          const scenarioResult = selectScenarioType(team.role, morale, random);
-
-          // Calculate OpFor BV
-          const playerBV = calculatePlayerBV(team);
-          const difficulty = campaign.options?.difficultyMultiplier ?? 1.0;
-          const opForBV = calculateOpForBV(playerBV, difficulty, random);
-
-          // Generate conditions
-          const conditions = generateRandomConditions(random);
-
-          // Wave 5 §8.1: stamp scenario id deterministically.
-          const scenarioId = buildScenarioId(contract, team, date);
-
-          const eventData = createScenarioEventData(
-            scenarioResult.scenarioType,
-            scenarioResult.isAttacker,
-            opForBV,
-            conditions,
-            contract,
-            team,
-            scenarioId,
-          );
-
-          // Emit event
-          events.push({
-            type: 'scenario_generated',
-            description: `Scenario generated for ${contract.name}: ${scenarioResult.scenarioType}`,
-            severity: 'info',
-            data: eventData,
-          });
-        }
-      }
-
-      return { events, campaign };
+      return runScenarioGeneration(campaign, date, random);
     },
   };
 }

--- a/src/lib/campaign/processors/turnoverProcessor.ts
+++ b/src/lib/campaign/processors/turnoverProcessor.ts
@@ -2,6 +2,7 @@ import type { ICampaign, ICampaignOptions } from '@/types/campaign/Campaign';
 import type { ICampaignRosterEntry } from '@/types/campaign/CampaignRosterEntry';
 import type { Transaction } from '@/types/campaign/Transaction';
 
+import { createDailyRandom } from '@/lib/campaign/utils/campaignRng';
 import { buildPilotLookup } from '@/lib/campaign/utils/pilotLookup';
 import { useCampaignRosterStore } from '@/stores/campaign/useCampaignRosterStore';
 import { usePilotStore } from '@/stores/usePilotStore';
@@ -151,7 +152,9 @@ export const turnoverProcessor: IDayProcessor = {
       entries,
       pilotsByPilotId,
       campaign,
-      Math.random,
+      // D-10 (2026-06-09 audit, W3.4): turnover target rolls draw from
+      // the campaign's seeded daily stream so days are replayable.
+      createDailyRandom(campaign, date, 'turnover'),
     );
     const updatedCampaign = applyTurnoverResults(campaign, report, date);
     const events = departuresToEvents(report);

--- a/src/lib/campaign/processors/vocationalTrainingProcessor.ts
+++ b/src/lib/campaign/processors/vocationalTrainingProcessor.ts
@@ -18,6 +18,7 @@ import type { ICampaign } from '@/types/campaign/Campaign';
 import type { ICampaignRosterEntry } from '@/types/campaign/CampaignRosterEntry';
 import type { IPilot } from '@/types/pilot/PilotInterfaces';
 
+import { createDailyRandom } from '@/lib/campaign/utils/campaignRng';
 import { buildPilotLookup } from '@/lib/campaign/utils/pilotLookup';
 import { useCampaignRosterStore } from '@/stores/campaign/useCampaignRosterStore';
 import { usePilotStore } from '@/stores/usePilotStore';
@@ -225,10 +226,12 @@ export const vocationalTrainingProcessor: IDayProcessor = {
   phase: DayPhase.EVENTS,
   displayName: 'Vocational Training',
 
-  process(campaign: ICampaign): IDayProcessorResult {
+  process(campaign: ICampaign, date: Date): IDayProcessorResult {
     const { updatedCampaign, events } = processVocationalTraining(
       campaign,
-      Math.random,
+      // D-10 (2026-06-09 audit, W3.4): vocational XP rolls draw from the
+      // campaign's seeded daily stream so days are replayable.
+      createDailyRandom(campaign, date, 'vocational-training'),
     );
     return { events, campaign: updatedCampaign };
   },

--- a/src/lib/campaign/utils/campaignRng.ts
+++ b/src/lib/campaign/utils/campaignRng.ts
@@ -1,0 +1,83 @@
+/**
+ * Campaign Daily RNG — seeded random streams for day processors
+ *
+ * Per audit finding D-10 (2026-06-09 audit, remediation W3.4): daily
+ * outcome rolls (healing checks, turnover, markets, scenario generation,
+ * random events, acquisition) previously drew from raw `Math.random`,
+ * making campaign days unreplayable. Every processor now derives its
+ * rolls from a deterministic stream keyed by:
+ *
+ *   (campaign seed, processed day, processor id)
+ *
+ * - The campaign seed is `campaign.rngSeed`, stamped at campaign creation
+ *   and persisted with the campaign (see `SerializedCampaignState.rngSeed`).
+ *   Legacy campaigns without a seed fall back to a hash of the campaign id
+ *   so they are replayable too (just with an id-derived seed).
+ * - The day key makes consecutive days roll differently.
+ * - The processor id isolates streams: registration-order changes or a
+ *   processor consuming more/fewer rolls never shifts the draws another
+ *   processor sees.
+ *
+ * @module lib/campaign/utils/campaignRng
+ */
+
+import type { ICampaign } from '@/types/campaign/Campaign';
+
+import { SeededRandom } from '@/simulation/core/SeededRandom';
+
+/** Random function shape every campaign roll consumer accepts: [0, 1). */
+export type RandomFn = () => number;
+
+/** Widened campaign view carrying the persisted RNG seed. */
+type ISeededCampaign = ICampaign & { readonly rngSeed?: number };
+
+/**
+ * FNV-1a 32-bit hash — stable string → uint32 derivation used for the
+ * legacy-campaign fallback seed and for folding day/stream keys into the
+ * campaign seed. Chosen for determinism + zero dependencies, not crypto.
+ */
+function fnv1a(text: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < text.length; i++) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+/**
+ * Resolve the campaign's RNG seed. Prefers the persisted `rngSeed`
+ * (stamped at creation since the D-10 fix); legacy campaigns fall back
+ * to a deterministic hash of the campaign id so replays still work.
+ */
+export function resolveCampaignSeed(campaign: ICampaign): number {
+  const seeded = campaign as ISeededCampaign;
+  return seeded.rngSeed !== undefined
+    ? seeded.rngSeed >>> 0
+    : fnv1a(campaign.id);
+}
+
+/**
+ * Create the seeded daily random stream for one processor's run.
+ *
+ * Same campaign state (seed + currentDate) and same processor id always
+ * produce the identical roll sequence — the replayability contract the
+ * D-10 determinism tests assert.
+ *
+ * @param campaign - campaign being processed (provides the seed)
+ * @param date - the day being processed (the pipeline's `processedDate`)
+ * @param streamId - the consuming processor's id (stream isolation)
+ */
+export function createDailyRandom(
+  campaign: ICampaign,
+  date: Date,
+  streamId: string,
+): RandomFn {
+  // Day key is the calendar date only — re-running the same day (e.g. a
+  // failed-save replay) must reproduce identical rolls.
+  const dayKey = date.toISOString().slice(0, 10);
+  const seed =
+    (resolveCampaignSeed(campaign) ^ fnv1a(`${dayKey}:${streamId}`)) >>> 0;
+  const rng = new SeededRandom(seed);
+  return () => rng.next();
+}

--- a/src/stores/campaign/__tests__/campaignCommandActions.test.ts
+++ b/src/stores/campaign/__tests__/campaignCommandActions.test.ts
@@ -54,6 +54,13 @@ function currentCampaign(): ICampaignWithCommand {
 describe('campaignCommandActions', () => {
   beforeEach(() => {
     jest.useFakeTimers();
+    // Clear persisted state BEFORE resetting the singleton: the next
+    // useCampaignStore() call rehydrates from localStorage, and since the
+    // D-1 persistence fix the round-trip preserves personnelMarket /
+    // contractMarket / loans — a prior test's campaign would otherwise
+    // leak into "no campaign loaded" assertions through the persist
+    // middleware's merge().
+    window.localStorage.clear();
     resetCampaignStore();
     useCampaignRosterStore.getState().reset();
     useCampaignPersistenceStore.getState().reset();

--- a/src/stores/campaign/__tests__/campaignCreationPreset.test.ts
+++ b/src/stores/campaign/__tests__/campaignCreationPreset.test.ts
@@ -1,0 +1,66 @@
+/**
+ * D-3 store-seam pin (2026-06-09 audit, W3.3): `createCampaign`'s
+ * `options` parameter is the production seam the wizard threads
+ * `applyPreset(...)` output through. These tests pin that seam at the
+ * store/service level: preset-derived options land on
+ * `campaign.options` and campaign-type defaults layer underneath the
+ * preset overrides, exactly as `applyPreset` documents.
+ *
+ * The red-first proof that the WIZARD passes these options lives in
+ * `CreateCampaignPage.preset.test.tsx` — this file guards the store
+ * half of the seam so a future signature change can't silently strand
+ * the wizard's options argument again.
+ */
+
+import { applyPreset } from '@/lib/campaign/presetService';
+import {
+  resetCampaignStore,
+  useCampaignStore,
+} from '@/stores/campaign/useCampaignStore';
+import { clientSafeStorage } from '@/stores/utils/clientSafeStorage';
+import { CampaignPreset } from '@/types/campaign/CampaignPreset';
+import { CampaignType } from '@/types/campaign/CampaignType';
+
+function resetWorld(): void {
+  resetCampaignStore();
+  clientSafeStorage.removeItem('campaign-store');
+}
+
+describe('createCampaign — preset-derived options seam (D-3)', () => {
+  beforeEach(resetWorld);
+  afterEach(resetWorld);
+
+  it('threads applyPreset output onto campaign.options', () => {
+    const store = useCampaignStore();
+    store
+      .getState()
+      .createCampaign(
+        'Casual Co.',
+        CampaignType.MERCENARY,
+        applyPreset(CampaignPreset.CASUAL, CampaignType.MERCENARY),
+      );
+
+    const options = store.getState().getCampaign()?.options;
+    expect(options?.healingRateMultiplier).toBe(2.0);
+    expect(options?.maintenanceCycleDays).toBe(0);
+    expect(options?.payForMaintenance).toBe(false);
+    expect(options?.useTaxes).toBe(false);
+    expect(options?.useTurnover).toBe(false);
+  });
+
+  it('layers campaign-type defaults under the preset overrides', () => {
+    const store = useCampaignStore();
+    // CUSTOM has no overrides, so the PIRATE type defaults shine through.
+    store
+      .getState()
+      .createCampaign(
+        'Black Marauders',
+        CampaignType.PIRATE,
+        applyPreset(CampaignPreset.CUSTOM, CampaignType.PIRATE),
+      );
+
+    const options = store.getState().getCampaign()?.options;
+    expect(options?.startingFunds).toBe(500000);
+    expect(options?.trackFactionStanding).toBe(false);
+  });
+});

--- a/src/stores/campaign/__tests__/campaignPersistenceRoundTrip.test.ts
+++ b/src/stores/campaign/__tests__/campaignPersistenceRoundTrip.test.ts
@@ -1,0 +1,462 @@
+/**
+ * D-1 (2026-06-09 audit) — campaign store persistence round-trip seam tests.
+ *
+ * The audit found `useCampaignStore.persistence.ts` silently destroys
+ * campaign state on every reload:
+ *
+ *  - `serializeCampaign` never writes `unitCombatStates`, and
+ *    `deserializeCampaign` hard-resets it to `{}` — every reload wipes
+ *    unit battle damage.
+ *  - `takeLoan` credits the principal as a `finances` transaction (which
+ *    IS persisted) and appends to the `campaign.loans` command ledger
+ *    (which is NOT persisted) — a reload keeps the borrowed cash and
+ *    erases the debt.
+ *  - The full-shape sweep found more silently-dropped fields:
+ *    `finances.loans` (ILoan amortization ledger), `activePreset`,
+ *    `currentSystemId`, `combatTeams`, `refitOrders`,
+ *    `unitConfigurations`, `unitPrestige`, `moraleState`,
+ *    `moraleTransitions`, `personnelMarket`, `contractMarket`.
+ *
+ * These tests exercise the WIRING (store action → clientSafeStorage →
+ * fresh store → reload), not the module in isolation:
+ *
+ *  1. damage a unit + take a loan → saveCampaign → loadCampaign on a
+ *     fresh store → damage AND ledger survive (RED pre-fix),
+ *  2. the same survival through the zustand persist partialize → merge
+ *     rehydrate cycle (the page-reload path; RED pre-fix),
+ *  3. the full-shape sweep round-trip (RED pre-fix),
+ *  4. backward compat: a pre-fix saved payload (no new fields) still
+ *     loads — missing fields default sanely (GREEN pre- and post-fix),
+ *  5. a compile-time drift guard: every `ICampaign` key must be carried
+ *     by `SerializedCampaignState` or named as separately persisted.
+ */
+
+import type { ICampaign } from '@/types/campaign/Campaign';
+import type { ICampaignWithCommand } from '@/types/campaign/CampaignCommandExtensions';
+import type { ILoan } from '@/types/campaign/Loan';
+import type { IUnitCombatState } from '@/types/campaign/UnitCombatState';
+import type { MechBuildConfig } from '@/utils/construction/constructionRules/types';
+
+import { CampaignPersonnelRole } from '@/types/campaign/enums/CampaignPersonnelRole';
+import { MarketExperienceLevel } from '@/types/campaign/markets/marketTypes';
+import { Money } from '@/types/campaign/Money';
+import { MoraleState } from '@/types/campaign/Prestige';
+import { RefitClass } from '@/types/campaign/Refit';
+import { CombatRole } from '@/types/campaign/scenario/scenarioTypes';
+import { createInitialCombatState } from '@/types/campaign/UnitCombatState';
+
+import { takeLoan } from '../campaignCommandActions';
+import { useCampaignPersistenceStore } from '../useCampaignPersistenceStore';
+import { useCampaignRosterStore } from '../useCampaignRosterStore';
+import { resetCampaignStore, useCampaignStore } from '../useCampaignStore';
+import { type SerializedCampaignState } from '../useCampaignStore.persistence';
+
+// =============================================================================
+// localStorage mock — clientSafeStorage delegates to window.localStorage;
+// a deterministic in-memory store lets us snapshot/restore persisted blobs
+// across simulated reloads within one Jest process (same pattern as
+// criticalRoundTrip.test.ts).
+// =============================================================================
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+  configurable: true,
+});
+
+// =============================================================================
+// Compile-time drift guard
+//
+// Every key of `ICampaign` must either round-trip through
+// `SerializedCampaignState` or be explicitly named here as persisted by a
+// separate store. If `ICampaign` gains a field that the serializer drops,
+// `DroppedCampaignKeys` stops being `never` and `npx tsc --noEmit` fails —
+// the same convention SerializedCampaign.ts (server path) documents for
+// its CAMPAIGN_MAP_FIELDS / CAMPAIGN_DATE_FIELDS constants.
+// =============================================================================
+
+/** Keys persisted OUTSIDE SerializedCampaignState, with their owner. */
+type SeparatelyPersistedKey =
+  | 'forces' // useForcesStore (own zustand persist, keyed per campaign)
+  | 'missions'; // useMissionsStore (own zustand persist, keyed per campaign)
+
+type DroppedCampaignKeys = Exclude<
+  keyof ICampaign,
+  keyof SerializedCampaignState | SeparatelyPersistedKey
+>;
+
+/**
+ * Fails the typecheck unless T is `never`. The `T extends never`
+ * CONSTRAINT is the guard — instantiating with a non-never key union is
+ * a compile error. The body is tuple-wrapped because a bare conditional
+ * distributes over `never` and collapses to `never` instead of `true`.
+ */
+type AssertNever<T extends never> = [T] extends [never] ? true : false;
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+/** A unit combat state carrying visible battle damage. */
+function makeDamagedCombatState(): IUnitCombatState {
+  return {
+    ...createInitialCombatState({
+      unitId: 'unit-alpha',
+      armorPerLocation: { CT: 20, LT: 15 },
+      structurePerLocation: { CT: 10, LT: 8 },
+      ammoPerBin: { 'bin-lrm10': 12 },
+    }),
+    currentArmorPerLocation: { CT: 5, LT: 0 },
+    currentStructurePerLocation: { CT: 7, LT: 3 },
+    destroyedLocations: ['LT'],
+    destroyedComponents: [
+      {
+        location: 'LT',
+        slot: 2,
+        componentType: 'weapon',
+        name: 'Medium Laser',
+        destroyedAt: 'match-001',
+      },
+    ],
+    heatEnd: 4,
+    ammoRemaining: { 'bin-lrm10': 2 },
+    lastCombatOutcomeId: 'match-001',
+    lastUpdated: '3025-02-01T00:00:00.000Z',
+  };
+}
+
+/** An amortization-engine loan (`IFinances.loans` — Money + Date fields). */
+function makeAmortizedLoan(): ILoan {
+  return {
+    id: 'iloan-001',
+    principal: new Money(1_000_000),
+    annualRate: 0.06,
+    termMonths: 24,
+    monthlyPayment: new Money(44_320),
+    remainingPrincipal: new Money(920_000),
+    startDate: new Date('3025-01-01T00:00:00.000Z'),
+    nextPaymentDate: new Date('3025-03-01T00:00:00.000Z'),
+    paymentsRemaining: 22,
+    isDefaulted: false,
+  };
+}
+
+/** Seed a campaign through the real store and return its id. */
+function seedCampaign(): string {
+  const store = useCampaignStore();
+  return store.getState().createCampaign('Round Trip Co', 'mercenary');
+}
+
+/** Read the live campaign with command-extension fields visible. */
+function currentCampaign(): ICampaignWithCommand {
+  return useCampaignStore().getState().getCampaign() as ICampaignWithCommand;
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('D-1 — campaign persistence round-trip (save → reload seam)', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    localStorageMock.clear();
+    resetCampaignStore();
+    useCampaignRosterStore.getState().reset();
+    useCampaignPersistenceStore.getState().reset();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    resetCampaignStore();
+  });
+
+  it('unit battle damage and the loan ledger survive saveCampaign → loadCampaign', () => {
+    const id = seedCampaign();
+    const store = useCampaignStore();
+
+    // Damage a unit the way the post-battle pipeline does — by writing
+    // the canonical unitCombatStates map onto the campaign.
+    store.getState().updateCampaign({
+      unitCombatStates: { 'unit-alpha': makeDamagedCombatState() },
+    });
+
+    // Take a loan through the REAL command action: credits the cash as a
+    // finances transaction AND appends to the campaign.loans ledger.
+    const loanResult = takeLoan({
+      principal: 500_000,
+      interestRate: 0.1,
+      termDays: 100,
+    });
+    expect(loanResult.applied).toBe(true);
+    const balanceAfterLoan = currentCampaign().finances.balance.amount;
+    expect(currentCampaign().loans).toHaveLength(1);
+
+    store.getState().saveCampaign();
+
+    // Simulate a full reload: drop the singleton, stand up a fresh store,
+    // and load the campaign record back from storage.
+    resetCampaignStore();
+    const fresh = useCampaignStore();
+    expect(fresh.getState().loadCampaign(id)).toBe(true);
+    const reloaded = fresh.getState().getCampaign() as ICampaignWithCommand;
+
+    // The borrowed cash survives (it always did — that is the asymmetry
+    // the audit flagged) ...
+    expect(reloaded.finances.balance.amount).toBeCloseTo(balanceAfterLoan);
+
+    // ... and now the DEBT must survive with it (RED pre-fix).
+    expect(reloaded.loans).toBeDefined();
+    expect(reloaded.loans).toHaveLength(1);
+    expect(reloaded.loans![0].principal).toBe(500_000);
+    expect(reloaded.loans![0].remainingBalance).toBeCloseTo(550_000);
+    expect(reloaded.loans![0].status).toBe('active');
+
+    // Unit battle damage must survive the reload (RED pre-fix).
+    const combatState = reloaded.unitCombatStates['unit-alpha'];
+    expect(combatState).toBeDefined();
+    expect(combatState.currentArmorPerLocation).toEqual({ CT: 5, LT: 0 });
+    expect(combatState.currentStructurePerLocation).toEqual({ CT: 7, LT: 3 });
+    expect(combatState.destroyedLocations).toEqual(['LT']);
+    expect(combatState.destroyedComponents).toHaveLength(1);
+    expect(combatState.ammoRemaining).toEqual({ 'bin-lrm10': 2 });
+    expect(combatState.heatEnd).toBe(4);
+    expect(combatState.lastCombatOutcomeId).toBe('match-001');
+  });
+
+  it('unit battle damage and the loan ledger survive the zustand partialize → merge rehydrate (page-reload path)', () => {
+    seedCampaign();
+    const store = useCampaignStore();
+
+    store.getState().updateCampaign({
+      unitCombatStates: { 'unit-alpha': makeDamagedCombatState() },
+    });
+    takeLoan({ principal: 250_000, interestRate: 0.2, termDays: 50 });
+
+    // The persist middleware auto-writes 'campaign-store' on every set();
+    // a page reload re-creates the store, which rehydrates via merge().
+    resetCampaignStore();
+    const rehydrated = useCampaignStore()
+      .getState()
+      .getCampaign() as ICampaignWithCommand;
+
+    expect(rehydrated).not.toBeNull();
+    expect(rehydrated.unitCombatStates['unit-alpha']).toBeDefined();
+    expect(
+      rehydrated.unitCombatStates['unit-alpha'].currentArmorPerLocation,
+    ).toEqual({ CT: 5, LT: 0 });
+    expect(rehydrated.loans).toHaveLength(1);
+    expect(rehydrated.loans![0].remainingBalance).toBeCloseTo(300_000);
+  });
+
+  it('every other silently-dropped campaign field survives the round-trip (full-shape sweep)', () => {
+    const id = seedCampaign();
+    const store = useCampaignStore();
+    const base = currentCampaign();
+
+    store.getState().updateCampaign({
+      activePreset: 'pirate',
+      currentSystemId: 'new-avalon',
+      combatTeams: [
+        { forceId: 'force-1', role: CombatRole.PATROL, battleChance: 60 },
+      ],
+      refitOrders: [
+        {
+          id: 'refit-001',
+          unitId: 'unit-alpha',
+          // Partial fixture — only round-trip identity matters here, not
+          // construction validity (cast-through-unknown is deliberate).
+          targetConfiguration: {
+            name: 'Target Config',
+          } as unknown as MechBuildConfig,
+          refitClass: RefitClass.EquipmentSwap,
+          estimatedCost: 120_000,
+          estimatedHours: 40,
+          hoursCompleted: 12,
+          status: 'in-progress',
+          createdAt: '3025-02-01T00:00:00.000Z',
+        },
+      ],
+      unitConfigurations: {
+        'unit-alpha': { name: 'Current Config' } as unknown as MechBuildConfig,
+      },
+      unitPrestige: [
+        {
+          unitId: 'unit-alpha',
+          score: 62,
+          history: [
+            {
+              matchId: 'match-001',
+              delta: 12,
+              scoreAfter: 62,
+              reason: 'Victory',
+              appliedAt: '3025-02-01T00:00:00.000Z',
+            },
+          ],
+        },
+      ],
+      moraleState: MoraleState.High,
+      moraleTransitions: [
+        {
+          from: MoraleState.Steady,
+          to: MoraleState.High,
+          direction: 'up',
+          reason: 'Victory streak',
+          occurredAt: '3025-02-01T00:00:00.000Z',
+        },
+      ],
+      personnelMarket: [
+        {
+          id: 'pmo-001',
+          name: 'Recruit One',
+          role: CampaignPersonnelRole.PILOT,
+          experienceLevel: MarketExperienceLevel.REGULAR,
+          skills: { gunnery: 4, piloting: 5 },
+          hireCost: 25_000,
+          expirationDate: '3025-03-01T00:00:00.000Z',
+        },
+      ],
+      contractMarket: { offers: [], declinedOfferIds: ['contract-77'] },
+      finances: {
+        transactions: base.finances.transactions,
+        balance: base.finances.balance,
+        loans: [makeAmortizedLoan()],
+      },
+    } as Partial<ICampaign>);
+
+    store.getState().saveCampaign();
+    resetCampaignStore();
+    const fresh = useCampaignStore();
+    expect(fresh.getState().loadCampaign(id)).toBe(true);
+    const reloaded = fresh.getState().getCampaign() as ICampaignWithCommand;
+
+    expect(reloaded.activePreset).toBe('pirate');
+    expect(reloaded.currentSystemId).toBe('new-avalon');
+    expect(reloaded.combatTeams).toEqual([
+      { forceId: 'force-1', role: CombatRole.PATROL, battleChance: 60 },
+    ]);
+    expect(reloaded.refitOrders).toHaveLength(1);
+    expect(reloaded.refitOrders![0].id).toBe('refit-001');
+    expect(reloaded.refitOrders![0].hoursCompleted).toBe(12);
+    expect(reloaded.unitConfigurations).toBeDefined();
+    expect(reloaded.unitConfigurations!['unit-alpha']).toEqual({
+      name: 'Current Config',
+    });
+    expect(reloaded.unitPrestige).toHaveLength(1);
+    expect(reloaded.unitPrestige![0].score).toBe(62);
+    expect(reloaded.unitPrestige![0].history).toHaveLength(1);
+    expect(reloaded.moraleState).toBe(MoraleState.High);
+    expect(reloaded.moraleTransitions).toHaveLength(1);
+    expect(reloaded.moraleTransitions![0].to).toBe(MoraleState.High);
+    expect(reloaded.personnelMarket).toHaveLength(1);
+    expect(reloaded.personnelMarket![0].hireCost).toBe(25_000);
+    expect(reloaded.contractMarket).toEqual({
+      offers: [],
+      declinedOfferIds: ['contract-77'],
+    });
+
+    // The amortization ledger must rehydrate with live Money / Date
+    // instances — financialProcessor.processLoanPayments calls
+    // Money.subtract and Date math on these.
+    expect(reloaded.finances.loans).toHaveLength(1);
+    const loan = reloaded.finances.loans![0];
+    expect(loan.principal).toBeInstanceOf(Money);
+    expect(loan.principal.amount).toBe(1_000_000);
+    expect(loan.monthlyPayment).toBeInstanceOf(Money);
+    expect(loan.remainingPrincipal.amount).toBe(920_000);
+    expect(loan.startDate).toBeInstanceOf(Date);
+    expect(loan.nextPaymentDate.toISOString()).toBe('3025-03-01T00:00:00.000Z');
+    expect(loan.paymentsRemaining).toBe(22);
+    expect(loan.isDefaulted).toBe(false);
+  });
+
+  it('a pre-fix saved payload (no new fields) still loads with sane defaults', () => {
+    // Exactly the shape serializeCampaign produced BEFORE this fix —
+    // no unitCombatStates, no loans, no finances.loans, none of the
+    // swept optional fields.
+    const legacy = {
+      id: 'campaign-legacy-1',
+      name: 'Legacy Campaign',
+      currentDate: '3025-01-15T00:00:00.000Z',
+      factionId: 'mercenary',
+      rootForceId: 'force-legacy-root',
+      finances: {
+        transactions: [
+          {
+            id: 'tx-1',
+            type: 'income',
+            amount: 100_000,
+            date: '3025-01-10T00:00:00.000Z',
+            description: 'Contract payment',
+          },
+        ],
+        balance: 1_500_000,
+      },
+      factionStandings: {},
+      options: currentDefaultOptions(),
+      campaignType: 'mercenary',
+      campaignStartDate: '3025-01-01T00:00:00.000Z',
+      pendingBattleOutcomes: [],
+      processedBattleIds: [],
+      reviewedBattleIds: {},
+      dailyBattleAudit: [],
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-02T00:00:00.000Z',
+    } as unknown as SerializedCampaignState;
+
+    localStorageMock.setItem(
+      'campaign-campaign-legacy-1',
+      JSON.stringify({ state: legacy }),
+    );
+
+    const fresh = useCampaignStore();
+    expect(fresh.getState().loadCampaign('campaign-legacy-1')).toBe(true);
+    const loaded = fresh.getState().getCampaign() as ICampaignWithCommand;
+
+    expect(loaded.id).toBe('campaign-legacy-1');
+    expect(loaded.finances.balance.amount).toBe(1_500_000);
+    // Missing fields default sanely — no crash, no garbage.
+    expect(loaded.unitCombatStates).toEqual({});
+    expect(loaded.loans).toBeUndefined();
+    expect(loaded.finances.loans).toBeUndefined();
+    expect(loaded.refitOrders).toBeUndefined();
+    expect(loaded.moraleState).toBeUndefined();
+    expect(loaded.currentSystemId).toBeUndefined();
+  });
+
+  it('compile-time: SerializedCampaignState covers every ICampaign field (drift guard)', () => {
+    // If a future ICampaign field is not added to SerializedCampaignState
+    // (or to SeparatelyPersistedKey with an owning store), this constant
+    // stops typechecking — `npx tsc --noEmit` fails the build.
+    const persistedShapeCoversCampaign: AssertNever<DroppedCampaignKeys> = true;
+    expect(persistedShapeCoversCampaign).toBe(true);
+  });
+});
+
+/**
+ * Default options snapshot for the legacy payload — read off a freshly
+ * created campaign so the fixture always matches the live default shape.
+ */
+function currentDefaultOptions(): unknown {
+  const id = useCampaignStore().getState().createCampaign('opts', 'mercenary');
+  const options = useCampaignStore().getState().getCampaign()!.options;
+  // Drop the helper campaign's persisted record so it can't leak into
+  // other assertions.
+  localStorageMock.removeItem(`campaign-${id}`);
+  resetCampaignStore();
+  return JSON.parse(JSON.stringify(options));
+}

--- a/src/stores/campaign/__tests__/coopBattleReconciliationWiring.test.ts
+++ b/src/stores/campaign/__tests__/coopBattleReconciliationWiring.test.ts
@@ -1,0 +1,247 @@
+/**
+ * D-4 wiring seam test (2026-06-09 audit, W3.3): completing a co-op
+ * battle reconciles state via `reconcileCoopBattle`.
+ *
+ * Before the fix, `reconcileCoopBattle` had ZERO production callers —
+ * a co-op host campaign's battle outcome was enqueued like any
+ * single-player outcome and the shared CO1 campaign state never saw
+ * the salvage / roster consequences.
+ *
+ * These tests exercise the PRODUCTION seam end-to-end, not the module
+ * in isolation: a real `CampaignMatchHost` is registered for a real
+ * co-op host campaign, then the battle "completes" by publishing a
+ * campaign-linked outcome on the combat-outcome bus (exactly what
+ * `InteractiveSession` does). The store's enqueue listener must drive
+ * the reconciliation through the host.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+
+import type {
+  ICombatOutcome,
+  IUnitCombatDelta,
+} from '@/types/combat/CombatOutcome';
+
+import {
+  _resetCombatOutcomeBus,
+  publishCombatOutcome,
+} from '@/engine/combatOutcomeBus';
+import {
+  _resetActiveCoopHosts,
+  registerActiveCoopHost,
+} from '@/lib/campaign/coop/coopHostRegistry';
+import { _resetDayPipeline } from '@/lib/campaign/dayPipeline';
+import { _resetBuiltinRegistration } from '@/lib/campaign/processors';
+import { InMemoryCampaignEventStore } from '@/lib/campaign/sync/InMemoryCampaignEventStore';
+import { CampaignMatchHost } from '@/lib/multiplayer/server/CampaignMatchHost';
+import { useCampaignRosterStore } from '@/stores/campaign/useCampaignRosterStore';
+import {
+  resetCampaignStore,
+  useCampaignStore,
+} from '@/stores/campaign/useCampaignStore';
+import { clientSafeStorage } from '@/stores/utils/clientSafeStorage';
+import { createEmptyCampaignState } from '@/types/campaign/CampaignSync';
+import { createHostCoopSession } from '@/types/campaign/CoopSession';
+import {
+  COMBAT_OUTCOME_VERSION,
+  CombatEndReason,
+  PilotFinalStatus,
+  UnitFinalStatus,
+} from '@/types/combat/CombatOutcome';
+import { GameSide } from '@/types/gameplay/GameSessionCoreTypes';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeDelta(
+  unitId: string,
+  side: GameSide,
+  finalStatus: UnitFinalStatus,
+): IUnitCombatDelta {
+  return {
+    unitId,
+    side,
+    destroyed: finalStatus === UnitFinalStatus.Destroyed,
+    finalStatus,
+    armorRemaining: {},
+    internalsRemaining: {},
+    destroyedLocations: [],
+    destroyedComponents: [],
+    heatEnd: 0,
+    ammoRemaining: {},
+    pilotState: {
+      conscious: true,
+      wounds: 0,
+      killed: false,
+      finalStatus: PilotFinalStatus.Active,
+    },
+  };
+}
+
+/**
+ * A campaign-linked outcome: one damaged player unit (-> roster change)
+ * and one destroyed OpFor unit (-> 50k flat wreck salvage per the
+ * `deriveCoopBattleConsequences` default derivation).
+ */
+function makeCoopOutcome(matchId: string): ICombatOutcome {
+  return {
+    version: COMBAT_OUTCOME_VERSION,
+    matchId,
+    contractId: 'contract-coop-1',
+    scenarioId: 'scenario-coop-1',
+    endReason: CombatEndReason.Destruction,
+    report: {
+      version: 1,
+      matchId,
+      winner: GameSide.Player,
+      reason: 'destruction',
+      turnCount: 4,
+      units: [],
+      mvpUnitId: null,
+      log: [],
+    },
+    unitDeltas: [
+      makeDelta('unit-A', GameSide.Player, UnitFinalStatus.Damaged),
+      makeDelta('opfor-1', GameSide.Opponent, UnitFinalStatus.Destroyed),
+    ],
+    capturedAt: '3025-06-15T12:00:00Z',
+  };
+}
+
+/** Flush the fire-and-forget reconciliation promise chain. */
+async function flushAsync(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/**
+ * Create a co-op HOST campaign on the real store and stand up a real
+ * `CampaignMatchHost` for it (the piece production session-lifecycle
+ * wiring will own — see coopHostRegistry module docs).
+ */
+async function setupHostedCoopCampaign(): Promise<{
+  campaignId: string;
+  host: CampaignMatchHost;
+}> {
+  const store = useCampaignStore();
+  const campaignId = store
+    .getState()
+    .createCampaign('Coop Wiring Co.', 'mercenary', undefined, {
+      coopSession: createHostCoopSession('ROOM42'),
+    });
+  const host = new CampaignMatchHost({
+    campaignId,
+    hostPlayerId: 'host-player',
+    eventStore: new InMemoryCampaignEventStore(),
+    initialState: {
+      ...createEmptyCampaignState(campaignId),
+      balance: 1_000_000,
+    },
+  });
+  await host.open();
+  registerActiveCoopHost(host);
+  return { campaignId, host };
+}
+
+function resetWorld(): void {
+  resetCampaignStore();
+  _resetCombatOutcomeBus();
+  _resetActiveCoopHosts();
+  _resetDayPipeline();
+  _resetBuiltinRegistration();
+  clientSafeStorage.removeItem('campaign-store');
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('co-op battle completion reconciles via reconcileCoopBattle (D-4)', () => {
+  beforeEach(resetWorld);
+  afterEach(resetWorld);
+
+  it('a completed co-op battle reconciles salvage + roster into the host state', async () => {
+    const { campaignId, host } = await setupHostedCoopCampaign();
+    // Give the roster store the unit's display name so the reconciled
+    // RosterUnitChanged event carries a designation, not a raw id.
+    useCampaignRosterStore.getState().initRoster(campaignId);
+    useCampaignRosterStore.getState().addUnit({
+      unitId: 'unit-A',
+      unitName: 'Atlas AS7-D',
+      chassisVariant: 'Atlas AS7-D',
+      readiness: 'Ready',
+    });
+
+    const outcome = makeCoopOutcome('match-coop-wire-1');
+    publishCombatOutcome({ matchId: outcome.matchId, outcome });
+    await flushAsync();
+
+    // The outcome still flows through the normal enqueue path…
+    expect(useCampaignStore().getState().getPendingOutcomeCount()).toBe(1);
+    // …AND the shared CO1 campaign state converged on the battle:
+    // one destroyed OpFor wreck -> 50k salvage pool credit.
+    expect(host.getState().salvagePool).toBe(50_000);
+    // The damaged player unit landed as a RosterUnitChanged.
+    expect(host.getState().rosterUnits['unit-A']?.status).toBe('damaged');
+    expect(host.getState().rosterUnits['unit-A']?.designation).toBe(
+      'Atlas AS7-D',
+    );
+    // No payout was claimed at this seam — balance untouched.
+    expect(host.getState().balance).toBe(1_000_000);
+  });
+
+  it('a re-published matchId never double-reconciles (dedup guard reused)', async () => {
+    const { host } = await setupHostedCoopCampaign();
+
+    const outcome = makeCoopOutcome('match-coop-wire-2');
+    publishCombatOutcome({ matchId: outcome.matchId, outcome });
+    await flushAsync();
+    publishCombatOutcome({ matchId: outcome.matchId, outcome });
+    await flushAsync();
+
+    expect(useCampaignStore().getState().getPendingOutcomeCount()).toBe(1);
+    // Salvage credited exactly once.
+    expect(host.getState().salvagePool).toBe(50_000);
+  });
+
+  it('a single-player campaign never touches a registered host', async () => {
+    const store = useCampaignStore();
+    const campaignId = store.getState().createCampaign('Solo Co.', 'mercenary');
+    // A host registered for the same campaign id must still be ignored —
+    // the gate keys off campaign.coopSession, not host availability.
+    const host = new CampaignMatchHost({
+      campaignId,
+      hostPlayerId: 'host-player',
+      eventStore: new InMemoryCampaignEventStore(),
+      initialState: createEmptyCampaignState(campaignId),
+    });
+    await host.open();
+    registerActiveCoopHost(host);
+
+    const outcome = makeCoopOutcome('match-solo-1');
+    publishCombatOutcome({ matchId: outcome.matchId, outcome });
+    await flushAsync();
+
+    expect(store.getState().getPendingOutcomeCount()).toBe(1);
+    expect(host.getState().salvagePool).toBe(0);
+    expect(Object.keys(host.getState().rosterUnits)).toHaveLength(0);
+  });
+
+  it('a co-op host campaign with no live host enqueues without throwing', async () => {
+    // The production state today: no session-lifecycle wiring registers
+    // a CampaignMatchHost, so the gate must be a clean no-op.
+    const store = useCampaignStore();
+    store
+      .getState()
+      .createCampaign('Hostless Coop Co.', 'mercenary', undefined, {
+        coopSession: createHostCoopSession('ROOM43'),
+      });
+
+    const outcome = makeCoopOutcome('match-hostless-1');
+    publishCombatOutcome({ matchId: outcome.matchId, outcome });
+    await flushAsync();
+
+    expect(store.getState().getPendingOutcomeCount()).toBe(1);
+  });
+});

--- a/src/stores/campaign/__tests__/useCampaignStore.reviewApplyLedger.test.ts
+++ b/src/stores/campaign/__tests__/useCampaignStore.reviewApplyLedger.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Seam test for audit finding D-6 (2026-06-09 audit, remediation W3.4).
+ *
+ * The review page's Apply runs `applyPostBattle` → `updateCampaign` →
+ * `markBattleReviewed`. Pre-fix, only the campaign-embedded
+ * `processedBattleIds` ledger learned about the applied match — the
+ * STORE-level ledger (the one `advanceDay`, `persistCampaignRecord`, and
+ * the enqueue dedup guard read) was never updated, so the next
+ * `advanceDay` rebuilt the campaign from the stale store ledger and a
+ * re-published outcome could re-enqueue + double-apply.
+ */
+import type { ICampaignWithBattleState } from '@/lib/campaign/processors/postBattleProcessor';
+import type { ICombatOutcome } from '@/types/combat/CombatOutcome';
+
+import { applyPostBattle } from '@/lib/campaign/processors/postBattleProcessor';
+import { createCampaignStore } from '@/stores/campaign/useCampaignStore';
+import {
+  COMBAT_OUTCOME_VERSION,
+  CombatEndReason,
+} from '@/types/combat/CombatOutcome';
+import { GameSide } from '@/types/gameplay/GameSessionInterfaces';
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+Object.defineProperty(global, 'localStorage', { value: localStorageMock });
+
+/** Minimal campaign-linked outcome (no unit deltas — ledger-only test). */
+function makeOutcome(matchId: string): ICombatOutcome {
+  return {
+    version: COMBAT_OUTCOME_VERSION,
+    matchId,
+    contractId: 'contract-1',
+    scenarioId: 'scenario-1',
+    endReason: CombatEndReason.ObjectiveMet,
+    capturedAt: '2026-06-09T00:00:00.000Z',
+    report: {
+      version: 1,
+      matchId,
+      winner: GameSide.Player,
+      reason: 'objective',
+      turnCount: 1,
+      units: [],
+      mvpUnitId: null,
+      log: [],
+    },
+    unitDeltas: [],
+  };
+}
+
+beforeEach(() => {
+  localStorageMock.clear();
+});
+
+describe('review-page Apply syncs the store-level processedBattleIds ledger (D-6)', () => {
+  /** Replays the exact review-page Apply sequence against a live store. */
+  function applyViaReviewPage(
+    store: ReturnType<typeof createCampaignStore>,
+    outcome: ICombatOutcome,
+  ): void {
+    const state = store.getState();
+    const campaign = state.campaign as ICampaignWithBattleState;
+    const result = applyPostBattle(outcome, campaign);
+    state.updateCampaign(result.campaign);
+    state.markBattleReviewed(outcome.matchId);
+  }
+
+  it('marks the applied match processed at store level and persists it', () => {
+    const store = createCampaignStore();
+    const campaignId = store
+      .getState()
+      .createCampaign('Review Ledger Co.', 'mercenary');
+    const outcome = makeOutcome('match-review-1');
+    store.getState().enqueueOutcome(outcome);
+
+    applyViaReviewPage(store, outcome);
+
+    // Store-level ledger learned about the applied battle…
+    expect(store.getState().processedBattleIds).toContain('match-review-1');
+    // …and the persisted record carries it (so a reload keeps the dedup).
+    const stored = localStorageMock.getItem(`campaign-${campaignId}`);
+    expect(stored).toBeTruthy();
+    const parsed = JSON.parse(stored!) as {
+      state: { processedBattleIds: string[] };
+    };
+    expect(parsed.state.processedBattleIds).toContain('match-review-1');
+  });
+
+  it('rejects a re-published outcome for an already-applied match', () => {
+    const store = createCampaignStore();
+    store.getState().createCampaign('Review Dedup Co.', 'mercenary');
+    const outcome = makeOutcome('match-review-2');
+    store.getState().enqueueOutcome(outcome);
+
+    applyViaReviewPage(store, outcome);
+
+    // The combat-outcome bus may re-publish the same matchId (HMR, replay,
+    // reconnect). The enqueue guard reads the STORE ledger — it must now
+    // know the battle was applied via the review page.
+    store.getState().enqueueOutcome(makeOutcome('match-review-2'));
+    expect(store.getState().getPendingOutcomes()).toHaveLength(0);
+  });
+});

--- a/src/stores/campaign/useCampaignStore.outcomes.ts
+++ b/src/stores/campaign/useCampaignStore.outcomes.ts
@@ -123,12 +123,31 @@ export function markCampaignBattleReviewed(
   const nextPending = pendingBattleOutcomes.filter(
     (o) => o.matchId !== matchId,
   );
-  set({ reviewedBattleIds, pendingBattleOutcomes: nextPending });
+  // D-6 remediation (2026-06-09 audit): the review page's Apply runs
+  // `applyPostBattle` (which stamps the matchId onto the CAMPAIGN-embedded
+  // processedBattleIds ledger) and then calls this action. Pre-fix the
+  // STORE-level ledger — the one advanceDay rebuilds the campaign from,
+  // persistCampaignRecord writes, and the enqueue dedup guard reads —
+  // never learned about the applied battle, so the next advanceDay erased
+  // the dedup and a re-published outcome could double-apply. Union the
+  // campaign-embedded ledger into the store ledger here so every
+  // downstream reader agrees. For a reviewed-but-never-applied battle the
+  // campaign ledger lacks the id and the union is a no-op.
+  const campaignLedger =
+    (campaign as ICampaignWithBattleState | null)?.processedBattleIds ?? [];
+  const nextProcessed = Array.from(
+    new Set([...processedBattleIds, ...campaignLedger]),
+  );
+  set({
+    reviewedBattleIds,
+    pendingBattleOutcomes: nextPending,
+    processedBattleIds: nextProcessed,
+  });
   if (campaign) {
     persistCampaignRecord(
       campaign,
       nextPending,
-      processedBattleIds,
+      nextProcessed,
       reviewedBattleIds,
     );
   }

--- a/src/stores/campaign/useCampaignStore.outcomes.ts
+++ b/src/stores/campaign/useCampaignStore.outcomes.ts
@@ -1,5 +1,6 @@
 import type { ICombatOutcome } from '@/types/combat/CombatOutcome';
 
+import { reconcileCoopOutcomeForCampaign } from '@/lib/campaign/coop/coopHostRegistry';
 import {
   applyPostBattle,
   type ICampaignWithBattleState,
@@ -7,6 +8,7 @@ import {
 
 import type { CampaignStore } from './useCampaignStore.types';
 
+import { useCampaignRosterStore } from './useCampaignRosterStore';
 import {
   emitPendingOutcomeAddedEvent,
   persistCampaignRecord,
@@ -56,6 +58,30 @@ export function enqueueCampaignOutcome(
     );
   }
   emitPendingOutcomeAddedEvent(campaign, outcome, nextPending.length);
+  // D-4 remediation (2026-06-09 audit): a co-op HOST campaign reconciles
+  // the battle's campaign-facing consequences (salvage, roster changes)
+  // into the shared CO1 event log the moment the outcome lands — this is
+  // the production caller `reconcileCoopBattle` shipped without. Runs
+  // AFTER the dedup guards above so a re-published matchId can never
+  // double-reconcile. Fire-and-forget: the gate never throws, and it
+  // resolves null for single-player campaigns, guest mirrors, or when no
+  // live CampaignMatchHost is registered for this campaign.
+  void reconcileCoopOutcomeForCampaign(
+    campaign,
+    outcome,
+    buildRosterDesignations(),
+  );
+}
+
+/**
+ * Unit id -> display name lookup for the reconciliation's
+ * `RosterUnitChanged` events. Read off the roster store (the campaign's
+ * unit-name source of truth); `deriveCoopBattleConsequences` falls back
+ * to the raw unit id for any unit missing here.
+ */
+function buildRosterDesignations(): Record<string, string> {
+  const units = useCampaignRosterStore.getState().units;
+  return Object.fromEntries(units.map((u) => [u.unitId, u.unitName]));
 }
 
 export function dequeueCampaignOutcome(

--- a/src/stores/campaign/useCampaignStore.persistence.ts
+++ b/src/stores/campaign/useCampaignStore.persistence.ts
@@ -4,13 +4,29 @@ import type {
   ICampaignOptions,
   IMission,
 } from '@/types/campaign/Campaign';
+import type {
+  ICampaignCommandExtensions,
+  ICampaignContractMarket,
+} from '@/types/campaign/CampaignCommandExtensions';
+import type { ICampaignLoan } from '@/types/campaign/CampaignLoan';
 import type { ICampaignRosterEntry } from '@/types/campaign/CampaignRosterEntry';
 import type { ICoopSession } from '@/types/campaign/CoopSession';
 import type { IFactionStanding } from '@/types/campaign/factionStanding/IFactionStanding';
 import type { IForce } from '@/types/campaign/Force';
 import type { IDailyBattleAuditEntry } from '@/types/campaign/IDailyBattleAuditEntry';
+import type { ILoan } from '@/types/campaign/Loan';
+import type { IPersonnelMarketOffer } from '@/types/campaign/markets/marketTypes';
+import type {
+  IMoraleTransition,
+  IUnitPrestige,
+  MoraleState,
+} from '@/types/campaign/Prestige';
+import type { IRefitOrder } from '@/types/campaign/Refit';
+import type { ICombatTeam } from '@/types/campaign/scenario/scenarioTypes';
 import type { Transaction } from '@/types/campaign/Transaction';
+import type { IUnitCombatState } from '@/types/campaign/UnitCombatState';
 import type { ICombatOutcome } from '@/types/combat/CombatOutcome';
+import type { MechBuildConfig } from '@/utils/construction/constructionRules/types';
 
 import { clientSafeStorage } from '@/stores/utils/clientSafeStorage';
 import { CampaignType } from '@/types/campaign/CampaignType';
@@ -19,6 +35,26 @@ import { Money } from '@/types/campaign/Money';
 import { emitPendingOutcomeAdded } from '@/utils/events/campaignOutcomeEvents';
 
 import { useCampaignRosterStore } from './useCampaignRosterStore';
+
+/**
+ * JSON-safe form of the amortization-engine `ILoan` (`IFinances.loans`).
+ * The live record carries `Money` instances and `Date`s; both are
+ * flattened here (Money → C-bill scalar, Date → ISO string) so the
+ * ledger survives `JSON.stringify`/`JSON.parse` without custom revivers —
+ * the same convention `finances.transactions` already follows.
+ */
+export interface SerializedAmortizedLoan {
+  id: string;
+  principal: number;
+  annualRate: number;
+  termMonths: number;
+  monthlyPayment: number;
+  remainingPrincipal: number;
+  startDate: string; // ISO 8601 string
+  nextPaymentDate: string; // ISO 8601 string
+  paymentsRemaining: number;
+  isDefaulted: boolean;
+}
 
 export interface SerializedCampaignState {
   id: string;
@@ -35,11 +71,19 @@ export interface SerializedCampaignState {
       description: string;
     }>;
     balance: number;
+    /**
+     * Amortization-engine loan ledger (`IFinances.loans`), flattened to
+     * JSON-safe scalars (D-1 fix, 2026-06-09 audit). Absent on pre-fix
+     * snapshots and on campaigns that never used the loan system.
+     */
+    loans?: SerializedAmortizedLoan[];
   };
   factionStandings: Record<string, IFactionStanding>;
   shoppingList?: IShoppingList;
   options: ICampaignOptions;
   campaignType: string;
+  /** Creation preset id. Absent on pre-fix snapshots (D-1 sweep). */
+  activePreset?: string;
   campaignStartDate: string;
   description?: string;
   iconUrl?: string;
@@ -47,6 +91,38 @@ export interface SerializedCampaignState {
   processedBattleIds: string[];
   reviewedBattleIds: Record<string, number>;
   dailyBattleAudit: IDailyBattleAuditEntry[];
+  /**
+   * Canonical per-unit post-deploy combat state (unit battle damage).
+   * Before the D-1 fix (2026-06-09 audit) this was silently dropped on
+   * save and hard-reset to `{}` on load — every reload wiped battle
+   * damage. Optional so pre-fix snapshots still load (defaults to `{}`).
+   */
+  unitCombatStates?: Readonly<Record<string, IUnitCombatState>>;
+  /**
+   * Campaign command-tier loan ledger (`ICampaignCommandExtensions.loans`,
+   * CP2b design D4). Before the D-1 fix a reload kept the borrowed cash
+   * (persisted as a finances transaction) but erased the debt. Every
+   * `ICampaignLoan` field is already a JSON-safe scalar.
+   */
+  loans?: readonly ICampaignLoan[];
+  /** Personnel-market hiring offers (CP2b design D2; D-1 sweep). */
+  personnelMarket?: readonly IPersonnelMarketOffer[];
+  /** Contract-market offers + declined ids (CP2b design D5; D-1 sweep). */
+  contractMarket?: ICampaignContractMarket;
+  /** Combat teams for AtB scenario generation (D-1 sweep). */
+  combatTeams?: readonly ICombatTeam[];
+  /** Refit orders (`add-campaign-refit-and-prestige` D2; D-1 sweep). */
+  refitOrders?: readonly IRefitOrder[];
+  /** Per-unit campaign loadouts written by completed refits (D5; D-1 sweep). */
+  unitConfigurations?: Readonly<Record<string, MechBuildConfig>>;
+  /** Per-unit prestige scores (D7; D-1 sweep). */
+  unitPrestige?: readonly IUnitPrestige[];
+  /** Company morale state (D8; D-1 sweep). */
+  moraleState?: MoraleState;
+  /** Company morale transition history (D9; D-1 sweep). */
+  moraleTransitions?: readonly IMoraleTransition[];
+  /** Starmap "you are here" pin (`wire-starmap-into-campaign`; D-1 sweep). */
+  currentSystemId?: string;
   /**
    * Co-op session metadata round-trip (`wire-coop-campaign-route`, Wave 6.1).
    * Absent on single-player campaigns; present on host or guest mirror
@@ -86,6 +162,11 @@ export function serializeCampaign(
       }
     ).dailyBattleAudit ?? [];
   const startDate = campaign.campaignStartDate ?? campaign.currentDate;
+  // Command-tier extension fields (loans / personnelMarket / contractMarket)
+  // live on the campaign behind `ICampaignCommandExtensions` — widen once
+  // so the serializer sees them (same convention as the server-side
+  // serializer in lib/campaign/persistence/serializeCampaign.ts).
+  const extended = campaign as ICampaign & ICampaignCommandExtensions;
   return {
     id: campaign.id,
     name: campaign.name,
@@ -101,11 +182,29 @@ export function serializeCampaign(
         description: t.description,
       })),
       balance: campaign.finances.balance.amount,
+      // D-1 fix: flatten the amortization-engine ledger (Money → scalar,
+      // Date → ISO) so financialProcessor's loan state survives reload.
+      // Omitted entirely when the campaign never used the loan system.
+      loans: campaign.finances.loans?.map(
+        (l): SerializedAmortizedLoan => ({
+          id: l.id,
+          principal: l.principal.amount,
+          annualRate: l.annualRate,
+          termMonths: l.termMonths,
+          monthlyPayment: l.monthlyPayment.amount,
+          remainingPrincipal: l.remainingPrincipal.amount,
+          startDate: l.startDate.toISOString(),
+          nextPaymentDate: l.nextPaymentDate.toISOString(),
+          paymentsRemaining: l.paymentsRemaining,
+          isDefaulted: l.isDefaulted,
+        }),
+      ),
     },
     factionStandings: campaign.factionStandings,
     shoppingList: campaign.shoppingList,
     options: campaign.options,
     campaignType: campaign.campaignType,
+    activePreset: campaign.activePreset,
     campaignStartDate: startDate.toISOString(),
     description: campaign.description,
     iconUrl: campaign.iconUrl,
@@ -113,6 +212,24 @@ export function serializeCampaign(
     processedBattleIds: [...processedBattleIds],
     reviewedBattleIds: { ...reviewedBattleIds },
     dailyBattleAudit: [...audit],
+    // D-1 fix (2026-06-09 audit): unit battle damage is canonical state —
+    // dropping it here was the audit's headline data-loss finding. The map
+    // is already JSON-safe (scalars, strings, plain records).
+    unitCombatStates: campaign.unitCombatStates,
+    // D-1 fix: the command-tier loan ledger. The borrowed cash is already
+    // persisted as a finances transaction; the debt must travel with it.
+    loans: extended.loans,
+    // D-1 sweep: remaining command/refit/prestige/starmap state that the
+    // pre-fix serializer silently dropped. All JSON-safe shapes.
+    personnelMarket: extended.personnelMarket,
+    contractMarket: extended.contractMarket,
+    combatTeams: campaign.combatTeams,
+    refitOrders: campaign.refitOrders,
+    unitConfigurations: campaign.unitConfigurations,
+    unitPrestige: campaign.unitPrestige,
+    moraleState: campaign.moraleState,
+    moraleTransitions: campaign.moraleTransitions,
+    currentSystemId: campaign.currentSystemId,
     // Per `wire-coop-campaign-route` Wave 6.1: the coopSession bit is
     // per-campaign identity (host vs guest vs single-player). Persisting it
     // here means a reload of a host or guest campaign still mounts the
@@ -147,17 +264,53 @@ export function deserializeCampaign(
         }),
       ),
       balance: new Money(serialized.finances.balance),
+      // D-1 fix: rehydrate the amortization ledger with live Money / Date
+      // instances — financialProcessor.processLoanPayments does Money math
+      // and Date comparisons on these. Absent on pre-fix snapshots.
+      loans: serialized.finances.loans?.map(
+        (l): ILoan => ({
+          id: l.id,
+          principal: new Money(l.principal),
+          annualRate: l.annualRate,
+          termMonths: l.termMonths,
+          monthlyPayment: new Money(l.monthlyPayment),
+          remainingPrincipal: new Money(l.remainingPrincipal),
+          startDate: new Date(l.startDate),
+          nextPaymentDate: new Date(l.nextPaymentDate),
+          paymentsRemaining: l.paymentsRemaining,
+          isDefaulted: l.isDefaulted,
+        }),
+      ),
     },
     factionStandings: serialized.factionStandings,
     shoppingList: serialized.shoppingList,
     options: serialized.options,
     campaignType: serialized.campaignType as CampaignType,
+    activePreset: serialized.activePreset,
     campaignStartDate: new Date(serialized.campaignStartDate),
     description: serialized.description,
     iconUrl: serialized.iconUrl,
     createdAt: serialized.createdAt,
     updatedAt: serialized.updatedAt,
-    unitCombatStates: {},
+    // D-1 fix (2026-06-09 audit): rehydrate unit battle damage instead of
+    // hard-resetting it. Pre-fix snapshots lack the field — default to the
+    // fresh-campaign empty map, which is the old (lossy) behavior for
+    // saves that never carried the state in the first place.
+    unitCombatStates: serialized.unitCombatStates ?? {},
+    // D-1 fix + sweep: command-tier ledger/markets and the
+    // refit/prestige/morale/starmap fields. All optional — absent on
+    // pre-fix snapshots, in which case the campaign simply carries no
+    // such field (every consumer already defaults to an empty projection).
+    loans: serialized.loans,
+    personnelMarket: serialized.personnelMarket,
+    contractMarket: serialized.contractMarket,
+    combatTeams: serialized.combatTeams,
+    refitOrders: serialized.refitOrders,
+    unitConfigurations: serialized.unitConfigurations,
+    unitPrestige: serialized.unitPrestige,
+    moraleState: serialized.moraleState,
+    moraleTransitions: serialized.moraleTransitions,
+    currentSystemId: serialized.currentSystemId,
     dailyBattleAudit: serialized.dailyBattleAudit,
     // Per `wire-coop-campaign-route` Wave 6.1: the coopSession field
     // survives reload so every co-op surface remounts on the same campaign.

--- a/src/stores/campaign/useCampaignStore.persistence.ts
+++ b/src/stores/campaign/useCampaignStore.persistence.ts
@@ -15,7 +15,10 @@ import type { IFactionStanding } from '@/types/campaign/factionStanding/IFaction
 import type { IForce } from '@/types/campaign/Force';
 import type { IDailyBattleAuditEntry } from '@/types/campaign/IDailyBattleAuditEntry';
 import type { ILoan } from '@/types/campaign/Loan';
-import type { IPersonnelMarketOffer } from '@/types/campaign/markets/marketTypes';
+import type {
+  IPersonnelMarketOffer,
+  IUnitMarketOffer,
+} from '@/types/campaign/markets/marketTypes';
 import type {
   IMoraleTransition,
   IUnitPrestige,
@@ -109,6 +112,14 @@ export interface SerializedCampaignState {
   personnelMarket?: readonly IPersonnelMarketOffer[];
   /** Contract-market offers + declined ids (CP2b design D5; D-1 sweep). */
   contractMarket?: ICampaignContractMarket;
+  /** Unit-market offers stored by unitMarketProcessor (audit D-7, W3.4). */
+  unitMarket?: readonly IUnitMarketOffer[];
+  /**
+   * Campaign RNG seed for replayable daily rolls (audit D-10, W3.4).
+   * Absent on pre-fix snapshots — consumers fall back to an id-derived
+   * seed via `resolveCampaignSeed`.
+   */
+  rngSeed?: number;
   /** Combat teams for AtB scenario generation (D-1 sweep). */
   combatTeams?: readonly ICombatTeam[];
   /** Refit orders (`add-campaign-refit-and-prestige` D2; D-1 sweep). */
@@ -223,6 +234,7 @@ export function serializeCampaign(
     // pre-fix serializer silently dropped. All JSON-safe shapes.
     personnelMarket: extended.personnelMarket,
     contractMarket: extended.contractMarket,
+    unitMarket: extended.unitMarket,
     combatTeams: campaign.combatTeams,
     refitOrders: campaign.refitOrders,
     unitConfigurations: campaign.unitConfigurations,
@@ -230,6 +242,8 @@ export function serializeCampaign(
     moraleState: campaign.moraleState,
     moraleTransitions: campaign.moraleTransitions,
     currentSystemId: campaign.currentSystemId,
+    // Audit D-10 (W3.4): the replayability seed travels with the campaign.
+    rngSeed: campaign.rngSeed,
     // Per `wire-coop-campaign-route` Wave 6.1: the coopSession bit is
     // per-campaign identity (host vs guest vs single-player). Persisting it
     // here means a reload of a host or guest campaign still mounts the
@@ -304,6 +318,7 @@ export function deserializeCampaign(
     loans: serialized.loans,
     personnelMarket: serialized.personnelMarket,
     contractMarket: serialized.contractMarket,
+    unitMarket: serialized.unitMarket,
     combatTeams: serialized.combatTeams,
     refitOrders: serialized.refitOrders,
     unitConfigurations: serialized.unitConfigurations,
@@ -311,6 +326,9 @@ export function deserializeCampaign(
     moraleState: serialized.moraleState,
     moraleTransitions: serialized.moraleTransitions,
     currentSystemId: serialized.currentSystemId,
+    // Audit D-10 (W3.4): rehydrate the replayability seed. Absent on
+    // pre-fix snapshots — daily RNG falls back to an id-derived seed.
+    rngSeed: serialized.rngSeed,
     dailyBattleAudit: serialized.dailyBattleAudit,
     // Per `wire-coop-campaign-route` Wave 6.1: the coopSession field
     // survives reload so every co-op surface remounts on the same campaign.

--- a/src/types/campaign/Campaign.ts
+++ b/src/types/campaign/Campaign.ts
@@ -196,6 +196,17 @@ export interface ICampaign {
   readonly coopSession?: ICoopSession;
 
   /**
+   * Campaign RNG seed (audit D-10, 2026-06-09 remediation W3.4).
+   *
+   * Stamped once at campaign creation and persisted with the campaign.
+   * Daily processors derive their outcome rolls from per-(seed, day,
+   * processor) streams via `lib/campaign/utils/campaignRng` so campaign
+   * days are replayable. OPTIONAL for backward compatibility — legacy
+   * campaigns without the field fall back to an id-derived seed.
+   */
+  readonly rngSeed?: number;
+
+  /**
    * Current star-system location (`wire-starmap-into-campaign`, Wave 6.4).
    *
    * The player's "you are here" pin on the starmap. The field is OPTIONAL
@@ -585,6 +596,10 @@ export function createCampaign(
     // canonical post-deploy combat-state map. Fresh campaigns start
     // empty; createInitialCombatState writes entries on first deploy.
     unitCombatStates: {},
+    // Audit D-10 (2026-06-09, W3.4): the only intentionally random step —
+    // every daily outcome roll after creation derives deterministically
+    // from this persisted seed (see lib/campaign/utils/campaignRng).
+    rngSeed: Math.floor(Math.random() * 0x100000000) >>> 0,
   };
 }
 

--- a/src/types/campaign/CampaignCommandExtensions.ts
+++ b/src/types/campaign/CampaignCommandExtensions.ts
@@ -23,7 +23,10 @@
 
 import type { ICampaign } from './Campaign';
 import type { ICampaignLoan } from './CampaignLoan';
-import type { IPersonnelMarketOffer } from './markets/marketTypes';
+import type {
+  IPersonnelMarketOffer,
+  IUnitMarketOffer,
+} from './markets/marketTypes';
 import type { IContract } from './Mission';
 
 /**
@@ -54,6 +57,16 @@ export interface ICampaignCommandExtensions {
 
   /** Current contract-market state (design D5). */
   readonly contractMarket?: ICampaignContractMarket;
+
+  /**
+   * Current unit-market offers (audit D-7, 2026-06-09 remediation W3.4).
+   *
+   * Written by `unitMarketProcessor` on its monthly refresh so the
+   * generated offers are no longer discarded. No command-UI page reads
+   * this yet — the field exists so the refresh the day report announces
+   * is real, persisted state a future Unit Market page can render.
+   */
+  readonly unitMarket?: readonly IUnitMarketOffer[];
 }
 
 /** `ICampaign` widened with the optional command-tier extension fields. */

--- a/src/types/campaign/SerializedCampaign.ts
+++ b/src/types/campaign/SerializedCampaign.ts
@@ -90,6 +90,12 @@ export interface SerializedCampaignBody {
    * serializes directly with no flattening.
    */
   readonly loans?: readonly ICampaignLoan[];
+  /**
+   * Campaign RNG seed for replayable daily rolls (audit D-10, 2026-06-09
+   * remediation W3.4). Optional and absent on pre-fix snapshots —
+   * consumers fall back to an id-derived seed.
+   */
+  readonly rngSeed?: number;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Wave W3 of the 2026-06-09 audit remediation (cluster D): the campaign engine's shipped-but-unwired subsystems are now wired, and the persistence path no longer destroys state. Tracker: `docs/audits/2026-06-09-remediation-tracker.md`.

- **D-1 (critical):** campaign persistence round-trip fixed — unit battle damage, the loan command ledger, the amortization ledger, and 10 more silently-dropped fields (presets, starmap position, combat teams, refits, morale, markets…) now survive save→reload on both the explicit-save and page-reload paths. Backward compatible by construction (optional fields, pre-fix payloads tested). A compile-time drift guard makes any future `ICampaign` field the serializer drops a `tsc` failure.
- **D-2:** financial, turnover, faction-standing, and vocational-training day-processors registered in production (17→21) with MekHQ-informed phase ordering, exactly-once semantics, and a necessary double-deduction gate on the financial processor mirroring the documented dailyCosts convention.
- **D-3/D-4:** campaign presets actually apply at creation; co-op post-battle reconciliation (`reconcileCoopBattle`) is invoked at the real completion seam.
- **D-5..D-10:** post-battle XP/wound application is idempotent across retries; review-page Apply updates the dedup ledger; market processors store the offers they generate; campaign kill/mission counters increment (auto-awards can fire); AtB scenario generation gets a real `combatTeams` seam; daily outcome rolls use the campaign's persisted seeded RNG — campaign days are replayable.

No spec deltas (cluster D is wiring gaps per the council decision). Every fix landed with red-first seam tests that exercise the wiring, not just the modules.

Follow-up flagged (tracker): the server-side autosave mirror (`SerializedCampaignBody`) drops the same extension fields the store path now persists — candidate W3 follow-on.

## Verification

- Full unit suite: 1,236 suites, 27,772 passed / 4 skipped (+35 new seam tests)
- CI-shaped perf-smoke lane locally green (4/4 suites)
- `tsc --noEmit` clean; oxlint 0 errors; `openspec validate --all --strict` 402/402
