### PR TITLE
Guard GM interventions with authority redaction

### DIFF
--- a/openspec/changes/add-gm-intervention-control-plane/tasks.md
+++ b/openspec/changes/add-gm-intervention-control-plane/tasks.md
@@ -8,12 +8,12 @@
 
 ## 2. Authority and Redaction Envelope
 
-- [ ] 2.1 Add GM authority context for actor, game, optional campaign, owned-state refs, and role.
-- [ ] 2.2 Implement an authority guard that rejects non-GM or non-owner requests before preview generation.
-- [ ] 2.3 Implement redaction helpers that split GM-private metadata from player-public net effects.
-- [ ] 2.4 Add unit tests proving non-owner player requests are rejected before preview generation and append no records/events.
-- [ ] 2.5 Add unit tests proving player-visible payloads exclude private reason, hidden notes, default outcome, and manual takeover notes.
-- [ ] 2.6 Add safe internal logging for rejected authorization attempts.
+- [x] 2.1 Add GM authority context for actor, game, optional campaign, owned-state refs, and role.
+- [x] 2.2 Implement an authority guard that rejects non-GM or non-owner requests before preview generation.
+- [x] 2.3 Implement redaction helpers that split GM-private metadata from player-public net effects.
+- [x] 2.4 Add unit tests proving non-owner player requests are rejected before preview generation and append no records/events.
+- [x] 2.5 Add unit tests proving player-visible payloads exclude private reason, hidden notes, default outcome, and manual takeover notes.
+- [x] 2.6 Add safe internal logging for rejected authorization attempts.
 
 ## 3. Cascade Preview Pipeline
 

