### PR TITLE
Establish GM intervention ledger foundation

### DIFF
--- a/openspec/changes/add-gm-intervention-control-plane/.openspec.yaml
+++ b/openspec/changes/add-gm-intervention-control-plane/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-20

--- a/openspec/changes/add-gm-intervention-control-plane/design.md
+++ b/openspec/changes/add-gm-intervention-control-plane/design.md
@@ -1,0 +1,216 @@
+## Context
+
+MekStation already has several pieces of the future GM control surface, but they are not yet a coherent authority model. The tactical command shell supports a `gm` shell mode and TacticalActionDock exposes starter GM command stubs. Gameplay state is event-derived, and campaign sync has ordered event logs. Fog-of-war and event visibility code already establish that different viewers can receive different projections. Encounter launch also snapshots source forces into game units with source references.
+
+The missing layer is a reusable intervention ledger abstraction plus domain implementers. The ledger decides how interventions are previewed, approved, appended, projected, redacted, and replayed. Domain implementers decide what a combat correction, unit reload, future finance reversal, or future time cascade means. The OMO council changed the implementation order from "event schema first" to "authority and redaction first" because GM interventions become replayable canonical history once appended.
+
+Stakeholders:
+
+- Game master: owns the campaign/game state they created and needs high-authority correction tools.
+- Player: needs rules-valid actions and truthful state without hidden GM reasoning or unrevealed scenario context.
+- Replay/sync systems: need deterministic, additive history rather than invisible direct mutations.
+- Future campaign systems: need a pattern that can later expand to post-combat, base/economy, and time cascades.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define a reusable intervention ledger interface that can be implemented by combat now and campaign/economy/time domains later.
+- Define a GM intervention envelope that separates authority, GM-private metadata, public net effect, cascade preview, approval, and additive ledger records.
+- Make authority and redaction the first implementation layer, before reducers or UI command handlers.
+- Support first-slice combat interventions: reposition/facing, damage and critical correction, heat/ammo correction, phase/initiative correction, lifecycle/ejection/withdrawal/destruction/rescue correction, and active-encounter unit customization reload.
+- Preserve live combat overlays during unit reload where possible, while replacing construction/loadout-derived fields from the current source unit definition.
+- Keep player-visible logs and replay streams limited to resulting state and public net effects.
+- Add tests for authority, redaction, cascade preview, event append/replay, reducer projection, unit reload reconciliation, and logging.
+
+**Non-Goals:**
+
+- No broad rewrite of gameplay or campaign event storage.
+- No direct mutation path that bypasses the event history.
+- No UI-first implementation where `shellMode === 'gm'` is treated as sufficient authority.
+- No replacement of normal player undo with GM semantics.
+- No first-slice implementation of post-combat, base/economy, or accumulated time cascades.
+- No change to BattleMech construction tech base rules except preserving and reloading existing construction/loadout fields during unit reconciliation.
+
+## Decisions
+
+### Decision 1: Use a reusable intervention ledger abstraction
+
+The implementation should start from a small ledger abstraction rather than a combat-only service. The ledger owns shared mechanics: append-only records, causality, preview status, public/private projection, approval state, and registered domain implementers. Domain implementers own domain-specific preview/apply rules.
+
+Alternative considered: build direct combat GM functions first and generalize later. Rejected because base/economy/time interventions have the same approval, redaction, and audit needs; building combat as a one-off would make the next phases repeat the same safety work.
+
+Sketch:
+
+```ts
+type InterventionDomain =
+  | 'combat'
+  | 'unit-reload'
+  | 'post-combat'
+  | 'economy'
+  | 'repair'
+  | 'salvage'
+  | 'time';
+
+interface IInterventionLedgerRecord<TPrivate = unknown, TPublic = unknown> {
+  id: string;
+  domain: InterventionDomain;
+  kind: GmInterventionKind;
+  status: 'previewed' | 'approved' | 'cancelled' | 'manual';
+  actorId: string;
+  targetRefs: readonly string[];
+  causedBy?: readonly string[];
+  supersedes?: readonly string[];
+  privateMetadata: TPrivate;
+  publicEffect: TPublic;
+  createdAt: string;
+  approvedAt?: string;
+}
+
+interface IInterventionLedgerImplementer<TCommand, TState> {
+  readonly domain: InterventionDomain;
+  preview(command: TCommand, state: TState): IGmCascadePreview;
+  apply(record: IInterventionLedgerRecord, state: TState): TState;
+  projectPublic(record: IInterventionLedgerRecord): IGmPublicEffect;
+  projectPrivate(record: IInterventionLedgerRecord): IGmPrivateMetadata;
+}
+```
+
+### Decision 2: Authority and redaction come before canonical append
+
+The first code slice should define an authority context and redaction envelope before any GM intervention event can be appended. The authority check answers whether the actor owns the game/campaign state or otherwise has GM authority. The redaction envelope answers which fields are GM-only and which net effect may be shown to players.
+
+Alternative considered: define event types first, then add redaction later. Rejected because the event-sourced gameplay pipeline will replay appended events as canonical history; a poorly shaped payload could leak GM intent or hidden state before redaction is complete.
+
+Sketch:
+
+```ts
+type GmInterventionKind =
+  | 'add'
+  | 'subtract'
+  | 'fix'
+  | 'undo'
+  | 'reload';
+
+interface IGmAuthorityContext {
+  actorId: string;
+  gameId: string;
+  campaignId?: string;
+  ownedStateIds: readonly string[];
+  role: 'gm' | 'player' | 'spectator';
+}
+
+interface IGmPrivateMetadata {
+  reason: string;
+  defaultOutcome?: string;
+  hiddenNotes?: string;
+  manualTakeoverNotes?: string;
+}
+
+interface IGmPublicEffect {
+  summary: string;
+  changedStateRefs: readonly string[];
+  visibleToPlayerIds?: readonly string[];
+}
+```
+
+### Decision 3: GM changes are additive interventions, not replay truncation
+
+GM undo and fixes should append corrective or superseding events. The existing normal undo behavior that truncates/replays history remains a local player/action convenience and should not be reused for GM adjudication.
+
+Alternative considered: reuse the current undo action for GM correction. Rejected because GM actions need auditability and public/private visibility, while history truncation erases the adjudication record.
+
+### Decision 4: Cascade preview is a pure projection before approval
+
+Each GM command should produce a preview from the current state without mutating the session. Approval appends the accepted intervention event; cancellation appends nothing. Manual takeover is used when the preview detects conflicts the system cannot safely resolve.
+
+Sketch:
+
+```ts
+interface IGmCascadePreview {
+  interventionId: string;
+  status: 'ready' | 'requires-manual-takeover' | 'blocked';
+  publicEffect: IGmPublicEffect;
+  privateMetadata: IGmPrivateMetadata;
+  affectedEventIds: readonly string[];
+  projectedEvents: readonly unknown[];
+  conflicts: readonly IGmInterventionConflict[];
+}
+```
+
+### Decision 5: UI calls the intervention pipeline; it does not own authority
+
+TacticalActionDock and tactical shell GM controls should become command surfaces only after the authority/redaction/intervention service is real. The shell may hide or show controls for ergonomics, but the service must reject unauthorized calls even if a UI bug exposes a command.
+
+Alternative considered: gate commands only by shell mode. Rejected because shell mode is presentation state, not ownership proof.
+
+### Decision 6: Unit reload is session reconciliation, not encounter relaunch
+
+Reloading a unit customization in an active encounter should rehydrate source construction/loadout fields by `unitRef` and `pilotRef`, then merge them into the current live unit. Runtime overlays are preserved by default:
+
+- position and facing
+- initiative and phase state
+- damage and critical state where compatible
+- heat
+- ammo and expended resources where compatible
+- pilot state
+- movement locks and committed action state
+- target locks or queued effects that remain valid
+
+If the source change removes a referenced component, changes armor structure enough to invalidate damage mapping, alters ammunition bins, or changes movement profile incompatibly, the preview status becomes `requires-manual-takeover`.
+
+### Decision 7: Campaign expansion follows combat proof
+
+Post-combat amendments, merchant/inventory/finance reversals, repair/salvage corrections, and time-based cascades should follow only after combat interventions prove the authority/redaction/event pattern. Campaign sync and co-op GM arbitration are integration points, not first-slice blockers.
+
+## State Management and Data Flow
+
+Combat first-slice flow:
+
+1. Tactical UI creates a candidate `IGmInterventionCommand`.
+2. Intervention ledger receives the command with `IGmAuthorityContext` and a target domain.
+3. Authority guard rejects non-GM or non-owner requests.
+4. Ledger routes the command to the registered domain implementer.
+5. Redaction envelope builder separates `IGmPrivateMetadata` from `IGmPublicEffect`.
+6. Preview projector computes `IGmCascadePreview` from the current game state and event history.
+7. GM approves, cancels, or takes manual control.
+8. Approved intervention appends an additive ledger record and any domain events needed for state derivation with causality/supersession metadata.
+9. Gameplay reducers derive the new state from the event stream.
+10. Player-facing log/replay projections receive only public net effects and resulting state.
+
+Zustand stores should remain consumers/orchestrators. The store may call the intervention ledger and append approved records/events, but it should not embed ownership, redaction, or cascade resolution rules in component-facing action handlers.
+
+## Validation, Logging, and Errors
+
+- Unauthorized GM intervention attempts MUST be rejected before preview generation and logged without GM-private metadata.
+- Preview generation MUST return structured conflicts instead of partially applying changes.
+- Approved interventions MUST log intervention kind, actor, target refs, public summary, and conflict/manual takeover status.
+- Player-visible logs MUST use the public net-effect payload only.
+- Tests MUST assert that GM-private fields do not appear in player projections, replay payloads, or public action logs.
+
+## Migration Plan
+
+1. Add the authority/redaction envelope types and tests without changing runtime behavior.
+2. Add GM authority/redaction envelope and tests.
+3. Add cascade preview/approval/cancel/manual takeover tests.
+4. Add combat implementer preview/apply reducers for the first-slice actions.
+5. Wire TacticalActionDock GM commands to call the intervention ledger.
+6. Add unit reload reconciliation and conflict/manual takeover tests.
+7. Add later campaign/post-combat/economy/time implementers after combat proof.
+
+Rollback strategy: because the change is additive, disable GM command registration and leave the normal gameplay event flow untouched. Existing combat sessions, campaign event logs, and player actions should continue to run without GM intervention events.
+
+## Risks / Trade-offs
+
+- Authority/redaction model may duplicate some fog-of-war visibility concepts -> Keep GM redaction narrowly focused on intervention metadata and public net effects; reuse fog filtering for player perspective where possible.
+- Unit reload preservation may hide invalid stale state -> Require conflict reporting and manual takeover when structural mapping is ambiguous.
+- Too many GM event types may fragment reducers -> Use a small intervention envelope plus focused projected events for state mutation where existing events already express the public state.
+- Campaign cascades may become complex quickly -> Defer them until combat establishes the event and redaction pattern.
+- Public net-effect logs may be too terse for player trust -> Include resulting state and visible changed refs, but keep private reason/default outcome GM-only.
+
+## Open Questions
+
+- Should a GM intervention event itself mutate state, or should it act as an audit wrapper around one or more projected domain events?
+- What is the exact owner identity source for local-only, hosted co-op, and future server-backed sessions?
+- Should manual takeover produce a distinct event kind, or the same intervention kind with `status: 'manual'` metadata?
+- How should partial unit reload conflicts be presented in the first UI pass: checklist, diff table, or staged conflict cards?

