### PR TITLE
Add GM cascade preview approval gate

### DIFF
--- a/openspec/changes/add-gm-intervention-control-plane/tasks.md
+++ b/openspec/changes/add-gm-intervention-control-plane/tasks.md
@@ -17,12 +17,12 @@
 
 ## 3. Cascade Preview Pipeline
 
-- [ ] 3.1 Implement pure preview generation for GM interventions that returns public net effect, private context, projected event effects, affected refs, and conflicts without mutating state.
-- [ ] 3.2 Implement approval flow that appends accepted intervention events only after GM approval.
-- [ ] 3.3 Implement blocked/deferred results for unsupported first-slice requests such as merchant reversal or accumulated time correction.
-- [ ] 3.4 Add tests proving preview does not mutate current game state or append events.
-- [ ] 3.5 Add tests proving approval appends the accepted intervention and updates derived state through normal event replay.
-- [ ] 3.6 Add regression coverage proving normal player undo remains separate from GM undo semantics.
+- [x] 3.1 Implement pure preview generation for GM interventions that returns public net effect, private context, projected event effects, affected refs, and conflicts without mutating state.
+- [x] 3.2 Implement approval flow that appends accepted intervention events only after GM approval.
+- [x] 3.3 Implement blocked/deferred results for unsupported first-slice requests such as merchant reversal or accumulated time correction.
+- [x] 3.4 Add tests proving preview does not mutate current game state or append events.
+- [x] 3.5 Add tests proving approval appends the accepted intervention and updates derived state through normal event replay.
+- [x] 3.6 Add regression coverage proving normal player undo remains separate from GM undo semantics.
 
 ## 4. Combat Intervention Implementer
 

