### PR TITLE
chore(openspec): tactical-map trust + combat-validation roadmap (council 2026-06-12)

### DIFF
--- a/openspec/changes/add-battlemech-combat-validation-suite/tasks.md
+++ b/openspec/changes/add-battlemech-combat-validation-suite/tasks.md
@@ -63,7 +63,7 @@
 - [x] 2.29 Integrate charge/DFA displacement-state rejection for helper, eligibility, event-sourced declaration/resolution, and runner resolution through optional combat displacement lifecycle state.
 - [x] 2.30 Integrate push displacement-state and counter-push rejection for helper, eligibility, event-sourced declaration/resolution, and runner resolution through optional combat displacement lifecycle ownership state.
 - [x] 2.31 Integrate DFA target movement-complete/immobile gate for helper, eligibility, and event-sourced declaration/resolution while preserving runner physical resolution as post-movement complete.
-- [ ] 2.32 Implement remaining physical unsupported gaps: remaining target class restrictions, full displacement-chain consequences, forbidden terrain displacement, and pilot skill roll fallout.
+- [ ] 2.32 BOUNDED GATE (rescoped 2026-06-12 per council decision): physical-attack coverage is complete when the machine-readable unresolved-row export (`getCombatValidationUnresolvedRows`) contains no physical-family rows other than explicitly source-pinned unsupported/out-of-scope blockers — every remaining target-class restriction, displacement-chain consequence, forbidden-terrain displacement, and PSR-fallout row is either integrated or pinned as an explicit blocker with row-level source refs. Verified by `npm run validate:combat` + the gap export; no open-ended implementation obligation remains in this change.
 - [x] 2.32.1 Add explicit target-object gates for invalid physical hex targets and push building/fuel-tank rejection across helper, event-sourced declaration, stale declared resolution, catalog, spec, and audit coverage while leaving non-unit damage resolution explicit out of scope.
 - [x] 2.32.2 Add helper-level DFA VTOL/WIGE elevation-reach gate while leaving runtime VTOL/WIGE motion-state hydration explicit out of scope.
 - [x] 2.32.3 Add the initial DFA mechanical jump booster rejection as an intermediate source-backed gate.
@@ -99,7 +99,7 @@
 
 ## 3. Full combat validation catalog
 
-- [ ] 3.1 Expand weapon attack action coverage across every weapon family and ammo family.
+- [ ] 3.1 BOUNDED GATE (rescoped 2026-06-12): weapon/ammo coverage is complete when every official BattleMech ranged-weapon and ammo id is classified in the catalog (integrated, helper-only, consumable-bin, explicit blocker, or out-of-scope split) with row-level source refs, exact-id pinning holds (3.1.15–3.1.24), the fallback bans stay enforced (static WEAPON_DATABASE subset + synthetic-medium-laser-fallback-ban traps), and the unresolved export contains no unclassified weapon/ammo rows. Verified by the catalog contract suite + gap export.
 - [x] 3.1.1 Cross-link every ammunition compatibility support row into the official-ammo requirement checklist.
 - [x] 3.1.2 Integrate TAG and standard NARC `DesignatorMarkerApplied` replay state through reducer tests, validation catalog rows, and OpenSpec coverage while leaving iNARC pod variants helper-only.
 - [x] 3.1.3 Integrate source-backed iNARC Homing marker state, direct NARC-compatible missile cluster modifier consumption, runner to-hit modifier consumption, and replay coverage while leaving ECM/Haywire/Nemesis pod effects helper-only.
@@ -127,7 +127,7 @@
 - [x] 3.1.22 Split damage-capable official Streak SRM ids from zero-damage Streak LRM/OS/prototype catalog rows so Streak runner support cannot hide data gaps.
 - [x] 3.1.23 Source-pin the official zero-damage Clan Plasma Cannon as a target-heat weapon family so zero damage cannot be treated as generic coverage.
 - [x] 3.1.24 Source-pin ammunition compatibility support rows to MekStation official ammo import, ammo hydration/tracking, and exact-id classification contract refs so official ammo coverage does not rely on prose-only catalog evidence.
-- [ ] 3.2 Expand movement validation coverage for terrain costs, disallowed terrain, facing changes, prone/stand-up, jumping, and movement damage.
+- [ ] 3.2 BOUNDED GATE (rescoped 2026-06-12): movement coverage is complete when every core movement rule row, per-TerrainType row family (movement/heat/attack-modifier/LOS/PSR), and movement action row carries row-level source refs (3.2.15–3.2.21 pattern), absent-action rows are either integrated or source-backed explicit blockers, and the unresolved export contains no movement-family rows without explicit blocker status. Turning-MP preview/commit unification is owned by the separate `fix-tactical-projection-agreement-gaps` change, not this gate.
 - [x] 3.2.1 Cross-link movement, terrain, LOS, attack-modifier, heat, and PSR support rows into movement/terrain requirement checklists.
 - [x] 3.2.2 Integrate source-backed active TSM movement speed into runner movement validation while leaving MASC, supercharger, and then-unsupported partial-wing movement behavior explicit.
 - [x] 3.2.3 Integrate source-backed Partial Wing jump MP and jump-heat behavior through explicit runner movement capability state while leaving atmosphere and damaged critical-slot refinements explicit.
@@ -157,7 +157,7 @@
 - [x] 3.2.25 Charge path-alignment turns as movement MP during ground movement validation so bent paths and final movement event decomposition conserve MP instead of granting free facing changes between path segments.
 - [x] 3.2.26 Integrate source-backed swamp bog-down through movement terrain PSR queueing, Swamp Beast PSR relief, failed-PSR `UnitStuck`/`isStuck` resolution, immediate jump-entry stuck handling, and stuck-state movement/go-prone/charge/DFA legality gates while leaving building collapse for a separate explicit-load slice.
 - [x] 3.2.27 Integrate source-backed explicit-load building collapse through movement terrain PSR queueing when BattleMech tonnage exceeds Building constructionFactor, while leaving damage-triggered, basement, top-floor, and WiGE flyover collapse side paths explicit.
-- [ ] 3.3 Expand heat validation coverage for buildup, dissipation, shutdown, ammo explosions, pilot damage, and heat-driven modifiers.
+- [ ] 3.3 BOUNDED GATE (rescoped 2026-06-12): heat coverage is complete when every heat rule row (weapon/movement/engine-crit heat, dissipation, thresholds, environment, shutdown/startup, ammo explosion, pilot heat damage, optional MaxTech boundaries, heat-driven modifiers) carries row-level source refs (3.3.9–3.3.10 pattern) and the unresolved export contains no heat-family rows without explicit blocker status. Verified by the heat contract suites + gap export.
 - [x] 3.3.1 Cross-link every heat rule support row into heat generation, dissipation, and lifecycle requirement checklists.
 - [x] 3.3.2 Add structured MegaMek source anchors for heat startup, avoidable/automatic shutdown, ammo-explosion risk, and pilot heat damage support rows.
 - [x] 3.3.3 Split heat-driven SPA catalog coverage by source truth: Some Like It Hot is source-backed, Hot Dog is anchored to MegaMek's hotDogMod target-number modifier, and Cool Under Fire remains local until an authority is identified.
@@ -169,7 +169,7 @@
 - [x] 3.3.9 Source-pin every heat rule row for weapon heat, movement/jump heat, engine crit heat, dissipation, heat-sink damage, threshold effects, water/fire/environment heat, shutdown/startup, ammo explosion, pilot heat damage, and optional MaxTech heat-damage boundaries; promote heat rule triad enforcement to row-level source refs while marking atmosphere heat as a MekStation deviation.
 - [x] 3.3.10 Add a first-class heat-driven-modifiers requirement so Hot Dog, Some Like It Hot, weapon cooling quirks, and local-only Cool Under Fire cannot be hidden inside integrated core heat lifecycle coverage.
 - [x] 3.3.11 Integrate explicit optional TacOps sprint/evade state into runner movement heat generation with source-backed normal-engine sprint heat and evasion heat surcharge while keeping movement-step declaration, authoritative state creation, and engine-variant/coolant refinements explicit gaps.
-- [ ] 3.4 Expand to-hit validation coverage for range, movement, terrain, pilot skills, special abilities, quirks, sensors, prone state, and indirect fire.
+- [ ] 3.4 BOUNDED GATE (rescoped 2026-06-12): to-hit coverage is complete when every range-bracket, to-hit modifier, invalid-target-state, AttackInvalid-reason, no-side-effect guard, SPA, and quirk row carries row-level source refs (3.4.30–3.4.36, 3.4.42 pattern), local-only SPAs/quirks are split into deviation or out-of-scope inventories, and the unresolved export contains no to-hit-family rows without explicit blocker status. Verified by the to-hit contract suites + gap export.
 - [x] 3.4.1 Add support-matrix tests that separate runner-integrated to-hit modifiers from helper-only modifier math.
 - [x] 3.4.2 Cross-link pilot skill, SPA, canonical SPA, quirk, and pilot modifier resolver support rows into pilot/SPAs/quirks requirement checklists.
 - [x] 3.4.3 Cross-link range bracket, attack invalidation, invalid target state, invalid side-effect, and to-hit modifier support rows into range/invalidation/to-hit requirement checklists.
@@ -268,7 +268,7 @@
 
 - [x] 4.1 Cross-check current physical legality gates against MegaMek behavior notes.
 - [x] 4.2 Add source anchors for remaining physical gaps before marking them integrated.