--- a/openspec/changes/add-gm-intervention-control-plane/proposal.md
+++ b/openspec/changes/add-gm-intervention-control-plane/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+MekStation needs game-master interventions to be authoritative, auditable, and safe for multiplayer visibility before tactical overrides become part of replayable combat history. The current tactical shell has GM-facing command stubs, but the codebase does not yet define owned-state authority, GM-private metadata, player-safe redaction, or additive undo/fix semantics for GM actions.
+
+## What Changes
+
+- Add a GM intervention control plane for owned campaign/game state that separates GM-only intent from player-visible net effects.
+- Define authority and redaction rules before any GM intervention can be appended to canonical combat or campaign history.
+- Introduce additive GM intervention actions for `add`, `subtract`, `fix`, `undo`, and `reload`, with approval, causality, cascade preview, and public result summaries.
+- Support the first combat intervention slice: reposition/facing, damage and critical correction, heat/ammo correction, phase/initiative correction, lifecycle/ejection/withdrawal/destruction/rescue correction, and active-encounter unit customization reload.
+- Treat unit customization reload as session reconciliation: reload construction/loadout-derived data from the source unit while preserving live combat overlays by default and escalating conflicts to GM manual takeover.
+- Defer post-combat amendments, base/economy fixes, and accumulated time cascades until the combat authority/redaction/event pipeline is proven.
+
+## Non-goals
+
+- No broad rewrite of the existing gameplay or campaign event stores.
+- No UI-first implementation where TacticalActionDock or shell mode becomes the authority source.
+- No replacement of normal player undo; GM undo is additive correction/supersession, not history truncation.
+- No campaign-wide economy/time cascade implementation in the first slice.
+- No exposure of hidden GM reasoning, private scenario notes, or unrevealed cascade details to non-GM players.
+
+## Capabilities
+
+### New Capabilities
+
+- `intervention-ledger-abstraction`: Covers reusable append-only ledger interfaces for GM intervention records, projections, causality, redaction, approval state, and domain implementers.
+- `gm-authority-redaction`: Covers owned-state GM authority checks and the separation of GM-private metadata from player-public net effects.
+- `gm-cascade-preview`: Covers pre-commit preview generation, approval, cancellation, conflict reporting, manual takeover, and unsupported/deferred outcomes.
+- `gm-combat-interventions`: Covers first-slice tactical combat intervention implementers for reposition/facing, damage/criticals, heat/ammo, phase/initiative, and lifecycle correction.
+- `gm-unit-reload-reconciliation`: Covers active-encounter unit customization reload as a ledger-backed reconciliation implementer that preserves live overlays and escalates conflicts.
+- `gm-campaign-intervention-boundaries`: Covers explicit first-slice deferral boundaries and future extension seams for post-combat, base/economy, repair/salvage, and accumulated time cascades.
+
+### Modified Capabilities
+
+- None. Existing event, session, fog-of-war, encounter, co-op, campaign sync, and command UI specs remain integration points; new GM intervention requirements live in split cross-cutting capabilities until implementation proves which existing capabilities need durable requirement deltas.
+
+## Impact
+
+- Affected tactical systems: tactical shell mode, TacticalActionDock GM commands, reusable intervention ledger adapters, gameplay event append/replay, state reducers, event visibility filtering, and combat event display/logging.
+- Affected campaign systems: co-op host/GM arbitration patterns, campaign sync vocabulary, ordered campaign event logs, post-combat review, finances/inventory/repair/salvage/time cascades in later phases.
+- Affected encounter/unit systems: encounter launch hydration, unitRef/pilotRef source lookups, custom unit version reads, and active session unit reconciliation.
+- Affected tests: authority and redaction tests, GM intervention event contract tests, reducer/cascade preview tests, public/private log tests, unit reload reconciliation tests, and regression coverage proving normal player actions remain rules-constrained.