--- a/src/lib/interventions/GmCascadePreviewPipeline.ts
+++ b/src/lib/interventions/GmCascadePreviewPipeline.ts
@@ -1,0 +1,238 @@
+import type {
+  IGmAuthorityContext,
+  IGmCascadeApprovalResult,
+  IGmCascadeCancellationResult,
+  IGmCascadePreview,
+  IInterventionLedgerCommand,
+  IInterventionLedgerPreview,
+  IInterventionLedgerRecord,
+  InterventionDomain,
+} from '@/types/interventions';
+
+import type { InterventionLedger } from './InterventionLedger';
+
+import { previewGmInterventionWithAuthority } from './GmInterventionAuthority';
+
+export interface ICreateGmCascadePreviewInput<
+  TState,
+  TCommandPayload = unknown,
+> {
+  readonly ledger: InterventionLedger<TState>;
+  readonly command: IInterventionLedgerCommand<TCommandPayload>;
+  readonly state: TState;
+  readonly authority: IGmAuthorityContext;
+  readonly interventionId?: string;
+  readonly now?: () => string;
+}
+
+export interface IApproveGmCascadePreviewInput<
+  TState,
+  TPrivate = unknown,
+  TPublic = unknown,
+  TDomainPayload = unknown,
+> {
+  readonly ledger: InterventionLedger<TState>;
+  readonly preview: IGmCascadePreview<TPrivate, TPublic, TDomainPayload>;
+  readonly state: TState;
+  readonly approvedAt?: string;
+  readonly createdAt?: string;
+}
+
+const DEFERRED_FIRST_SLICE_DOMAINS = new Set<InterventionDomain>([
+  'post-combat',
+  'economy',
+  'repair',
+  'salvage',
+  'time',
+]);
+
+let generatedIdSequence = 0;
+
+export function createGmCascadePreview<TState, TCommandPayload>(
+  input: ICreateGmCascadePreviewInput<TState, TCommandPayload>,
+): IGmCascadePreview {
+  const { authority, command, interventionId, ledger, state } = input;
+  const previewResult = previewGmInterventionWithAuthority({
+    ledger,
+    command,
+    state,
+    authority,
+  });
+  const resolvedInterventionId =
+    interventionId ?? createDefaultInterventionId(input.now);
+
+  if (previewResult.status === 'rejected') {
+    return {
+      interventionId: resolvedInterventionId,
+      status: 'rejected',
+      domain: previewResult.domain,
+      kind: previewResult.kind,
+      actorId: previewResult.actorId,
+      targetRefs: previewResult.targetRefs,
+      affectedStateRefs: previewResult.targetRefs,
+      projectedEvents: [],
+      conflicts: [],
+      reason: previewResult.reason,
+    };
+  }
+
+  const status =
+    previewResult.status === 'unsupported' &&
+    DEFERRED_FIRST_SLICE_DOMAINS.has(previewResult.domain)
+      ? 'deferred'
+      : normalizePreviewStatus(previewResult);
+
+  return {
+    interventionId: resolvedInterventionId,
+    status,
+    domain: previewResult.domain,
+    kind: previewResult.kind,
+    actorId: previewResult.actorId,
+    targetRefs: previewResult.targetRefs,
+    affectedStateRefs: affectedStateRefs(previewResult),
+    privateMetadata: previewResult.privateMetadata,
+    publicEffect: previewResult.publicEffect,
+    domainPayload: previewResult.domainPayload,
+    projectedEvents: previewResult.projectedEvents ?? [],
+    conflicts: previewResult.conflicts,
+    causedBy: previewResult.causedBy,
+    supersedes: previewResult.supersedes,
+    reason: previewResult.reason,
+  };
+}
+
+export function approveGmCascadePreview<
+  TState,
+  TPrivate,
+  TPublic,
+  TDomainPayload,
+>(
+  input: IApproveGmCascadePreviewInput<
+    TState,
+    TPrivate,
+    TPublic,
+    TDomainPayload
+  >,
+): IGmCascadeApprovalResult<TState> {
+  const { ledger, preview, state } = input;
+
+  if (preview.status !== 'ready') {
+    return {
+      status: 'blocked',
+      state,
+      appended: false,
+      reason: `Cannot approve GM cascade preview with status "${preview.status}".`,
+    };
+  }
+
+  if (!preview.privateMetadata || !preview.publicEffect) {
+    return {
+      status: 'blocked',
+      state,
+      appended: false,
+      reason:
+        'Cannot approve GM cascade preview without private metadata and public effect.',
+    };
+  }
+
+  const record = buildApprovedRecord(input);
+  ledger.appendApprovedRecord(record);
+  const applyResult = ledger.apply(record, state);
+
+  if (applyResult.status === 'unsupported') {
+    return {
+      status: 'blocked',
+      state,
+      appended: true,
+      record,
+      reason: applyResult.reason,
+    };
+  }
+
+  return {
+    status: 'approved',
+    state: applyResult.state,
+    appended: true,
+    record,
+  };
+}
+
+export function cancelGmCascadePreview<TState>(
+  preview: IGmCascadePreview,
+  state: TState,
+): IGmCascadeCancellationResult<TState> {
+  return {
+    status: 'cancelled',
+    state,
+    appended: false,
+  };
+}
+
+function buildApprovedRecord<TState, TPrivate, TPublic, TDomainPayload>(
+  input: IApproveGmCascadePreviewInput<
+    TState,
+    TPrivate,
+    TPublic,
+    TDomainPayload
+  >,
+): IInterventionLedgerRecord<TPrivate, TPublic, TDomainPayload> {
+  const { approvedAt, createdAt, preview } = input;
+  const approvalTime = approvedAt ?? new Date().toISOString();
+
+  return {
+    id: preview.interventionId,
+    domain: preview.domain,
+    kind: preview.kind,
+    status: 'approved',
+    actorId: preview.actorId,
+    targetRefs: preview.targetRefs,
+    causedBy: preview.causedBy,
+    supersedes: preview.supersedes,
+    privateMetadata: preview.privateMetadata as TPrivate,
+    publicEffect: preview.publicEffect as TPublic,
+    domainPayload: preview.domainPayload,
+    createdAt: createdAt ?? approvalTime,
+    approvedAt: approvalTime,
+  };
+}
+
+function normalizePreviewStatus(
+  preview: IInterventionLedgerPreview,
+): IGmCascadePreview['status'] {
+  if (
+    preview.status === 'ready' &&
+    preview.conflicts.some((conflict) => conflict.requiresManualTakeover)
+  ) {
+    return 'requires-manual-takeover';
+  }
+
+  return preview.status;
+}
+
+function affectedStateRefs(
+  preview: IInterventionLedgerPreview,
+): readonly string[] {
+  return uniqueRefs([
+    ...preview.targetRefs,
+    ...changedStateRefs(preview.publicEffect),
+    ...preview.conflicts.flatMap((conflict) => conflict.affectedRefs ?? []),
+  ]);
+}
+
+function changedStateRefs(publicEffect: unknown): readonly string[] {
+  if (!publicEffect || typeof publicEffect !== 'object') return [];
+  const maybeRefs = (publicEffect as { changedStateRefs?: unknown })
+    .changedStateRefs;
+  return Array.isArray(maybeRefs)
+    ? maybeRefs.filter((ref): ref is string => typeof ref === 'string')
+    : [];
+}
+
+function uniqueRefs(refs: readonly string[]): readonly string[] {
+  return Array.from(new Set(refs));
+}
+
+function createDefaultInterventionId(now?: () => string): string {
+  generatedIdSequence += 1;
+  return `gm-int-${now?.() ?? new Date().toISOString()}-${generatedIdSequence}`;
+}