--- a/src/lib/interventions/GmInterventionAuthority.ts
+++ b/src/lib/interventions/GmInterventionAuthority.ts
@@ -1,0 +1,205 @@
+import type {
+  GmAuthorityDecision,
+  IGmAuthorityContext,
+  IGmInterventionRedactionEnvelope,
+  IGmPrivateMetadata,
+  IGmPublicEffect,
+  IGmVisibleInterventionRecord,
+  IInterventionLedgerCommand,
+  IInterventionLedgerPreview,
+  IInterventionLedgerRecord,
+  IPlayerVisibleInterventionRecord,
+  IRejectedGmInterventionRequest,
+} from '@/types/interventions';
+
+import { logger } from '@/utils/logger';
+
+import type { InterventionLedger } from './InterventionLedger';
+
+export type GmInterventionPreviewWithAuthorityResult<
+  TPrivate = unknown,
+  TPublic = unknown,
+  TDomainPayload = unknown,
+> =
+  | IInterventionLedgerPreview<TPrivate, TPublic, TDomainPayload>
+  | IRejectedGmInterventionRequest;
+
+export interface IPreviewGmInterventionWithAuthorityInput<
+  TState,
+  TCommandPayload = unknown,
+> {
+  readonly ledger: InterventionLedger<TState>;
+  readonly command: IInterventionLedgerCommand<TCommandPayload>;
+  readonly state: TState;
+  readonly authority: IGmAuthorityContext;
+  readonly logRejection?: boolean;
+}
+
+export interface IGmInterventionAuthorizationFailureLog {
+  readonly level: 'warn';
+  readonly service: 'gm-intervention';
+  readonly event: 'authorization-rejected';
+  readonly message: string;
+  readonly actorId: string;
+  readonly role: string;
+  readonly gameId: string;
+  readonly campaignId?: string;
+  readonly domain: string;
+  readonly kind: string;
+  readonly targetRefs: readonly string[];
+  readonly rejectionCode: string;
+  readonly rejectionReason: string;
+}
+
+const toGameRef = (gameId: string): string => `game:${gameId}`;
+const toCampaignRef = (campaignId: string): string => `campaign:${campaignId}`;
+
+export function evaluateGmInterventionAuthority(
+  authority: IGmAuthorityContext,
+  command: IInterventionLedgerCommand,
+): GmAuthorityDecision {
+  if (authority.actorId !== command.actorId) {
+    return {
+      status: 'rejected',
+      code: 'actor-mismatch',
+      reason: 'Intervention actor does not match the authority context actor.',
+    };
+  }
+
+  if (authority.role !== 'gm') {
+    return {
+      status: 'rejected',
+      code: 'gm-role-required',
+      reason: 'Only the owning GM can request GM intervention previews.',
+    };
+  }
+
+  if (!ownsTargetState(authority)) {
+    return {
+      status: 'rejected',
+      code: 'state-not-owned',
+      reason:
+        'GM authority context does not own the target game or campaign state.',
+    };
+  }
+
+  return { status: 'authorized' };
+}
+
+export function previewGmInterventionWithAuthority<TState, TCommandPayload>(
+  input: IPreviewGmInterventionWithAuthorityInput<TState, TCommandPayload>,
+): GmInterventionPreviewWithAuthorityResult {
+  const { authority, command, ledger, logRejection = true, state } = input;
+  const decision = evaluateGmInterventionAuthority(authority, command);
+
+  if (decision.status === 'rejected') {
+    const rejection: IRejectedGmInterventionRequest = {
+      status: 'rejected',
+      code: decision.code,
+      reason: decision.reason,
+      actorId: authority.actorId,
+      role: authority.role,
+      gameId: authority.gameId,
+      campaignId: authority.campaignId,
+      domain: command.domain,
+      kind: command.kind,
+      targetRefs: command.targetRefs,
+    };
+
+    if (logRejection) {
+      logGmInterventionAuthorizationFailure(rejection);
+    }
+
+    return rejection;
+  }
+
+  return ledger.preview(command, state);
+}
+
+export function buildGmInterventionRedactionEnvelope<
+  TPrivate extends IGmPrivateMetadata,
+  TPublic extends IGmPublicEffect,
+>(
+  privateMetadata: TPrivate,
+  publicEffect: TPublic,
+): IGmInterventionRedactionEnvelope<TPrivate, TPublic> {
+  return {
+    privateMetadata,
+    publicEffect,
+  };
+}
+
+export function projectInterventionRecordForPlayer<
+  TPublic extends IGmPublicEffect,
+>(
+  record: IInterventionLedgerRecord<unknown, TPublic>,
+): IPlayerVisibleInterventionRecord<TPublic> {
+  return {
+    id: record.id,
+    domain: record.domain,
+    kind: record.kind,
+    status: record.status,
+    actorId: record.actorId,
+    targetRefs: record.targetRefs,
+    causedBy: record.causedBy,
+    supersedes: record.supersedes,
+    publicEffect: record.publicEffect,
+    createdAt: record.createdAt,
+    approvedAt: record.approvedAt,
+  };
+}
+
+export function projectInterventionRecordForGm<
+  TPrivate extends IGmPrivateMetadata,
+  TPublic extends IGmPublicEffect,
+>(
+  record: IInterventionLedgerRecord<TPrivate, TPublic>,
+): IGmVisibleInterventionRecord<TPrivate, TPublic> {
+  return {
+    ...projectInterventionRecordForPlayer(record),
+    privateMetadata: record.privateMetadata,
+  };
+}
+
+export function logGmInterventionAuthorizationFailure(
+  rejection: IRejectedGmInterventionRequest,
+  emit: (
+    message: string,
+    entry: IGmInterventionAuthorizationFailureLog,
+  ) => void = logger.warn,
+): IGmInterventionAuthorizationFailureLog {
+  const entry: IGmInterventionAuthorizationFailureLog = {
+    level: 'warn',
+    service: 'gm-intervention',
+    event: 'authorization-rejected',
+    message: 'Rejected GM intervention before preview generation.',
+    actorId: rejection.actorId,
+    role: rejection.role,
+    gameId: rejection.gameId,
+    campaignId: rejection.campaignId,
+    domain: rejection.domain,
+    kind: rejection.kind,
+    targetRefs: rejection.targetRefs,
+    rejectionCode: rejection.code,
+    rejectionReason: rejection.reason,
+  };
+
+  emit('[gm-intervention:authorization-rejected]', entry);
+  return entry;
+}
+
+function ownsTargetState(authority: IGmAuthorityContext): boolean {
+  const ownedRefs = new Set(authority.ownedStateRefs);
+  if (
+    ownedRefs.has(authority.gameId) ||
+    ownedRefs.has(toGameRef(authority.gameId))
+  ) {
+    return true;
+  }
+
+  if (!authority.campaignId) return false;
+  return (
+    ownedRefs.has(authority.campaignId) ||
+    ownedRefs.has(toCampaignRef(authority.campaignId))
+  );
+}