--- a/openspec/changes/add-gm-intervention-control-plane/specs/gm-authority-redaction/spec.md
+++ b/openspec/changes/add-gm-intervention-control-plane/specs/gm-authority-redaction/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: GM Owned-State Authority
+
+The system SHALL allow GM intervention actions only when the requesting actor has GM authority over the target game or campaign state. Presentation state such as tactical shell mode SHALL NOT be sufficient authority by itself.
+
+#### Scenario: Owner GM can preview intervention
+- **GIVEN** an actor with GM authority over game `G`
+- **WHEN** the actor requests a GM intervention preview for game `G`
+- **THEN** the system SHALL evaluate the intervention request
+- **AND** the system SHALL return either a preview, conflict list, or blocked result
+
+#### Scenario: Non-owner player is rejected
+- **GIVEN** an actor without GM authority over game `G`
+- **WHEN** the actor requests a GM intervention preview for game `G`
+- **THEN** the system SHALL reject the request before preview generation
+- **AND** no GM intervention event SHALL be appended
+- **AND** no GM-private metadata SHALL be returned to the actor
+
+### Requirement: GM Private Metadata Redaction
+
+The system SHALL separate GM-private metadata from player-public net effects for every GM intervention. GM-private metadata SHALL NOT appear in player-facing action logs, player replay streams, player event projections, or non-GM UI state.
+
+#### Scenario: Player log receives only public net effect
+- **GIVEN** an approved GM intervention with a private reason and a public summary
+- **WHEN** a non-GM player views the action log
+- **THEN** the log SHALL show the public summary and resulting changed state
+- **AND** the log SHALL NOT show the private reason, hidden notes, default outcome, or manual takeover notes
+
+#### Scenario: GM ledger receives full intervention detail
+- **GIVEN** an approved GM intervention with private metadata and a public summary
+- **WHEN** the owning GM views the GM ledger
+- **THEN** the ledger SHALL show the private metadata
+- **AND** the ledger SHALL show the public net effect that players can see
+
+### Requirement: Authorization Failure Logging
+
+The system SHALL log rejected GM intervention attempts with actor, target, domain, and rejection reason, but SHALL NOT log GM-private metadata to player-visible logs.
+
+#### Scenario: Unauthorized request produces safe log
+- **GIVEN** a non-owner player attempts a GM intervention
+- **WHEN** the authority guard rejects the request
+- **THEN** the system SHALL produce an internal rejection log entry
+- **AND** no player-visible log entry SHALL include private GM metadata

--- a/openspec/changes/add-gm-intervention-control-plane/specs/gm-campaign-intervention-boundaries/spec.md
+++ b/openspec/changes/add-gm-intervention-control-plane/specs/gm-campaign-intervention-boundaries/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: First Slice Defers Campaign Cascades
+
+The first implementation slice SHALL limit runtime application to combat interventions and SHALL defer post-combat amendments, base/economy corrections, repair/salvage corrections, and accumulated time cascades until the combat authority/redaction/ledger pipeline is validated.
+
+#### Scenario: Base economy intervention is not silently applied
+- **GIVEN** a GM requests a merchant transaction reversal before the base/economy cascade phase is implemented
+- **WHEN** the intervention pipeline evaluates the request
+- **THEN** the system SHALL return an explicit unsupported or deferred result
+- **AND** the system SHALL NOT silently mutate finances or inventory
+
+#### Scenario: Time cascade intervention is not silently applied
+- **GIVEN** a GM requests an accumulated time correction before the time cascade phase is implemented
+- **WHEN** the intervention pipeline evaluates the request
+- **THEN** the system SHALL return an explicit unsupported or deferred result
+- **AND** the system SHALL NOT advance or rewind campaign time
+
+### Requirement: Future Campaign Implementer Seams
+
+The system SHALL document extension seams for future intervention ledger implementers that target post-combat, base/economy, repair, salvage, and accumulated time domains.
+
+#### Scenario: Future domain declares required state roots
+- **GIVEN** a future campaign-domain implementer is designed
+- **WHEN** it declares its intervention domain
+- **THEN** it SHALL identify the state roots it can mutate
+- **AND** it SHALL identify the public projection fields that non-GM players may see
+
+### Requirement: Deferred Domain Logging
+
+The system SHALL log deferred domain intervention attempts so missing campaign support is visible during testing without applying unsupported state changes.
+
+#### Scenario: Deferred request is logged safely
+- **GIVEN** a GM requests a deferred time cascade intervention
+- **WHEN** the intervention pipeline returns a deferred result
+- **THEN** the system SHALL log the domain, actor, target refs, and deferred reason
+- **AND** the log SHALL NOT include hidden scenario notes in any player-visible output