--- a/src/lib/interventions/__tests__/GmCascadePreviewPipeline.test.ts
+++ b/src/lib/interventions/__tests__/GmCascadePreviewPipeline.test.ts
@@ -1,0 +1,343 @@
+import type {
+  IGmAuthorityContext,
+  IGmPrivateMetadata,
+  IGmPublicEffect,
+  IInterventionLedgerCommand,
+  IInterventionLedgerImplementer,
+  IInterventionLedgerPreview,
+} from '@/types/interventions';
+
+import {
+  approveGmCascadePreview,
+  cancelGmCascadePreview,
+  createGmCascadePreview,
+} from '../GmCascadePreviewPipeline';
+import { InterventionLedger } from '../InterventionLedger';
+
+interface TestEvent {
+  readonly id: string;
+  readonly type: string;
+  readonly delta?: number;
+}
+
+interface TestState {
+  readonly value: number;
+  readonly events: readonly TestEvent[];
+}
+
+interface TestPayload {
+  readonly delta: number;
+  readonly conflict?: boolean;
+}
+
+interface TestDomainPayload {
+  readonly delta: number;
+  readonly projectedEvents: readonly TestEvent[];
+}
+
+const gmAuthority: IGmAuthorityContext = {
+  actorId: 'gm-1',
+  role: 'gm',
+  gameId: 'game-1',
+  ownedStateRefs: ['game:game-1'],
+};
+
+const makeState = (): TestState => ({
+  value: 10,
+  events: [
+    { id: 'player-move-1', type: 'player-move' },
+    { id: 'player-attack-1', type: 'player-attack' },
+  ],
+});
+
+const makeCommand = (
+  overrides: Partial<IInterventionLedgerCommand<TestPayload>> = {},
+): IInterventionLedgerCommand<TestPayload> => ({
+  domain: 'combat',
+  kind: 'fix',
+  actorId: 'gm-1',
+  targetRefs: ['unit:atlas-1'],
+  payload: { delta: 3 },
+  causedBy: ['player-attack-1'],
+  ...overrides,
+});
+
+function makeLedger(): InterventionLedger<TestState> {
+  const implementer: IInterventionLedgerImplementer<
+    IInterventionLedgerCommand<TestPayload>,
+    TestState,
+    IGmPrivateMetadata,
+    IGmPublicEffect,
+    TestDomainPayload
+  > = {
+    domain: 'combat',
+    preview(
+      command,
+    ): IInterventionLedgerPreview<
+      IGmPrivateMetadata,
+      IGmPublicEffect,
+      TestDomainPayload
+    > {
+      const delta = command.payload?.delta ?? 0;
+      const projectedEvents = [
+        {
+          id: 'projected-gm-adjustment',
+          type: 'gm-value-adjusted',
+          delta,
+        },
+      ];
+
+      return {
+        domain: command.domain,
+        kind: command.kind,
+        status: command.payload?.conflict
+          ? 'requires-manual-takeover'
+          : 'ready',
+        actorId: command.actorId,
+        targetRefs: command.targetRefs,
+        causedBy: command.causedBy,
+        supersedes: command.supersedes,
+        privateMetadata: {
+          reason: 'GM-only cascade reason.',
+          defaultOutcome: 'The original event would stand.',
+        },
+        publicEffect: {
+          summary: 'Value corrected.',
+          changedStateRefs: ['state:value', ...command.targetRefs],
+        },
+        domainPayload: {
+          delta,
+          projectedEvents,
+        },
+        projectedEvents,
+        conflicts: command.payload?.conflict
+          ? [
+              {
+                code: 'manual-review',
+                message: 'GM must choose conflict handling.',
+                affectedRefs: command.targetRefs,
+                requiresManualTakeover: true,
+              },
+            ]
+          : [],
+      };
+    },
+    apply(record, state): TestState {
+      const delta = record.domainPayload?.delta ?? 0;
+      return {
+        value: state.value + delta,
+        events: [
+          ...state.events,
+          {
+            id: record.id,
+            type: `gm-${record.kind}`,
+            delta,
+          },
+        ],
+      };
+    },
+    projectPublic(record): IGmPublicEffect {
+      return record.publicEffect;
+    },
+    projectPrivate(record): IGmPrivateMetadata {
+      return record.privateMetadata;
+    },
+  };
+
+  return new InterventionLedger<TestState>().register(implementer);
+}
+
+describe('GM cascade preview pipeline', () => {
+  it('generates a pure preview without mutating state or appending records', () => {
+    const ledger = makeLedger();
+    const state = makeState();
+    const originalState = {
+      ...state,
+      events: [...state.events],
+    };
+
+    const preview = createGmCascadePreview({
+      ledger,
+      command: makeCommand(),
+      state,
+      authority: gmAuthority,
+      interventionId: 'gm-int-preview',
+    });
+
+    expect(preview).toMatchObject({
+      interventionId: 'gm-int-preview',
+      status: 'ready',
+      domain: 'combat',
+      affectedStateRefs: ['unit:atlas-1', 'state:value'],
+      publicEffect: {
+        summary: 'Value corrected.',
+      },
+      privateMetadata: {
+        reason: 'GM-only cascade reason.',
+      },
+      projectedEvents: [
+        {
+          id: 'projected-gm-adjustment',
+          type: 'gm-value-adjusted',
+          delta: 3,
+        },
+      ],
+    });
+    expect(state).toEqual(originalState);
+    expect(ledger.getRecords()).toEqual([]);
+  });
+
+  it('approves a ready preview by appending a record and deriving state through the implementer', () => {
+    const ledger = makeLedger();
+    const state = makeState();
+    const preview = createGmCascadePreview({
+      ledger,
+      command: makeCommand(),
+      state,
+      authority: gmAuthority,
+      interventionId: 'gm-int-approved',
+    });
+
+    const result = approveGmCascadePreview({
+      ledger,
+      preview,
+      state,
+      createdAt: '2026-06-20T00:00:00.000Z',
+      approvedAt: '2026-06-20T00:01:00.000Z',
+    });
+
+    expect(result.status).toBe('approved');
+    expect(result.appended).toBe(true);
+    expect(result.state).toEqual({
+      value: 13,
+      events: [
+        ...state.events,
+        {
+          id: 'gm-int-approved',
+          type: 'gm-fix',
+          delta: 3,
+        },
+      ],
+    });
+    expect(ledger.getRecords()).toHaveLength(1);
+    expect(ledger.getRecords()[0]).toMatchObject({
+      id: 'gm-int-approved',
+      status: 'approved',
+      causedBy: ['player-attack-1'],
+    });
+  });
+
+  it('cancels a preview without appending or changing derived state', () => {
+    const ledger = makeLedger();
+    const state = makeState();
+    const preview = createGmCascadePreview({
+      ledger,
+      command: makeCommand(),
+      state,
+      authority: gmAuthority,
+      interventionId: 'gm-int-cancelled',
+    });
+
+    const result = cancelGmCascadePreview(preview, state);
+
+    expect(result).toEqual({
+      status: 'cancelled',
+      state,
+      appended: false,
+    });
+    expect(ledger.getRecords()).toEqual([]);
+  });
+
+  it('requires manual takeover for unresolved conflicts and blocks approval', () => {
+    const ledger = makeLedger();
+    const state = makeState();
+    const preview = createGmCascadePreview({
+      ledger,
+      command: makeCommand({ payload: { delta: 3, conflict: true } }),
+      state,
+      authority: gmAuthority,
+      interventionId: 'gm-int-conflict',
+    });
+
+    const result = approveGmCascadePreview({
+      ledger,
+      preview,
+      state,
+    });
+
+    expect(preview.status).toBe('requires-manual-takeover');
+    expect(preview.conflicts[0]).toMatchObject({
+      code: 'manual-review',
+      requiresManualTakeover: true,
+    });
+    expect(result).toMatchObject({
+      status: 'blocked',
+      state,
+      appended: false,
+    });
+    expect(ledger.getRecords()).toEqual([]);
+  });
+
+  it('returns deferred previews for unsupported first-slice campaign domains without mutation', () => {
+    const ledger = makeLedger();
+    const state = makeState();
+
+    const preview = createGmCascadePreview({
+      ledger,
+      command: makeCommand({
+        domain: 'economy',
+        kind: 'undo',
+        targetRefs: ['merchant-tx:1'],
+      }),
+      state,
+      authority: gmAuthority,
+      interventionId: 'gm-int-deferred',
+    });
+
+    expect(preview).toMatchObject({
+      interventionId: 'gm-int-deferred',
+      status: 'deferred',
+      domain: 'economy',
+      targetRefs: ['merchant-tx:1'],
+      affectedStateRefs: ['merchant-tx:1'],
+      projectedEvents: [],
+      conflicts: [],
+    });
+    expect(preview.reason).toContain('economy');
+    expect(state).toEqual(makeState());
+    expect(ledger.getRecords()).toEqual([]);
+  });
+
+  it('keeps GM undo additive instead of truncating normal player event history', () => {
+    const ledger = makeLedger();
+    const state = makeState();
+    const preview = createGmCascadePreview({
+      ledger,
+      command: makeCommand({
+        kind: 'undo',
+        payload: { delta: -2 },
+        supersedes: ['player-attack-1'],
+      }),
+      state,
+      authority: gmAuthority,
+      interventionId: 'gm-int-undo',
+    });
+
+    const result = approveGmCascadePreview({
+      ledger,
+      preview,
+      state,
+    });
+
+    expect(result.status).toBe('approved');
+    expect(result.state.events).toEqual([
+      { id: 'player-move-1', type: 'player-move' },
+      { id: 'player-attack-1', type: 'player-attack' },
+      { id: 'gm-int-undo', type: 'gm-undo', delta: -2 },
+    ]);
+    expect(ledger.getRecords()[0]).toMatchObject({
+      kind: 'undo',
+      supersedes: ['player-attack-1'],
+    });
+  });
+});

