### PR TITLE
Add GM combat intervention implementer

### DIFF
--- a/openspec/changes/add-gm-intervention-control-plane/tasks.md
+++ b/openspec/changes/add-gm-intervention-control-plane/tasks.md
@@ -26,13 +26,13 @@
 
 ## 4. Combat Intervention Implementer
 
-- [ ] 4.1 Register a combat-domain implementer with the reusable intervention ledger.
-- [ ] 4.2 Implement preview/apply support for reposition and facing corrections.
-- [ ] 4.3 Implement preview/apply support for damage and critical state corrections.
-- [ ] 4.4 Implement preview/apply support for heat and ammo corrections.
-- [ ] 4.5 Implement preview/apply support for phase, initiative, and turn ownership corrections.
-- [ ] 4.6 Implement preview/apply support for ejection, withdrawal, disabled, destroyed, and rescued lifecycle corrections.
-- [ ] 4.7 Add reducer and replay tests for every first-slice combat intervention family.
+- [x] 4.1 Register a combat-domain implementer with the reusable intervention ledger.
+- [x] 4.2 Implement preview/apply support for reposition and facing corrections.
+- [x] 4.3 Implement preview/apply support for damage and critical state corrections.
+- [x] 4.4 Implement preview/apply support for heat and ammo corrections.
+- [x] 4.5 Implement preview/apply support for phase, initiative, and turn ownership corrections.
+- [x] 4.6 Implement preview/apply support for ejection, withdrawal, disabled, destroyed, and rescued lifecycle corrections.
+- [x] 4.7 Add reducer and replay tests for every first-slice combat intervention family.
 
 ## 5. Unit Reload Implementer
 