--- a/openspec/changes/add-gm-intervention-control-plane/specs/gm-cascade-preview/spec.md
+++ b/openspec/changes/add-gm-intervention-control-plane/specs/gm-cascade-preview/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Preview Before Commit
+
+The system SHALL compute a cascade preview before applying any GM intervention. The preview SHALL include public net effect, GM-private context, affected state references, projected event effects, and conflicts. No state mutation SHALL occur until the GM approves the preview or completes manual takeover.
+
+#### Scenario: Preview does not mutate state
+- **GIVEN** a current game state `S`
+- **WHEN** the GM requests a preview for a damage correction
+- **THEN** the system SHALL return the projected net effect
+- **AND** the current game state SHALL remain equal to `S`
+- **AND** no intervention event SHALL be appended
+
+### Requirement: Approval and Cancellation
+
+The system SHALL append an intervention record only after GM approval. Cancelling a preview SHALL append no intervention and SHALL leave state unchanged.
+
+#### Scenario: Approval appends accepted intervention
+- **GIVEN** a ready GM intervention preview
+- **WHEN** the GM approves the preview
+- **THEN** the system SHALL append the approved intervention to canonical history
+- **AND** the derived game state SHALL reflect the approved net effect
+
+#### Scenario: Cancellation appends nothing
+- **GIVEN** a ready GM intervention preview
+- **WHEN** the GM cancels the preview
+- **THEN** no intervention record SHALL be appended
+- **AND** derived game state SHALL remain unchanged
+
+### Requirement: Conflict and Manual Takeover Result
+
+The preview pipeline SHALL return a manual-takeover result when the system cannot safely resolve a cascade automatically. The system SHALL NOT append the intervention until the GM resolves or accepts the conflict handling.
+
+#### Scenario: Conflict requires manual takeover
+- **GIVEN** a GM intervention preview with conflicts the system cannot resolve safely
+- **WHEN** the preview is returned
+- **THEN** the preview status SHALL indicate manual takeover is required
+- **AND** the system SHALL NOT append the intervention until the GM resolves or accepts the conflict handling
+
+### Requirement: Deferred Domain Result
+
+The preview pipeline SHALL return explicit deferred or unsupported results for domains that are not implemented in the current slice.
+
+#### Scenario: Deferred domain does not mutate state
+- **GIVEN** the economy domain is not implemented
+- **WHEN** the GM previews a merchant transaction reversal
+- **THEN** the preview pipeline SHALL return a deferred or unsupported result
+- **AND** finances and inventory SHALL remain unchanged

--- a/openspec/changes/add-gm-intervention-control-plane/specs/gm-combat-interventions/spec.md
+++ b/openspec/changes/add-gm-intervention-control-plane/specs/gm-combat-interventions/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: Tactical Combat Intervention Implementer
+
+The system SHALL provide a combat-domain intervention implementer for the reusable intervention ledger. The implementer SHALL support first-slice GM corrections for reposition/facing, damage and criticals, heat/ammo, phase/initiative, turn ownership, and lifecycle state.
+
+#### Scenario: Combat implementer registers with ledger
+- **GIVEN** the GM intervention ledger initializes
+- **WHEN** the combat intervention implementer is registered
+- **THEN** commands targeting the combat domain SHALL route through the combat implementer
+- **AND** commands targeting unregistered domains SHALL NOT route through the combat implementer
+
+### Requirement: Combat State Corrections
+
+The combat intervention implementer SHALL preview and apply approved corrections to derived combat state through additive intervention records and reducer-compatible projected effects.
+
+#### Scenario: GM repositions unit
+- **GIVEN** the GM has authority over an active game
+- **WHEN** the GM approves a reposition intervention for a unit
+- **THEN** the derived game state SHALL show the unit at the approved coordinate and facing
+- **AND** the player-visible log SHALL show only the resulting position/facing change
+
+#### Scenario: GM corrects damage and critical state
+- **GIVEN** the GM has authority over an active game
+- **WHEN** the GM approves a damage and critical correction
+- **THEN** the derived game state SHALL reflect the approved armor, structure, and critical state
+- **AND** the intervention SHALL remain traceable as a GM correction
+
+#### Scenario: GM corrects heat and ammo
+- **GIVEN** the GM has authority over an active game
+- **WHEN** the GM approves a heat or ammo correction
+- **THEN** the derived game state SHALL reflect the approved heat or ammunition values
+- **AND** the player-visible net effect SHALL NOT reveal hidden GM reasoning
+
+### Requirement: Turn and Lifecycle Corrections
+
+The combat intervention implementer SHALL preview and apply approved corrections to phase, initiative, turn ownership, ejection, withdrawal, disabled, destroyed, and rescued states.
+
+#### Scenario: GM corrects phase or initiative
+- **GIVEN** the GM has authority over an active game
+- **WHEN** the GM approves a phase, initiative, or turn ownership correction
+- **THEN** the derived game state SHALL reflect the approved phase or initiative order
+- **AND** normal player actions SHALL continue to be validated against the corrected state
+
+#### Scenario: GM corrects lifecycle state
+- **GIVEN** the GM has authority over an active game
+- **WHEN** the GM approves an ejection, withdrawal, disabled, destroyed, or rescued-state correction
+- **THEN** the derived game state SHALL reflect the approved lifecycle state
+- **AND** player-facing logs SHALL show only the resulting state change

