### PR TITLE
Keep campaign cascades deferred until supported

### DIFF
--- a/docs/architecture/gm-campaign-intervention-boundaries.md
+++ b/docs/architecture/gm-campaign-intervention-boundaries.md
@@ -1,0 +1,23 @@
+# GM Campaign Intervention Boundaries
+
+This note documents the first-slice boundary for GM interventions outside active combat. The ledger, authority, redaction, preview, and approval pipeline is live for combat and unit reload. Campaign cascade domains stay explicit deferred domains until their own implementers can prove mutation scope, replay order, and player-safe projection.
+
+## Deferred Domains
+
+| Domain        | Future mutable roots                                                              | Future public projection fields                                     | First-slice result    |
+| ------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------- | --------------------- |
+| `post-combat` | scenario result, payout summary, injury/death outcomes, salvage offer state       | public result delta, visible casualty/salvage summary, changed refs | deferred, no mutation |
+| `economy`     | campaign funds, merchant transaction ledger, inventory lots, market stock         | net C-bill delta, public inventory delta, merchant transaction ref  | deferred, no mutation |
+| `repair`      | repair queue, parts usage, technician assignment, bay schedule                    | public queue delta, visible repair status, changed unit refs        | deferred, no mutation |
+| `salvage`     | salvage pool, claim assignments, scrapping/selling decisions, inventory additions | public salvage delta, visible inventory delta, claim refs           | deferred, no mutation |
+| `time`        | campaign clock, travel progress, contract deadlines, queued time effects          | public time delta, visible deadline/travel changes, changed refs    | deferred, no mutation |
+
+## Future Implementer Seams
+
+- Post-combat amendments should wrap combat outcome edits and campaign sync deltas in one preview so payouts, injuries, salvage, and objective state cannot drift independently.
+- Co-op GM arbitration should extend the authority context with host/owner identity and explicit arbitration records before allowing another GM to mutate a campaign owned by someone else.
+- Finance and inventory reversals should treat merchant transactions as reversible ledger entries with net funds, stock, and inventory effects previewed together.
+- Repair and salvage corrections should validate that unit refs, parts, bay capacity, and technician assignments still exist before approval.
+- Time cascades should preview every accumulated effect caused by the clock change, including travel, deadlines, repair ticks, hiring windows, and contract availability.
+
+Player-facing records for these future domains must show only the resulting public net effect and changed state refs. GM-private reason, default outcome, hidden scenario notes, and manual takeover notes stay in private projection only.

--- a/openspec/changes/add-gm-intervention-control-plane/tasks.md
+++ b/openspec/changes/add-gm-intervention-control-plane/tasks.md
@@ -53,10 +53,10 @@
 
 ## 7. Campaign Boundary and Deferred Cascades
 
-- [ ] 7.1 Add explicit deferred/unsupported results for post-combat, base/economy, repair/salvage, and time-cascade interventions in the first slice.
-- [ ] 7.2 Document future implementer seams for post-combat, campaign sync, co-op GM arbitration, finance/inventory reversal, repair/salvage correction, and time cascade phases.
-- [ ] 7.3 Add tests proving deferred campaign interventions do not silently mutate finances, inventory, repair queues, salvage, travel, or campaign time.
-- [ ] 7.4 Add safe logging for deferred domain attempts without leaking hidden scenario notes to player-visible output.
+- [x] 7.1 Add explicit deferred/unsupported results for post-combat, base/economy, repair/salvage, and time-cascade interventions in the first slice.
+- [x] 7.2 Document future implementer seams for post-combat, campaign sync, co-op GM arbitration, finance/inventory reversal, repair/salvage correction, and time cascade phases.
+- [x] 7.3 Add tests proving deferred campaign interventions do not silently mutate finances, inventory, repair queues, salvage, travel, or campaign time.
+- [x] 7.4 Add safe logging for deferred domain attempts without leaking hidden scenario notes to player-visible output.
 
 ## 8. Validation
 

--- a/src/lib/interventions/GmCascadePreviewPipeline.ts
+++ b/src/lib/interventions/GmCascadePreviewPipeline.ts
@@ -9,6 +9,8 @@ import type {
   InterventionDomain,
 } from '@/types/interventions';
 
+import { logger } from '@/utils/logger';
+
 import type { InterventionLedger } from './InterventionLedger';
 
 import { previewGmInterventionWithAuthority } from './GmInterventionAuthority';
@@ -23,6 +25,8 @@ export interface ICreateGmCascadePreviewInput<
   readonly authority: IGmAuthorityContext;
   readonly interventionId?: string;
   readonly now?: () => string;
+  readonly logDeferred?: boolean;
+  readonly emitDeferredLog?: GmDeferredInterventionLogger;
 }
 
 export interface IApproveGmCascadePreviewInput<
@@ -47,6 +51,23 @@ const DEFERRED_FIRST_SLICE_DOMAINS = new Set<InterventionDomain>([
 ]);
 
 let generatedIdSequence = 0;