-- [ ] 4.3 Cross-check weapon, heat, movement, SPA, quirk, and lifecycle rows against rulebook/MegaMek/MekHQ references before implementation claims.
+- [ ] 4.3 BOUNDED GATE (rescoped 2026-06-12): source-truth cross-checking is complete when the row-level source-reference contract (4.3.102) passes for every indexed support row — no row claims integration without a rulebook/MegaMek/MekHQ anchor, and the aggregate unresolved-row inventory checks (4.3.103) plus the `validate:combat:gaps` wiring (4.3.124) stay green. Verified by the contract suite; no open-ended cross-check obligation remains in this change.
 - [x] 4.3.1 Add structured MegaMek source anchors for heat-induced ammo explosion threshold and ammo-bin selection behavior.
 - [x] 4.3.2 Add structured MegaMek source anchors for ejection original-unit removal and post-battle ejected-count behavior.
 - [x] 4.3.3 Add structured MegaMek source anchors for TAG and NARC marker application, TAG turn clearing, and iNARC variant scope.
@@ -478,3 +478,9 @@
 - [x] 4.3.200 Align indirect-fire projection and commit paths so spotter SPA hydration accepts current `pilotSpas` state, legacy `abilities` remains supported, and no-spotter blocked-LOS attempts reject without locking an attack.
 - [x] 4.3.201 Align vehicle critical location replay with runtime vehicle combat state so location-sensitive criticals update armor/structure, availability, motive, turret, rotor, and destruction-cause state through reducer replay.
 - [x] 4.3.202 Preserve merged tactical-map behavior while closing terrain identity gaps by keeping generated buildings component-stable, water/building levels positive, wreck terrain replayable, and LOS/cover metadata intact.
+
+## 5. Change closure (added 2026-06-12 per council decision)
+
+- [ ] 5.1 Run the six bounded gates (2.32, 3.1-3.4, 4.3): execute `node scripts/validate-combat-suite.mjs` and the unresolved-row export; confirm every remaining row is an explicit source-pinned blocker, deviation, or out-of-scope split - then check the gate boxes with the export snapshot linked in the PR.
+- [ ] 5.2 Resolve the proposal's open questions in the proposal document (promotion order for remaining physical blockers; source-anchor exactness policy; OpenSpec validation as CI gate decision) so the change carries no open questions into archive.
+- [ ] 5.3 Final strict validation (`npx openspec validate add-battlemech-combat-validation-suite --strict`) and archive the change (sync the combat-resolution delta into the source-of-truth spec), restoring the zero-in-flight-changes baseline held since audit W6.A.

--- a/openspec/changes/add-isometric-elevation-extrusion/.openspec.yaml
+++ b/openspec/changes/add-isometric-elevation-extrusion/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-12

--- a/openspec/changes/add-isometric-elevation-extrusion/design.md
+++ b/openspec/changes/add-isometric-elevation-extrusion/design.md
@@ -1,0 +1,48 @@
+# Design: Add Isometric Elevation Extrusion
+
+## Context
+
+Isometric mode is a presentation transform over the same axial battlefield state: a single CSS/SVG matrix (`projection.ts` — shear+rotate, rotate-before-shear ordering fixed in audit W2 C-15) with discrete rotation steps 0–5, scene assembly and depth ordering in `buildIsometricSceneItems` / `isometricDepthKey` (`HexMapDisplay.isometric.ts`), occlusion ghosting via the single occlusion sweep (W5.1 perf shape), and `centerOn` corrected for the isometric transform (W5.1). Elevated hexes currently render as flat tiles at an offset — height is only readable through labels and occlusion side effects.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Elevated hexes read as solid stacked terrain: visible extrusion skirts proportional to elevation, correctly depth-ordered at every rotation step.
+- Shipped rotation behavior captured as camera-controls requirements with tests, including the player-facing control surface.
+- No change to occluder semantics, hit-testing targets, or projection data.
+
+**Non-Goals:**
+- WebGL/three.js substrate change; continuous rotation; lighting/shading models beyond a flat face tint.
+- Top-down rendering changes.
+
+## Decisions
+
+**D1 — Extrusion = per-hex skirt polygons generated in the isometric scene builder, not a transform change.**
+For each hex with elevation > 0, `buildIsometricSceneItems` emits 1–2 visible side-face polygons (the faces toward the camera for the current rotation step) beneath the existing top face, with height `elevation × ISO_ELEVATION_UNIT` (the same vertical offset constant the top-face placement already uses). Faces get a darkened terrain tint (flat shading, two fixed luminance steps for the two visible faces). Alternative — CSS 3D transforms per hex: rejected, breaks the single-matrix model and the existing depth-sort assumptions. Alternative — one merged silhouette path per elevation plateau: rejected for v1 (harder invalidation, marginal node savings); revisit if node count hurts.
+
+**D2 — Depth ordering reuses `isometricDepthKey` with a face-rank tiebreaker.**
+Skirt faces sort with their owner hex's depth key, ranked immediately before the hex top face so tops always paint over their own skirts; unit tokens keep their existing ordering relative to hex tops. Camera-facing face selection is a pure function of rotation step (six-case lookup), unit-tested per step. This keeps the painter's algorithm intact — no z-buffer emulation.
+
+**D3 — Occlusion semantics unchanged; extrusion is visual only.**
+The occlusion sweep continues to operate on hex elevation data, not on rendered skirt geometry. Skirts never register as hover/hit targets (pointer-events none); occluder highlights and hover explanations keep their current metadata contract. This honors the existing "Isometric Occluder Hex Highlights" / "Isometric Occluder Hover Explanations" requirements without deltas.
+
+**D4 — Rotation retro-spec: camera-controls gains an ADDED requirement; control surface verified first.**
+The shipped behavior (six discrete headings, scene depth re-sort per step, centerOn preservation, reduced-motion) becomes a camera-controls requirement. Task order verifies whether a player-facing rotation control (button/hotkey) exists; if absent, this change adds it next to the existing camera controls (zoom/fit) using the same interaction-store pattern. UNVERIFIED at authoring time: presence of a rotation hotkey/button — the requirement is written against behavior, with the control surface as a scenario.
+
+**D5 — Rotation transition animation is a stretch task, gated on reduced motion.**
+A short interpolated transform transition between steps, fully disabled under `prefers-reduced-motion` (consistent with "Reduced Motion Disables Camera Easing"). Lands only if it doesn't complicate the matrix path; otherwise dropped without affecting the change's finish line.
+
+## Risks / Trade-offs
+
+- [Node count grows by ~1–2 polygons per elevated hex; large mountainous maps could slow pan/zoom] → Skirts only for elevation > 0 (most hexes flat); polygons memoized with the same referential-stability patterns as HexCell (W5); visual smoke + existing perf budgets gate the PR.
+- [Skirts visually colliding with badge/labels or unit tokens at low elevations] → Tops always paint over own skirts (D2); Storybook stress states for adjacent cliffs, units in pits, and rotation cycles.
+- [Face-selection bugs at specific rotation steps produce "floating" tiles] → Per-step unit tests assert the visible-face lookup for all six steps; full-rotation-cycle test extends the existing "Full rotation cycle restores original occluder state" coverage.
+- [Retro-spec reveals the rotation control surface never shipped player-facing] → That gap becomes an in-scope task (D4) rather than a surprise; scope is one control + hotkey, consistent with existing camera-controls patterns.
+
+## Migration Plan
+
+Single PR, UI-only. Rollback = revert. Storybook + visual smoke baselines updated in the same PR.
+
+## Open Questions
+
+- Whether a player-facing rotation control already exists (resolved by task 1.1; determines whether task 3.2 is verification or implementation).

--- a/openspec/changes/add-isometric-elevation-extrusion/proposal.md
+++ b/openspec/changes/add-isometric-elevation-extrusion/proposal.md
@@ -1,0 +1,35 @@
+# Change: Add Isometric Elevation Extrusion
+
+## Why
+
+Isometric mode already ships discrete six-step camera rotation, depth sorting (`isometricDepthKey`), occlusion ghosting, and a corrected rotate-before-shear projection (audit W2 C-15, W5 centerOn fix) — but elevated hexes still render as flat tiles, so stacked elevation is hard to read as a 2.5D battlefield, and none of the shipped rotation behavior is specced in `camera-controls` (the spec has zero isometric requirements, so regressions there are invisible to spec validation). Council decision 2026-06-12: extrusion is the one remaining isometric item with legibility payoff; the shipped rotation behavior needs retro-speccing.
+
+## What Changes
+
+- Render stacked elevation extrusion in isometric mode: per-hex elevation skirts/walls keyed off hex elevation so height reads visually, depth-sorted with the existing `isometricDepthKey` ordering and compatible with the occlusion ghosting sweep.
+- Retro-spec the shipped isometric camera rotation into `camera-controls`: six discrete headings, player-facing rotation control, center-preservation under rotation, reduced-motion behavior. Implement any part of the control surface found missing during verification.
+- Optional polish (only if cheap after the above): animated rotation transition honoring reduced motion.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+## Modified Capabilities
+
+- `tactical-map-interface`: "Isometric Presentation" gains stacked elevation extrusion scenarios (skirt rendering, depth ordering, occlusion interplay).
+- `camera-controls`: gains an ADDED "Isometric Camera Rotation" requirement retro-speccing the shipped discrete rotation behavior and its control surface.
+
+## Impact
+
+- `src/components/gameplay/HexMapDisplay/HexMapDisplay.isometric.ts` (scene items + depth keys), `HexCell` isometric render path (skirt polygons), `projection.ts` (no math changes expected — consumes existing transform), camera/rotation control components.
+- Isometric Jest suites, Storybook isometric stories, tactical-map visual smoke.
+- No engine/projection-data changes; no combat-resolution delta — does not conflict with the active validation-suite change.
+
+## Non-goals
+
+- No three.js/WebGL rewrite — the SVG substrate stays (council decision: extrusion in SVG, effort M).
+- No top-down work (sibling change: `add-topdown-tactical-legibility`).
+- No new occlusion semantics — existing occluder metadata/highlight requirements stand; extrusion must not change which hexes count as occluders.
+- No continuous/free camera rotation; headings stay discrete.