--- a/openspec/changes/add-gm-intervention-control-plane/specs/gm-unit-reload-reconciliation/spec.md
+++ b/openspec/changes/add-gm-intervention-control-plane/specs/gm-unit-reload-reconciliation/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Active Encounter Unit Reload Implementer
+
+The system SHALL provide a reload intervention implementer that rehydrates construction/loadout-derived fields from the current source unit definition into an active encounter without resetting the encounter.
+
+#### Scenario: Reload uses source references
+- **GIVEN** an active encounter unit has `unitRef` and `pilotRef`
+- **WHEN** the GM previews a unit reload intervention
+- **THEN** the reload implementer SHALL read the current source unit definition by `unitRef`
+- **AND** the reload implementer SHALL read the current pilot data by `pilotRef` when pilot data is required
+
+### Requirement: Reload Preserves Compatible Live Overlays
+
+The reload implementer SHALL preserve compatible live combat overlays by default while replacing construction/loadout-derived fields from the source unit.
+
+#### Scenario: Reload preserves live overlays by default
+- **GIVEN** an active encounter unit has a source unit reference and live combat overlays
+- **WHEN** the GM previews a unit reload intervention
+- **THEN** the preview SHALL replace construction/loadout-derived fields from the source unit
+- **AND** the preview SHALL preserve position, facing, initiative state, phase state, damage state, heat, ammo, pilot state, movement locks, and committed action state where compatible
+
+### Requirement: Reload Conflict Manual Takeover
+
+The reload implementer SHALL identify conflicts where live overlays cannot be safely preserved and SHALL require GM manual takeover before commit.
+
+#### Scenario: Reload conflict escalates to manual takeover
+- **GIVEN** a source unit update removes or changes data needed to preserve live overlays
+- **WHEN** the GM previews a unit reload intervention
+- **THEN** the preview SHALL identify the conflicting fields
+- **AND** the preview SHALL require GM manual takeover before commit
+
+### Requirement: Reload Does Not Reset Encounter
+
+The reload implementer SHALL update only the targeted active unit and SHALL preserve unrelated units, encounter status, and prior event history.
+
+#### Scenario: Reload does not reset encounter
+- **GIVEN** an active encounter with multiple units and an event history
+- **WHEN** the GM approves a reload intervention for one unit
+- **THEN** the encounter SHALL remain active
+- **AND** unrelated units and prior event history SHALL remain present

--- a/openspec/changes/add-gm-intervention-control-plane/specs/intervention-ledger-abstraction/spec.md
+++ b/openspec/changes/add-gm-intervention-control-plane/specs/intervention-ledger-abstraction/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Reusable Intervention Ledger Interface
+
+The system SHALL define a reusable append-only intervention ledger abstraction that can be implemented by combat, campaign, economy, repair, salvage, and time-cascade domains without changing the public GM intervention contract.
+
+#### Scenario: Domain implements ledger interface
+- **GIVEN** a domain-specific implementer for combat interventions
+- **WHEN** the implementer is registered with the intervention ledger
+- **THEN** the implementer SHALL expose append, preview projection, public projection, private projection, and replay application entry points
+- **AND** the implementer SHALL identify its domain key
+
+#### Scenario: Unsupported domain is explicit
+- **GIVEN** no registered implementer exists for domain `economy`
+- **WHEN** a GM intervention command targets domain `economy`
+- **THEN** the ledger abstraction SHALL return an explicit unsupported result
+- **AND** the ledger SHALL NOT silently mutate economy state
+
+### Requirement: Append-Only Causality Contract
+
+The intervention ledger SHALL append approved intervention records and SHALL preserve causality references to prior events, prior intervention records, or affected state references. It SHALL NOT truncate canonical gameplay or campaign history.
+
+#### Scenario: Superseding correction preserves original event
+- **GIVEN** a prior event `E` exists in canonical history
+- **WHEN** an approved GM correction supersedes `E`
+- **THEN** the ledger SHALL append a new intervention record linked to `E`
+- **AND** event `E` SHALL remain present in history
+
+### Requirement: Private and Public Ledger Projections
+
+The intervention ledger SHALL expose separate projection functions for GM-private review and player-public output. Public projection SHALL include only net effect and visible changed state. Private projection MAY include GM reason, default outcome, hidden notes, and manual takeover notes.
+
+#### Scenario: Same record projects differently by viewer authority
+- **GIVEN** an intervention record with private metadata and public net effect
+- **WHEN** the record is projected for a player
+- **THEN** the projection SHALL omit private metadata
+- **WHEN** the same record is projected for the owning GM
+- **THEN** the projection MAY include private metadata

--- a/openspec/changes/add-gm-intervention-control-plane/tasks.md
+++ b/openspec/changes/add-gm-intervention-control-plane/tasks.md
@@ -1,0 +1,67 @@
+## 1. Intervention Ledger Abstraction
+
+- [x] 1.1 Add reusable intervention ledger types for domain, intervention kind, append-only record, causality refs, approval status, public projection, private projection, and conflict details.
+- [x] 1.2 Add the intervention ledger implementer interface with preview, apply, public projection, private projection, and domain key entry points.
+- [x] 1.3 Implement ledger registration/routing so combat and unit reload can register as first-slice implementers while economy/time return explicit unsupported results.
+- [x] 1.4 Add tests proving registered domains route to their implementer and unregistered domains return unsupported without mutation.
+- [x] 1.5 Add tests proving the same ledger record projects differently for GM-private and player-public viewers.
+
+## 2. Authority and Redaction Envelope
+
+- [ ] 2.1 Add GM authority context for actor, game, optional campaign, owned-state refs, and role.
+- [ ] 2.2 Implement an authority guard that rejects non-GM or non-owner requests before preview generation.
+- [ ] 2.3 Implement redaction helpers that split GM-private metadata from player-public net effects.
+- [ ] 2.4 Add unit tests proving non-owner player requests are rejected before preview generation and append no records/events.
+- [ ] 2.5 Add unit tests proving player-visible payloads exclude private reason, hidden notes, default outcome, and manual takeover notes.
+- [ ] 2.6 Add safe internal logging for rejected authorization attempts.
+
+## 3. Cascade Preview Pipeline
+
+- [ ] 3.1 Implement pure preview generation for GM interventions that returns public net effect, private context, projected event effects, affected refs, and conflicts without mutating state.
+- [ ] 3.2 Implement approval flow that appends accepted intervention events only after GM approval.
+- [ ] 3.3 Implement blocked/deferred results for unsupported first-slice requests such as merchant reversal or accumulated time correction.
+- [ ] 3.4 Add tests proving preview does not mutate current game state or append events.
+- [ ] 3.5 Add tests proving approval appends the accepted intervention and updates derived state through normal event replay.
+- [ ] 3.6 Add regression coverage proving normal player undo remains separate from GM undo semantics.
+
+## 4. Combat Intervention Implementer
+
+- [ ] 4.1 Register a combat-domain implementer with the reusable intervention ledger.
+- [ ] 4.2 Implement preview/apply support for reposition and facing corrections.
+- [ ] 4.3 Implement preview/apply support for damage and critical state corrections.
+- [ ] 4.4 Implement preview/apply support for heat and ammo corrections.
+- [ ] 4.5 Implement preview/apply support for phase, initiative, and turn ownership corrections.
+- [ ] 4.6 Implement preview/apply support for ejection, withdrawal, disabled, destroyed, and rescued lifecycle corrections.
+- [ ] 4.7 Add reducer and replay tests for every first-slice combat intervention family.
+
+## 5. Unit Reload Implementer
+
+- [ ] 5.1 Register a unit-reload-domain implementer with the reusable intervention ledger.
+- [ ] 5.2 Implement active-encounter unit reload preview that rehydrates construction/loadout-derived fields from the source unit by `unitRef` and pilot data by `pilotRef`.
+- [ ] 5.3 Preserve compatible live overlays by default: position, facing, initiative/phase state, damage state, heat, ammo, pilot state, movement locks, and committed action state.
+- [ ] 5.4 Detect reload conflicts for removed components, incompatible armor/structure mapping, changed ammo bins, changed movement profile, or invalid target/queued effects.
+- [ ] 5.5 Add manual-takeover result support for reload conflicts and block commit until the GM resolves or accepts conflict handling.
+- [ ] 5.6 Add tests proving reload updates one active unit without resetting the encounter, unrelated units, or prior event history.
+
+## 6. Tactical Command Surface
+
+- [ ] 6.1 Replace TacticalActionDock GM command stubs with calls into the GM intervention preview pipeline.
+- [ ] 6.2 Ensure shell mode controls visibility/ergonomics only; service-level authority remains required for every GM command.
+- [ ] 6.3 Add confirmation UI that shows GM-private detail, player-public net effect, conflicts, and manual-takeover state before approval.
+- [ ] 6.4 Add player-facing log/replay UI coverage showing only resulting state and public net effect.
+- [ ] 6.5 Add accessibility coverage for the GM confirmation/manual takeover controls.
+
+## 7. Campaign Boundary and Deferred Cascades
+
+- [ ] 7.1 Add explicit deferred/unsupported results for post-combat, base/economy, repair/salvage, and time-cascade interventions in the first slice.
+- [ ] 7.2 Document future implementer seams for post-combat, campaign sync, co-op GM arbitration, finance/inventory reversal, repair/salvage correction, and time cascade phases.
+- [ ] 7.3 Add tests proving deferred campaign interventions do not silently mutate finances, inventory, repair queues, salvage, travel, or campaign time.
+- [ ] 7.4 Add safe logging for deferred domain attempts without leaking hidden scenario notes to player-visible output.
+
+## 8. Validation
+
+- [ ] 8.1 Run targeted GM intervention unit tests and integration tests.
+- [ ] 8.2 Run relevant gameplay event/reducer, fog/redaction, encounter launch, and tactical command tests.
+- [ ] 8.3 Run LSP diagnostics or TypeScript checks over changed files.
+- [ ] 8.4 Run `cmd /c openspec validate add-gm-intervention-control-plane --strict`.
+- [ ] 8.5 Update the task checklist with completed verification evidence before archive or PR handoff.

