### PR TITLE
Add GM unit reload reconciliation

### DIFF
--- a/openspec/changes/add-gm-intervention-control-plane/tasks.md
+++ b/openspec/changes/add-gm-intervention-control-plane/tasks.md
@@ -36,12 +36,12 @@
 
 ## 5. Unit Reload Implementer
 
-- [ ] 5.1 Register a unit-reload-domain implementer with the reusable intervention ledger.
-- [ ] 5.2 Implement active-encounter unit reload preview that rehydrates construction/loadout-derived fields from the source unit by `unitRef` and pilot data by `pilotRef`.
-- [ ] 5.3 Preserve compatible live overlays by default: position, facing, initiative/phase state, damage state, heat, ammo, pilot state, movement locks, and committed action state.
-- [ ] 5.4 Detect reload conflicts for removed components, incompatible armor/structure mapping, changed ammo bins, changed movement profile, or invalid target/queued effects.
-- [ ] 5.5 Add manual-takeover result support for reload conflicts and block commit until the GM resolves or accepts conflict handling.
-- [ ] 5.6 Add tests proving reload updates one active unit without resetting the encounter, unrelated units, or prior event history.
+- [x] 5.1 Register a unit-reload-domain implementer with the reusable intervention ledger.
+- [x] 5.2 Implement active-encounter unit reload preview that rehydrates construction/loadout-derived fields from the source unit by `unitRef` and pilot data by `pilotRef`.
+- [x] 5.3 Preserve compatible live overlays by default: position, facing, initiative/phase state, damage state, heat, ammo, pilot state, movement locks, and committed action state.
+- [x] 5.4 Detect reload conflicts for removed components, incompatible armor/structure mapping, changed ammo bins, changed movement profile, or invalid target/queued effects.
+- [x] 5.5 Add manual-takeover result support for reload conflicts and block commit until the GM resolves or accepts conflict handling.
+- [x] 5.6 Add tests proving reload updates one active unit without resetting the encounter, unrelated units, or prior event history.
 
 ## 6. Tactical Command Surface
 

--- a/src/lib/interventions/GmUnitReloadConflictDetection.ts
+++ b/src/lib/interventions/GmUnitReloadConflictDetection.ts
@@ -1,0 +1,233 @@
+import type { IGameUnit } from '@/types/gameplay/GameSessionInterfaces';
+import type {
+  IGmUnitReloadInterventionState,
+  IGmUnitReloadInterventionUnitState,
+  IGmUnitReloadSourceSnapshot,
+  IInterventionConflict,
+} from '@/types/interventions';
+
+import { LockState, MovementType } from '@/types/gameplay';
+
+export interface IGmUnitReloadConflictInput {
+  readonly currentUnit: IGmUnitReloadInterventionUnitState;
+  readonly sessionUnit: IGameUnit;
+  readonly source: IGmUnitReloadSourceSnapshot;
+  readonly state: IGmUnitReloadInterventionState;
+}
+
+export function detectGmUnitReloadConflicts(
+  input: IGmUnitReloadConflictInput,
+): readonly IInterventionConflict[] {
+  return [
+    ...detectRemovedComponents(input.currentUnit, input.source.unit),
+    ...detectArmorStructureConflicts(input.currentUnit, input.source),
+    ...detectAmmoBinConflicts(input.currentUnit, input.source),
+    ...detectMovementProfileConflict(input),
+    ...detectQueuedTargetConflicts(input.currentUnit, input.state),
+  ];
+}
+
+export function applyGmUnitReloadManualResolution(
+  conflicts: readonly IInterventionConflict[],
+  acceptedCodes: readonly string[],
+): readonly IInterventionConflict[] {
+  const accepted = new Set(acceptedCodes);
+  return conflicts.map((entry) => ({
+    ...entry,
+    requiresManualTakeover: !accepted.has(entry.code),
+  }));
+}
+
+function detectRemovedComponents(
+  current: IGmUnitReloadInterventionUnitState,
+  source: IGameUnit,
+): readonly IInterventionConflict[] {
+  if (!source.weaponLocationById) return [];
+  const sourceWeaponIds = new Set(Object.keys(source.weaponLocationById));
+  const liveWeaponRefs = [
+    ...(current.destroyedEquipment ?? []),
+    ...(current.weaponsFiredThisTurn ?? []),
+    ...(current.jammedWeapons ?? []),
+  ];
+  const removed = liveWeaponRefs.filter(
+    (weaponId) => !sourceWeaponIds.has(weaponId),
+  );
+  if (removed.length === 0) return [];
+
+  return [
+    conflict(
+      'unit-reload-component-removed',
+      `Source unit removed live component references: ${unique(removed).join(', ')}.`,
+      [unitFieldRef(current.id, 'components')],
+    ),
+  ];
+}
+
+function detectArmorStructureConflicts(
+  current: IGmUnitReloadInterventionUnitState,
+  source: IGmUnitReloadSourceSnapshot,
+): readonly IInterventionConflict[] {
+  const armorConflict = detectMissingLocations(
+    Object.keys(current.armor),
+    source.armorLocations,
+    'unit-reload-armor-map-incompatible',
+    `Source unit no longer maps live armor locations.`,
+    unitFieldRef(current.id, 'armor'),
+  );
+  const structureConflict = detectMissingLocations(
+    Object.keys(current.structure),
+    source.structureLocations,
+    'unit-reload-structure-map-incompatible',
+    `Source unit no longer maps live structure locations.`,
+    unitFieldRef(current.id, 'structure'),
+  );
+
+  return [...armorConflict, ...structureConflict];
+}
+
+function detectAmmoBinConflicts(
+  current: IGmUnitReloadInterventionUnitState,
+  source: IGmUnitReloadSourceSnapshot,
+): readonly IInterventionConflict[] {
+  const sourceBinIds = new Set(
+    source.ammoBinIds ??
+      source.unit.ammoConstruction?.map((bin) => bin.binId) ??
+      [],
+  );
+  if (sourceBinIds.size === 0 && !source.unit.ammoConstruction) return [];
+
+  const removedBins = Object.keys(current.ammoState ?? {}).filter(
+    (binId) => !sourceBinIds.has(binId),
+  );
+  if (removedBins.length === 0) return [];
+
+  return [
+    conflict(
+      'unit-reload-ammo-bin-removed',
+      `Source unit removed live ammo bins: ${removedBins.join(', ')}.`,
+      [unitFieldRef(current.id, 'ammoState')],
+    ),
+  ];
+}
+
+function detectMovementProfileConflict(
+  input: IGmUnitReloadConflictInput,
+): readonly IInterventionConflict[] {
+  const before = movementProfileKey(input.sessionUnit);
+  const after =
+    input.source.movementProfileKey ?? movementProfileKey(input.source.unit);
+  if (before === after || !hasCommittedMovementState(input.currentUnit)) {
+    return [];
+  }
+
+  return [
+    conflict(
+      'unit-reload-movement-profile-changed',
+      `Source unit movement profile changed from "${before}" to "${after}" while live movement state exists.`,
+      [unitFieldRef(input.currentUnit.id, 'movement')],
+    ),
+  ];
+}
+
+function detectQueuedTargetConflicts(
+  current: IGmUnitReloadInterventionUnitState,
+  state: IGmUnitReloadInterventionState,
+): readonly IInterventionConflict[] {
+  const conflicts: IInterventionConflict[] = [];
+  if (current.pendingAction) {
+    conflicts.push(
+      conflict(
+        'unit-reload-pending-action-present',
+        'Unit has a pending action that must be reviewed after reload.',
+        [unitFieldRef(current.id, 'pendingAction')],
+      ),
+    );
+  }
+
+  const missingTargets = targetRefsForUnit(current).filter(
+    (targetId) => !state.units[targetId],
+  );
+  if (missingTargets.length > 0) {
+    conflicts.push(
+      conflict(
+        'unit-reload-target-ref-invalid',
+        `Unit has queued target references that are no longer valid: ${unique(missingTargets).join(', ')}.`,
+        [unitFieldRef(current.id, 'targets')],
+      ),
+    );
+  }
+
+  return conflicts;
+}
+
+function detectMissingLocations(
+  currentLocations: readonly string[],
+  sourceLocations: readonly string[] | undefined,
+  code: string,
+  message: string,
+  ref: string,
+): readonly IInterventionConflict[] {
+  if (!sourceLocations) return [];
+  const sourceSet = new Set(sourceLocations);
+  const missing = currentLocations.filter(
+    (location) => !sourceSet.has(location),
+  );
+  return missing.length > 0
+    ? [conflict(code, `${message} Missing: ${missing.join(', ')}.`, [ref])]
+    : [];
+}
+
+function hasCommittedMovementState(
+  unit: IGmUnitReloadInterventionUnitState,
+): boolean {
+  return (
+    unit.movementThisTurn !== MovementType.Stationary ||
+    unit.hexesMovedThisTurn > 0 ||
+    unit.lockState !== LockState.Pending ||
+    Boolean(unit.pendingAction) ||
+    Boolean(unit.pendingConversionStepCount) ||
+    Boolean(unit.pendingAltitudeControlStepCount)
+  );
+}
+
+function movementProfileKey(unit: IGameUnit): string {
+  return [
+    unit.unitType ?? 'legacy',
+    unit.movementMode ?? 'none',
+    unit.motionType ?? 'none',
+    unit.isQuad ? 'quad' : 'non-quad',
+  ].join('|');
+}
+
+function targetRefsForUnit(
+  unit: IGmUnitReloadInterventionUnitState,
+): readonly string[] {
+  return [
+    unit.designatedTargetId,
+    unit.displacementAttackTargetId,
+    unit.targetedByDisplacementAttackerId,
+    unit.spotTargetId,
+    unit.grappledUnitId,
+  ].filter((value): value is string => typeof value === 'string');
+}
+
+function conflict(
+  code: string,
+  message: string,
+  affectedRefs: readonly string[],
+): IInterventionConflict {
+  return {
+    code,
+    message,
+    affectedRefs,
+    requiresManualTakeover: true,
+  };
+}
+
+function unitFieldRef(unitId: string, field: string): string {
+  return `unit:${unitId}:${field}`;
+}
+
+function unique(values: readonly string[]): readonly string[] {
+  return Array.from(new Set(values));
+}