--- a/openspec/changes/add-isometric-elevation-extrusion/specs/camera-controls/spec.md
+++ b/openspec/changes/add-isometric-elevation-extrusion/specs/camera-controls/spec.md
@@ -1,0 +1,39 @@
+# camera-controls Delta — add-isometric-elevation-extrusion
+
+## ADDED Requirements
+
+### Requirement: Isometric Camera Rotation
+
+The camera system SHALL provide discrete isometric battlefield rotation across
+six 60-degree headings, exposed through a player-facing control, preserving the
+centered view target across heading changes and honoring reduced-motion
+preferences for any rotation transition.
+
+#### Scenario: Player rotates the battlefield through discrete headings
+
+- **GIVEN** the tactical map is in isometric mode
+- **WHEN** the player activates the rotate control (or its hotkey)
+- **THEN** the camera SHALL advance to the adjacent discrete heading
+- **AND** the scene SHALL re-render with depth ordering correct for the new heading
+- **AND** repeated activation SHALL cycle through all six headings back to the original
+
+#### Scenario: Rotation preserves the centered view target
+
+- **GIVEN** the isometric camera is centered on a unit or hex
+- **WHEN** the player rotates to another heading
+- **THEN** the centered target SHALL remain within the viewport after the rotation
+- **AND** subsequent center-on requests SHALL account for the active heading's transform
+
+#### Scenario: Reduced motion disables rotation transition animation
+
+- **GIVEN** the player has reduced motion enabled
+- **WHEN** the camera changes heading
+- **THEN** the heading change SHALL apply instantly without interpolated transition
+- **AND** the resulting scene SHALL be identical to the animated path's end state
+
+#### Scenario: Rotation control is unavailable in top-down mode
+
+- **GIVEN** the tactical map is in top-down mode
+- **WHEN** the camera controls render
+- **THEN** the isometric rotate control SHALL be hidden or disabled
+- **AND** entering isometric mode SHALL restore the control with the last active heading

--- a/openspec/changes/add-isometric-elevation-extrusion/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/add-isometric-elevation-extrusion/specs/tactical-map-interface/spec.md
@@ -1,0 +1,53 @@
+# tactical-map-interface Delta — add-isometric-elevation-extrusion
+
+## MODIFIED Requirements
+
+### Requirement: Isometric Presentation
+
+The tactical map interface SHALL render isometric mode as a presentation layer
+over the same axial battlefield state while keeping elevation stacks, camera
+rotation, and occlusion aids inspectable. Hexes with positive elevation SHALL
+render visible extrusion faces so stacked elevation reads as solid terrain
+height, depth-ordered correctly at every discrete camera heading, without
+changing occluder semantics, hover targets, or projection data.
+
+#### Scenario: Rotation updates active terrain occluder
+
+- **GIVEN** a unit may be hidden behind different elevated terrain from different isometric camera headings
+- **WHEN** the player rotates the isometric camera until another elevated hex is in front of the unit
+- **THEN** token foreground boost metadata SHALL identify the newly active occluder hex and elevation
+- **AND** the previous occluder hex SHALL no longer expose active occluder highlight metadata
+- **AND** hover context for the new occluder SHALL show its elevation, camera heading, affected unit ids, and source reason
+
+#### Scenario: Full rotation cycle restores original occluder state
+
+- **GIVEN** an isometric battlefield has a camera-dependent elevated-terrain occluder
+- **WHEN** the player rotates through all six discrete camera headings and returns to the original heading
+- **THEN** the projection layer SHALL expose the original rotation step
+- **AND** scene depth metadata SHALL match the original heading
+- **AND** active occluder metadata and highlights SHALL return to the original terrain hex
+
+#### Scenario: Elevated hexes render camera-facing extrusion faces
+
+- **GIVEN** the tactical map is in isometric mode
+- **AND** a hex has positive elevation
+- **WHEN** the isometric scene renders at any discrete camera heading
+- **THEN** the hex SHALL render its camera-facing extrusion faces beneath its top face with height proportional to its elevation
+- **AND** the visible face selection SHALL correspond to the current rotation step
+- **AND** zero-elevation hexes SHALL render no extrusion faces
+
+#### Scenario: Extrusion faces depth-sort with their owner hex
+
+- **GIVEN** adjacent hexes of different elevations render in isometric mode
+- **WHEN** the scene depth-orders its items
+- **THEN** each hex's extrusion faces SHALL paint immediately beneath that hex's top face in the shared depth ordering
+- **AND** unit tokens SHALL keep their existing depth ordering relative to hex top faces
+- **AND** rotating through all six headings SHALL never produce a lower hex painting over a nearer higher hex's faces
+
+#### Scenario: Extrusion is visual-only and preserves interaction semantics
+
+- **GIVEN** isometric extrusion faces are rendered
+- **WHEN** the player hovers, clicks, or inspects occluder highlights
+- **THEN** extrusion faces SHALL NOT be hover or hit targets
+- **AND** occluder metadata, occluder highlights, and hover explanations SHALL be unchanged from the pre-extrusion contract
+- **AND** movement, combat, LOS, and fog projection data SHALL be byte-identical with extrusion enabled or absent

--- a/openspec/changes/add-isometric-elevation-extrusion/tasks.md
+++ b/openspec/changes/add-isometric-elevation-extrusion/tasks.md
@@ -1,0 +1,25 @@
+# Tasks: Add Isometric Elevation Extrusion
+
+## 1. Verification of shipped rotation surface
+
+- [ ] 1.1 Verify whether a player-facing isometric rotation control/hotkey exists (search camera controls, tactical shell command registry, keyboard handlers); record the finding in the PR description — decides whether task 3.2 is verification or implementation.
+- [ ] 1.2 Confirm current `isometricDepthKey` ordering semantics and the six-step rotation lookup with a characterization test (pins pre-extrusion behavior before scene-builder changes).
+
+## 2. Extrusion rendering
+
+- [ ] 2.1 Add the per-step camera-facing face-selection lookup (pure function, six cases) with unit tests for all six headings.
+- [ ] 2.2 Emit extrusion face polygons for elevation > 0 hexes in `buildIsometricSceneItems` with height `elevation × ISO_ELEVATION_UNIT`, darkened terrain tint per face, `pointer-events: none`, memoized for referential stability.
+- [ ] 2.3 Rank faces immediately beneath their owner hex's top face in the shared depth ordering; assert token-vs-top ordering unchanged.
+- [ ] 2.4 Full-rotation-cycle test: no lower hex paints over a nearer higher hex's faces at any heading; occluder metadata byte-identical with extrusion on/off.
+
+## 3. Camera-controls rotation retro-spec
+
+- [ ] 3.1 Add camera-controls Jest coverage for: six-heading cycle, centerOn preservation under active heading, reduced-motion instant heading change.
+- [ ] 3.2 Implement (or verify, per 1.1) the player-facing rotate control + hotkey next to existing camera controls; hidden/disabled in top-down; restores last heading on isometric re-entry.
+- [ ] 3.3 (Stretch, droppable) Interpolated rotation transition between headings, fully disabled under reduced motion.
+
+## 4. Stories, smoke, verification
+
+- [ ] 4.1 Storybook stories: adjacent cliffs, unit in a pit behind a wall, six-heading rotation cycle on a mountainous fixture.
+- [ ] 4.2 Update tactical-map visual smoke baselines for isometric scenes.
+- [ ] 4.3 `npx tsc --noEmit --skipLibCheck`, lint, affected Jest suites, Storybook build green; pan/zoom perf on a mountainous 30×34 map shows no regression vs the W5 baseline; `npx openspec validate add-isometric-elevation-extrusion --strict`.

--- a/openspec/changes/add-topdown-tactical-legibility/.openspec.yaml
+++ b/openspec/changes/add-topdown-tactical-legibility/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-12