--- a/src/lib/interventions/InterventionLedger.ts
+++ b/src/lib/interventions/InterventionLedger.ts
@@ -1,0 +1,133 @@
+import type {
+  IInterventionLedgerCommand,
+  IInterventionLedgerImplementer,
+  IInterventionLedgerPreview,
+  IInterventionLedgerRecord,
+  InterventionApplyResult,
+  InterventionDomain,
+} from '@/types/interventions';
+
+export interface IInterventionLedgerOptions {
+  readonly unsupportedReason?: (domain: InterventionDomain) => string;
+}
+
+const defaultUnsupportedReason = (domain: InterventionDomain): string =>
+  `No intervention ledger implementer registered for domain "${domain}".`;
+
+export class InterventionLedger<TState = unknown> {
+  private readonly implementers = new Map<
+    InterventionDomain,
+    IInterventionLedgerImplementer<IInterventionLedgerCommand, TState>
+  >();
+
+  private readonly records: IInterventionLedgerRecord[] = [];
+
+  constructor(private readonly options: IInterventionLedgerOptions = {}) {}
+
+  register(
+    implementer: IInterventionLedgerImplementer<
+      IInterventionLedgerCommand,
+      TState
+    >,
+  ): this {
+    if (this.implementers.has(implementer.domain)) {
+      throw new Error(
+        `Intervention ledger implementer already registered for domain "${implementer.domain}".`,
+      );
+    }
+
+    this.implementers.set(implementer.domain, implementer);
+    return this;
+  }
+
+  hasImplementer(domain: InterventionDomain): boolean {
+    return this.implementers.has(domain);
+  }
+
+  preview(
+    command: IInterventionLedgerCommand,
+    state: TState,
+  ): IInterventionLedgerPreview {
+    const implementer = this.implementers.get(command.domain);
+    if (!implementer) {
+      return {
+        domain: command.domain,
+        kind: command.kind,
+        status: 'unsupported',
+        actorId: command.actorId,
+        targetRefs: command.targetRefs,
+        causedBy: command.causedBy,
+        supersedes: command.supersedes,
+        conflicts: [],
+        reason: this.unsupportedReason(command.domain),
+      };
+    }
+
+    return implementer.preview(command, state);
+  }
+
+  appendApprovedRecord(
+    record: IInterventionLedgerRecord,
+  ): IInterventionLedgerRecord {
+    if (record.status !== 'approved' && record.status !== 'manual') {
+      throw new Error(
+        `Cannot append intervention record "${record.id}" with status "${record.status}".`,
+      );
+    }
+
+    this.records.push(record);
+    return record;
+  }
+
+  apply(
+    record: IInterventionLedgerRecord,
+    state: TState,
+  ): InterventionApplyResult<TState> {
+    const implementer = this.implementers.get(record.domain);
+    if (!implementer) {
+      return {
+        status: 'unsupported',
+        domain: record.domain,
+        kind: record.kind,
+        reason: this.unsupportedReason(record.domain),
+        state,
+      };
+    }
+
+    return {
+      status: 'applied',
+      domain: record.domain,
+      record,
+      state: implementer.apply(record, state),
+    };
+  }
+
+  projectPublic<TPublic = unknown>(record: IInterventionLedgerRecord): TPublic {
+    const implementer = this.implementers.get(record.domain);
+    if (!implementer) {
+      return record.publicEffect as TPublic;
+    }
+
+    return implementer.projectPublic(record) as TPublic;
+  }
+
+  projectPrivate<TPrivate = unknown>(
+    record: IInterventionLedgerRecord,
+  ): TPrivate {
+    const implementer = this.implementers.get(record.domain);
+    if (!implementer) {
+      return record.privateMetadata as TPrivate;
+    }
+
+    return implementer.projectPrivate(record) as TPrivate;
+  }
+
+  getRecords(): readonly IInterventionLedgerRecord[] {
+    return [...this.records];
+  }
+
+  private unsupportedReason(domain: InterventionDomain): string {
+    const { unsupportedReason = defaultUnsupportedReason } = this.options;
+    return unsupportedReason(domain);
+  }
+}