--- a/src/lib/interventions/__tests__/GmInterventionAuthority.test.ts
+++ b/src/lib/interventions/__tests__/GmInterventionAuthority.test.ts
@@ -1,0 +1,253 @@
+import type {
+  IInterventionLedgerCommand,
+  IInterventionLedgerImplementer,
+  IInterventionLedgerPreview,
+  IInterventionLedgerRecord,
+  IGmAuthorityContext,
+  IGmPrivateMetadata,
+  IGmPublicEffect,
+} from '@/types/interventions';
+
+import { logger } from '@/utils/logger';
+
+import {
+  buildGmInterventionRedactionEnvelope,
+  previewGmInterventionWithAuthority,
+  projectInterventionRecordForGm,
+  projectInterventionRecordForPlayer,
+} from '../GmInterventionAuthority';
+import { InterventionLedger } from '../InterventionLedger';
+
+interface TestState {
+  readonly units: readonly string[];
+}
+
+interface TestCommandPayload {
+  readonly correction: string;
+  readonly privateMetadata?: IGmPrivateMetadata;
+}
+
+const gmAuthority: IGmAuthorityContext = {
+  actorId: 'gm-1',
+  role: 'gm',
+  gameId: 'game-1',
+  campaignId: 'campaign-1',
+  ownedStateRefs: ['game:game-1'],
+};
+
+const makeCommand = (
+  overrides: Partial<IInterventionLedgerCommand<TestCommandPayload>> = {},
+): IInterventionLedgerCommand<TestCommandPayload> => ({
+  domain: 'combat',
+  kind: 'fix',
+  actorId: 'gm-1',
+  targetRefs: ['game:game-1', 'unit:atlas-1'],
+  payload: {
+    correction: 'armor correction',
+  },
+  ...overrides,
+});
+
+const makeRecord = (
+  overrides: Partial<
+    IInterventionLedgerRecord<IGmPrivateMetadata, IGmPublicEffect>
+  > = {},
+): IInterventionLedgerRecord<IGmPrivateMetadata, IGmPublicEffect> => ({
+  id: 'gm-int-1',
+  domain: 'combat',
+  kind: 'fix',
+  status: 'approved',
+  actorId: 'gm-1',
+  targetRefs: ['unit:atlas-1'],
+  privateMetadata: {
+    reason: 'Secret scenario correction.',
+    defaultOutcome: 'The unit would have been destroyed.',
+    hiddenNotes: 'Hidden reinforcements stay unrevealed.',
+    manualTakeoverNotes: 'GM manually chose the least disruptive repair.',
+  },
+  publicEffect: {
+    summary: 'Atlas armor state corrected.',
+    changedStateRefs: ['unit:atlas-1'],
+  },
+  createdAt: '2026-06-20T00:00:00.000Z',
+  approvedAt: '2026-06-20T00:01:00.000Z',
+  ...overrides,
+});
+
+function makeLedger(preview: jest.Mock): InterventionLedger<TestState> {
+  const implementer: IInterventionLedgerImplementer<
+    IInterventionLedgerCommand<TestCommandPayload>,
+    TestState,
+    IGmPrivateMetadata,
+    IGmPublicEffect
+  > = {
+    domain: 'combat',
+    preview(
+      command,
+    ): IInterventionLedgerPreview<IGmPrivateMetadata, IGmPublicEffect> {
+      preview(command);
+      return {
+        domain: command.domain,
+        kind: command.kind,
+        status: 'ready',
+        actorId: command.actorId,
+        targetRefs: command.targetRefs,
+        privateMetadata: {
+          reason: 'GM-only preview reason.',
+        },
+        publicEffect: {
+          summary: 'Public correction preview.',
+          changedStateRefs: command.targetRefs,
+        },
+        conflicts: [],
+      };
+    },
+    apply(_record, state): TestState {
+      return state;
+    },
+    projectPublic(record): IGmPublicEffect {
+      return record.publicEffect;
+    },
+    projectPrivate(record): IGmPrivateMetadata {
+      return record.privateMetadata;
+    },
+  };
+
+  return new InterventionLedger<TestState>().register(implementer);
+}
+
+describe('GM intervention authority and redaction', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('allows the owning GM to generate an intervention preview', () => {
+    const preview = jest.fn();
+    const ledger = makeLedger(preview);
+
+    const result = previewGmInterventionWithAuthority({
+      ledger,
+      command: makeCommand(),
+      state: { units: ['unit:atlas-1'] },
+      authority: gmAuthority,
+    });
+
+    expect(result.status).toBe('ready');
+    expect(preview).toHaveBeenCalledTimes(1);
+    expect(ledger.getRecords()).toEqual([]);
+  });
+
+  it('rejects a non-owner player before preview generation and appends no records', () => {
+    const preview = jest.fn();
+    const warnSpy = jest
+      .spyOn(logger, 'warn')
+      .mockImplementation(() => undefined);
+    const ledger = makeLedger(preview);
+
+    const result = previewGmInterventionWithAuthority({
+      ledger,
+      command: makeCommand({
+        actorId: 'player-1',
+        payload: {
+          correction: 'secret correction',
+          privateMetadata: {
+            reason: 'Do not show this reason.',
+            hiddenNotes: 'Hidden ambush remains unknown.',
+          },
+        },
+      }),
+      state: { units: ['unit:atlas-1'] },
+      authority: {
+        actorId: 'player-1',
+        role: 'player',
+        gameId: 'game-1',
+        ownedStateRefs: [],
+      },
+    });
+
+    expect(result).toMatchObject({
+      status: 'rejected',
+      code: 'gm-role-required',
+      domain: 'combat',
+      actorId: 'player-1',
+    });
+    expect(preview).not.toHaveBeenCalled();
+    expect(ledger.getRecords()).toEqual([]);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]?.[0]).toBe(
+      '[gm-intervention:authorization-rejected]',
+    );
+    expect(warnSpy.mock.calls[0]?.[1]).toMatchObject({
+      level: 'warn',
+      service: 'gm-intervention',
+      event: 'authorization-rejected',
+      actorId: 'player-1',
+      gameId: 'game-1',
+    });
+    expect(JSON.stringify(warnSpy.mock.calls)).not.toContain(
+      'Do not show this reason',
+    );
+    expect(JSON.stringify(warnSpy.mock.calls)).not.toContain(
+      'Hidden ambush remains unknown',
+    );
+  });
+
+  it('splits private metadata from player-public net effect', () => {
+    const envelope = buildGmInterventionRedactionEnvelope(
+      {
+        reason: 'GM-only correction.',
+        defaultOutcome: 'Target would otherwise be destroyed.',
+        hiddenNotes: 'Scenario objective stays hidden.',
+        manualTakeoverNotes: 'GM selected a manual outcome.',
+      },
+      {
+        summary: 'Target damage corrected.',
+        changedStateRefs: ['unit:atlas-1'],
+      },
+    );
+
+    expect(envelope.publicEffect).toEqual({
+      summary: 'Target damage corrected.',
+      changedStateRefs: ['unit:atlas-1'],
+    });
+    expect(envelope.privateMetadata.hiddenNotes).toBe(
+      'Scenario objective stays hidden.',
+    );
+  });
+
+  it('keeps private reason, hidden notes, default outcome, and manual notes out of player logs', () => {
+    const record = makeRecord();
+    const playerProjection = projectInterventionRecordForPlayer(record);
+    const gmProjection = projectInterventionRecordForGm(record);
+
+    expect(playerProjection).toEqual({
+      id: 'gm-int-1',
+      domain: 'combat',
+      kind: 'fix',
+      status: 'approved',
+      actorId: 'gm-1',
+      targetRefs: ['unit:atlas-1'],
+      publicEffect: {
+        summary: 'Atlas armor state corrected.',
+        changedStateRefs: ['unit:atlas-1'],
+      },
+      createdAt: '2026-06-20T00:00:00.000Z',
+      approvedAt: '2026-06-20T00:01:00.000Z',
+    });
+
+    const playerJson = JSON.stringify(playerProjection);
+    expect(playerJson).not.toContain('privateMetadata');
+    expect(playerJson).not.toContain('Secret scenario correction');
+    expect(playerJson).not.toContain('unit would have been destroyed');
+    expect(playerJson).not.toContain('Hidden reinforcements');
+    expect(playerJson).not.toContain('manual');
+
+    expect(gmProjection.privateMetadata).toMatchObject({
+      reason: 'Secret scenario correction.',
+      defaultOutcome: 'The unit would have been destroyed.',
+      hiddenNotes: 'Hidden reinforcements stay unrevealed.',
+      manualTakeoverNotes: 'GM manually chose the least disruptive repair.',
+    });
+  });
+});