--- a/openspec/changes/add-topdown-tactical-legibility/design.md
+++ b/openspec/changes/add-topdown-tactical-legibility/design.md
@@ -1,0 +1,48 @@
+# Design: Add Top-Down Tactical Legibility
+
+## Context
+
+Top-down hexes render as SVG polygons (`HexCell.tsx`) with terrain tints and overlay layers composed in `HexMapDisplay.layers.tsx`. `formatElevationLabel` ("+N"/"-N") exists in `HexCell.labels.tsx` but is consumed only by tooltips and the isometric label path. The movement overlay (`MovementCostOverlay` + reachable-hex tinting) encodes state primarily by hue: walk cyan, run yellow, jump red (with diagonal pattern), blocked dark gray; MP cost text renders per tile. The spec's readability requirement already mandates an on-hex elevation number; this design closes the implementation gap and strengthens the non-color encodings, Antiyoy-style legibility without an art rewrite.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Persistent per-hex elevation badge in top-down mode, readable at playable zoom levels, toggleable, sourced from the same terrain seed as the projection.
+- Blocked tiles and the walk/run distinction carry a non-hue encoding (hatch/icon/border weight) in addition to color.
+- Terrain labels/glyphs remain distinguishable beneath badges and overlay encodings.
+
+**Non-Goals:**
+- Isometric rendering, rotation, extrusion (sibling change).
+- Any change to projection data, movement legality, or engine behavior.
+- WCAG full-audit of the map (only the overlay-encoding additions are in scope).
+
+## Decisions
+
+**D1 — Elevation badge is a dedicated SVG text layer on `HexCell`, not a new overlay component.**
+Badge renders inside the existing hex cell group (same transform), positioned at a corner anchor so unit tokens and MP cost text stay unobstructed. Zero-elevation hexes render no badge (noise reduction); negative elevations always render (water depth/ditches are tactically critical). Alternative — separate `<ElevationBadgeLayer>` over the board: rejected, doubles per-hex node count and complicates the isometric depth path for no benefit since badges are per-hex static.
+
+**D2 — Zoom behavior: badge hides below a readability threshold instead of scaling indefinitely.**
+Below the zoom level where badge text would render under ~8px effective, the badge layer hides (single CSS class toggle driven by the existing zoom state) — matching the spec's "at playable zoom levels" wording. Alternative — always render and let text shrink: rejected, produces unreadable smudges that defeat the legibility goal.
+
+**D3 — Toggle lives with the existing overlay toggles (`interaction.showElevationBadges`, default ON in top-down).**
+Reuses the established `interaction.show*Overlay` state shape in the map interaction store; persisted with the same mechanism as other overlay toggles. Isometric mode ignores the flag (it has its own elevation presentation).
+
+**D4 — Non-color encodings extend the existing SVG `<pattern>` approach.**
+Jump already uses a diagonal pattern; blocked tiles add a cross-hatch pattern + a small "blocked" glyph at the badge anchor opposite corner; run tiles add a dashed border stroke while walk keeps solid fill. Patterns are defined once in the SVG `<defs>` and referenced per tile — no per-tile pattern instantiation. Alternative — icon sprites per state: rejected for node-count and visual noise at small zoom.
+
+**D5 — Single data source: badges read `terrain.elevation` from the same hex model the projection consumes.**
+No second elevation lookup; the badge component receives the already-loaded hex terrain object. Replay/recovery surfaces get badges for free since they render through the same `HexMapDisplay`.
+
+## Risks / Trade-offs
+
+- [Per-hex text nodes increase SVG node count on 30×34 boards (~1000 hexes)] → Badges skip elevation-0 hexes (majority on most maps); layer hides at low zoom; reuse the W5 memoization patterns (`HexCell` memo + handler identity) so badge props stay referentially stable.
+- [Badge collides visually with MP cost text or unit tokens on busy hexes] → Fixed corner anchor + collision priority rule (unit token > MP cost > badge); verified in Storybook stress states.
+- [Pattern fills can flicker on pan/zoom in some browsers] → Patterns in shared `<defs>` with `patternUnits="userSpaceOnUse"`, the same approach the jump pattern already ships.
+
+## Migration Plan
+
+Single PR, UI-only. Rollback = revert. Storybook stories + visual smoke updated in the same PR.
+
+## Open Questions
+
+- None blocking; exact badge anchor corner and glyph choice resolved during implementation against Storybook stress fixtures.

--- a/openspec/changes/add-topdown-tactical-legibility/proposal.md
+++ b/openspec/changes/add-topdown-tactical-legibility/proposal.md
@@ -1,0 +1,34 @@
+# Change: Add Top-Down Tactical Legibility
+
+## Why
+
+The spec already requires elevation to be "visible as a readable number on or near the hex" (tactical-map-interface → Top-Down Terrain And Elevation Readability), but the shipped top-down view only exposes elevation through hover tooltips and isometric labels — there is no persistent per-hex elevation badge, so players cannot read the battlefield's height profile at a glance (council decision 2026-06-12, verified: `formatElevationLabel` exists in `HexCell.labels.tsx` but is not wired to a flat-view badge overlay). Movement overlay states also lean on color tints alone for the walk/run and blocked distinctions, which fails the goal that overlays communicate "without relying only on color."
+
+## What Changes
+
+- Render a persistent, toggleable per-hex elevation badge in top-down mode at playable zoom levels, fed by the same terrain seed the projection uses (no new data source).
+- Add non-color-only encodings to the movement overlay: a distinct hatch/icon for blocked tiles and a secondary (non-hue) encoding distinguishing walk from run reach, complementing the existing jump diagonal pattern and MP cost text.
+- Keep terrain glyphs/labels distinguishable under the new badge layer (legibility constraint, not a redesign).
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+## Modified Capabilities
+
+- `tactical-map-interface`: "Top-Down Terrain And Elevation Readability" gains persistent elevation-badge scenarios (visibility, zoom behavior, toggle, single data source); "Reachable Hex Overlay by MP Type" gains non-color-only encoding scenarios for blocked tiles and the walk/run distinction.
+
+## Impact
+
+- `src/components/gameplay/HexMapDisplay/HexCell.labels.tsx`, `HexCell.tsx` (badge layer), `HexMapDisplay.layers.tsx` / `Overlays.tsx` (movement overlay encodings), overlay legend components.
+- Visual smoke (`tactical-map-visual-smoke`) and Storybook stories for HexMapDisplay states.
+- No engine, projection, or rules changes; no combat-resolution delta — does not conflict with the active validation-suite change.
+
+## Non-goals
+
+- No isometric work (separate change: `add-isometric-elevation-extrusion`).
+- No projection/engine agreement work (separate change: `fix-tactical-projection-agreement-gaps`).
+- No new per-hex to-hit surfacing — combined hover explanation and combat tooltip requirements already cover combat context per hex.
+- No terrain art overhaul; existing terrain visuals stay, badges layer on top.

--- a/openspec/changes/add-topdown-tactical-legibility/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/add-topdown-tactical-legibility/specs/tactical-map-interface/spec.md
@@ -1,0 +1,99 @@
+# tactical-map-interface Delta — add-topdown-tactical-legibility
+
+## MODIFIED Requirements
+
+### Requirement: Top-Down Terrain And Elevation Readability
+
+Top-down tactical map mode SHALL present a clear board-game hex view where terrain type and elevation are easy to reference during movement and combat planning.
+
+Each rendered hex SHALL expose terrain type and elevation. Elevation SHALL be visible as a readable number on or near the hex at playable zoom levels, while terrain visuals and overlays remain distinguishable. The on-hex elevation number SHALL be rendered as a persistent, toggleable badge layer in top-down mode, sourced from the same terrain data the tactical projection consumes.
+
+Replay and recovery surfaces SHALL render terrain and elevation from the same event-log terrain seed used by the game session, so saved matches start with the same battlefield information as live play.
+
+#### Scenario: Terrain and elevation hover context exposes projection provenance
+
+- **GIVEN** a player inspects terrain/elevation context from a terrain-only, unreachable, movement-only, combat-only, or combined tactical hover
+- **WHEN** the tooltip renders terrain and elevation rows
+- **THEN** those rows SHALL expose stable machine-readable primary terrain, feature-level, and elevation attributes
+- **AND** those rows SHALL expose the terrain/elevation projection source references and rule references from the shared tactical projection when available
+- **AND** combined movement+combat hovers SHALL use the same terrain/elevation context representation as movement-only and combat-only hovers instead of a separate UI-only terrain calculation
+- **AND** adding this metadata SHALL NOT change movement reachability, combat legality, LOS classification, terrain generation, terrain labels, elevation labels, or action resolution
+
+#### Scenario: Persistent elevation badges render on non-zero hexes in top-down mode
+
+- **GIVEN** the tactical map is in top-down mode at a playable zoom level
+- **AND** the elevation badge toggle is enabled
+- **WHEN** the board renders
+- **THEN** every hex with non-zero elevation SHALL display its signed elevation number as an on-hex badge without requiring hover
+- **AND** zero-elevation hexes SHALL display no badge
+- **AND** the badge value SHALL come from the same hex terrain data the tactical projection consumes
+
+#### Scenario: Elevation badges hide below the readability zoom threshold
+
+- **GIVEN** elevation badges are enabled in top-down mode
+- **WHEN** the player zooms out past the zoom level at which badge text would no longer be readable
+- **THEN** the badge layer SHALL hide rather than render unreadable text
+- **AND** zooming back in past the threshold SHALL restore the badges without re-toggling
+
+#### Scenario: Elevation badge toggle behaves like other overlay toggles
+
+- **GIVEN** the player disables the elevation badge toggle
+- **WHEN** the board renders in top-down mode
+- **THEN** no elevation badges SHALL render
+- **AND** elevation SHALL remain available through hover context
+- **AND** the toggle state SHALL persist with the same mechanism as the other overlay toggles
+- **AND** isometric mode SHALL keep its own elevation presentation regardless of the toggle
+
+#### Scenario: Badges do not obscure tokens or movement cost text
+
+- **GIVEN** a hex renders an elevation badge together with a unit token and movement overlay MP cost text
+- **WHEN** the hex renders at a playable zoom level
+- **THEN** the unit token and MP cost text SHALL remain unobstructed
+- **AND** the badge SHALL keep a fixed anchor position so the board reads consistently across hexes
+
+### Requirement: Reachable Hex Overlay by MP Type
+
+The tactical map interface SHALL render a reachable-hex overlay during the Movement phase for the selected Player-side unit, coloring each tile by the movement type (Walk, Run, Jump) required to reach it using the MegaMek movement palette: Walk cyan, Run yellow, Jump red, and projected illegal/blocked movement dark gray. Each overlay state SHALL also carry a non-color encoding so movement legality and movement type remain distinguishable without relying on hue alone.
+
+**Priority**: Critical
+
+#### Scenario: Walk-range tiles rendered cyan
+
+- **GIVEN** a selected unit has 5 walk MP and the player selects MP type Walk
+- **WHEN** the overlay renders
+- **THEN** every hex with `mpCost <= 5` via walk SHALL be tinted cyan (`#67e8f9`)
+- **AND** each tile SHALL display its MP cost in small text
+
+#### Scenario: Run-range tiles rendered yellow
+
+- **GIVEN** the player selects MP type Run
+- **WHEN** the overlay renders
+- **THEN** tiles reachable only with run MP SHALL be tinted yellow (`#fef08a`)
+- **AND** walk-reachable fallback tiles SHALL retain Walk movement metadata when the Run projection is blocked
+
+#### Scenario: Jump-range tiles rendered red with pattern
+
+- **GIVEN** the player selects MP type Jump
+- **WHEN** the overlay renders
+- **THEN** landing hexes reachable with jump SHALL be tinted red (`#f87171`) with a distinct diagonal pattern
+
+#### Scenario: Blocked movement projections rendered dark gray
+
+- **GIVEN** a movement projection exists for an illegal or over-capacity destination
+- **WHEN** the overlay renders that projected blocked tile
+- **THEN** the blocked movement tile SHALL be tinted dark gray (`#64748b`)
+- **AND** tiles with no movement projection SHALL have no movement overlay tint
+
+#### Scenario: Blocked tiles carry a non-color encoding
+
+- **GIVEN** a movement projection marks a destination blocked or illegal
+- **WHEN** the overlay renders that tile
+- **THEN** the tile SHALL render a distinct non-hue encoding (such as a cross-hatch pattern or blocked glyph) in addition to the dark gray tint
+- **AND** the encoding SHALL be distinguishable from the jump diagonal pattern
+
+#### Scenario: Walk and run reach distinguishable without hue
+
+- **GIVEN** the overlay renders walk-reachable and run-only-reachable tiles
+- **WHEN** the tiles render at a playable zoom level
+- **THEN** run-only tiles SHALL carry a non-hue encoding (such as a dashed border) distinguishing them from walk tiles
+- **AND** the overlay legend SHALL document the non-color encodings alongside the palette colors