--- a/src/lib/interventions/GmCombatInterventionImplementer.ts
+++ b/src/lib/interventions/GmCombatInterventionImplementer.ts
@@ -1,0 +1,166 @@
+import type {
+  IGmCombatInterventionCommandPayload,
+  IGmCombatInterventionDomainPayload,
+  IGmCombatInterventionState,
+  IGmCombatPublicEffect,
+  IGmPrivateMetadata,
+  IInterventionConflict,
+  IInterventionLedgerCommand,
+  IInterventionLedgerImplementer,
+  IInterventionLedgerPreview,
+  IInterventionLedgerRecord,
+} from '@/types/interventions';
+
+import type { InterventionLedger } from './InterventionLedger';
+
+import { buildGmCombatProjectedEffect } from './GmCombatInterventionPreview';
+import {
+  applyGmCombatProjectedEffects,
+  projectCombatEffectsForRecord,
+} from './GmCombatInterventionProjection';
+import { buildGmInterventionRedactionEnvelope } from './GmInterventionAuthority';
+
+type CombatPreview = IInterventionLedgerPreview<
+  IGmPrivateMetadata,
+  IGmCombatPublicEffect,
+  IGmCombatInterventionDomainPayload
+>;
+
+type CombatCommand =
+  IInterventionLedgerCommand<IGmCombatInterventionCommandPayload>;
+
+type CombatRecord = IInterventionLedgerRecord<
+  IGmPrivateMetadata,
+  IGmCombatPublicEffect,
+  IGmCombatInterventionDomainPayload
+>;
+
+const COMBAT_DOMAIN = 'combat' as const;
+
+export function createGmCombatInterventionImplementer(): IInterventionLedgerImplementer<
+  CombatCommand,
+  IGmCombatInterventionState,
+  IGmPrivateMetadata,
+  IGmCombatPublicEffect,
+  IGmCombatInterventionDomainPayload
+> {
+  return {
+    domain: COMBAT_DOMAIN,
+    preview(command, state): CombatPreview {
+      if (!isCombatCommandPayload(command.payload)) {
+        return blockedCombatPreview(
+          command,
+          'combat-payload-invalid',
+          'Combat intervention command requires a correction and GM-private reason.',
+        );
+      }
+
+      const projected = buildGmCombatProjectedEffect(command.payload, state);
+      if (!projected.effect) {
+        return blockedCombatPreview(
+          command,
+          projected.code,
+          projected.reason,
+          projected.affectedRefs,
+        );
+      }
+
+      const envelope = buildGmInterventionRedactionEnvelope(
+        command.payload.privateMetadata,
+        {
+          summary: command.payload.publicSummary ?? projected.summary,
+          family: command.payload.correction.family,
+          changedStateRefs: projected.changedStateRefs,
+          visibleToPlayerIds: command.payload.visibleToPlayerIds,
+        },
+      );
+
+      return {
+        domain: COMBAT_DOMAIN,
+        kind: command.kind,
+        status: 'ready',
+        actorId: command.actorId,
+        targetRefs: command.targetRefs,
+        causedBy: command.causedBy,
+        supersedes: command.supersedes,
+        privateMetadata: envelope.privateMetadata,
+        publicEffect: envelope.publicEffect,
+        domainPayload: {
+          correction: command.payload.correction,
+          projectedEffects: [projected.effect],
+        },
+        projectedEvents: [projected.effect],
+        conflicts: [],
+      };
+    },
+    apply(record, state): IGmCombatInterventionState {
+      return applyGmCombatProjectedEffects(
+        state,
+        projectCombatEffectsForRecord(record as CombatRecord),
+      );
+    },
+    projectPublic(record): IGmCombatPublicEffect {
+      return record.publicEffect;
+    },
+    projectPrivate(record): IGmPrivateMetadata {
+      return record.privateMetadata;
+    },
+  };
+}
+
+export function registerGmCombatInterventionImplementer(
+  ledger: InterventionLedger<IGmCombatInterventionState>,
+): InterventionLedger<IGmCombatInterventionState> {
+  return ledger.register(
+    createGmCombatInterventionImplementer() as IInterventionLedgerImplementer<
+      IInterventionLedgerCommand,
+      IGmCombatInterventionState
+    >,
+  );
+}
+
+function blockedCombatPreview(
+  command: IInterventionLedgerCommand,
+  code: string,
+  reason: string,
+  affectedRefs: readonly string[] = command.targetRefs,
+): CombatPreview {
+  const conflict: IInterventionConflict = {
+    code,
+    message: reason,
+    affectedRefs,
+  };
+
+  return {
+    domain: COMBAT_DOMAIN,
+    kind: command.kind,
+    status: 'blocked',
+    actorId: command.actorId,
+    targetRefs: command.targetRefs,
+    causedBy: command.causedBy,
+    supersedes: command.supersedes,
+    conflicts: [conflict],
+    reason,
+  };
+}
+
+function isCombatCommandPayload(
+  payload: unknown,
+): payload is IGmCombatInterventionCommandPayload {
+  if (!isRecord(payload)) return false;
+  if (!isRecord(payload.privateMetadata)) return false;
+  if (typeof payload.privateMetadata.reason !== 'string') return false;
+  if (!isRecord(payload.correction)) return false;
+
+  return (
+    payload.correction.family === 'reposition-facing' ||
+    payload.correction.family === 'damage-critical' ||
+    payload.correction.family === 'heat-ammo' ||
+    payload.correction.family === 'turn-order' ||
+    payload.correction.family === 'lifecycle'
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/src/lib/interventions/GmCombatInterventionPreview.ts
+++ b/src/lib/interventions/GmCombatInterventionPreview.ts
@@ -1,0 +1,380 @@
+import type {
+  IGmCombatDamageCriticalCorrection,
+  IGmCombatHeatAmmoCorrection,
+  IGmCombatInterventionCommandPayload,
+  IGmCombatInterventionState,
+  IGmCombatInterventionUnitState,
+  IGmCombatLifecycleCorrection,
+  IGmCombatProjectedEffect,
+  IGmCombatRepositionFacingCorrection,
+  IGmCombatTurnOrderCorrection,
+} from '@/types/interventions';
+
+type LifecycleEffect = Extract<
+  IGmCombatProjectedEffect,
+  { readonly family: 'lifecycle' }
+>;
+
+type LifecyclePatch = LifecycleEffect['after'];
+
+export interface IGmCombatProjectedEffectResult {
+  readonly effect: IGmCombatProjectedEffect;
+  readonly changedStateRefs: readonly string[];
+  readonly summary: string;
+}
+
+export interface IGmCombatProjectedEffectFailure {
+  readonly effect?: undefined;
+  readonly code: string;
+  readonly reason: string;
+  readonly affectedRefs?: readonly string[];
+}
+
+export function buildGmCombatProjectedEffect(
+  payload: IGmCombatInterventionCommandPayload,
+  state: IGmCombatInterventionState,
+): IGmCombatProjectedEffectResult | IGmCombatProjectedEffectFailure {
+  const { correction } = payload;
+
+  if (correction.family === 'turn-order') {
+    return buildTurnOrderEffect(correction, state, payload.publicSummary);
+  }
+
+  const unit = state.units[correction.unitId];
+  if (!unit) {
+    return {
+      code: 'combat-unit-not-found',
+      reason: `Combat unit "${correction.unitId}" was not found.`,
+      affectedRefs: [unitRef(correction.unitId)],
+    };
+  }
+
+  switch (correction.family) {
+    case 'reposition-facing':
+      return buildRepositionFacingEffect(
+        correction,
+        unit,
+        payload.publicSummary,
+      );
+    case 'damage-critical':
+      return buildDamageCriticalEffect(correction, unit, payload.publicSummary);
+    case 'heat-ammo':
+      return buildHeatAmmoEffect(correction, unit, payload.publicSummary);
+    case 'lifecycle':
+      return buildLifecycleEffect(correction, unit, payload.publicSummary);
+  }
+}
+
+function buildRepositionFacingEffect(
+  correction: IGmCombatRepositionFacingCorrection,
+  unit: IGmCombatInterventionUnitState,
+  summaryOverride?: string,
+): IGmCombatProjectedEffectResult {
+  const after = {
+    position: correction.position,
+    facing: correction.facing,
+    secondaryFacing: correction.secondaryFacing,
+  };
+  const changedStateRefs = [
+    unitRef(unit.id),
+    ...(correction.position ? [unitFieldRef(unit.id, 'position')] : []),
+    ...(correction.facing !== undefined
+      ? [unitFieldRef(unit.id, 'facing')]
+      : []),
+    ...(correction.secondaryFacing !== undefined
+      ? [unitFieldRef(unit.id, 'secondaryFacing')]
+      : []),
+  ];
+  const summary =
+    summaryOverride ?? `Unit ${unit.id} position/facing corrected by the GM.`;
+
+  return {
+    summary,
+    changedStateRefs,
+    effect: {
+      type: 'gm.combat.reposition_facing_corrected',
+      family: 'reposition-facing',
+      unitId: unit.id,
+      before: {
+        position: unit.position,
+        facing: unit.facing,
+        secondaryFacing: unit.secondaryFacing,
+      },
+      after,
+      changedStateRefs,
+      publicSummary: summary,
+    },
+  };
+}
+
+function buildDamageCriticalEffect(
+  correction: IGmCombatDamageCriticalCorrection,
+  unit: IGmCombatInterventionUnitState,
+  summaryOverride?: string,
+): IGmCombatProjectedEffectResult {
+  const after = {
+    armor: correction.armor
+      ? { ...unit.armor, ...correction.armor }
+      : undefined,
+    structure: correction.structure
+      ? { ...unit.structure, ...correction.structure }
+      : undefined,
+    componentDamage: correction.componentDamage,
+    destroyedLocations: correction.destroyedLocations,
+    destroyedEquipment: correction.destroyedEquipment,
+  };
+  const changedStateRefs = [
+    unitRef(unit.id),
+    unitFieldRef(unit.id, 'damage'),
+    ...(correction.componentDamage
+      ? [unitFieldRef(unit.id, 'componentDamage')]
+      : []),
+  ];
+  const summary =
+    summaryOverride ??
+    `Unit ${unit.id} damage and critical state corrected by the GM.`;
+
+  return {
+    summary,
+    changedStateRefs,
+    effect: {
+      type: 'gm.combat.damage_critical_corrected',
+      family: 'damage-critical',
+      unitId: unit.id,
+      before: {
+        armor: unit.armor,
+        structure: unit.structure,
+        componentDamage: unit.componentDamage,
+        destroyedLocations: unit.destroyedLocations,
+        destroyedEquipment: unit.destroyedEquipment,
+      },
+      after,
+      changedStateRefs,
+      publicSummary: summary,
+    },
+  };
+}
+
+function buildHeatAmmoEffect(
+  correction: IGmCombatHeatAmmoCorrection,
+  unit: IGmCombatInterventionUnitState,
+  summaryOverride?: string,
+): IGmCombatProjectedEffectResult {
+  const after = {
+    heat: correction.heat,
+    ammo: correction.ammo ? { ...unit.ammo, ...correction.ammo } : undefined,
+    ammoState: correction.ammoState
+      ? { ...(unit.ammoState ?? {}), ...correction.ammoState }
+      : undefined,
+  };
+  const changedStateRefs = [
+    unitRef(unit.id),
+    ...(correction.heat !== undefined ? [unitFieldRef(unit.id, 'heat')] : []),
+    ...(correction.ammo ? [unitFieldRef(unit.id, 'ammo')] : []),
+    ...(correction.ammoState ? [unitFieldRef(unit.id, 'ammoState')] : []),
+  ];
+  const summary =
+    summaryOverride ?? `Unit ${unit.id} heat/ammo corrected by the GM.`;
+
+  return {
+    summary,
+    changedStateRefs,
+    effect: {
+      type: 'gm.combat.heat_ammo_corrected',
+      family: 'heat-ammo',
+      unitId: unit.id,
+      before: {
+        heat: unit.heat,
+        ammo: unit.ammo,
+        ammoState: unit.ammoState,
+      },
+      after,
+      changedStateRefs,
+      publicSummary: summary,
+    },
+  };
+}
+
+function buildTurnOrderEffect(
+  correction: IGmCombatTurnOrderCorrection,
+  state: IGmCombatInterventionState,
+  summaryOverride?: string,
+): IGmCombatProjectedEffectResult | IGmCombatProjectedEffectFailure {
+  const unknownOrderUnit = correction.initiativeOrder?.find(
+    (unitId) => !state.units[unitId],
+  );
+  if (unknownOrderUnit) {
+    return {
+      code: 'combat-initiative-unit-not-found',
+      reason: `Initiative order references unknown unit "${unknownOrderUnit}".`,
+      affectedRefs: [unitRef(unknownOrderUnit)],
+    };
+  }
+
+  if (correction.activeUnitId && !state.units[correction.activeUnitId]) {
+    return {
+      code: 'combat-active-unit-not-found',
+      reason: `Active unit "${correction.activeUnitId}" was not found.`,
+      affectedRefs: [unitRef(correction.activeUnitId)],
+    };
+  }
+
+  const initiativeOrder = correction.initiativeOrder ?? state.initiativeOrder;
+  const activeUnitIndex =
+    correction.activationIndex ??
+    resolveActivationIndex(initiativeOrder, correction.activeUnitId);
+  const after = {
+    phase: correction.phase,
+    initiativeWinner: correction.initiativeWinner,
+    firstMover: correction.firstMover,
+    activationIndex: activeUnitIndex,
+    initiativeOrder,
+    activeUnitId:
+      correction.activeUnitId ??
+      resolveActiveUnitId(initiativeOrder, activeUnitIndex),
+  };
+  const changedStateRefs = [
+    gameRef(state.gameId),
+    gameFieldRef(state.gameId, 'turn-order'),
+  ];
+  const summary =
+    summaryOverride ??
+    `Combat phase, initiative, or active turn corrected by the GM.`;
+
+  return {
+    summary,
+    changedStateRefs,
+    effect: {
+      type: 'gm.combat.turn_order_corrected',
+      family: 'turn-order',
+      before: {
+        phase: state.phase,
+        initiativeWinner: state.initiativeWinner,
+        firstMover: state.firstMover,
+        activationIndex: state.activationIndex,
+        initiativeOrder: state.initiativeOrder,
+        activeUnitId: state.activeUnitId,
+      },
+      after,
+      changedStateRefs,
+      publicSummary: summary,
+    },
+  };
+}
+
+function buildLifecycleEffect(
+  correction: IGmCombatLifecycleCorrection,
+  unit: IGmCombatInterventionUnitState,
+  summaryOverride?: string,
+): IGmCombatProjectedEffectResult {
+  const after = lifecyclePatch(correction);
+  const changedStateRefs = [
+    unitRef(unit.id),
+    unitFieldRef(unit.id, 'lifecycle'),
+  ];
+  const summary =
+    summaryOverride ??
+    `Unit ${unit.id} lifecycle state corrected to ${correction.lifecycle}.`;
+
+  return {
+    summary,
+    changedStateRefs,
+    effect: {
+      type: 'gm.combat.lifecycle_corrected',
+      family: 'lifecycle',
+      unitId: unit.id,
+      before: {
+        destroyed: unit.destroyed,
+        destructionCause: unit.destructionCause,
+        hasEjected: unit.hasEjected,
+        isWithdrawing: unit.isWithdrawing,
+        hasRetreated: unit.hasRetreated,
+        shutdown: unit.shutdown,
+        rescued: unit.rescued,
+        retreatTargetEdge: unit.retreatTargetEdge,
+      },
+      after,
+      changedStateRefs,
+      publicSummary: summary,
+    },
+  };
+}
+
+function lifecyclePatch(
+  correction: IGmCombatLifecycleCorrection,
+): LifecyclePatch {
+  switch (correction.lifecycle) {
+    case 'active':
+      return inactiveLifecyclePatch();
+    case 'ejected':
+      return { ...inactiveLifecyclePatch(), hasEjected: true };
+    case 'withdrawing':
+      return {
+        ...inactiveLifecyclePatch(),
+        isWithdrawing: true,
+        retreatTargetEdge: correction.retreatTargetEdge,
+      };
+    case 'withdrawn':
+      return { ...inactiveLifecyclePatch(), hasRetreated: true };
+    case 'disabled':
+      return { ...inactiveLifecyclePatch(), shutdown: true };
+    case 'destroyed':
+      return {
+        ...inactiveLifecyclePatch(),
+        destroyed: true,
+        destructionCause: correction.destructionCause ?? 'damage',
+      };
+    case 'rescued':
+      return {
+        ...inactiveLifecyclePatch(),
+        hasRetreated: true,
+        rescued: true,
+      };
+  }
+}
+
+function inactiveLifecyclePatch(): LifecyclePatch {
+  return {
+    destroyed: false,
+    destructionCause: undefined,
+    hasEjected: false,
+    isWithdrawing: false,
+    hasRetreated: false,
+    shutdown: false,
+    rescued: false,
+    retreatTargetEdge: undefined,
+  };
+}
+
+function resolveActivationIndex(
+  initiativeOrder: readonly string[] | undefined,
+  activeUnitId: string | null | undefined,
+): number | undefined {
+  if (!initiativeOrder || !activeUnitId) return undefined;
+  const index = initiativeOrder.indexOf(activeUnitId);
+  return index >= 0 ? index : undefined;
+}
+
+function resolveActiveUnitId(
+  initiativeOrder: readonly string[] | undefined,
+  activationIndex: number | undefined,
+): string | null | undefined {
+  if (!initiativeOrder || activationIndex === undefined) return undefined;
+  return initiativeOrder[activationIndex] ?? null;
+}
+
+function unitRef(unitId: string): string {
+  return `unit:${unitId}`;
+}
+
+function unitFieldRef(unitId: string, field: string): string {
+  return `unit:${unitId}:${field}`;
+}
+
+function gameRef(gameId: string): string {
+  return `game:${gameId}`;
+}
+
+function gameFieldRef(gameId: string, field: string): string {
+  return `game:${gameId}:${field}`;
+}

--- a/src/lib/interventions/GmCombatInterventionProjection.ts
+++ b/src/lib/interventions/GmCombatInterventionProjection.ts
@@ -1,0 +1,144 @@
+import type {
+  IGmCombatInterventionDomainPayload,
+  IGmCombatInterventionState,
+  IGmCombatInterventionUnitState,
+  IGmCombatProjectedEffect,
+  IGmCombatPublicEffect,
+  IGmPrivateMetadata,
+  IInterventionLedgerRecord,
+} from '@/types/interventions';
+
+type CombatRecord = IInterventionLedgerRecord<
+  IGmPrivateMetadata,
+  IGmCombatPublicEffect,
+  IGmCombatInterventionDomainPayload
+>;
+
+type TurnOrderEffect = Extract<
+  IGmCombatProjectedEffect,
+  { readonly family: 'turn-order' }
+>;
+
+export function projectCombatEffectsForRecord(
+  record: CombatRecord,
+): readonly IGmCombatProjectedEffect[] {
+  if (!record.domainPayload) return [];
+
+  return record.domainPayload.projectedEffects.map(
+    (effect) =>
+      ({
+        ...effect,
+        interventionId: record.id,
+      }) as IGmCombatProjectedEffect,
+  );
+}
+
+export function applyGmCombatProjectedEffects(
+  state: IGmCombatInterventionState,
+  effects: readonly IGmCombatProjectedEffect[],
+): IGmCombatInterventionState {
+  return effects.reduce(applyGmCombatProjectedEffect, state);
+}
+
+function applyGmCombatProjectedEffect(
+  state: IGmCombatInterventionState,
+  effect: IGmCombatProjectedEffect,
+): IGmCombatInterventionState {
+  switch (effect.family) {
+    case 'reposition-facing':
+      return appendGmCombatEvent(
+        patchUnit(state, effect.unitId, definedUnitPatch(effect.after)),
+        effect,
+      );
+    case 'damage-critical':
+      return appendGmCombatEvent(
+        patchUnit(state, effect.unitId, definedUnitPatch(effect.after)),
+        effect,
+      );
+    case 'heat-ammo':
+      return appendGmCombatEvent(
+        patchUnit(state, effect.unitId, definedUnitPatch(effect.after)),
+        effect,
+      );
+    case 'turn-order':
+      return appendGmCombatEvent(applyTurnOrderEffect(state, effect), effect);
+    case 'lifecycle':
+      return appendGmCombatEvent(
+        patchUnit(state, effect.unitId, {
+          destroyed: effect.after.destroyed,
+          destructionCause: effect.after.destructionCause,
+          hasEjected: effect.after.hasEjected,
+          isWithdrawing: effect.after.isWithdrawing,
+          hasRetreated: effect.after.hasRetreated,
+          shutdown: effect.after.shutdown,
+          rescued: effect.after.rescued,
+          retreatTargetEdge: effect.after.retreatTargetEdge,
+        }),
+        effect,
+      );
+  }
+}
+
+function applyTurnOrderEffect(
+  state: IGmCombatInterventionState,
+  effect: TurnOrderEffect,
+): IGmCombatInterventionState {
+  return {
+    ...state,
+    ...(effect.after.phase !== undefined ? { phase: effect.after.phase } : {}),
+    ...(effect.after.initiativeWinner !== undefined
+      ? { initiativeWinner: effect.after.initiativeWinner }
+      : {}),
+    ...(effect.after.firstMover !== undefined
+      ? { firstMover: effect.after.firstMover }
+      : {}),
+    ...(effect.after.activationIndex !== undefined
+      ? { activationIndex: effect.after.activationIndex }
+      : {}),
+    ...(effect.after.initiativeOrder !== undefined
+      ? { initiativeOrder: effect.after.initiativeOrder }
+      : {}),
+    ...(effect.after.activeUnitId !== undefined
+      ? { activeUnitId: effect.after.activeUnitId }
+      : {}),
+  };
+}
+
+function patchUnit(
+  state: IGmCombatInterventionState,
+  unitId: string,
+  patch: Partial<IGmCombatInterventionUnitState>,
+): IGmCombatInterventionState {
+  const unit = state.units[unitId];
+  if (!unit) return state;
+
+  return {
+    ...state,
+    units: {
+      ...state.units,
+      [unitId]: {
+        ...unit,
+        ...patch,
+      },
+    },
+  };
+}
+
+function appendGmCombatEvent(
+  state: IGmCombatInterventionState,
+  effect: IGmCombatProjectedEffect,
+): IGmCombatInterventionState {
+  return {
+    ...state,
+    gmInterventionEvents: [...(state.gmInterventionEvents ?? []), effect],
+  };
+}
+
+function definedUnitPatch<T extends Partial<IGmCombatInterventionUnitState>>(
+  value: T,
+): Partial<IGmCombatInterventionUnitState> {
+  const entries = Object.entries(value).filter(
+    ([, entryValue]) => entryValue !== undefined,
+  );
+  return Object.fromEntries(entries) as Partial<IGmCombatInterventionUnitState>;
+}

--- a/src/lib/interventions/__tests__/GmCombatInterventionImplementer.test.ts
+++ b/src/lib/interventions/__tests__/GmCombatInterventionImplementer.test.ts
@@ -1,0 +1,427 @@
+import type {
+  IGmAuthorityContext,
+  IGmCombatInterventionCommandPayload,
+  IGmCombatInterventionDomainPayload,
+  IGmCombatInterventionState,
+  IGmCombatInterventionUnitState,
+  IGmCombatPublicEffect,
+  IGmPrivateMetadata,
+  IInterventionLedgerCommand,
+  IInterventionLedgerRecord,
+} from '@/types/interventions';
+
+import {
+  GamePhase,
+  GameSide,
+  GameStatus,
+  LockState,
+} from '@/types/gameplay/GameSessionInterfaces';
+import { Facing, MovementType } from '@/types/gameplay/HexGridInterfaces';
+
+import {
+  applyGmCombatProjectedEffects,
+  approveGmCascadePreview,
+  createGmCascadePreview,
+  projectCombatEffectsForRecord,
+  projectInterventionRecordForPlayer,
+  registerGmCombatInterventionImplementer,
+} from '../index';
+import { InterventionLedger } from '../InterventionLedger';
+
+type CombatRecord = IInterventionLedgerRecord<
+  IGmPrivateMetadata,
+  IGmCombatPublicEffect,
+  IGmCombatInterventionDomainPayload
+>;
+
+const gmAuthority: IGmAuthorityContext = {
+  actorId: 'gm-1',
+  role: 'gm',
+  gameId: 'game-1',
+  ownedStateRefs: ['game:game-1'],
+};
+
+const componentDamage = {
+  engineHits: 0,
+  gyroHits: 0,
+  sensorHits: 0,
+  lifeSupport: 0,
+  cockpitHit: false,
+  actuators: {},
+  weaponsDestroyed: [],
+  heatSinksDestroyed: 0,
+  jumpJetsDestroyed: 0,
+};
+
+function makeState(): IGmCombatInterventionState {
+  return {
+    gameId: 'game-1',
+    status: GameStatus.Active,
+    turn: 3,
+    phase: GamePhase.Movement,
+    initiativeWinner: GameSide.Player,
+    firstMover: GameSide.Player,
+    activationIndex: 0,
+    initiativeOrder: ['atlas-1', 'locust-1'],
+    activeUnitId: 'atlas-1',
+    units: {
+      'atlas-1': makeUnit('atlas-1', GameSide.Player),
+      'locust-1': makeUnit('locust-1', GameSide.Opponent),
+    },
+    turnEvents: [],
+  };
+}
+
+function makeUnit(
+  id: string,
+  side: GameSide,
+  overrides: Partial<IGmCombatInterventionUnitState> = {},
+): IGmCombatInterventionUnitState {
+  return {
+    id,
+    side,
+    position: { q: 1, r: 1 },
+    facing: Facing.North,
+    heat: 4,
+    movementThisTurn: MovementType.Stationary,
+    hexesMovedThisTurn: 0,
+    armor: {
+      head: 9,
+      centerTorso: 30,
+      leftArm: 16,
+    },
+    structure: {
+      head: 3,
+      centerTorso: 20,
+      leftArm: 8,
+    },
+    destroyedLocations: [],
+    destroyedEquipment: [],
+    ammo: {
+      ac20: 5,
+    },
+    ammoState: {
+      ac20Bin: {
+        binId: 'ac20Bin',
+        weaponType: 'AC/20',
+        location: 'leftTorso',
+        remainingRounds: 5,
+        maxRounds: 5,
+        isExplosive: true,
+      },
+    },
+    pilotWounds: 0,
+    pilotConscious: true,
+    destroyed: false,
+    lockState: LockState.Pending,
+    componentDamage,
+    ...overrides,
+  };
+}
+
+function makeLedger(): InterventionLedger<IGmCombatInterventionState> {
+  return registerGmCombatInterventionImplementer(
+    new InterventionLedger<IGmCombatInterventionState>(),
+  );
+}
+
+function makeCommand(
+  payload: IGmCombatInterventionCommandPayload,
+  overrides: Partial<
+    IInterventionLedgerCommand<IGmCombatInterventionCommandPayload>
+  > = {},
+): IInterventionLedgerCommand<IGmCombatInterventionCommandPayload> {
+  return {
+    domain: 'combat',
+    kind: 'fix',
+    actorId: 'gm-1',
+    targetRefs:
+      payload.correction.family === 'turn-order'
+        ? ['game:game-1:turn-order']
+        : [`unit:${payload.correction.unitId}`],
+    payload,
+    causedBy: ['player-event-1'],
+    ...overrides,
+  };
+}
+
+function payload(
+  correction: IGmCombatInterventionCommandPayload['correction'],
+  publicSummary?: string,
+): IGmCombatInterventionCommandPayload {
+  return {
+    correction,
+    publicSummary,
+    privateMetadata: {
+      reason: 'Hidden GM adjudication reason.',
+      defaultOutcome: 'The original result would remain.',
+      hiddenNotes: 'Secret scenario branch stays private.',
+    },
+  };
+}
+
+function approveCommand(
+  command: IInterventionLedgerCommand<IGmCombatInterventionCommandPayload>,
+  state = makeState(),
+): {
+  readonly state: IGmCombatInterventionState;
+  readonly record: CombatRecord;
+} {
+  const ledger = makeLedger();
+  const preview = createGmCascadePreview({
+    ledger,
+    command,
+    state,
+    authority: gmAuthority,
+    interventionId: `gm-int-${command.payload?.correction.family}`,
+  });
+
+  const result = approveGmCascadePreview({
+    ledger,
+    preview,
+    state,
+    createdAt: '2026-06-20T00:00:00.000Z',
+    approvedAt: '2026-06-20T00:01:00.000Z',
+  });
+
+  expect(result.status).toBe('approved');
+  if (result.status !== 'approved' || !result.record) {
+    throw new Error('Expected combat GM intervention approval.');
+  }
+
+  return {
+    state: result.state as IGmCombatInterventionState,
+    record: result.record as CombatRecord,
+  };
+}
+
+describe('GM combat intervention implementer', () => {
+  it('registers the combat domain and leaves unregistered domains unsupported', () => {
+    const ledger = makeLedger();
+    const state = makeState();
+
+    const preview = ledger.preview(
+      makeCommand(
+        payload({
+          family: 'reposition-facing',
+          unitId: 'atlas-1',
+          position: { q: 3, r: 2 },
+          facing: Facing.South,
+        }),
+      ),
+      state,
+    );
+    const unsupported = ledger.preview(
+      {
+        domain: 'economy',
+        kind: 'undo',
+        actorId: 'gm-1',
+        targetRefs: ['merchant-tx:1'],
+      },
+      state,
+    );
+
+    expect(ledger.hasImplementer('combat')).toBe(true);
+    expect(preview.status).toBe('ready');
+    expect(unsupported.status).toBe('unsupported');
+  });
+
+  it('previews and applies reposition/facing corrections with public-only player output', () => {
+    const command = makeCommand(
+      payload(
+        {
+          family: 'reposition-facing',
+          unitId: 'atlas-1',
+          position: { q: 5, r: 4 },
+          facing: Facing.Southwest,
+          secondaryFacing: Facing.Northwest,
+        },
+        'Atlas moved to hex 5,4 and facing corrected.',
+      ),
+    );
+
+    const result = approveCommand(command);
+    const unit = result.state.units['atlas-1'];
+    const playerRecord = projectInterventionRecordForPlayer(result.record);
+
+    expect(unit.position).toEqual({ q: 5, r: 4 });
+    expect(unit.facing).toBe(Facing.Southwest);
+    expect(unit.secondaryFacing).toBe(Facing.Northwest);
+    expect(playerRecord.publicEffect).toMatchObject({
+      summary: 'Atlas moved to hex 5,4 and facing corrected.',
+      changedStateRefs: [
+        'unit:atlas-1',
+        'unit:atlas-1:position',
+        'unit:atlas-1:facing',
+        'unit:atlas-1:secondaryFacing',
+      ],
+    });
+    expect(JSON.stringify(playerRecord)).not.toContain('Hidden GM');
+    expect(JSON.stringify(playerRecord)).not.toContain('Secret scenario');
+  });
+
+  it('previews and applies damage and critical corrections traceably', () => {
+    const correctedComponentDamage = {
+      ...componentDamage,
+      engineHits: 1,
+      weaponsDestroyed: ['medium-laser-1'],
+    };
+
+    const result = approveCommand(
+      makeCommand(
+        payload({
+          family: 'damage-critical',
+          unitId: 'atlas-1',
+          armor: { centerTorso: 21 },
+          structure: { leftArm: 0 },
+          componentDamage: correctedComponentDamage,
+          destroyedLocations: ['leftArm'],
+          destroyedEquipment: ['medium-laser-1'],
+        }),
+      ),
+    );
+    const unit = result.state.units['atlas-1'];
+
+    expect(unit.armor.centerTorso).toBe(21);
+    expect(unit.structure.leftArm).toBe(0);
+    expect(unit.componentDamage?.engineHits).toBe(1);
+    expect(unit.destroyedLocations).toEqual(['leftArm']);
+    expect(unit.destroyedEquipment).toEqual(['medium-laser-1']);
+    expect(result.record).toMatchObject({
+      domain: 'combat',
+      kind: 'fix',
+      causedBy: ['player-event-1'],
+      privateMetadata: {
+        reason: 'Hidden GM adjudication reason.',
+      },
+    });
+  });
+
+  it('previews and applies heat and ammo corrections without leaking hidden reasoning', () => {
+    const result = approveCommand(
+      makeCommand(
+        payload({
+          family: 'heat-ammo',
+          unitId: 'atlas-1',
+          heat: 14,
+          ammo: { ac20: 2 },
+          ammoState: {
+            ac20Bin: {
+              binId: 'ac20Bin',
+              weaponType: 'AC/20',
+              location: 'leftTorso',
+              remainingRounds: 2,
+              maxRounds: 5,
+              isExplosive: true,
+            },
+          },
+        }),
+      ),
+    );
+    const unit = result.state.units['atlas-1'];
+    const playerRecord = projectInterventionRecordForPlayer(result.record);
+
+    expect(unit.heat).toBe(14);
+    expect(unit.ammo.ac20).toBe(2);
+    expect(unit.ammoState?.ac20Bin.remainingRounds).toBe(2);
+    expect(playerRecord.publicEffect.summary).toBe(
+      'Unit atlas-1 heat/ammo corrected by the GM.',
+    );
+    expect(JSON.stringify(playerRecord)).not.toContain('defaultOutcome');
+    expect(JSON.stringify(playerRecord)).not.toContain('hiddenNotes');
+  });
+
+  it('previews and applies phase, initiative, and turn ownership corrections', () => {
+    const result = approveCommand(
+      makeCommand(
+        payload({
+          family: 'turn-order',
+          phase: GamePhase.WeaponAttack,
+          initiativeWinner: GameSide.Opponent,
+          firstMover: GameSide.Opponent,
+          initiativeOrder: ['atlas-1', 'locust-1'],
+          activeUnitId: 'locust-1',
+        }),
+      ),
+    );
+
+    expect(result.state.phase).toBe(GamePhase.WeaponAttack);
+    expect(result.state.initiativeWinner).toBe(GameSide.Opponent);
+    expect(result.state.firstMover).toBe(GameSide.Opponent);
+    expect(result.state.activationIndex).toBe(1);
+    expect(result.state.activeUnitId).toBe('locust-1');
+  });
+
+  it.each([
+    ['ejected', { hasEjected: true }],
+    ['withdrawing', { isWithdrawing: true, retreatTargetEdge: 'north' }],
+    ['withdrawn', { hasRetreated: true }],
+    ['disabled', { shutdown: true }],
+    ['destroyed', { destroyed: true, destructionCause: 'damage' }],
+    ['rescued', { rescued: true, hasRetreated: true }],
+  ] as const)(
+    'previews and applies %s lifecycle corrections',
+    (lifecycle, expectedPatch) => {
+      const result = approveCommand(
+        makeCommand(
+          payload({
+            family: 'lifecycle',
+            unitId: 'atlas-1',
+            lifecycle,
+            retreatTargetEdge:
+              lifecycle === 'withdrawing' ? 'north' : undefined,
+          }),
+        ),
+      );
+
+      expect(result.state.units['atlas-1']).toMatchObject(expectedPatch);
+      expect(result.record.publicEffect.summary).toBe(
+        `Unit atlas-1 lifecycle state corrected to ${lifecycle}.`,
+      );
+    },
+  );
+
+  it.each([
+    payload({
+      family: 'reposition-facing',
+      unitId: 'atlas-1',
+      position: { q: 2, r: 3 },
+      facing: Facing.Northeast,
+    }),
+    payload({
+      family: 'damage-critical',
+      unitId: 'atlas-1',
+      armor: { head: 7 },
+      structure: { centerTorso: 18 },
+      componentDamage: { ...componentDamage, sensorHits: 1 },
+    }),
+    payload({
+      family: 'heat-ammo',
+      unitId: 'atlas-1',
+      heat: 8,
+      ammo: { ac20: 4 },
+    }),
+    payload({
+      family: 'turn-order',
+      phase: GamePhase.PhysicalAttack,
+      initiativeOrder: ['locust-1', 'atlas-1'],
+      activeUnitId: 'atlas-1',
+    }),
+    payload({
+      family: 'lifecycle',
+      unitId: 'atlas-1',
+      lifecycle: 'rescued',
+    }),
+  ])('replays projected effects for %s corrections', (commandPayload) => {
+    const state = makeState();
+    const command = makeCommand(commandPayload);
+    const approved = approveCommand(command, state);
+    const replayed = applyGmCombatProjectedEffects(
+      state,
+      projectCombatEffectsForRecord(approved.record),
+    );
+
+    expect(replayed).toEqual(approved.state);
+    expect(replayed.gmInterventionEvents).toHaveLength(1);
+  });
+});

--- a/src/lib/interventions/index.ts
+++ b/src/lib/interventions/index.ts
@@ -10,6 +10,16 @@ export type {
 } from './GmCascadePreviewPipeline';
 
 export {
+  createGmCombatInterventionImplementer,
+  registerGmCombatInterventionImplementer,
+} from './GmCombatInterventionImplementer';
+
+export {
+  applyGmCombatProjectedEffects,
+  projectCombatEffectsForRecord,
+} from './GmCombatInterventionProjection';
+
+export {
   buildGmInterventionRedactionEnvelope,
   evaluateGmInterventionAuthority,
   logGmInterventionAuthorizationFailure,

--- a/src/types/interventions/GmCombatInterventionTypes.ts
+++ b/src/types/interventions/GmCombatInterventionTypes.ts
@@ -1,0 +1,237 @@
+import type {
+  GamePhase,
+  GameSide,
+  IAmmoSlotState,
+  IComponentDamageState,
+  IGameState,
+  IUnitGameState,
+  IUnitDestroyedPayload,
+} from '@/types/gameplay/GameSessionInterfaces';
+import type {
+  Facing,
+  IHexCoordinate,
+} from '@/types/gameplay/HexGridInterfaces';
+
+import type {
+  IGmPrivateMetadata,
+  IGmPublicEffect,
+} from './GmInterventionAuthorityTypes';
+
+export type GmCombatCorrectionFamily =
+  | 'reposition-facing'
+  | 'damage-critical'
+  | 'heat-ammo'
+  | 'turn-order'
+  | 'lifecycle';
+
+export type GmCombatLifecycleState =
+  | 'active'
+  | 'ejected'
+  | 'withdrawing'
+  | 'withdrawn'
+  | 'disabled'
+  | 'destroyed'
+  | 'rescued';
+
+export interface IGmCombatInterventionUnitState extends IUnitGameState {
+  readonly rescued?: boolean;
+}
+
+export interface IGmCombatInterventionState extends Omit<IGameState, 'units'> {
+  readonly units: Record<string, IGmCombatInterventionUnitState>;
+  readonly initiativeOrder?: readonly string[];
+  readonly activeUnitId?: string | null;
+  readonly gmInterventionEvents?: readonly IGmCombatProjectedEffect[];
+}
+
+export interface IGmCombatRepositionFacingCorrection {
+  readonly family: 'reposition-facing';
+  readonly unitId: string;
+  readonly position?: IHexCoordinate;
+  readonly facing?: Facing;
+  readonly secondaryFacing?: Facing;
+}
+
+export interface IGmCombatDamageCriticalCorrection {
+  readonly family: 'damage-critical';
+  readonly unitId: string;
+  readonly armor?: Record<string, number>;
+  readonly structure?: Record<string, number>;
+  readonly componentDamage?: IComponentDamageState;
+  readonly destroyedLocations?: readonly string[];
+  readonly destroyedEquipment?: readonly string[];
+}
+
+export interface IGmCombatHeatAmmoCorrection {
+  readonly family: 'heat-ammo';
+  readonly unitId: string;
+  readonly heat?: number;
+  readonly ammo?: Record<string, number>;
+  readonly ammoState?: Record<string, IAmmoSlotState>;
+}
+
+export interface IGmCombatTurnOrderCorrection {
+  readonly family: 'turn-order';
+  readonly phase?: GamePhase;
+  readonly initiativeWinner?: GameSide;
+  readonly firstMover?: GameSide;
+  readonly activationIndex?: number;
+  readonly initiativeOrder?: readonly string[];
+  readonly activeUnitId?: string | null;
+}
+
+export interface IGmCombatLifecycleCorrection {
+  readonly family: 'lifecycle';
+  readonly unitId: string;
+  readonly lifecycle: GmCombatLifecycleState;
+  readonly retreatTargetEdge?: 'north' | 'south' | 'east' | 'west';
+  readonly destructionCause?: IUnitDestroyedPayload['cause'];
+}
+
+export type GmCombatInterventionCorrection =
+  | IGmCombatRepositionFacingCorrection
+  | IGmCombatDamageCriticalCorrection
+  | IGmCombatHeatAmmoCorrection
+  | IGmCombatTurnOrderCorrection
+  | IGmCombatLifecycleCorrection;
+
+export interface IGmCombatInterventionCommandPayload {
+  readonly correction: GmCombatInterventionCorrection;
+  readonly privateMetadata: IGmPrivateMetadata;
+  readonly publicSummary?: string;
+  readonly visibleToPlayerIds?: readonly string[];
+}
+
+export type GmCombatProjectedEffectType =
+  | 'gm.combat.reposition_facing_corrected'
+  | 'gm.combat.damage_critical_corrected'
+  | 'gm.combat.heat_ammo_corrected'
+  | 'gm.combat.turn_order_corrected'
+  | 'gm.combat.lifecycle_corrected';
+
+export interface IGmCombatProjectedEffectBase<TType extends string> {
+  readonly type: TType;
+  readonly family: GmCombatCorrectionFamily;
+  readonly interventionId?: string;
+  readonly changedStateRefs: readonly string[];
+  readonly publicSummary: string;
+}
+
+export interface IGmCombatRepositionFacingEffect extends IGmCombatProjectedEffectBase<'gm.combat.reposition_facing_corrected'> {
+  readonly family: 'reposition-facing';
+  readonly unitId: string;
+  readonly before: Pick<
+    IGmCombatInterventionUnitState,
+    'position' | 'facing' | 'secondaryFacing'
+  >;
+  readonly after: Partial<
+    Pick<
+      IGmCombatInterventionUnitState,
+      'position' | 'facing' | 'secondaryFacing'
+    >
+  >;
+}
+
+export interface IGmCombatDamageCriticalEffect extends IGmCombatProjectedEffectBase<'gm.combat.damage_critical_corrected'> {
+  readonly family: 'damage-critical';
+  readonly unitId: string;
+  readonly before: Pick<
+    IGmCombatInterventionUnitState,
+    | 'armor'
+    | 'structure'
+    | 'componentDamage'
+    | 'destroyedLocations'
+    | 'destroyedEquipment'
+  >;
+  readonly after: Partial<
+    Pick<
+      IGmCombatInterventionUnitState,
+      | 'armor'
+      | 'structure'
+      | 'componentDamage'
+      | 'destroyedLocations'
+      | 'destroyedEquipment'
+    >
+  >;
+}
+
+export interface IGmCombatHeatAmmoEffect extends IGmCombatProjectedEffectBase<'gm.combat.heat_ammo_corrected'> {
+  readonly family: 'heat-ammo';
+  readonly unitId: string;
+  readonly before: Pick<
+    IGmCombatInterventionUnitState,
+    'heat' | 'ammo' | 'ammoState'
+  >;
+  readonly after: Partial<
+    Pick<IGmCombatInterventionUnitState, 'heat' | 'ammo' | 'ammoState'>
+  >;
+}
+
+export interface IGmCombatTurnOrderEffect extends IGmCombatProjectedEffectBase<'gm.combat.turn_order_corrected'> {
+  readonly family: 'turn-order';
+  readonly before: Pick<
+    IGmCombatInterventionState,
+    | 'phase'
+    | 'initiativeWinner'
+    | 'firstMover'
+    | 'activationIndex'
+    | 'initiativeOrder'
+    | 'activeUnitId'
+  >;
+  readonly after: Partial<
+    Pick<
+      IGmCombatInterventionState,
+      | 'phase'
+      | 'initiativeWinner'
+      | 'firstMover'
+      | 'activationIndex'
+      | 'initiativeOrder'
+      | 'activeUnitId'
+    >
+  >;
+}
+
+export interface IGmCombatLifecycleEffect extends IGmCombatProjectedEffectBase<'gm.combat.lifecycle_corrected'> {
+  readonly family: 'lifecycle';
+  readonly unitId: string;
+  readonly before: Pick<
+    IGmCombatInterventionUnitState,
+    | 'destroyed'
+    | 'destructionCause'
+    | 'hasEjected'
+    | 'isWithdrawing'
+    | 'hasRetreated'
+    | 'shutdown'
+    | 'rescued'
+    | 'retreatTargetEdge'
+  >;
+  readonly after: Partial<
+    Pick<
+      IGmCombatInterventionUnitState,
+      | 'destroyed'
+      | 'destructionCause'
+      | 'hasEjected'
+      | 'isWithdrawing'
+      | 'hasRetreated'
+      | 'shutdown'
+      | 'rescued'
+      | 'retreatTargetEdge'
+    >
+  >;
+}
+
+export type IGmCombatProjectedEffect =
+  | IGmCombatRepositionFacingEffect
+  | IGmCombatDamageCriticalEffect
+  | IGmCombatHeatAmmoEffect
+  | IGmCombatTurnOrderEffect
+  | IGmCombatLifecycleEffect;
+
+export interface IGmCombatInterventionDomainPayload {
+  readonly correction: GmCombatInterventionCorrection;
+  readonly projectedEffects: readonly IGmCombatProjectedEffect[];
+}
+
+export interface IGmCombatPublicEffect extends IGmPublicEffect {
+  readonly family: GmCombatCorrectionFamily;
+}

--- a/src/types/interventions/index.ts
+++ b/src/types/interventions/index.ts
@@ -6,6 +6,29 @@ export type {
 } from './GmCascadePreviewTypes';
 
 export type {
+  GmCombatCorrectionFamily,
+  GmCombatInterventionCorrection,
+  GmCombatLifecycleState,
+  GmCombatProjectedEffectType,
+  IGmCombatDamageCriticalCorrection,
+  IGmCombatDamageCriticalEffect,
+  IGmCombatHeatAmmoCorrection,
+  IGmCombatHeatAmmoEffect,
+  IGmCombatInterventionCommandPayload,
+  IGmCombatInterventionDomainPayload,
+  IGmCombatInterventionState,
+  IGmCombatInterventionUnitState,
+  IGmCombatLifecycleCorrection,
+  IGmCombatLifecycleEffect,
+  IGmCombatProjectedEffect,
+  IGmCombatPublicEffect,
+  IGmCombatRepositionFacingCorrection,
+  IGmCombatRepositionFacingEffect,
+  IGmCombatTurnOrderCorrection,
+  IGmCombatTurnOrderEffect,
+} from './GmCombatInterventionTypes';
+
+export type {
   GmAuthorityDecision,
   GmInterventionActorRole,
   GmInterventionAuthorityRejectionCode,


### PR DESCRIPTION
## Summary
- Adds the combat-domain GM intervention implementer and registration helper for the reusable ledger.
- Supports preview/apply/replay for reposition/facing, damage and critical correction, heat/ammo correction, phase/initiative/turn ownership, and lifecycle/ejection/withdrawal/disabled/destroyed/rescued corrections.
- Keeps GM-private reason/default/notes out of player projections and marks OpenSpec tasks 4.1-4.7 complete.

## Verification
- npm.cmd test -- --runTestsByPath src/lib/interventions/__tests__/InterventionLedger.test.ts src/lib/interventions/__tests__/GmInterventionAuthority.test.ts src/lib/interventions/__tests__/GmCascadePreviewPipeline.test.ts src/lib/interventions/__tests__/GmCombatInterventionImplementer.test.ts
- npx.cmd tsc --noEmit --skipLibCheck --pretty false
- npx.cmd oxlint src/lib/interventions src/types/interventions
- npx.cmd oxfmt --check targeted intervention files and tasks
- cmd /c openspec validate add-gm-intervention-control-plane --strict
- pre-commit hook: lint-staged + npm.cmd run build

## Deferred
- TacticalActionDock UI wiring, unit reload reconciliation, and campaign/time/economy deferred boundaries remain in later specs.