--- a/src/lib/interventions/index.ts
+++ b/src/lib/interventions/index.ts
@@ -1,4 +1,15 @@
 export {
+  approveGmCascadePreview,
+  cancelGmCascadePreview,
+  createGmCascadePreview,
+} from './GmCascadePreviewPipeline';
+
+export type {
+  IApproveGmCascadePreviewInput,
+  ICreateGmCascadePreviewInput,
+} from './GmCascadePreviewPipeline';
+
+export {
   buildGmInterventionRedactionEnvelope,
   evaluateGmInterventionAuthority,
   logGmInterventionAuthorizationFailure,

--- a/src/types/interventions/GmCascadePreviewTypes.ts
+++ b/src/types/interventions/GmCascadePreviewTypes.ts
@@ -1,0 +1,50 @@
+import type {
+  GmInterventionKind,
+  IInterventionConflict,
+  IInterventionLedgerRecord,
+  InterventionDomain,
+} from './InterventionLedgerTypes';
+
+export type GmCascadePreviewStatus =
+  | 'ready'
+  | 'requires-manual-takeover'
+  | 'blocked'
+  | 'unsupported'
+  | 'deferred'
+  | 'rejected';
+
+export interface IGmCascadePreview<
+  TPrivate = unknown,
+  TPublic = unknown,
+  TDomainPayload = unknown,
+> {
+  readonly interventionId: string;
+  readonly status: GmCascadePreviewStatus;
+  readonly domain: InterventionDomain;
+  readonly kind: GmInterventionKind;
+  readonly actorId: string;
+  readonly targetRefs: readonly string[];
+  readonly affectedStateRefs: readonly string[];
+  readonly privateMetadata?: TPrivate;
+  readonly publicEffect?: TPublic;
+  readonly domainPayload?: TDomainPayload;
+  readonly projectedEvents: readonly unknown[];
+  readonly conflicts: readonly IInterventionConflict[];
+  readonly causedBy?: readonly string[];
+  readonly supersedes?: readonly string[];
+  readonly reason?: string;
+}
+
+export interface IGmCascadeApprovalResult<TState = unknown> {
+  readonly status: 'approved' | 'blocked';
+  readonly state: TState;
+  readonly appended: boolean;
+  readonly record?: IInterventionLedgerRecord;
+  readonly reason?: string;
+}
+
+export interface IGmCascadeCancellationResult<TState = unknown> {
+  readonly status: 'cancelled';
+  readonly state: TState;
+  readonly appended: false;
+}

--- a/src/types/interventions/index.ts
+++ b/src/types/interventions/index.ts
@@ -1,4 +1,11 @@
 export type {
+  GmCascadePreviewStatus,
+  IGmCascadeApprovalResult,
+  IGmCascadeCancellationResult,
+  IGmCascadePreview,
+} from './GmCascadePreviewTypes';
+
+export type {
   GmAuthorityDecision,
   GmInterventionActorRole,
   GmInterventionAuthorityRejectionCode,


### PR DESCRIPTION
## Summary
- Adds a pure GM cascade preview pipeline over the ledger + authority layer.
- Preview returns public net effect, GM-private context, projected events, affected refs, conflicts, and explicit deferred status for first-slice unsupported campaign/economy/time-style domains.
- Approval appends one accepted ledger record and applies through the registered implementer; cancellation appends nothing.
- Adds regression coverage that GM undo remains additive and does not truncate normal player event history.
- Marks only tasks 3.1-3.6 complete; combat/domain implementers, unit reload, UI command surface, and campaign boundaries remain pending.

## Verification
- npm.cmd test -- --runTestsByPath src/lib/interventions/__tests__/InterventionLedger.test.ts src/lib/interventions/__tests__/GmInterventionAuthority.test.ts src/lib/interventions/__tests__/GmCascadePreviewPipeline.test.ts
- npx.cmd tsc --noEmit --skipLibCheck --pretty false
- npx.cmd oxlint src/lib/interventions src/types/interventions
- npx.cmd oxfmt --check src/lib/interventions src/types/interventions openspec/changes/add-gm-intervention-control-plane/tasks.md
- cmd /c openspec validate add-gm-intervention-control-plane --strict
- git diff --cached --check

## Remaining Specs
- gm-combat-interventions
- gm-unit-reload-reconciliation
- gm-campaign-intervention-boundaries