--- a/openspec/changes/add-topdown-tactical-legibility/tasks.md
+++ b/openspec/changes/add-topdown-tactical-legibility/tasks.md
@@ -1,0 +1,25 @@
+# Tasks: Add Top-Down Tactical Legibility
+
+## 1. Elevation badge layer
+
+- [ ] 1.1 Add the elevation badge render path to `HexCell` (corner-anchored SVG text inside the existing hex group), fed by the hex's terrain elevation, skipping elevation-0 hexes, signed formatting via `formatElevationLabel`.
+- [ ] 1.2 Add `showElevationBadges` to the map interaction store following the existing overlay-toggle shape (default ON in top-down, ignored in isometric), persisted like the other overlay toggles.
+- [ ] 1.3 Implement the zoom readability threshold: hide the badge layer below the cutoff via the existing zoom state; restore on zoom-in without re-toggle.
+- [ ] 1.4 Enforce collision priority (unit token > MP cost text > badge) at the fixed anchor; verify against Storybook stress states with tokens + overlays + badges on one hex.
+
+## 2. Non-color overlay encodings
+
+- [ ] 2.1 Add the blocked-tile cross-hatch pattern + blocked glyph to the shared SVG `<defs>` and reference it from blocked movement tiles (alongside the existing dark gray tint), visually distinct from the jump diagonal pattern.
+- [ ] 2.2 Add the run-only dashed-border encoding distinguishing run tiles from walk tiles without hue.
+- [ ] 2.3 Update the overlay legend to document the non-color encodings alongside the palette colors.
+
+## 3. Tests and stories
+
+- [ ] 3.1 Unit tests: badge renders signed values on non-zero hexes, no badge at elevation 0, toggle off removes badges, zoom threshold hides/restores the layer, badge data source equals the projection's hex terrain object.
+- [ ] 3.2 Unit tests: blocked tiles render the cross-hatch encoding, run-only tiles render the dashed border, legend lists both.
+- [ ] 3.3 Storybook stories for badge-dense boards (negative elevations, water depths) and encoding combinations; update tactical-map visual smoke baselines.
+
+## 4. Verification
+
+- [ ] 4.1 `npx tsc --noEmit --skipLibCheck`, lint, affected Jest suites, Storybook build, and visual smoke green; `npx openspec validate add-topdown-tactical-legibility --strict`.
+- [ ] 4.2 Manual dev-browser pass on a 30×34 map: badges readable at default zoom, no perf regression on pan/zoom (compare against the W5 occlusion-sweep baseline behavior).

--- a/openspec/changes/fix-tactical-projection-agreement-gaps/.openspec.yaml
+++ b/openspec/changes/fix-tactical-projection-agreement-gaps/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-12