--- a/src/lib/interventions/index.ts
+++ b/src/lib/interventions/index.ts
@@ -1,4 +1,13 @@
 export {
+  buildGmInterventionRedactionEnvelope,
+  evaluateGmInterventionAuthority,
+  logGmInterventionAuthorizationFailure,
+  previewGmInterventionWithAuthority,
+  projectInterventionRecordForGm,
+  projectInterventionRecordForPlayer,
+} from './GmInterventionAuthority';
+
+export {
   InterventionLedger,
   type IInterventionLedgerOptions,
 } from './InterventionLedger';

--- a/src/types/interventions/GmInterventionAuthorityTypes.ts
+++ b/src/types/interventions/GmInterventionAuthorityTypes.ts
@@ -1,0 +1,93 @@
+import type {
+  GmInterventionKind,
+  IInterventionLedgerRecord,
+  InterventionDomain,
+} from './InterventionLedgerTypes';
+
+export type GmInterventionActorRole = 'gm' | 'player' | 'spectator';
+
+export type GmInterventionAuthorityRejectionCode =
+  | 'actor-mismatch'
+  | 'gm-role-required'
+  | 'state-not-owned';
+
+export interface IGmAuthorityContext {
+  readonly actorId: string;
+  readonly role: GmInterventionActorRole;
+  readonly gameId: string;
+  readonly campaignId?: string;
+  readonly ownedStateRefs: readonly string[];
+}
+
+export interface IGmPrivateMetadata {
+  readonly reason: string;
+  readonly defaultOutcome?: string;
+  readonly hiddenNotes?: string;
+  readonly manualTakeoverNotes?: string;
+  readonly [key: string]: unknown;
+}
+
+export interface IGmPublicEffect {
+  readonly summary: string;
+  readonly changedStateRefs: readonly string[];
+  readonly visibleToPlayerIds?: readonly string[];
+  readonly [key: string]: unknown;
+}
+
+export interface IGmAuthorityAuthorizedDecision {
+  readonly status: 'authorized';
+}
+
+export interface IGmAuthorityRejectedDecision {
+  readonly status: 'rejected';
+  readonly code: GmInterventionAuthorityRejectionCode;
+  readonly reason: string;
+}
+
+export type GmAuthorityDecision =
+  | IGmAuthorityAuthorizedDecision
+  | IGmAuthorityRejectedDecision;
+
+export interface IRejectedGmInterventionRequest {
+  readonly status: 'rejected';
+  readonly code: GmInterventionAuthorityRejectionCode;
+  readonly reason: string;
+  readonly actorId: string;
+  readonly role: GmInterventionActorRole;
+  readonly gameId: string;
+  readonly campaignId?: string;
+  readonly domain: InterventionDomain;
+  readonly kind: GmInterventionKind;
+  readonly targetRefs: readonly string[];
+}
+
+export interface IGmInterventionRedactionEnvelope<
+  TPrivate extends IGmPrivateMetadata = IGmPrivateMetadata,
+  TPublic extends IGmPublicEffect = IGmPublicEffect,
+> {
+  readonly privateMetadata: TPrivate;
+  readonly publicEffect: TPublic;
+}
+
+export interface IPlayerVisibleInterventionRecord<
+  TPublic extends IGmPublicEffect = IGmPublicEffect,
+> {
+  readonly id: string;
+  readonly domain: InterventionDomain;
+  readonly kind: GmInterventionKind;
+  readonly status: IInterventionLedgerRecord['status'];
+  readonly actorId: string;
+  readonly targetRefs: readonly string[];
+  readonly causedBy?: readonly string[];
+  readonly supersedes?: readonly string[];
+  readonly publicEffect: TPublic;
+  readonly createdAt: string;
+  readonly approvedAt?: string;
+}
+
+export interface IGmVisibleInterventionRecord<
+  TPrivate extends IGmPrivateMetadata = IGmPrivateMetadata,
+  TPublic extends IGmPublicEffect = IGmPublicEffect,
+> extends IPlayerVisibleInterventionRecord<TPublic> {
+  readonly privateMetadata: TPrivate;
+}