+
+export interface IGmDeferredInterventionAttemptLog {
+  readonly level: 'warn';
+  readonly service: 'gm-intervention';
+  readonly event: 'domain-deferred';
+  readonly message: string;
+  readonly actorId: string;
+  readonly domain: string;
+  readonly kind: string;
+  readonly targetRefs: readonly string[];
+  readonly deferredReason: string;
+}
+
+export type GmDeferredInterventionLogger = (
+  message: string,
+  entry: IGmDeferredInterventionAttemptLog,
+) => void;
 
 export function createGmCascadePreview<TState, TCommandPayload>(
   input: ICreateGmCascadePreviewInput<TState, TCommandPayload>,
@@ -82,7 +103,7 @@ export function createGmCascadePreview<TState, TCommandPayload>(
       ? 'deferred'
       : normalizePreviewStatus(previewResult);
 
-  return {
+  const preview: IGmCascadePreview = {
     interventionId: resolvedInterventionId,
     status,
     domain: previewResult.domain,
@@ -99,6 +120,37 @@ export function createGmCascadePreview<TState, TCommandPayload>(
     supersedes: previewResult.supersedes,
     reason: previewResult.reason,
   };
+
+  if (preview.status === 'deferred' && input.logDeferred !== false) {
+    logGmDeferredInterventionAttempt(preview, input.emitDeferredLog);
+  }
+
+  return preview;
+}
+
+export function logGmDeferredInterventionAttempt(
+  preview: Pick<
+    IGmCascadePreview,
+    'actorId' | 'domain' | 'kind' | 'targetRefs' | 'reason'
+  >,
+  emit: GmDeferredInterventionLogger = logger.warn,
+): IGmDeferredInterventionAttemptLog {
+  const entry: IGmDeferredInterventionAttemptLog = {
+    level: 'warn',
+    service: 'gm-intervention',
+    event: 'domain-deferred',
+    message: 'Deferred GM intervention domain without mutation.',
+    actorId: preview.actorId,
+    domain: preview.domain,
+    kind: preview.kind,
+    targetRefs: preview.targetRefs,
+    deferredReason:
+      preview.reason ??
+      `GM intervention domain "${preview.domain}" is deferred in this slice.`,
+  };
+
+  emit('[gm-intervention:domain-deferred]', entry);
+  return entry;
 }
 
 export function approveGmCascadePreview<

--- a/src/lib/interventions/__tests__/GmCampaignInterventionBoundaries.test.ts
+++ b/src/lib/interventions/__tests__/GmCampaignInterventionBoundaries.test.ts
@@ -1,0 +1,184 @@
+import type {
+  IGmAuthorityContext,
+  IGmPrivateMetadata,
+  IInterventionLedgerCommand,
+  InterventionDomain,
+} from '@/types/interventions';
+
+import type { IGmDeferredInterventionAttemptLog } from '../index';
+
+import {
+  approveGmCascadePreview,
+  createGmCascadePreview,
+  InterventionLedger,
+} from '../index';
+
+interface CampaignBoundaryState {
+  readonly finances: {
+    readonly cbills: number;
+  };
+  readonly inventory: readonly string[];
+  readonly repairQueue: readonly string[];
+  readonly salvage: readonly string[];
+  readonly travel: {
+    readonly currentSystem: string;
+    readonly destinationSystem?: string;
+  };
+  readonly campaignTime: {
+    readonly day: number;
+    readonly hoursElapsed: number;
+  };
+  readonly postCombat: {
+    readonly completedScenarioIds: readonly string[];
+  };
+}
+
+interface DeferredCommandPayload {
+  readonly privateMetadata: IGmPrivateMetadata;
+}
+
+const deferredDomains = [
+  'post-combat',
+  'economy',
+  'repair',
+  'salvage',
+  'time',
+] as const satisfies readonly InterventionDomain[];
+
+const gmAuthority: IGmAuthorityContext = {
+  actorId: 'gm-1',
+  role: 'gm',
+  gameId: 'game-1',
+  campaignId: 'campaign-1',
+  ownedStateRefs: ['campaign:campaign-1'],
+};
+
+function makeState(): CampaignBoundaryState {
+  return {
+    finances: {
+      cbills: 1200000,
+    },
+    inventory: ['medium-laser', 'ac20-ammo-ton'],
+    repairQueue: ['repair-job-1'],
+    salvage: ['salvage-lot-1'],
+    travel: {
+      currentSystem: 'Galatea',
+      destinationSystem: 'Outreach',
+    },
+    campaignTime: {
+      day: 42,
+      hoursElapsed: 6,
+    },
+    postCombat: {
+      completedScenarioIds: ['scenario-1'],
+    },
+  };
+}
+
+function makeCommand(
+  domain: InterventionDomain,
+): IInterventionLedgerCommand<DeferredCommandPayload> {
+  return {
+    domain,
+    kind: domain === 'time' ? 'fix' : 'undo',
+    actorId: 'gm-1',
+    targetRefs: [`${domain}:root`],
+    payload: {
+      privateMetadata: {
+        reason: 'GM wants to adjust a campaign cascade.',
+        defaultOutcome: 'The campaign state would remain unchanged.',
+        hiddenNotes: 'secret merchant inventory branch',
+      },
+    },
+  };
+}
+
+describe('GM campaign intervention boundaries', () => {
+  it.each(deferredDomains)(
+    'defers %s interventions without mutating campaign roots',
+    (domain) => {
+      const state = makeState();
+      const ledger = new InterventionLedger<CampaignBoundaryState>();
+      const logs: Array<{
+        readonly message: string;
+        readonly entry: IGmDeferredInterventionAttemptLog;
+      }> = [];
+
+      const preview = createGmCascadePreview({
+        ledger,
+        command: makeCommand(domain),
+        state,
+        authority: gmAuthority,
+        interventionId: `gm-int-${domain}`,
+        emitDeferredLog(message, entry): void {
+          logs.push({ message, entry });
+        },
+      });
+      const result = approveGmCascadePreview({
+        ledger,
+        preview,
+        state,
+      });
+
+      expect(preview).toMatchObject({
+        interventionId: `gm-int-${domain}`,
+        status: 'deferred',
+        domain,
+        targetRefs: [`${domain}:root`],
+        affectedStateRefs: [`${domain}:root`],
+        projectedEvents: [],
+        conflicts: [],
+      });
+      expect(result).toMatchObject({
+        status: 'blocked',
+        state,
+        appended: false,
+      });
+      expect(result.state).toBe(state);
+      expect(ledger.getRecords()).toEqual([]);
+      expect(logs).toHaveLength(1);
+      expect(logs[0]).toMatchObject({
+        message: '[gm-intervention:domain-deferred]',
+        entry: {
+          level: 'warn',
+          service: 'gm-intervention',
+          event: 'domain-deferred',
+          actorId: 'gm-1',
+          domain,
+          kind: domain === 'time' ? 'fix' : 'undo',
+          targetRefs: [`${domain}:root`],
+        },
+      });
+      expect(JSON.stringify(result.state)).toBe(JSON.stringify(makeState()));
+    },
+  );
+
+  it('logs deferred attempts without exposing hidden scenario notes', () => {
+    const state = makeState();
+    const ledger = new InterventionLedger<CampaignBoundaryState>();
+    const logs: Array<{
+      readonly message: string;
+      readonly entry: IGmDeferredInterventionAttemptLog;
+    }> = [];
+
+    const preview = createGmCascadePreview({
+      ledger,
+      command: makeCommand('economy'),
+      state,
+      authority: gmAuthority,
+      interventionId: 'gm-int-safe-log',
+      emitDeferredLog(message, entry): void {
+        logs.push({ message, entry });
+      },
+    });
+
+    expect(preview.status).toBe('deferred');
+    expect(JSON.stringify(preview)).not.toContain('secret merchant');
+    expect(JSON.stringify(logs)).not.toContain('secret merchant');
+    expect(logs[0]?.entry).toMatchObject({
+      domain: 'economy',
+      deferredReason:
+        'No intervention ledger implementer registered for domain "economy".',
+    });
+  });
+});

--- a/src/lib/interventions/index.ts
+++ b/src/lib/interventions/index.ts
@@ -2,11 +2,14 @@ export {
   approveGmCascadePreview,
   cancelGmCascadePreview,
   createGmCascadePreview,
+  logGmDeferredInterventionAttempt,
 } from './GmCascadePreviewPipeline';
 
 export type {
+  GmDeferredInterventionLogger,
   IApproveGmCascadePreviewInput,
   ICreateGmCascadePreviewInput,
+  IGmDeferredInterventionAttemptLog,
 } from './GmCascadePreviewPipeline';
 
 export {


### PR DESCRIPTION
## Summary
- Add the final named GM campaign-boundary slice for deferred post-combat, economy, repair, salvage, and time-cascade domains.
- Emit safe internal deferred-domain logs without leaking hidden GM notes into player-visible projections.
- Document future campaign implementer seams and mark Campaign Boundary tasks complete.

## Verification
- npm.cmd test -- --runTestsByPath src/lib/interventions/__tests__/GmCascadePreviewPipeline.test.ts src/lib/interventions/__tests__/GmCampaignInterventionBoundaries.test.ts
- npx.cmd tsc --noEmit --skipLibCheck --pretty false
- npx.cmd oxlint src/lib/interventions src/types/interventions
- npx.cmd oxfmt --check src/lib/interventions/GmCascadePreviewPipeline.ts src/lib/interventions/index.ts src/lib/interventions/__tests__/GmCampaignInterventionBoundaries.test.ts docs/architecture/gm-campaign-intervention-boundaries.md
- cmd /c openspec validate add-gm-intervention-control-plane --strict
- commit hook: full npm run build

## Archive note
This finishes the sixth ordered named spec slice. The OpenSpec task file still has Tactical Command Surface items open; those are not currently represented as a split spec and should be implemented or split before the whole change is archived.