--- a/src/lib/interventions/GmUnitReloadInterventionImplementer.ts
+++ b/src/lib/interventions/GmUnitReloadInterventionImplementer.ts
@@ -1,0 +1,198 @@
+import type {
+  IGmPrivateMetadata,
+  IGmUnitReloadInterventionCommandPayload,
+  IGmUnitReloadInterventionDomainPayload,
+  IGmUnitReloadInterventionState,
+  IGmUnitReloadPublicEffect,
+  IInterventionConflict,
+  IInterventionLedgerCommand,
+  IInterventionLedgerImplementer,
+  IInterventionLedgerPreview,
+  IInterventionLedgerRecord,
+} from '@/types/interventions';
+
+import type { InterventionLedger } from './InterventionLedger';
+
+import { buildGmInterventionRedactionEnvelope } from './GmInterventionAuthority';
+import {
+  applyGmUnitReloadProjectedEffects,
+  projectUnitReloadEffectsForRecord,
+} from './GmUnitReloadInterventionProjection';
+import { buildGmUnitReloadProjectedEffect } from './GmUnitReloadReconciliation';
+
+type UnitReloadPreview = IInterventionLedgerPreview<
+  IGmPrivateMetadata,
+  IGmUnitReloadPublicEffect,
+  IGmUnitReloadInterventionDomainPayload
+>;
+
+type UnitReloadCommand =
+  IInterventionLedgerCommand<IGmUnitReloadInterventionCommandPayload>;
+
+type UnitReloadRecord = IInterventionLedgerRecord<
+  IGmPrivateMetadata,
+  IGmUnitReloadPublicEffect,
+  IGmUnitReloadInterventionDomainPayload
+>;
+
+const UNIT_RELOAD_DOMAIN = 'unit-reload' as const;
+
+export function createGmUnitReloadInterventionImplementer(): IInterventionLedgerImplementer<
+  UnitReloadCommand,
+  IGmUnitReloadInterventionState,
+  IGmPrivateMetadata,
+  IGmUnitReloadPublicEffect,
+  IGmUnitReloadInterventionDomainPayload
+> {
+  return {
+    domain: UNIT_RELOAD_DOMAIN,
+    preview(command, state): UnitReloadPreview {
+      if (command.kind !== 'reload') {
+        return blockedUnitReloadPreview(
+          command,
+          'unit-reload-kind-invalid',
+          'Unit reload intervention command must use kind "reload".',
+        );
+      }
+
+      if (!isUnitReloadCommandPayload(command.payload)) {
+        return blockedUnitReloadPreview(
+          command,
+          'unit-reload-payload-invalid',
+          'Unit reload command requires a unit id, source map, and GM-private reason.',
+        );
+      }
+
+      const projected = buildGmUnitReloadProjectedEffect(
+        command.payload,
+        state,
+      );
+      if (!projected.effect) {
+        return blockedUnitReloadPreview(
+          command,
+          projected.code,
+          projected.reason,
+          projected.affectedRefs,
+        );
+      }
+
+      const envelope = buildGmInterventionRedactionEnvelope(
+        {
+          ...command.payload.privateMetadata,
+          manualTakeoverNotes:
+            command.payload.privateMetadata.manualTakeoverNotes ??
+            manualTakeoverSummary(projected.conflicts) ??
+            command.payload.manualResolution?.notes,
+        },
+        {
+          summary: projected.summary,
+          family: UNIT_RELOAD_DOMAIN,
+          changedStateRefs: projected.changedStateRefs,
+          visibleToPlayerIds: command.payload.visibleToPlayerIds,
+        },
+      );
+      const status = projected.conflicts.some(
+        (conflict) => conflict.requiresManualTakeover,
+      )
+        ? 'requires-manual-takeover'
+        : 'ready';
+
+      return {
+        domain: UNIT_RELOAD_DOMAIN,
+        kind: command.kind,
+        status,
+        actorId: command.actorId,
+        targetRefs: command.targetRefs,
+        causedBy: command.causedBy,
+        supersedes: command.supersedes,
+        privateMetadata: envelope.privateMetadata,
+        publicEffect: envelope.publicEffect,
+        domainPayload: {
+          reload: {
+            unitId: projected.effect.unitId,
+            unitRef: projected.effect.unitRef,
+            pilotRef: projected.effect.pilotRef,
+          },
+          projectedEffects: [projected.effect],
+        },
+        projectedEvents: [projected.effect],
+        conflicts: projected.conflicts,
+      };
+    },
+    apply(record, state): IGmUnitReloadInterventionState {
+      return applyGmUnitReloadProjectedEffects(
+        state,
+        projectUnitReloadEffectsForRecord(record as UnitReloadRecord),
+      );
+    },
+    projectPublic(record): IGmUnitReloadPublicEffect {
+      return record.publicEffect;
+    },
+    projectPrivate(record): IGmPrivateMetadata {
+      return record.privateMetadata;
+    },
+  };
+}
+
+export function registerGmUnitReloadInterventionImplementer(
+  ledger: InterventionLedger<IGmUnitReloadInterventionState>,
+): InterventionLedger<IGmUnitReloadInterventionState> {
+  return ledger.register(
+    createGmUnitReloadInterventionImplementer() as IInterventionLedgerImplementer<
+      IInterventionLedgerCommand,
+      IGmUnitReloadInterventionState
+    >,
+  );
+}
+
+function blockedUnitReloadPreview(
+  command: IInterventionLedgerCommand,
+  code: string,
+  reason: string,
+  affectedRefs: readonly string[] = command.targetRefs,
+): UnitReloadPreview {
+  const conflict: IInterventionConflict = {
+    code,
+    message: reason,
+    affectedRefs,
+  };
+
+  return {
+    domain: UNIT_RELOAD_DOMAIN,
+    kind: command.kind,
+    status: 'blocked',
+    actorId: command.actorId,
+    targetRefs: command.targetRefs,
+    causedBy: command.causedBy,
+    supersedes: command.supersedes,
+    conflicts: [conflict],
+    reason,
+  };
+}
+
+function isUnitReloadCommandPayload(
+  payload: unknown,
+): payload is IGmUnitReloadInterventionCommandPayload {
+  if (!isRecord(payload)) return false;
+  if (typeof payload.unitId !== 'string') return false;
+  if (!isRecord(payload.privateMetadata)) return false;
+  if (typeof payload.privateMetadata.reason !== 'string') return false;
+  return isRecord(payload.sourceUnitsByRef);
+}
+
+function manualTakeoverSummary(
+  conflicts: readonly IInterventionConflict[],
+): string | undefined {
+  const unresolved = conflicts.filter(
+    (conflict) => conflict.requiresManualTakeover,
+  );
+  return unresolved.length > 0
+    ? `Reload requires manual takeover for: ${unresolved
+        .map((conflict) => conflict.code)
+        .join(', ')}.`
+    : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/src/lib/interventions/GmUnitReloadInterventionProjection.ts
+++ b/src/lib/interventions/GmUnitReloadInterventionProjection.ts
@@ -1,0 +1,61 @@
+import type {
+  IGmPrivateMetadata,
+  IGmUnitReloadInterventionDomainPayload,
+  IGmUnitReloadInterventionState,
+  IGmUnitReloadProjectedEffect,
+  IGmUnitReloadPublicEffect,
+  IInterventionLedgerRecord,
+} from '@/types/interventions';
+
+type UnitReloadRecord = IInterventionLedgerRecord<
+  IGmPrivateMetadata,
+  IGmUnitReloadPublicEffect,
+  IGmUnitReloadInterventionDomainPayload
+>;
+
+export function projectUnitReloadEffectsForRecord(
+  record: UnitReloadRecord,
+): readonly IGmUnitReloadProjectedEffect[] {
+  if (!record.domainPayload) return [];
+
+  return record.domainPayload.projectedEffects.map((effect) => ({
+    ...effect,
+    interventionId: record.id,
+  }));
+}
+
+export function applyGmUnitReloadProjectedEffects(
+  state: IGmUnitReloadInterventionState,
+  effects: readonly IGmUnitReloadProjectedEffect[],
+): IGmUnitReloadInterventionState {
+  return effects.reduce(applyGmUnitReloadProjectedEffect, state);
+}
+
+function applyGmUnitReloadProjectedEffect(
+  state: IGmUnitReloadInterventionState,
+  effect: IGmUnitReloadProjectedEffect,
+): IGmUnitReloadInterventionState {
+  return appendGmUnitReloadEvent(
+    {
+      ...state,
+      units: {
+        ...state.units,
+        [effect.unitId]: effect.after.unit,
+      },
+      sessionUnits: state.sessionUnits?.map((unit) =>
+        unit.id === effect.unitId ? effect.after.sessionUnit : unit,
+      ),
+    },
+    effect,
+  );
+}
+
+function appendGmUnitReloadEvent(
+  state: IGmUnitReloadInterventionState,
+  effect: IGmUnitReloadProjectedEffect,
+): IGmUnitReloadInterventionState {
+  return {
+    ...state,
+    gmUnitReloadEvents: [...(state.gmUnitReloadEvents ?? []), effect],
+  };
+}

--- a/src/lib/interventions/GmUnitReloadReconciliation.ts
+++ b/src/lib/interventions/GmUnitReloadReconciliation.ts
@@ -1,0 +1,293 @@
+import type {
+  IAmmoSlotState,
+  IGameUnit,
+} from '@/types/gameplay/GameSessionInterfaces';
+import type {
+  IGmUnitReloadInterventionCommandPayload,
+  IGmUnitReloadInterventionState,
+  IGmUnitReloadInterventionUnitState,
+  IGmUnitReloadPilotSnapshot,
+  IGmUnitReloadProjectedEffect,
+  IGmUnitReloadSourceSnapshot,
+  IInterventionConflict,
+} from '@/types/interventions';
+
+import { createInitialUnitState } from '@/utils/gameplay/gameState';
+
+import {
+  applyGmUnitReloadManualResolution,
+  detectGmUnitReloadConflicts,
+} from './GmUnitReloadConflictDetection';
+
+export interface IGmUnitReloadProjectionResult {
+  readonly effect: IGmUnitReloadProjectedEffect;
+  readonly changedStateRefs: readonly string[];
+  readonly summary: string;
+  readonly conflicts: readonly IInterventionConflict[];
+}
+
+export interface IGmUnitReloadProjectionFailure {
+  readonly effect?: undefined;
+  readonly code: string;
+  readonly reason: string;
+  readonly affectedRefs?: readonly string[];
+}
+
+const PRESERVED_OVERLAY_FIELDS = [
+  'position',
+  'facing',
+  'secondaryFacing',
+  'torsoTwist',
+  'heat',
+  'externalHeatThisTurn',
+  'pendingExternalHeat',
+  'movementThisTurn',
+  'hexesMovedThisTurn',
+  'movedBackwardThisTurn',
+  'usedMechanicalJumpBoosterThisTurn',
+  'armor',
+  'structure',
+  'startingInternalStructure',
+  'destroyedLocations',
+  'destroyedEquipment',
+  'destroyedArtemisFcs',
+  'componentDamage',
+  'ammo',
+  'pilotWounds',
+  'pilotConscious',
+  'destroyed',
+  'destructionCause',
+  'lockState',
+  'pendingAction',
+  'damageThisPhase',
+  'prone',
+  'isStuck',
+  'hullDown',
+  'shutdown',
+  'pendingPSRs',
+  'weaponsFiredThisTurn',
+  'jammedWeapons',
+  'narcedBy',
+  'iNarcPods',
+  'tagDesignated',
+  'isRetreating',
+  'retreatTargetEdge',
+  'hasRetreated',
+  'hasEjected',
+  'isWithdrawing',
+  'edgePointsRemaining',
+  'unitHeight',
+  'conversionMode',
+  'pendingConversionStepCount',
+  'pendingConversionMpCost',
+  'pendingAltitudeControlStepCount',
+  'pendingAltitudeControlMpCost',
+  'lamAirMekAltitude',
+  'combatState',
+] as const satisfies readonly (keyof IGmUnitReloadInterventionUnitState)[];
+
+export function buildGmUnitReloadProjectedEffect(
+  payload: IGmUnitReloadInterventionCommandPayload,
+  state: IGmUnitReloadInterventionState,
+): IGmUnitReloadProjectionResult | IGmUnitReloadProjectionFailure {
+  const currentUnit = state.units[payload.unitId];
+  if (!currentUnit) {
+    return failure(
+      'unit-reload-active-unit-not-found',
+      `Active unit "${payload.unitId}" was not found.`,
+      [unitRef(payload.unitId)],
+    );
+  }
+
+  const sessionUnit = state.sessionUnits?.find(
+    (unit) => unit.id === payload.unitId,
+  );
+  if (!sessionUnit) {
+    return failure(
+      'unit-reload-session-unit-not-found',
+      `Session unit binding "${payload.unitId}" was not found.`,
+      [unitRef(payload.unitId)],
+    );
+  }
+
+  const unitRefId = payload.unitRef ?? sessionUnit.unitRef;
+  const pilotRefId = payload.pilotRef ?? sessionUnit.pilotRef;
+  const source = payload.sourceUnitsByRef[unitRefId];
+  if (!source) {
+    return failure(
+      'unit-reload-source-unit-not-found',
+      `Source unit "${unitRefId}" was not found.`,
+      [unitFieldRef(payload.unitId, 'unitRef')],
+    );
+  }
+
+  const pilot = payload.pilotsByRef?.[pilotRefId] ?? source.pilot;
+  const nextSessionUnit = buildReloadedSessionUnit(
+    sessionUnit,
+    source,
+    unitRefId,
+    pilotRefId,
+    pilot,
+  );
+  const seededUnit = createInitialUnitState(
+    nextSessionUnit,
+    currentUnit.position,
+    currentUnit.facing,
+  );
+  const detectedConflicts = detectGmUnitReloadConflicts({
+    currentUnit,
+    sessionUnit,
+    source,
+    state,
+  });
+  const conflicts = applyGmUnitReloadManualResolution(
+    detectedConflicts,
+    payload.manualResolution?.acceptedConflictCodes ?? [],
+  );
+  const nextUnit = preserveCompatibleOverlays(
+    currentUnit,
+    seededUnit,
+    conflicts,
+  );
+  const changedStateRefs = [
+    unitRef(payload.unitId),
+    unitFieldRef(payload.unitId, 'loadout'),
+    unitFieldRef(payload.unitId, 'pilot'),
+    unitFieldRef(payload.unitId, 'live-overlays'),
+  ];
+  const summary =
+    payload.publicSummary ??
+    `Unit ${payload.unitId} source data reloaded by the GM.`;
+
+  return {
+    summary,
+    changedStateRefs,
+    conflicts,
+    effect: {
+      type: 'gm.unit_reload.rehydrated',
+      family: 'unit-reload',
+      unitId: payload.unitId,
+      unitRef: unitRefId,
+      pilotRef: pilotRefId,
+      before: {
+        unit: currentUnit,
+        sessionUnit,
+      },
+      after: {
+        unit: nextUnit,
+        sessionUnit: nextSessionUnit,
+      },
+      preservedOverlayFields: PRESERVED_OVERLAY_FIELDS,
+      changedStateRefs,
+      publicSummary: summary,
+    },
+  };
+}
+
+function buildReloadedSessionUnit(
+  current: IGameUnit,
+  source: IGmUnitReloadSourceSnapshot,
+  unitRef: string,
+  pilotRef: string,
+  pilot: IGmUnitReloadPilotSnapshot | undefined,
+): IGameUnit {
+  return {
+    ...current,
+    ...source.unit,
+    id: current.id,
+    side: current.side,
+    unitRef,
+    pilotRef,
+    gunnery: pilot?.gunnery ?? source.unit.gunnery,
+    piloting: pilot?.piloting ?? source.unit.piloting,
+    pilotSpas: pilot?.pilotSpas ?? source.unit.pilotSpas,
+    abilities: pilot?.abilities ?? source.unit.abilities,
+    pilotToughness: pilot?.pilotToughness ?? source.unit.pilotToughness,
+    edgePointsRemaining:
+      pilot?.edgePointsRemaining ?? source.unit.edgePointsRemaining,
+    neuralInterfaceActive:
+      pilot?.neuralInterfaceActive ?? source.unit.neuralInterfaceActive,
+  };
+}
+
+function preserveCompatibleOverlays(
+  current: IGmUnitReloadInterventionUnitState,
+  seeded: IGmUnitReloadInterventionUnitState,
+  conflicts: readonly IInterventionConflict[],
+): IGmUnitReloadInterventionUnitState {
+  const patch: Record<string, unknown> = {};
+  for (const field of PRESERVED_OVERLAY_FIELDS) {
+    patch[field] = current[field];
+  }
+
+  return {
+    ...seeded,
+    ...patch,
+    ammoState: reconcileAmmoState(
+      current.ammoState,
+      seeded.ammoState,
+      conflicts,
+    ),
+  };
+}
+
+function reconcileAmmoState(
+  current: Record<string, IAmmoSlotState> | undefined,
+  seeded: Record<string, IAmmoSlotState> | undefined,
+  conflicts: readonly IInterventionConflict[],
+): Record<string, IAmmoSlotState> | undefined {
+  if (!seeded) return current;
+  const preserveRemovedBins = !isConflictAccepted(
+    conflicts,
+    'unit-reload-ammo-bin-removed',
+  );
+  const next: Record<string, IAmmoSlotState> = {};
+
+  for (const [binId, sourceBin] of Object.entries(seeded)) {
+    const liveBin = current?.[binId];
+    next[binId] = liveBin
+      ? {
+          ...sourceBin,
+          remainingRounds: Math.min(
+            liveBin.remainingRounds,
+            sourceBin.maxRounds,
+          ),
+        }
+      : sourceBin;
+  }
+
+  if (preserveRemovedBins) {
+    for (const [binId, liveBin] of Object.entries(current ?? {})) {
+      if (!next[binId]) next[binId] = liveBin;
+    }
+  }
+
+  return next;
+}
+
+function failure(
+  code: string,
+  reason: string,
+  affectedRefs: readonly string[],
+): IGmUnitReloadProjectionFailure {
+  return { code, reason, affectedRefs };
+}
+
+function unitRef(unitId: string): string {
+  return `unit:${unitId}`;
+}
+
+function unitFieldRef(unitId: string, field: string): string {
+  return `unit:${unitId}:${field}`;
+}
+
+function isConflictAccepted(
+  conflicts: readonly IInterventionConflict[],
+  code: string,
+): boolean {
+  return conflicts.some(
+    (conflictEntry) =>
+      conflictEntry.code === code &&
+      conflictEntry.requiresManualTakeover === false,
+  );
+}

--- a/src/lib/interventions/__tests__/GmUnitReloadInterventionImplementer.test.ts
+++ b/src/lib/interventions/__tests__/GmUnitReloadInterventionImplementer.test.ts
@@ -1,0 +1,477 @@
+import type { IGameUnit } from '@/types/gameplay';
+import type {
+  IGmAuthorityContext,
+  IGmPrivateMetadata,
+  IGmUnitReloadInterventionCommandPayload,
+  IGmUnitReloadInterventionDomainPayload,
+  IGmUnitReloadInterventionState,
+  IGmUnitReloadInterventionUnitState,
+  IGmUnitReloadPublicEffect,
+  IInterventionLedgerCommand,
+  IInterventionLedgerRecord,
+} from '@/types/interventions';
+
+import {
+  Facing,
+  GamePhase,
+  GameSide,
+  GameStatus,
+  LockState,
+  MovementType,
+} from '@/types/gameplay';
+
+import {
+  applyGmUnitReloadProjectedEffects,
+  approveGmCascadePreview,
+  createGmCascadePreview,
+  projectUnitReloadEffectsForRecord,
+  registerGmUnitReloadInterventionImplementer,
+} from '../index';
+import { InterventionLedger } from '../InterventionLedger';
+
+type UnitReloadRecord = IInterventionLedgerRecord<
+  IGmPrivateMetadata,
+  IGmUnitReloadPublicEffect,
+  IGmUnitReloadInterventionDomainPayload
+>;
+
+const gmAuthority: IGmAuthorityContext = {
+  actorId: 'gm-1',
+  role: 'gm',
+  gameId: 'game-1',
+  ownedStateRefs: ['game:game-1'],
+};
+
+const priorEvent = {
+  id: 'prior-event-1',
+} as IGmUnitReloadInterventionState['turnEvents'][number];
+
+const componentDamage = {
+  engineHits: 0,
+  gyroHits: 0,
+  sensorHits: 0,
+  lifeSupport: 0,
+  cockpitHit: false,
+  actuators: {},
+  weaponsDestroyed: [],
+  heatSinksDestroyed: 0,
+  jumpJetsDestroyed: 0,
+};
+
+function makeState(
+  overrides: Partial<IGmUnitReloadInterventionState> = {},
+): IGmUnitReloadInterventionState {
+  const atlasSession = makeSessionUnit();
+  const locustSession = makeSessionUnit({
+    id: 'locust-1',
+    name: 'Locust LCT-1V',
+    side: GameSide.Opponent,
+    unitRef: 'locust-source',
+    pilotRef: 'pilot-2',
+    tonnage: 20,
+    heatSinks: 10,
+    ammoConstruction: [],
+    weaponLocationById: {},
+  });
+
+  return {
+    gameId: 'game-1',
+    status: GameStatus.Active,
+    turn: 4,
+    phase: GamePhase.Movement,
+    activationIndex: 1,
+    initiativeWinner: GameSide.Player,
+    firstMover: GameSide.Opponent,
+    units: {
+      'atlas-1': makeActiveUnit('atlas-1', GameSide.Player),
+      'locust-1': makeActiveUnit('locust-1', GameSide.Opponent, {
+        position: { q: -2, r: 1 },
+        heat: 0,
+      }),
+    },
+    sessionUnits: [atlasSession, locustSession],
+    turnEvents: [priorEvent],
+    ...overrides,
+  };
+}
+
+function makeSessionUnit(overrides: Partial<IGameUnit> = {}): IGameUnit {
+  return {
+    id: 'atlas-1',
+    name: 'Atlas AS7-D',
+    side: GameSide.Player,
+    unitRef: 'atlas-source',
+    pilotRef: 'pilot-1',
+    gunnery: 4,
+    piloting: 5,
+    movementMode: 'walk',
+    tonnage: 100,
+    heatSinks: 10,
+    heatSinkType: 'single',
+    hasTSM: false,
+    abilities: ['steady-hand'],
+    weaponLocationById: {
+      ac20: 'rightArm',
+      mediumLaser: 'leftArm',
+    },
+    ammoConstruction: [
+      {
+        binId: 'ac20-bin',
+        weaponType: 'AC/20',
+        location: 'leftTorso',
+        maxRounds: 5,
+        damagePerRound: 20,
+        isExplosive: true,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function makeSourceSnapshot(
+  overrides: Partial<IGameUnit> = {},
+  snapshotOverrides: {
+    readonly armorLocations?: readonly string[];
+    readonly structureLocations?: readonly string[];
+    readonly ammoBinIds?: readonly string[];
+  } = {},
+) {
+  return {
+    unit: makeSessionUnit({
+      id: 'catalog-atlas',
+      name: 'Atlas AS7-K',
+      heatSinks: 20,
+      heatSinkType: 'double',
+      hasTSM: true,
+      weaponLocationById: {
+        ac20: 'rightArm',
+        mediumLaser: 'leftArm',
+        gauss: 'rightTorso',
+      },
+      ...overrides,
+    }),
+    pilot: {
+      gunnery: 3,
+      piloting: 4,
+      pilotSpas: ['maneuvering-ace'],
+      abilities: ['maneuvering-ace'],
+      pilotToughness: 1,
+      edgePointsRemaining: 2,
+      neuralInterfaceActive: true,
+    },
+    armorLocations: ['head', 'centerTorso', 'leftArm'],
+    structureLocations: ['head', 'centerTorso', 'leftArm'],
+    ammoBinIds: ['ac20-bin'],
+    ...snapshotOverrides,
+  };
+}
+
+function makeActiveUnit(
+  id: string,
+  side: GameSide,
+  overrides: Partial<IGmUnitReloadInterventionUnitState> = {},
+): IGmUnitReloadInterventionUnitState {
+  return {
+    id,
+    side,
+    position: { q: 3, r: 2 },
+    facing: Facing.North,
+    secondaryFacing: Facing.Northeast,
+    heat: 8,
+    movementThisTurn: MovementType.Run,
+    hexesMovedThisTurn: 4,
+    gunnery: 4,
+    piloting: 5,
+    heatSinks: 10,
+    heatSinkType: 'single',
+    hasTSM: false,
+    armor: {
+      head: 9,
+      centerTorso: 25,
+      leftArm: 12,
+    },
+    structure: {
+      head: 3,
+      centerTorso: 20,
+      leftArm: 8,
+    },
+    startingInternalStructure: {
+      head: 3,
+      centerTorso: 31,
+      leftArm: 17,
+    },
+    destroyedLocations: ['leftArm'],
+    destroyedEquipment: ['mediumLaser'],
+    ammo: {
+      ac20: 2,
+    },
+    ammoState: {
+      'ac20-bin': {
+        binId: 'ac20-bin',
+        weaponType: 'AC/20',
+        location: 'leftTorso',
+        remainingRounds: 2,
+        maxRounds: 5,
+        damagePerRound: 20,
+        isExplosive: true,
+      },
+    },
+    pilotWounds: 1,
+    pilotConscious: true,
+    destroyed: false,
+    lockState: LockState.Locked,
+    componentDamage,
+    weaponsFiredThisTurn: ['ac20'],
+    edgePointsRemaining: 1,
+    ...overrides,
+  };
+}
+
+function makeLedger(): InterventionLedger<IGmUnitReloadInterventionState> {
+  return registerGmUnitReloadInterventionImplementer(
+    new InterventionLedger<IGmUnitReloadInterventionState>(),
+  );
+}
+
+function makeCommand(
+  payload: IGmUnitReloadInterventionCommandPayload,
+  overrides: Partial<
+    IInterventionLedgerCommand<IGmUnitReloadInterventionCommandPayload>
+  > = {},
+): IInterventionLedgerCommand<IGmUnitReloadInterventionCommandPayload> {
+  return {
+    domain: 'unit-reload',
+    kind: 'reload',
+    actorId: 'gm-1',
+    targetRefs: [`unit:${payload.unitId}`],
+    payload,
+    causedBy: ['session-launch-1'],
+    ...overrides,
+  };
+}
+
+function payload(
+  overrides: Partial<IGmUnitReloadInterventionCommandPayload> = {},
+): IGmUnitReloadInterventionCommandPayload {
+  return {
+    unitId: 'atlas-1',
+    sourceUnitsByRef: {
+      'atlas-source': makeSourceSnapshot(),
+    },
+    privateMetadata: {
+      reason: 'Hidden GM reload reason.',
+      defaultOutcome: 'The stale encounter loadout would remain.',
+      hiddenNotes: 'Catalog update should stay private.',
+    },
+    ...overrides,
+  };
+}
+
+function previewReload(
+  command: IInterventionLedgerCommand<IGmUnitReloadInterventionCommandPayload>,
+  state = makeState(),
+) {
+  const ledger = makeLedger();
+  return createGmCascadePreview({
+    ledger,
+    command,
+    state,
+    authority: gmAuthority,
+    interventionId: 'gm-int-unit-reload',
+  });
+}
+
+function approveReload(
+  command: IInterventionLedgerCommand<IGmUnitReloadInterventionCommandPayload>,
+  state = makeState(),
+): {
+  readonly state: IGmUnitReloadInterventionState;
+  readonly record: UnitReloadRecord;
+} {
+  const ledger = makeLedger();
+  const preview = createGmCascadePreview({
+    ledger,
+    command,
+    state,
+    authority: gmAuthority,
+    interventionId: 'gm-int-unit-reload',
+  });
+  const result = approveGmCascadePreview({
+    ledger,
+    preview,
+    state,
+    createdAt: '2026-06-20T00:00:00.000Z',
+    approvedAt: '2026-06-20T00:01:00.000Z',
+  });
+
+  expect(result.status).toBe('approved');
+  if (result.status !== 'approved' || !result.record) {
+    throw new Error('Expected reload GM intervention approval.');
+  }
+
+  return {
+    state: result.state as IGmUnitReloadInterventionState,
+    record: result.record as UnitReloadRecord,
+  };
+}
+
+describe('GM unit reload intervention implementer', () => {
+  it('registers unit reload and previews source unit plus pilot data', () => {
+    const preview = previewReload(makeCommand(payload()));
+
+    expect(preview.status).toBe('ready');
+    expect(preview.domainPayload).toMatchObject({
+      reload: {
+        unitId: 'atlas-1',
+        unitRef: 'atlas-source',
+        pilotRef: 'pilot-1',
+      },
+    });
+    const event = preview.projectedEvents[0] as
+      | undefined
+      | { after?: { unit?: IGmUnitReloadInterventionUnitState } };
+    expect(event?.after?.unit).toMatchObject({
+      heatSinks: 20,
+      heatSinkType: 'double',
+      hasTSM: true,
+      gunnery: 3,
+      piloting: 4,
+      abilities: ['maneuvering-ace'],
+      pilotToughness: 1,
+      neuralInterfaceActive: true,
+    });
+  });
+
+  it('preserves compatible live overlays while replacing source-backed fields', () => {
+    const start = makeState();
+    const result = approveReload(makeCommand(payload()), start);
+    const unit = result.state.units['atlas-1'];
+
+    expect(unit).toMatchObject({
+      heatSinks: 20,
+      heatSinkType: 'double',
+      hasTSM: true,
+      position: { q: 3, r: 2 },
+      facing: Facing.North,
+      secondaryFacing: Facing.Northeast,
+      heat: 8,
+      movementThisTurn: MovementType.Run,
+      lockState: LockState.Locked,
+      pilotWounds: 1,
+      pilotConscious: true,
+      destroyedLocations: ['leftArm'],
+      destroyedEquipment: ['mediumLaser'],
+    });
+    expect(unit.ammoState?.['ac20-bin'].remainingRounds).toBe(2);
+    expect(
+      result.state.sessionUnits?.find((entry) => entry.id === 'atlas-1'),
+    ).toMatchObject({
+      name: 'Atlas AS7-K',
+      heatSinks: 20,
+      gunnery: 3,
+      piloting: 4,
+    });
+  });
+
+  it('requires manual takeover for incompatible reload conflicts before commit', () => {
+    const command = makeCommand(
+      payload({
+        sourceUnitsByRef: {
+          'atlas-source': makeSourceSnapshot(
+            {
+              ammoConstruction: [
+                {
+                  binId: 'gauss-bin',
+                  weaponType: 'Gauss Rifle',
+                  location: 'rightTorso',
+                  maxRounds: 8,
+                  damagePerRound: 15,
+                  isExplosive: true,
+                },
+              ],
+            },
+            { ammoBinIds: ['gauss-bin'] },
+          ),
+        },
+      }),
+    );
+    const state = makeState();
+    const ledger = makeLedger();
+    const preview = createGmCascadePreview({
+      ledger,
+      command,
+      state,
+      authority: gmAuthority,
+      interventionId: 'gm-int-conflict',
+    });
+    const result = approveGmCascadePreview({ ledger, preview, state });
+
+    expect(preview.status).toBe('requires-manual-takeover');
+    expect(preview.conflicts.map((conflict) => conflict.code)).toContain(
+      'unit-reload-ammo-bin-removed',
+    );
+    expect(result).toMatchObject({
+      status: 'blocked',
+      appended: false,
+    });
+  });
+
+  it('allows approved manual conflict handling and removes incompatible live bins', () => {
+    const command = makeCommand(
+      payload({
+        sourceUnitsByRef: {
+          'atlas-source': makeSourceSnapshot(
+            {
+              ammoConstruction: [
+                {
+                  binId: 'gauss-bin',
+                  weaponType: 'Gauss Rifle',
+                  location: 'rightTorso',
+                  maxRounds: 8,
+                  damagePerRound: 15,
+                  isExplosive: true,
+                },
+              ],
+            },
+            { ammoBinIds: ['gauss-bin'] },
+          ),
+        },
+        manualResolution: {
+          acceptedConflictCodes: ['unit-reload-ammo-bin-removed'],
+          notes: 'GM accepts removing the stale AC/20 bin.',
+        },
+      }),
+    );
+    const result = approveReload(command);
+    const unit = result.state.units['atlas-1'];
+
+    expect(unit.ammoState?.['ac20-bin']).toBeUndefined();
+    expect(unit.ammoState?.['gauss-bin']).toMatchObject({
+      weaponType: 'Gauss Rifle',
+      remainingRounds: 8,
+    });
+    expect(result.record.privateMetadata.manualTakeoverNotes).toBe(
+      'GM accepts removing the stale AC/20 bin.',
+    );
+  });
+
+  it('updates only the target unit and preserves encounter state plus history', () => {
+    const start = makeState();
+    const result = approveReload(makeCommand(payload()), start);
+    const replayed = applyGmUnitReloadProjectedEffects(
+      start,
+      projectUnitReloadEffectsForRecord(result.record),
+    );
+
+    expect(result.state.status).toBe(GameStatus.Active);
+    expect(result.state.phase).toBe(GamePhase.Movement);
+    expect(result.state.activationIndex).toBe(1);
+    expect(result.state.turnEvents).toEqual([priorEvent]);
+    expect(result.state.units['locust-1']).toBe(start.units['locust-1']);
+    expect(
+      result.state.sessionUnits?.find((unit) => unit.id === 'locust-1'),
+    ).toBe(start.sessionUnits?.[1]);
+    expect(result.state.gmUnitReloadEvents).toHaveLength(1);
+    expect(replayed).toEqual(result.state);
+  });
+});

--- a/src/lib/interventions/index.ts
+++ b/src/lib/interventions/index.ts
@@ -20,6 +20,16 @@ export {
 } from './GmCombatInterventionProjection';
 
 export {
+  createGmUnitReloadInterventionImplementer,
+  registerGmUnitReloadInterventionImplementer,
+} from './GmUnitReloadInterventionImplementer';
+
+export {
+  applyGmUnitReloadProjectedEffects,
+  projectUnitReloadEffectsForRecord,
+} from './GmUnitReloadInterventionProjection';
+
+export {
   buildGmInterventionRedactionEnvelope,
   evaluateGmInterventionAuthority,
   logGmInterventionAuthorizationFailure,

--- a/src/types/interventions/GmUnitReloadInterventionTypes.ts
+++ b/src/types/interventions/GmUnitReloadInterventionTypes.ts
@@ -1,0 +1,94 @@
+import type {
+  IGameUnit,
+  IUnitGameState,
+} from '@/types/gameplay/GameSessionInterfaces';
+
+import type {
+  IGmCombatInterventionState,
+  IGmCombatInterventionUnitState,
+} from './GmCombatInterventionTypes';
+import type {
+  IGmPrivateMetadata,
+  IGmPublicEffect,
+} from './GmInterventionAuthorityTypes';
+
+export interface IGmUnitReloadPilotSnapshot {
+  readonly gunnery: number;
+  readonly piloting: number;
+  readonly pilotSpas?: readonly string[];
+  readonly abilities?: readonly string[];
+  readonly pilotToughness?: number;
+  readonly edgePointsRemaining?: number;
+  readonly neuralInterfaceActive?: boolean;
+}
+
+export interface IGmUnitReloadSourceSnapshot {
+  readonly unit: IGameUnit;
+  readonly pilot?: IGmUnitReloadPilotSnapshot;
+  readonly armorLocations?: readonly string[];
+  readonly structureLocations?: readonly string[];
+  readonly ammoBinIds?: readonly string[];
+  readonly movementProfileKey?: string;
+}
+
+export interface IGmUnitReloadManualResolution {
+  readonly acceptedConflictCodes?: readonly string[];
+  readonly notes?: string;
+}
+
+export interface IGmUnitReloadInterventionCommandPayload {
+  readonly unitId: string;
+  readonly unitRef?: string;
+  readonly pilotRef?: string;
+  readonly sourceUnitsByRef: Readonly<
+    Record<string, IGmUnitReloadSourceSnapshot>
+  >;
+  readonly pilotsByRef?: Readonly<Record<string, IGmUnitReloadPilotSnapshot>>;
+  readonly manualResolution?: IGmUnitReloadManualResolution;
+  readonly privateMetadata: IGmPrivateMetadata;
+  readonly publicSummary?: string;
+  readonly visibleToPlayerIds?: readonly string[];
+}
+
+export type IGmUnitReloadInterventionUnitState = IGmCombatInterventionUnitState;
+
+export interface IGmUnitReloadInterventionState extends IGmCombatInterventionState {
+  readonly units: Record<string, IGmUnitReloadInterventionUnitState>;
+  readonly sessionUnits?: readonly IGameUnit[];
+  readonly gmUnitReloadEvents?: readonly IGmUnitReloadProjectedEffect[];
+}
+
+export interface IGmUnitReloadCommandProjection {
+  readonly unitId: string;
+  readonly unitRef: string;
+  readonly pilotRef: string;
+}
+
+export interface IGmUnitReloadProjectedEffect {
+  readonly type: 'gm.unit_reload.rehydrated';
+  readonly family: 'unit-reload';
+  readonly interventionId?: string;
+  readonly unitId: string;
+  readonly unitRef: string;
+  readonly pilotRef: string;
+  readonly before: {
+    readonly unit: IGmUnitReloadInterventionUnitState;
+    readonly sessionUnit: IGameUnit;
+  };
+  readonly after: {
+    readonly unit: IUnitGameState;
+    readonly sessionUnit: IGameUnit;
+  };
+  readonly preservedOverlayFields: readonly string[];
+  readonly changedStateRefs: readonly string[];
+  readonly publicSummary: string;
+}
+
+export interface IGmUnitReloadInterventionDomainPayload {
+  readonly reload: IGmUnitReloadCommandProjection;
+  readonly projectedEffects: readonly IGmUnitReloadProjectedEffect[];
+}
+
+export interface IGmUnitReloadPublicEffect extends IGmPublicEffect {
+  readonly family: 'unit-reload';
+}

--- a/src/types/interventions/index.ts
+++ b/src/types/interventions/index.ts
@@ -29,6 +29,19 @@ export type {
 } from './GmCombatInterventionTypes';
 
 export type {
+  IGmUnitReloadCommandProjection,
+  IGmUnitReloadInterventionCommandPayload,
+  IGmUnitReloadInterventionDomainPayload,
+  IGmUnitReloadInterventionState,
+  IGmUnitReloadInterventionUnitState,
+  IGmUnitReloadManualResolution,
+  IGmUnitReloadPilotSnapshot,
+  IGmUnitReloadProjectedEffect,
+  IGmUnitReloadPublicEffect,
+  IGmUnitReloadSourceSnapshot,
+} from './GmUnitReloadInterventionTypes';
+
+export type {
   GmAuthorityDecision,
   GmInterventionActorRole,
   GmInterventionAuthorityRejectionCode,


### PR DESCRIPTION
## Summary
- Add the unit-reload GM intervention domain implementer and registration.
- Rehydrate active encounter units from source `unitRef` and pilot `pilotRef` without resetting the encounter.
- Preserve compatible live overlays, detect unsafe reload conflicts, and require or record GM manual takeover handling.

## Verification
- `npm.cmd test -- --runTestsByPath src/lib/interventions/__tests__/InterventionLedger.test.ts src/lib/interventions/__tests__/GmInterventionAuthority.test.ts src/lib/interventions/__tests__/GmCascadePreviewPipeline.test.ts src/lib/interventions/__tests__/GmCombatInterventionImplementer.test.ts src/lib/interventions/__tests__/GmUnitReloadInterventionImplementer.test.ts`
- `npx.cmd tsc --noEmit --skipLibCheck --pretty false`
- `npx.cmd oxlint src/lib/interventions src/types/interventions`
- `npx.cmd oxfmt --check src/lib/interventions/GmUnitReloadConflictDetection.ts src/lib/interventions/GmUnitReloadReconciliation.ts src/lib/interventions/GmUnitReloadInterventionProjection.ts src/lib/interventions/GmUnitReloadInterventionImplementer.ts src/lib/interventions/__tests__/GmUnitReloadInterventionImplementer.test.ts src/types/interventions/GmUnitReloadInterventionTypes.ts src/lib/interventions/index.ts src/types/interventions/index.ts`
- `cmd /c openspec validate add-gm-intervention-control-plane --strict`
- Commit hook: lint-staged, `npx tsc --noEmit --skipLibCheck`, and full `npm run build`

## Notes
- Tactical command UI wiring is intentionally left to the next ordered spec slice.
- Existing unrelated QC/logging workspace changes were left unstaged.