--- a/src/types/interventions/index.ts
+++ b/src/types/interventions/index.ts
@@ -1,4 +1,19 @@
 export type {
+  GmAuthorityDecision,
+  GmInterventionActorRole,
+  GmInterventionAuthorityRejectionCode,
+  IGmAuthorityAuthorizedDecision,
+  IGmAuthorityContext,
+  IGmAuthorityRejectedDecision,
+  IGmInterventionRedactionEnvelope,
+  IGmPrivateMetadata,
+  IGmPublicEffect,
+  IGmVisibleInterventionRecord,
+  IPlayerVisibleInterventionRecord,
+  IRejectedGmInterventionRequest,
+} from './GmInterventionAuthorityTypes';
+
+export type {
   GmInterventionKind,
   IAppliedInterventionResult,
   IInterventionConflict,


### PR DESCRIPTION
## Summary
- Adds GM authority context types for actor, role, game/campaign ownership, and owned-state refs.
- Adds previewGmInterventionWithAuthority so unauthorized actors are rejected before domain preview generation and before records/events can be appended.
- Adds redaction helpers that project player-visible intervention records without private reason, hidden notes, default outcome, or manual takeover notes.
- Adds sanitized internal authorization failure logging through the existing logger.warn surface, without depending on the separate diagnostic logger work currently dirty locally.
- Marks only tasks 2.1-2.6 complete; cascade preview, combat, unit reload, UI, and campaign boundaries remain pending.

## Verification
- npm.cmd test -- --runTestsByPath src/lib/interventions/__tests__/InterventionLedger.test.ts src/lib/interventions/__tests__/GmInterventionAuthority.test.ts
- npx.cmd tsc --noEmit --skipLibCheck --pretty false
- npx.cmd oxlint src/lib/interventions src/types/interventions
- npx.cmd oxfmt --check src/lib/interventions src/types/interventions openspec/changes/add-gm-intervention-control-plane/tasks.md
- cmd /c openspec validate add-gm-intervention-control-plane --strict
- git diff --cached --check

## Remaining Specs
- gm-cascade-preview
- gm-combat-interventions
- gm-unit-reload-reconciliation
- gm-campaign-intervention-boundaries