--- a/src/lib/interventions/__tests__/InterventionLedger.test.ts
+++ b/src/lib/interventions/__tests__/InterventionLedger.test.ts
@@ -1,0 +1,224 @@
+import type {
+  IInterventionLedgerCommand,
+  IInterventionLedgerImplementer,
+  IInterventionLedgerPreview,
+  IInterventionLedgerRecord,
+} from '@/types/interventions';
+
+import { InterventionLedger } from '../InterventionLedger';
+
+interface CounterState {
+  readonly value: number;
+}
+
+interface TestPrivateMetadata {
+  readonly reason: string;
+  readonly hiddenNotes: string;
+}
+
+interface TestPublicEffect {
+  readonly summary: string;
+  readonly changedStateRefs: readonly string[];
+}
+
+interface TestDomainPayload {
+  readonly delta: number;
+}
+
+const makeRecord = (
+  overrides: Partial<
+    IInterventionLedgerRecord<
+      TestPrivateMetadata,
+      TestPublicEffect,
+      TestDomainPayload
+    >
+  > = {},
+): IInterventionLedgerRecord<
+  TestPrivateMetadata,
+  TestPublicEffect,
+  TestDomainPayload
+> => ({
+  id: 'gm-int-1',
+  domain: 'combat',
+  kind: 'fix',
+  status: 'approved',
+  actorId: 'gm-1',
+  targetRefs: ['unit-1'],
+  causedBy: ['event-prior'],
+  supersedes: ['event-old-damage'],
+  privateMetadata: {
+    reason: 'Correct missed armor damage.',
+    hiddenNotes: 'NPC ambush remains hidden.',
+  },
+  publicEffect: {
+    summary: 'Unit armor corrected.',
+    changedStateRefs: ['unit-1'],
+  },
+  domainPayload: {
+    delta: 2,
+  },
+  createdAt: '2026-06-20T00:00:00.000Z',
+  approvedAt: '2026-06-20T00:01:00.000Z',
+  ...overrides,
+});
+
+const combatImplementer: IInterventionLedgerImplementer<
+  IInterventionLedgerCommand<TestDomainPayload>,
+  CounterState,
+  TestPrivateMetadata,
+  TestPublicEffect,
+  TestDomainPayload
+> = {
+  domain: 'combat',
+  preview(
+    command,
+  ): IInterventionLedgerPreview<
+    TestPrivateMetadata,
+    TestPublicEffect,
+    TestDomainPayload
+  > {
+    return {
+      domain: command.domain,
+      kind: command.kind,
+      status: 'ready',
+      actorId: command.actorId,
+      targetRefs: command.targetRefs,
+      causedBy: command.causedBy,
+      supersedes: command.supersedes,
+      privateMetadata: {
+        reason: 'GM preview reason',
+        hiddenNotes: 'GM-only note',
+      },
+      publicEffect: {
+        summary: 'Public preview summary',
+        changedStateRefs: command.targetRefs,
+      },
+      domainPayload: command.payload,
+      projectedEvents: [],
+      conflicts: [],
+    };
+  },
+  apply(record, state): CounterState {
+    return {
+      value: state.value + (record.domainPayload?.delta ?? 0),
+    };
+  },
+  projectPublic(record): TestPublicEffect {
+    return {
+      summary: record.publicEffect.summary,
+      changedStateRefs: record.publicEffect.changedStateRefs,
+    };
+  },
+  projectPrivate(record): TestPrivateMetadata {
+    return record.privateMetadata;
+  },
+};
+
+describe('InterventionLedger', () => {
+  it('routes registered domains through their implementer', () => {
+    const ledger = new InterventionLedger<CounterState>().register(
+      combatImplementer,
+    );
+
+    const command: IInterventionLedgerCommand<TestDomainPayload> = {
+      domain: 'combat',
+      kind: 'fix',
+      actorId: 'gm-1',
+      targetRefs: ['unit-1'],
+      payload: { delta: 3 },
+      causedBy: ['event-prior'],
+      supersedes: ['event-old-damage'],
+    };
+
+    const preview = ledger.preview(command, { value: 1 });
+    expect(preview.status).toBe('ready');
+    expect(preview.domain).toBe('combat');
+    expect(preview.publicEffect).toEqual({
+      summary: 'Public preview summary',
+      changedStateRefs: ['unit-1'],
+    });
+
+    const record = makeRecord({ domainPayload: { delta: 3 } });
+    const result = ledger.apply(record, { value: 1 });
+
+    expect(result.status).toBe('applied');
+    if (result.status === 'applied') {
+      expect(result.state).toEqual({ value: 4 });
+    }
+  });
+
+  it('returns explicit unsupported results for unregistered domains without mutating state', () => {
+    const ledger = new InterventionLedger<CounterState>();
+    const state = { value: 7 };
+
+    const preview = ledger.preview(
+      {
+        domain: 'economy',
+        kind: 'undo',
+        actorId: 'gm-1',
+        targetRefs: ['merchant-tx-1'],
+      },
+      state,
+    );
+
+    expect(preview).toMatchObject({
+      domain: 'economy',
+      kind: 'undo',
+      status: 'unsupported',
+      actorId: 'gm-1',
+      targetRefs: ['merchant-tx-1'],
+    });
+    expect(preview.reason).toContain('economy');
+
+    const result = ledger.apply(makeRecord({ domain: 'economy' }), state);
+
+    expect(result).toMatchObject({
+      status: 'unsupported',
+      domain: 'economy',
+      state,
+    });
+    expect(result.state).toBe(state);
+  });
+
+  it('appends approved records without truncating prior causality references', () => {
+    const ledger = new InterventionLedger<CounterState>();
+    const record = makeRecord();
+
+    ledger.appendApprovedRecord(record);
+    const records = ledger.getRecords();
+
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      id: 'gm-int-1',
+      causedBy: ['event-prior'],
+      supersedes: ['event-old-damage'],
+    });
+    expect(records[0]).toBe(record);
+  });
+
+  it('rejects non-approved records from the append-only approved ledger path', () => {
+    const ledger = new InterventionLedger<CounterState>();
+    const record = makeRecord({ status: 'previewed' });
+
+    expect(() => ledger.appendApprovedRecord(record)).toThrow(
+      /Cannot append intervention record/,
+    );
+    expect(ledger.getRecords()).toEqual([]);
+  });
+
+  it('projects the same record differently for public and private viewers', () => {
+    const ledger = new InterventionLedger<CounterState>().register(
+      combatImplementer,
+    );
+    const record = makeRecord();
+
+    expect(ledger.projectPublic<TestPublicEffect>(record)).toEqual({
+      summary: 'Unit armor corrected.',
+      changedStateRefs: ['unit-1'],
+    });
+    expect(ledger.projectPrivate<TestPrivateMetadata>(record)).toEqual({
+      reason: 'Correct missed armor damage.',
+      hiddenNotes: 'NPC ambush remains hidden.',
+    });
+  });
+});