--- a/openspec/changes/fix-tactical-projection-agreement-gaps/design.md
+++ b/openspec/changes/fix-tactical-projection-agreement-gaps/design.md
@@ -1,0 +1,58 @@
+# Design: Fix Tactical Projection Agreement Gaps
+
+## Context
+
+PR #801 (audit W1) hydrated the combat projection's to-hit through the shared engine state builders (`buildWeaponAttack*ToHitState`), aligned attack gates and minimum range with the commit path, and added `src/engine/InteractiveSession.attackProjectionAgreement.scenario.test.ts` (~40 cases). Three movement-side residuals were left:
+
+1. **W1.3 deferral (tracked in `docs/audits/2026-06-09-remediation-tracker.md`):** `validateMovement` charges `calculateGroundPathTurningMpCost`; the reachability projection models no facing. Disagreement is surfaced via a `validatorDisagreement` diagnostic in `src/utils/gameplay/movement/commitValidation.ts` — projection stays authoritative, nothing fails when they drift.
+2. **Jump candidate gate:** `deriveReachableHexes` (`src/utils/gameplay/movement/reachable.ts`) selects jump candidates with a flat `hexDistance <= jumpMP` filter ahead of per-hex derivation; engine jump legality (elevation gate fixed in W2 C-13) is enforced elsewhere, and no test proves the two agree.
+3. **UI-local range math:** `CombatPlanningPanel.tsx` computes `rangeToTarget` from raw `hexDistance` instead of the projection's `combat.distance`/`rangeBracket` — the last second-source-of-truth in the combat planning surface.
+
+The attack agreement suite has zero movement cases, so the existing `movement-system` requirement "Integrated Movement Projection Agreement" is unenforced by any executable evidence.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Movement projection and committed movement validation charge identical turning/facing MP for the same path.
+- `validatorDisagreement` becomes a CI-failing condition (zero tolerance on represented modes), not advisory telemetry.
+- Jump reachability shown on the map equals jump legality the engine enforces (no false-reachable, no false-blocked).
+- All combat-planning range/bracket display values trace to the combat projection.
+- A parametrized movement agreement suite mirrors the attack agreement suite across move modes and scenario fixtures.
+
+**Non-Goals:**
+- No new projection layer/façade (council decision 2026-06-12: #801/#802 already delivered the shared-state unification; this is residual-site repair).
+- No new movement rules; no change to which modes are represented. Unsupported modes are enumerated, not implemented.
+- No catalog/validation-suite rows (owned by the active `add-battlemech-combat-validation-suite` change).
+
+## Decisions
+
+**D1 — Turning MP enters the projection via the shared path-cost helper, not a new facing dimension.**
+`IMovementRangeHex` already carries the derived `path` per destination. The projection applies the same `calculateGroundPathTurningMpCost` (the function `validateMovement` charges) over that derived path and adds the result to `mpCost` before reachability/legality classification. Alternative considered: modeling facing as a search dimension in the A* (MegaMek `MovePath` style) — rejected for this change as a search-space rewrite with the same observable outcome for cost agreement; can be revisited if path-optimality bugs surface (the current path may be turn-suboptimal, but both sides price the *same* path, which is what agreement requires).
+
+**D2 — `validatorDisagreement` promotion is test-level, not a production throw.**
+Production commit behavior keeps projection-authoritative resolution (W1.3 decision stands — no player-facing hard failure). Promotion happens in the agreement suite: every scenario asserts the commit-path diagnostic list is empty. CI fails on any drift; players never see a crash. Alternative (throw in `validateCommittedMovement`): rejected — turns a consistency bug into a gameplay outage.
+
+**D3 — Jump gate: keep the distance pre-filter as a superset optimization; final reachability comes from per-hex legality shared with the engine.**
+The flat `hexDistance <= jumpMP` filter remains as the cheap candidate bound (jump range in BattleTech is hex distance), but each candidate then passes through the same jump legality helper the engine/sim-runner uses (elevation delta gate, prohibited-terrain landing, stacking). If investigation shows the per-hex derivation already applies all engine gates, D3 reduces to proving it: the agreement cases become the deliverable and the gate is documented as a pure superset filter. Either way the finish line is the same — zero jump preview/commit disagreements in the suite.
+
+**D4 — `CombatPlanningPanel` consumes `ICombatRangeHex`.**
+Replace local `hexDistance` calls with the projection lookup already available to the page (`buildTacticalMapHexProjectionLookup` output). Where the panel must show a value for a hex outside the current lookup (edge: target beyond max weapon range), it calls the same exported helper the projection uses — never an inline recomputation.
+
+**D5 — Movement agreement suite lives beside the attack suite and reuses its fixtures.**
+New `src/engine/InteractiveSession.movementProjectionAgreement.scenario.test.ts`, parametrized over the existing `src/testing/tactical-map.*` scenario fixtures × move modes (walk, run, jump + represented vehicle/VTOL/WiGE modes). Per (scenario, mode, destination): compare projection `{reachable, mpCost, terrainCost, elevationDelta, heatGenerated, blockedReason}` against committed-validation outcome for the same path. Modes not represented in fixtures are asserted against an explicit `UNSUPPORTED_AGREEMENT_MODES` list so silent skips are impossible (mirrors the validation suite's no-silent-gap doctrine).
+
+## Risks / Trade-offs
+
+- [Reachable sets shrink visibly: hexes that cost turning MP may flip from reachable to unreachable in the preview] → This is the correct rules outcome; release-notes the change; agreement suite pins the new truth.
+- [Per-candidate jump legality + turning cost over the full reachable set adds compute on large maps] → Costs are computed on already-derived paths; memoize the turning-cost helper per path signature; perf budget asserted by existing overlay perf tests (3× widening rule if flaky).
+- [Vehicle/VTOL fixture coverage may not exist for all modes] → D5's explicit unsupported-mode enumeration converts missing fixtures into visible, tracked gaps instead of silent ones.
+- [Panel refactor could regress non-combat phases where projection lookup is empty] → Keep helper fallback path (same exported function), add panel render test for empty-lookup phase.
+
+## Migration Plan
+
+Single PR; no data migration. Rollback = revert. The agreement suite lands in the same PR as the fixes so the assertions are green at merge (red-first locally to prove they catch the pre-fix drift).
+
+## Open Questions
+
+- Does the per-hex jump derivation (post-gate) already apply the engine elevation gate? (Determines whether D3 is a fix or a proof; resolved in task 1.)
+- Exact tactical-map-interface requirement heading for the panel-range scenario — "Weapon Command Preview Uses Combat Projection Impact" vs "Contextual Target Comparison"; pick at delta authoring after reading both (resolved in specs artifact).

--- a/openspec/changes/fix-tactical-projection-agreement-gaps/proposal.md
+++ b/openspec/changes/fix-tactical-projection-agreement-gaps/proposal.md
@@ -1,0 +1,37 @@
+# Change: Fix Tactical Projection Agreement Gaps
+
+## Why
+
+The 2026-06-09 audit remediation (PRs #801/#802) unified the combat projection with the engine commit path and added a 544-line attack-side agreement suite, but it explicitly deferred the movement side: turning-MP/facing divergence is only surfaced as a `validatorDisagreement` diagnostic (remediation tracker W1.3), the jump reachability candidate gate is a flat `hexDistance <= jumpMP` filter ahead of per-hex legality, and `CombatPlanningPanel` still computes `rangeToTarget` from raw `hexDistance` instead of the projection. The agreement test suite contains zero movement cases, so the spec's existing "Integrated Movement Projection Agreement" requirement has no executable enforcement — the exact gap class that let UI/engine drift accumulate before the audit.
+
+## What Changes
+
+- Unify turning/facing MP between movement projection and committed movement validation: the reachability projection accounts for the same `calculateGroundPathTurningMpCost` charges that `validateMovement` enforces, and the `validatorDisagreement` diagnostic is promoted from advisory telemetry to a CI-failing assertion (zero disagreements on represented movement modes).
+- Replace the flat jump distance pre-gate in `deriveReachableHexes` with candidate selection that agrees with engine jump legality (elevation/clearance gates), or prove via agreement cases that the pre-gate cannot admit a hex the engine rejects.
+- Consolidate `CombatPlanningPanel` range/bracket display onto the combat projection (`combat.distance` / `rangeBracket`) — removing the last UI-local range computation.
+- Extend the preview↔commit agreement suite with a parametrized movement channel: reachability, MP cost, terrain cost, elevation delta, heat, blocked reason, and destination legality compared between projection and commit across move modes (walk, run, jump, and represented vehicle/VTOL/WiGE modes) on fixed scenarios; unsupported modes are explicitly enumerated rather than silently skipped.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `movement-system`: "Integrated Movement Projection Agreement" gains turning/facing MP parity, jump candidate-gate parity, and an executable-agreement-coverage requirement (the `validatorDisagreement` zero-tolerance assertion).
+- `tactical-map-interface`: "Rules-Backed Movement Projection" gains turning-cost projection scenarios; the combat-side requirement governing weapon range display gains a scenario pinning panel range/bracket values to the combat projection rather than independent distance math.
+
+## Impact
+
+- `src/utils/gameplay/movement/reachable.ts` (jump candidate gate, turning MP in projection), `src/utils/gameplay/movement/commitValidation.ts` (`validatorDisagreement` promotion), `src/utils/gameplay/movement/validation.ts` (shared turning-cost entry point).
+- `src/components/gameplay/CombatPlanningPanel.tsx` (consume projection range).
+- `src/engine/InteractiveSession.attackProjectionAgreement.scenario.test.ts` (or sibling movement agreement suite) — new parametrized movement agreement cases over the existing `src/testing/tactical-map.*` scenario fixtures.
+- No combat-resolution delta — does not conflict with the active `add-battlemech-combat-validation-suite` change.
+
+## Non-goals
+
+- No new projection layer or façade — PRs #801/#802 already routed projection through shared engine state builders; this change repairs the named residual sites only.
+- No isometric/legibility UI work (separate changes: `add-topdown-tactical-legibility`, `add-isometric-elevation-extrusion`).
+- No expansion of combat validation catalog rows (owned by the active validation-suite change).
+- Full airborne VTOL/WiGE altitude pathing controls remain out of scope (existing spec boundary stands); their *agreement* status is enumerated, not implemented.

--- a/openspec/changes/fix-tactical-projection-agreement-gaps/specs/movement-system/spec.md
+++ b/openspec/changes/fix-tactical-projection-agreement-gaps/specs/movement-system/spec.md
@@ -1,0 +1,68 @@
+# movement-system Delta — fix-tactical-projection-agreement-gaps
+
+## MODIFIED Requirements
+
+### Requirement: Integrated Movement Projection Agreement
+
+Movement projection SHALL represent the same destination legality, MP cost,
+terrain cost, elevation cost, heat impact, stand-up state, and blocked reason
+that committed movement validation and resolution will enforce for represented
+unit movement modes. Turning and facing-change MP SHALL be priced identically
+by the projection and by committed movement validation for the same path, and
+jump candidate selection SHALL agree with engine jump legality. Agreement SHALL
+be enforced by an executable parametrized agreement suite, and any
+`validatorDisagreement` diagnostic raised by committed movement validation
+SHALL be a test-failing condition for represented movement modes.
+
+#### Scenario: Represented movement modes stay preview/commit aligned
+
+- **GIVEN** a represented unit previews walk, run, jump, vehicle-style, VTOL,
+  WiGE, naval, hover, tracked, UMU, infantry, prone, or stand-up movement
+- **WHEN** the projection marks a destination legal, costly, blocked, or
+  unreachable
+- **THEN** the committed movement path for the unchanged destination SHALL spend
+  the same MP and heat or reject with the same reason
+- **AND** terrain and elevation contributors SHALL remain inspectable by the
+  player before commit.
+
+#### Scenario: Turning MP priced identically by projection and commit validation
+
+- **GIVEN** a represented ground unit previews a bent movement path whose
+  committed validation charges path-alignment or terminal facing-change MP
+- **WHEN** the reachability projection derives the MP cost for that destination
+- **THEN** the projected MP cost SHALL include the same turning charges computed
+  by the shared turning-cost function that committed movement validation applies
+- **AND** a destination whose turning charges exceed the remaining MP SHALL be
+  projected unreachable rather than discovered illegal at commit.
+
+#### Scenario: Jump candidate gate agrees with engine jump legality
+
+- **GIVEN** a represented unit previews jump movement
+- **WHEN** jump candidate hexes are derived for the projection
+- **THEN** every hex projected jump-reachable SHALL be accepted by committed
+  jump validation for the same unit state, including elevation-delta and
+  landing-terrain gates
+- **AND** every hex rejected by committed jump validation SHALL NOT be projected
+  jump-reachable
+- **AND** any distance pre-filter SHALL only ever exclude hexes that committed
+  validation would also reject.
+
+#### Scenario: Validator disagreement is a failing condition in the agreement suite
+
+- **GIVEN** the parametrized movement agreement suite runs a represented
+  movement mode across the shared tactical-map scenario fixtures
+- **WHEN** committed movement validation produces any `validatorDisagreement`
+  diagnostic for a projected destination
+- **THEN** the agreement suite SHALL fail
+- **AND** production commit behavior SHALL remain projection-authoritative with
+  no player-facing hard failure.
+
+#### Scenario: Unsupported agreement modes are enumerated, not skipped
+
+- **GIVEN** a movement mode has no scenario fixture or no represented runtime
+  support in the agreement suite
+- **WHEN** the agreement suite enumerates its mode coverage
+- **THEN** that mode SHALL appear in an explicit unsupported-agreement-mode list
+  asserted by the suite
+- **AND** removing runtime support for a previously covered mode SHALL fail the
+  suite rather than silently shrinking coverage.

--- a/openspec/changes/fix-tactical-projection-agreement-gaps/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/fix-tactical-projection-agreement-gaps/specs/tactical-map-interface/spec.md
@@ -1,0 +1,69 @@
+# tactical-map-interface Delta — fix-tactical-projection-agreement-gaps
+
+## MODIFIED Requirements
+
+### Requirement: Rules-Backed Movement Projection
+
+Movement overlays SHALL be derived from shared movement projection data and
+SHALL explain legal, blocked, and consequential movement outcomes before the
+player commits them.
+
+#### Scenario: Encoded cliff movement appears in map projection
+
+- **GIVEN** a selected represented unit previews movement across an encoded
+  directional cliff edge
+- **WHEN** the movement mode is WiGE, tracked, wheeled, or hover
+- **THEN** the destination projection SHALL expose the same added cost or
+  terrain-blocked reason that committed movement validation would apply
+- **AND** ordinary elevation changes without cliff metadata SHALL continue to
+  display as non-cliff movement.
+
+#### Scenario: Turning charges appear in the movement overlay cost
+
+- **GIVEN** a selected represented ground unit previews a destination whose
+  derived path includes facing changes that committed movement validation
+  charges as MP
+- **WHEN** the movement overlay renders that destination's MP cost
+- **THEN** the displayed MP cost SHALL include the turning charges
+- **AND** the per-hex movement explanation SHALL list the turning contribution
+  so the player can see why the destination costs more than its hex distance.
+
+### Requirement: Weapon Command Preview Uses Combat Projection Impact
+
+The tactical command preview SHALL use shared combat projection weapon impact metadata for projected weapon attack heat and ammo usage, and combat planning surfaces SHALL derive displayed range and range bracket values from the shared combat projection rather than independent distance computation.
+
+#### Scenario: Attack preview heat and ammo come from combat projection
+
+**GIVEN** a weapon attack command preview receives combat projection data for an attackable target
+**AND** the projection contains available weapon impact metadata
+**WHEN** the command preview is built
+**THEN** preview heat SHALL equal the combat projection's available weapon heat
+**AND** preview ammo usage SHALL be derived from the combat projection's available weapon impacts
+**AND** preview weapon ids and names SHALL match the projected available weapon impacts.
+
+#### Scenario: Blocked attack preview spends no heat or ammo
+
+**GIVEN** a weapon attack command preview receives combat projection data for a blocked target
+**WHEN** the command preview is built
+**THEN** preview heat SHALL be zero
+**AND** preview ammo usage SHALL be empty
+**AND** the blocked reason SHALL remain the projection-derived attack invalid detail or blocked reason.
+
+#### Scenario: Expected damage can still use weapon status data
+
+**GIVEN** combat projection data provides weapon impact metadata
+**AND** weapon status data is available for those projected weapons
+**WHEN** the command preview is built
+**THEN** expected damage MAY be computed from weapon status damage values until combat projection carries damage envelope metadata.
+
+#### Scenario: Combat planning range display traces to the combat projection
+
+**GIVEN** the combat planning surface displays a range or range bracket for a
+selected target
+**WHEN** the displayed value is computed
+**THEN** it SHALL be read from the combat projection's distance and range
+bracket for that target hex
+**AND** when the target hex is absent from the current projection lookup the
+value SHALL be computed by the same exported helper the projection uses
+**AND** no combat planning surface SHALL compute range or bracket from
+independent inline distance math.

--- a/openspec/changes/fix-tactical-projection-agreement-gaps/tasks.md
+++ b/openspec/changes/fix-tactical-projection-agreement-gaps/tasks.md
@@ -1,0 +1,33 @@
+# Tasks: Fix Tactical Projection Agreement Gaps
+
+## 1. Investigation and red-first evidence
+
+- [ ] 1.1 Read `deriveReachableHexes` jump candidate flow end-to-end and document (in the PR description) whether the per-hex derivation already applies the engine elevation/landing gates after the flat `hexDistance <= jumpMP` pre-filter — resolves design Open Question 1 and decides whether task 3 is a fix or a proof.
+- [ ] 1.2 Write a red-first movement agreement probe: one scenario fixture where a bent path's committed validation charges turning MP the projection omits, demonstrating the `validatorDisagreement` diagnostic fires today (proves W1.3 drift is observable before the fix).
+
+## 2. Turning/facing MP unification
+
+- [ ] 2.1 Apply the shared turning-cost function (`calculateGroundPathTurningMpCost`) to the projection's derived path in `deriveReachableHexes` / `deriveMovementRangeHexForDestination`, adding turning charges to `mpCost` before reachability classification.
+- [ ] 2.2 Surface the turning contribution in the per-hex movement explanation breakdown (movement projection detail rows) so the overlay can list it.
+- [ ] 2.3 Verify destinations whose turning charges exceed remaining MP project as unreachable; update reachable-hex tests.
+
+## 3. Jump candidate-gate parity
+
+- [ ] 3.1 Route every jump candidate through the same jump legality helper the engine/sim-runner enforces (elevation-delta gate, prohibited landing terrain, stacking), keeping the distance pre-filter only as a proven superset bound.
+- [ ] 3.2 Add jump agreement cases: projected-jump-reachable set equals commit-accepted set on fixtures with elevation walls, prohibited landing hexes, and occupied destinations.
+
+## 4. Combat planning range consolidation
+
+- [ ] 4.1 Replace `CombatPlanningPanel` raw `hexDistance` range/bracket computation with reads from the combat projection lookup; fall back to the same exported projection helper when the target hex is outside the lookup.
+- [ ] 4.2 Add a panel render test for the empty-lookup phase (no regression outside combat phases) and a test pinning displayed range/bracket to projection values.
+
+## 5. Movement agreement suite
+
+- [ ] 5.1 Create `InteractiveSession.movementProjectionAgreement.scenario.test.ts` parametrized over the shared tactical-map scenario fixtures × move modes (walk, run, jump + represented vehicle/VTOL/WiGE modes), comparing projection `{reachable, mpCost, terrainCost, elevationDelta, heatGenerated, blockedReason}` against committed-validation outcomes per destination.
+- [ ] 5.2 Assert the commit-path `validatorDisagreement` diagnostic list is empty in every agreement case (CI promotion of W1.3); confirm task 1.2's red probe now passes.
+- [ ] 5.3 Add the explicit `UNSUPPORTED_AGREEMENT_MODES` enumeration assertion so missing fixtures/modes are visible, and dropping a covered mode fails the suite.
+
+## 6. Verification and documentation
+
+- [ ] 6.1 Full verification: `npx tsc --noEmit --skipLibCheck`, lint, affected Jest suites, and the movement+attack agreement suites green; run `npx openspec validate fix-tactical-projection-agreement-gaps --strict`.
+- [ ] 6.2 Update `docs/audits/2026-06-09-remediation-tracker.md` W1.3 row: deferral closed by this change (turning-MP unified, diagnostic promoted to CI assertion).

--- a/openspec/council-decisions/2026-06-12-tactical-map-and-combat-validation-roadmap.md
+++ b/openspec/council-decisions/2026-06-12-tactical-map-and-combat-validation-roadmap.md
@@ -1,0 +1,57 @@
+# OMO Council — Tactical Map Trust + Combat Validation Suite Roadmap
+
+> Date: 2026-06-12 · Variant: Heavy (7 Phase-2 seats + Phase-3 cross-attack) · Judge: VERIFIED (1-pass)
+> Brief origin: user goals "fully trustworthy rules-backed tactical map" + "catalog-driven BattleMech combat validation suite", to be validated against merged work and decomposed into OpenSpec changes via /opsx:ff.
+
+**Headline:** Both goals are ~80% shipped already — the council killed the "build a shared projection layer" framing (the layer exists, and the 2026-06-09 audit's six projection-drift bugs B-1..B-6 were already fixed in merged PRs #801/#802) and replaced it with four bounded units: targeted trust repairs + agreement-test expansion, umbrella closure inside the already-active validation-suite change, and two UI-only legibility changes.
+
+**Brief:** Determine how much of Goal A (rules-backed trustworthy tactical map + 2.5D isometric) and Goal B (catalog-driven combat validation suite) is already satisfied by merged MekStation work, and decompose the remainder into ordered OpenSpec changes with finish-line validations.
+
+**Option space considered:** one mega-change per goal · fine-grained breakout (6+ changes incl. a new `add-combat-projection-contract` foundation) · validation-first vs map-first sequencing · hybrid around a new shared "rules projection API" · descope isometric · continue-vs-restructure the active validation-suite change.
+
+## What is ALREADY satisfied by merged work (validation result)
+
+Verified this session (paths read at worktree HEAD = main `cf6d0b639`):
+
+- **Shared rules-backed projection data exists and is UI-consumed.** `src/utils/gameplay/tacticalMapProjection.ts` (`buildTacticalMapHexProjectionLookup` → `ITacticalMapHexProjection`) merges `IMovementRangeHex` (from `deriveReachableHexes` → engine `getValidDestinations`, `src/utils/gameplay/movement/validation.ts:316`) and `ICombatRangeHex` (from `src/utils/gameplay/combatProjection.ts` using the same `calculateToHit`/`classifyLOS`/`determineArc` primitives as the engine commit path). Per-hex annotations already carried: `mpCost, terrainCost, elevationDelta, elevationCost, heatGenerated, blockedReason, movementInvalidReason, rangeBracket, firingArc, losState, lineOfSightBlocker, targetCoverModifier, toHitNumber, expectedDamage`.
+- **The audit's projection-drift bugs are fixed.** 2026-06-09 audit findings B-1..B-6 (`docs/audits/2026-06-09-full-codebase-review.md:54-59`) were remediated in PR #801 (`db1733614` — projection to-hit hydrated through shared `buildWeaponAttack*ToHitState` builders; attack gates + minimum-range aligned; movement-heat call sites unified; permissive commit fallback removed) and PR #802 (MegaMek rule alignments incl. C-13 sim-runner jump elevation gate, C-15 isometric rotate-before-shear). Tracker: `docs/audits/2026-06-09-remediation-tracker.md` (W0–W6 done; e2e triage T1–T4 done).
+- **A preview↔commit agreement test exists** — `src/engine/InteractiveSession.attackProjectionAgreement.scenario.test.ts` (added in #801, ~40 cases) — but it covers attack/to-hit/LOS/range/arc ONLY; zero movement cases (verified by reading the suite this session).
+- **Isometric is substantially shipped:** discrete rotation (`MapIsometricRotationStep` 0–5), depth sorting (`isometricDepthKey`, `buildIsometricSceneItems` in `src/components/gameplay/HexMapDisplay/HexMapDisplay.isometric.ts`), occlusion ghosting (occlusion sweep in `HexMapDisplay.state.tsx`) — all with tests; rotate-before-shear ordering fixed in W2.
+- **Goal B substrate is complete:** `src/simulation/runner/CombatValidationCatalog.ts` (~20 support-map sections, levels integrated/partial/out-of-scope + evidence + sourceRefs), machine-readable gap export `getCombatValidationUnresolvedRows` (`src/simulation/runner/CombatValidationGapInventory.ts:43`), scope traps + fallback guards (`CombatValidationScopeSupport.ts` — synthetic-medium-laser-fallback-ban L285; WEAPON_DATABASE subset contract pinned in `battlemechCombatCatalog.contract.test.ts:917`), knownLimitations bypass enforced (`src/simulation/core/knownLimitations.ts:166` `KNOWN_LIMITATION_BYPASS_INVARIANTS`), runner `scripts/validate-combat-suite.mjs` (34 Jest files + gap-inventory print + openspec strict validate).
+- **Named hazards re-checked by adversary seat:** ejection lifecycle = COVERED (`src/simulation/runner/__tests__/ejectionLifecycle.integration.test.ts` + intent wire tests); physical catalog vs runtime = COVERED (`physicalWeaponCatalogBoundary.behavior.test.ts:82-105` proves 0 unsupported ids; claws/talons classified modifier-only); WEAPON_DATABASE / synthetic medium laser = real but catalog-pinned (task 3.1.9 checked); MML string damage = contained to display layer; catalog scale = 34 official equipment JSONs (no CI risk).
+
+## What is NOT yet satisfied (the remaining gap)
+
+1. **W1.3 explicit deferral (live):** turning-MP/facing divergence — `validateMovement` charges `calculateGroundPathTurningMpCost`, the reachability projection models no facing; disagreement is surfaced via a `validatorDisagreement` diagnostic only (`movement/commitValidation.ts`), not unified, not CI-asserted.
+2. **Jump-reachability fidelity:** `src/utils/gameplay/movement/reachable.ts` jump candidate gate is flat `hexDistance ≤ jumpMP` (lines ~100-103/149-153) ahead of per-hex legality — preview/commit jump agreement is untested.
+3. **Second source of truth in UI:** `CombatPlanningPanel.tsx:209-217` computes `rangeToTarget` via raw `hexDistance`, bypassing the projection's `combat.distance`/`rangeBracket`.
+4. **Agreement suite has no movement channel:** no reachability/jump/turning preview↔commit cases; vehicle/VTOL movement-mode agreement unverified.
+5. **Top-down legibility:** no persistent per-hex elevation badge in flat view (`formatElevationLabel` exists, wired only to tooltips/isometric labels); non-color-only overlay encodings incomplete.
+6. **Isometric remainder:** stacked elevation extrusion (per-hex skirts) not built; `openspec/specs/camera-controls/spec.md` has zero isometric-rotation requirements (shipped behavior unspecced); rotation animation polish optional.
+7. **Goal B finish line:** active change `openspec/changes/add-battlemech-combat-validation-suite/` held from archive with 6 open umbrella tasks (2.32, 3.1–3.4, 4.3) that are open-ended "expand coverage" families with no convergence criterion.
+
+## Decision — four bounded units of work
+
+| # | Unit | Form | Deltas | Finish-line validation |
+|---|------|------|--------|------------------------|
+| 1 | `fix-tactical-projection-agreement-gaps` | NEW change | movement-system, tactical-map-interface | Agreement suite extended with parametrized movement/jump/turning cases across move modes + unit types (vehicle/VTOL covered or explicitly gap-tracked); `validatorDisagreement` promoted from diagnostic to CI-failing assertion; jump preview legality = engine legality; CombatPlanningPanel consumes projection; suite green. |
+| 2 | Close + archive the ACTIVE change | EDIT active change (no new change; avoids combat-resolution delta conflict) | (existing combat-resolution delta) | Umbrellas 2.32/3.1–3.4/4.3 converted to bounded acceptance criteria enumerated against `getCombatValidationUnresolvedRows`; `validate-combat-suite.mjs` green; gap inventory contains only explicit out-of-scope/gap rows; `openspec validate --strict` green; change archived. |
+| 3 | `add-topdown-tactical-legibility` | NEW change | tactical-map-interface | Persistent per-hex elevation badges in top-down; non-color-only state encodings; per-hex predicted to-hit/cover surfaced in overlay UI; visual smoke + spec scenarios pass. |
+| 4 | `add-isometric-elevation-extrusion` | NEW change | camera-controls, tactical-map-interface | Stacked elevation extrusion skirts depth-sort correctly; shipped rotation/depth-sort/occlusion retro-specced into camera-controls; rotation cycle + reduced-motion tests pass. |
+
+**Sequencing:** Units 1 and 2 are independent — run in parallel lanes. Units 3 and 4 are UI-only, independent of each other, can follow or interleave; nothing blocks on them. No unit authors a combat-resolution delta except the already-active change (Momus's serialization constraint honored).
+
+**Why:** All three proposers withdrew the new-layer/façade architecture in Phase 3 after captain verification showed #801/#802 already delivered the shared-state unification; the structurally-sound half of Metis's kill (no new layer; targeted repairs; close umbrellas in place) became the winning shape. MegaMek prior art (Librarian) confirms the engine-computes/UI-renders pattern MekStation already follows and the golden-corpus catalog-contract pattern (`BulkUnitFileTest`) the suite already mirrors.
+
+**Survival Score:** Killed and replaced (architecture) / Modified (roadmap) — the Phase-2 frontrunner (new engine-side projection façade + 6-change roadmap) died under cross-attack; Prometheus collapsed 6 changes to ~2; the surviving plan is adversary-shaped.
+
+**Trade-offs accepted:** no new façade means UI keeps consuming multiple engine entry points (projection lookup + pure helpers) — agreement tests, not a single boundary, are the divergence guard; isometric rotation animation deferred; rubble-cover rules decision and T2-F1/F2/F3 residue tracked separately (not folded into these units).
+
+**Second-order consequences (6-month):** the agreement suite becomes the standing contract for any future overlay work — new overlay channels must add agreement cases or fail review; archiving the active change restores a clean "no in-flight changes" baseline so future combat work authors fresh deltas without conflict.
+
+**Open risks:** jump-gate severity contested (flat pre-gate may only over-filter rather than show false-reachable hexes — Unit 1 scope could shrink on investigation); umbrella closure may surface new unsupported rows that resist bounding (mitigation: rows may close as explicit out-of-scope, not only as integrated); isometric extrusion may interact with W5 occlusion-sweep performance fixes.
+
+**Dissent on record:** Metis's kill cited audit bugs B-1..B-6 as live when W1 had already fixed them — the factual half failed, the structural half won. Prometheus preferred the W1.3 facing fix as a delta inside the active change; captain ruled it into Unit 1 (movement-system delta — the active change carries only a combat-resolution delta, and the conflict constraint applies only there).
+
+---
+*Appendix* — **Decision crux:** whether projection/engine divergence was structural (missing boundary) or residual (named sites) — #801/#802 evidence settled it as residual. **Context factors:** active change archivability; OpenSpec one-delta-per-capability serialization. **Token cost:** Heavy run, ~700K subagent tokens (7 Phase-2 + 3 Phase-3 + judge).


### PR DESCRIPTION
## Summary

Heavy council run validated the two standing goals (rules-backed tactical map; catalog-driven combat validation suite) against merged work and decomposed the remainder into four bounded units of work. Decision record: `openspec/council-decisions/2026-06-12-tactical-map-and-combat-validation-roadmap.md`.

**Validation findings (what is already shipped):**
- The shared rules-backed projection layer exists and is UI-consumed (`tacticalMapProjection.ts`); audit findings B-1..B-6 were fixed in #801/#802 with a 544-line attack agreement suite.
- Isometric discrete rotation, depth sorting, and occlusion ghosting are shipped with tests.
- The Goal B substrate (catalog, gap export, fallback bans, knownLimitations bypass, validate-combat-suite runner) is complete; ejection lifecycle and physical-catalog runtime coverage verified as closed.

**New artifacts (3 new changes + 1 rescope, all strict-valid, 203/203):**
1. `fix-tactical-projection-agreement-gaps` — closes the W1.3 turning-MP/facing deferral (promotes `validatorDisagreement` to CI assertion), jump candidate-gate parity, CombatPlanningPanel projection consolidation, and a parametrized movement agreement suite. Deltas: movement-system, tactical-map-interface.
2. `add-topdown-tactical-legibility` — persistent per-hex elevation badges + non-color overlay encodings. Delta: tactical-map-interface.
3. `add-isometric-elevation-extrusion` — stacked elevation skirts, camera-controls rotation retro-spec. Deltas: camera-controls (ADDED), tactical-map-interface.
4. Active change `add-battlemech-combat-validation-suite` — open umbrellas 2.32/3.1–3.4/4.3 rescoped into bounded gates tied to `getCombatValidationUnresolvedRows`, plus a closure section (gates → open questions → strict validate → archive).

No new change touches combat-resolution, so nothing conflicts with the active change's delta.

## Test plan

- `npx openspec validate --all --strict` — 203/203 green (docs/openspec-only PR; CI runs the docs-only lane).