--- a/src/lib/interventions/index.ts
+++ b/src/lib/interventions/index.ts
@@ -1,0 +1,4 @@
+export {
+  InterventionLedger,
+  type IInterventionLedgerOptions,
+} from './InterventionLedger';

--- a/src/types/interventions/InterventionLedgerTypes.ts
+++ b/src/types/interventions/InterventionLedgerTypes.ts
@@ -1,0 +1,124 @@
+export type KnownInterventionDomain =
+  | 'combat'
+  | 'unit-reload'
+  | 'post-combat'
+  | 'economy'
+  | 'repair'
+  | 'salvage'
+  | 'time';
+
+export type InterventionDomain = KnownInterventionDomain | (string & {});
+
+export type GmInterventionKind = 'add' | 'subtract' | 'fix' | 'undo' | 'reload';
+
+export type InterventionLedgerRecordStatus =
+  | 'previewed'
+  | 'approved'
+  | 'cancelled'
+  | 'manual';
+
+export type InterventionPreviewStatus =
+  | 'ready'
+  | 'requires-manual-takeover'
+  | 'blocked'
+  | 'unsupported';
+
+export interface IInterventionConflict {
+  readonly code: string;
+  readonly message: string;
+  readonly affectedRefs?: readonly string[];
+  readonly requiresManualTakeover?: boolean;
+}
+
+export interface IInterventionLedgerCommand<TPayload = unknown> {
+  readonly domain: InterventionDomain;
+  readonly kind: GmInterventionKind;
+  readonly actorId: string;
+  readonly targetRefs: readonly string[];
+  readonly payload?: TPayload;
+  readonly causedBy?: readonly string[];
+  readonly supersedes?: readonly string[];
+}
+
+export interface IInterventionLedgerRecord<
+  TPrivate = unknown,
+  TPublic = unknown,
+  TDomainPayload = unknown,
+> {
+  readonly id: string;
+  readonly domain: InterventionDomain;
+  readonly kind: GmInterventionKind;
+  readonly status: InterventionLedgerRecordStatus;
+  readonly actorId: string;
+  readonly targetRefs: readonly string[];
+  readonly causedBy?: readonly string[];
+  readonly supersedes?: readonly string[];
+  readonly privateMetadata: TPrivate;
+  readonly publicEffect: TPublic;
+  readonly domainPayload?: TDomainPayload;
+  readonly createdAt: string;
+  readonly approvedAt?: string;
+}
+
+export interface IInterventionLedgerPreview<
+  TPrivate = unknown,
+  TPublic = unknown,
+  TDomainPayload = unknown,
+> {
+  readonly domain: InterventionDomain;
+  readonly kind: GmInterventionKind;
+  readonly status: InterventionPreviewStatus;
+  readonly actorId: string;
+  readonly targetRefs: readonly string[];
+  readonly privateMetadata?: TPrivate;
+  readonly publicEffect?: TPublic;
+  readonly domainPayload?: TDomainPayload;
+  readonly causedBy?: readonly string[];
+  readonly supersedes?: readonly string[];
+  readonly projectedEvents?: readonly unknown[];
+  readonly conflicts: readonly IInterventionConflict[];
+  readonly reason?: string;
+}
+
+export interface IUnsupportedInterventionResult<TState = unknown> {
+  readonly status: 'unsupported';
+  readonly domain: InterventionDomain;
+  readonly kind?: GmInterventionKind;
+  readonly reason: string;
+  readonly state: TState;
+}
+
+export interface IAppliedInterventionResult<TState = unknown> {
+  readonly status: 'applied';
+  readonly domain: InterventionDomain;
+  readonly record: IInterventionLedgerRecord;
+  readonly state: TState;
+}
+
+export type InterventionApplyResult<TState = unknown> =
+  | IAppliedInterventionResult<TState>
+  | IUnsupportedInterventionResult<TState>;
+
+export interface IInterventionLedgerImplementer<
+  TCommand extends IInterventionLedgerCommand = IInterventionLedgerCommand,
+  TState = unknown,
+  TPrivate = unknown,
+  TPublic = unknown,
+  TDomainPayload = unknown,
+> {
+  readonly domain: InterventionDomain;
+  preview(
+    command: TCommand,
+    state: TState,
+  ): IInterventionLedgerPreview<TPrivate, TPublic, TDomainPayload>;
+  apply(
+    record: IInterventionLedgerRecord<TPrivate, TPublic, TDomainPayload>,
+    state: TState,
+  ): TState;
+  projectPublic(
+    record: IInterventionLedgerRecord<TPrivate, TPublic, TDomainPayload>,
+  ): TPublic;
+  projectPrivate(
+    record: IInterventionLedgerRecord<TPrivate, TPublic, TDomainPayload>,
+  ): TPrivate;
+}

--- a/src/types/interventions/index.ts
+++ b/src/types/interventions/index.ts
@@ -1,0 +1,15 @@
+export type {
+  GmInterventionKind,
+  IAppliedInterventionResult,
+  IInterventionConflict,
+  IInterventionLedgerCommand,
+  IInterventionLedgerImplementer,
+  IInterventionLedgerPreview,
+  IInterventionLedgerRecord,
+  InterventionApplyResult,
+  InterventionDomain,
+  InterventionLedgerRecordStatus,
+  InterventionPreviewStatus,
+  IUnsupportedInterventionResult,
+  KnownInterventionDomain,
+} from './InterventionLedgerTypes';


### PR DESCRIPTION
## Summary
- Adds the add-gm-intervention-control-plane OpenSpec package split into six verifiable specs.
- Implements the first spec, intervention-ledger-abstraction, as a reusable append-only ledger contract with domain implementer routing, unsupported-domain results, causality refs, and public/private projections.
- Marks only tasks 1.1-1.5 complete; authority/redaction, cascade preview, combat, unit reload, and campaign intervention specs remain pending by design.

## Verification
- npm.cmd test -- --runTestsByPath src/lib/interventions/__tests__/InterventionLedger.test.ts
- npx.cmd tsc --noEmit --skipLibCheck --pretty false
- npx.cmd oxlint src/lib/interventions src/types/interventions
- npx.cmd oxfmt --check src/lib/interventions src/types/interventions openspec/changes/add-gm-intervention-control-plane/tasks.md
- cmd /c openspec validate add-gm-intervention-control-plane --strict
- git diff --cached --check

## Remaining Specs
- gm-authority-redaction
- gm-cascade-preview
- gm-combat-interventions
- gm-unit-reload-reconciliation
- gm-campaign-intervention-boundaries