### PR TITLE
Route GM tactical commands through intervention previews

### DIFF
--- a/openspec/changes/add-gm-intervention-control-plane/specs/gm-tactical-command-surface/spec.md
+++ b/openspec/changes/add-gm-intervention-control-plane/specs/gm-tactical-command-surface/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: Tactical GM Commands Use Intervention Preview Pipeline
+
+The tactical command dock SHALL replace GM command stub dispatches with GM intervention preview requests. Shell mode MAY control whether GM controls are visible, but it SHALL NOT be treated as service-level authority.
+
+#### Scenario: GM command produces preview intent
+- **GIVEN** the tactical dock is rendered in GM shell mode
+- **WHEN** a GM command is committed without a mounted preview service
+- **THEN** the command SHALL dispatch a structured GM intervention preview intent
+- **AND** it SHALL NOT dispatch legacy stub action ids
+
+#### Scenario: Service authority rejects exposed controls
+- **GIVEN** a GM command is visible because the shell is in GM mode
+- **WHEN** the preview service evaluates the request with non-GM authority
+- **THEN** the confirmation surface SHALL show a rejected preview
+- **AND** approval SHALL remain disabled
+
+### Requirement: GM Confirmation Shows Private and Public Effects
+
+The tactical GM confirmation UI SHALL show GM-private detail, player-public net effect, conflicts, and manual-takeover state before approval.
+
+#### Scenario: Ready preview can be approved
+- **GIVEN** the GM preview service returns a ready intervention preview
+- **WHEN** the confirmation UI renders
+- **THEN** it SHALL show the GM-private reason
+- **AND** it SHALL show the player-public summary and changed state refs
+- **AND** approving SHALL call the GM intervention approval handler
+
+#### Scenario: Manual takeover state is explicit
+- **GIVEN** the GM preview service returns a manual-takeover preview
+- **WHEN** the confirmation UI renders
+- **THEN** it SHALL show the blocking conflict
+- **AND** the approval control SHALL be disabled
+- **AND** the manual takeover control SHALL call the manual takeover handler
+
+### Requirement: Player Log Uses Public Projection Only
+
+The tactical command surface SHALL render player-facing intervention log entries from public projections only.
+
+#### Scenario: Hidden GM notes are not shown in public log
+- **GIVEN** a GM intervention record contains GM-private hidden notes
+- **WHEN** the player-facing log surface renders the record
+- **THEN** it SHALL show only the public net effect
+- **AND** it SHALL NOT show hidden notes, private reason, or default outcome
+
+### Requirement: GM Confirmation Is Accessible
+
+The GM confirmation and manual takeover controls SHALL expose accessible dialog semantics and named controls.
+
+#### Scenario: Confirmation dialog is screen-reader reachable
+- **GIVEN** a GM intervention preview is open
+- **WHEN** assistive technology queries the command surface
+- **THEN** the confirmation surface SHALL be exposed as a labelled dialog
+- **AND** approve, cancel, and manual takeover controls SHALL be reachable by accessible name or role

--- a/openspec/changes/add-gm-intervention-control-plane/tasks.md
+++ b/openspec/changes/add-gm-intervention-control-plane/tasks.md
@@ -45,11 +45,11 @@
 
 ## 6. Tactical Command Surface
 
-- [ ] 6.1 Replace TacticalActionDock GM command stubs with calls into the GM intervention preview pipeline.
-- [ ] 6.2 Ensure shell mode controls visibility/ergonomics only; service-level authority remains required for every GM command.
-- [ ] 6.3 Add confirmation UI that shows GM-private detail, player-public net effect, conflicts, and manual-takeover state before approval.
-- [ ] 6.4 Add player-facing log/replay UI coverage showing only resulting state and public net effect.
-- [ ] 6.5 Add accessibility coverage for the GM confirmation/manual takeover controls.
+- [x] 6.1 Replace TacticalActionDock GM command stubs with calls into the GM intervention preview pipeline.
+- [x] 6.2 Ensure shell mode controls visibility/ergonomics only; service-level authority remains required for every GM command.
+- [x] 6.3 Add confirmation UI that shows GM-private detail, player-public net effect, conflicts, and manual-takeover state before approval.
+- [x] 6.4 Add player-facing log/replay UI coverage showing only resulting state and public net effect.
+- [x] 6.5 Add accessibility coverage for the GM confirmation/manual takeover controls.
 
 ## 7. Campaign Boundary and Deferred Cascades
 
@@ -60,8 +60,16 @@
 
 ## 8. Validation
 
-- [ ] 8.1 Run targeted GM intervention unit tests and integration tests.
-- [ ] 8.2 Run relevant gameplay event/reducer, fog/redaction, encounter launch, and tactical command tests.
-- [ ] 8.3 Run LSP diagnostics or TypeScript checks over changed files.
-- [ ] 8.4 Run `cmd /c openspec validate add-gm-intervention-control-plane --strict`.
-- [ ] 8.5 Update the task checklist with completed verification evidence before archive or PR handoff.
+- [x] 8.1 Run targeted GM intervention unit tests and integration tests.
+- [x] 8.2 Run relevant gameplay event/reducer, fog/redaction, encounter launch, and tactical command tests.
+- [x] 8.3 Run LSP diagnostics or TypeScript checks over changed files.
+- [x] 8.4 Run `cmd /c openspec validate add-gm-intervention-control-plane --strict`.
+- [x] 8.5 Update the task checklist with completed verification evidence before archive or PR handoff.
+
+Verification evidence:
+
+- `npm.cmd test -- src/lib/interventions/__tests__ src/components/gameplay/TacticalActionDock src/lib/campaign/encounter/__tests__/launchCampaignEncounter.test.ts src/lib/multiplayer/server/__tests__/fogOfWar.test.ts src/lib/multiplayer/server/__tests__/ServerMatchHost.fogOfWarIntegration.test.ts src/components/gameplay/__tests__/GameplayLayout.viewModel.test.ts src/__tests__/unit/utils/gameplay/gameSession.test.ts src/utils/gameplay/gameState/__tests__/phaseManagement.test.ts`
+- `npx.cmd tsc --noEmit --skipLibCheck --pretty false`
+- `npx.cmd oxlint src/lib/interventions src/components/gameplay/TacticalActionDock src/types/interventions`
+- `npx.cmd oxfmt --check src/lib/interventions/GmTacticalCommandPreviewAdapter.ts src/lib/interventions/index.ts src/lib/interventions/__tests__/GmTacticalCommandPreviewAdapter.test.ts src/components/gameplay/TacticalActionDock/TacticalActionDock.tsx src/components/gameplay/TacticalActionDock/TacticalActionDock.gmIntervention.tsx src/components/gameplay/TacticalActionDock/index.ts src/components/gameplay/TacticalActionDock/commands/gmReferralCommands.ts src/components/gameplay/TacticalActionDock/commands/__tests__/gmReferralCommands.test.ts src/components/gameplay/TacticalActionDock/__tests__/TacticalActionDock.04.gmIntervention.test.tsx openspec/changes/add-gm-intervention-control-plane/specs/gm-tactical-command-surface/spec.md`
+- `cmd /c openspec validate add-gm-intervention-control-plane --strict`

--- a/src/components/gameplay/TacticalActionDock/TacticalActionDock.gmIntervention.tsx
+++ b/src/components/gameplay/TacticalActionDock/TacticalActionDock.gmIntervention.tsx
@@ -1,0 +1,227 @@
+import React from 'react';
+
+import type { GmTacticalCommandId } from '@/lib/interventions';
+import type {
+  ITacticalCommand,
+  ITacticalCommandContext,
+} from '@/types/gameplay';
+import type {
+  IGmCascadePreview,
+  IGmPrivateMetadata,
+  IGmPublicEffect,
+  IPlayerVisibleInterventionRecord,
+} from '@/types/interventions';
+
+export interface IGmTacticalCommandPreviewRequest {
+  readonly commandId: GmTacticalCommandId;
+  readonly command: ITacticalCommand;
+  readonly ctx: ITacticalCommandContext;
+}
+
+export interface IGmTacticalInterventionSurface {
+  readonly preview: (
+    request: IGmTacticalCommandPreviewRequest,
+  ) => IGmCascadePreview<IGmPrivateMetadata, IGmPublicEffect>;
+  readonly approve?: (
+    preview: IGmCascadePreview<IGmPrivateMetadata, IGmPublicEffect>,
+  ) => void;
+  readonly cancel?: (
+    preview: IGmCascadePreview<IGmPrivateMetadata, IGmPublicEffect>,
+  ) => void;
+  readonly manualTakeover?: (
+    preview: IGmCascadePreview<IGmPrivateMetadata, IGmPublicEffect>,
+  ) => void;
+  readonly playerLog?: readonly IPlayerVisibleInterventionRecord<IGmPublicEffect>[];
+}
+
+export interface IGmPreviewState {
+  readonly commandLabel: string;
+  readonly preview: IGmCascadePreview<IGmPrivateMetadata, IGmPublicEffect>;
+}
+
+interface GmInterventionConfirmationPanelProps {
+  readonly previewState: IGmPreviewState;
+  readonly onApprove?: () => void;
+  readonly onCancel: () => void;
+  readonly onManualTakeover?: () => void;
+}
+
+export function GmInterventionConfirmationPanel({
+  previewState,
+  onApprove,
+  onCancel,
+  onManualTakeover,
+}: GmInterventionConfirmationPanelProps): React.ReactElement {
+  const { commandLabel, preview } = previewState;
+  const titleId = `gm-intervention-confirm-title-${preview.interventionId}`;
+  const detailId = `gm-intervention-confirm-detail-${preview.interventionId}`;
+  const publicSummary =
+    preview.publicEffect?.summary ??
+    preview.reason ??
+    'No player-visible effect is available yet.';
+  const changedStateRefs = preview.publicEffect?.changedStateRefs ?? [];
+  const manualTakeoverRequired =
+    preview.status === 'requires-manual-takeover' ||
+    preview.conflicts.some((conflict) => conflict.requiresManualTakeover);
+  const approveDisabled = preview.status !== 'ready' || !onApprove;
+  const manualTakeoverDisabled = !manualTakeoverRequired || !onManualTakeover;
+
+  return (
+    <section
+      role="dialog"
+      aria-modal="false"
+      aria-labelledby={titleId}
+      aria-describedby={detailId}
+      className="border-border-theme bg-surface-raised max-w-md rounded border p-3 text-sm shadow"
+      data-testid="gm-intervention-confirmation"
+      data-gm-preview-status={preview.status}
+    >
+      <div className="mb-2 flex items-start justify-between gap-3">
+        <div>
+          <h3 id={titleId} className="text-text-theme-primary font-semibold">
+            {commandLabel}
+          </h3>
+          <p
+            id={detailId}
+            className="text-text-theme-secondary text-xs"
+            data-testid="gm-intervention-preview-status"
+          >
+            {preview.status}
+          </p>
+        </div>
+        <button
+          type="button"
+          className="text-text-theme-secondary hover:text-text-theme-primary focus:ring-border-theme rounded px-2 py-1 text-xs focus:ring-2 focus:outline-none"
+          onClick={onCancel}
+          data-testid="gm-intervention-cancel"
+          aria-label="Cancel GM intervention preview"
+        >
+          Cancel
+        </button>
+      </div>
+
+      <div className="space-y-2">
+        <section data-testid="gm-intervention-public-effect">
+          <h4 className="text-text-theme-secondary text-xs font-semibold uppercase">
+            Player Net Effect
+          </h4>
+          <p className="text-text-theme-primary">{publicSummary}</p>
+          {changedStateRefs.length > 0 && (
+            <p className="text-text-theme-secondary text-xs">
+              {changedStateRefs.join(', ')}
+            </p>
+          )}
+        </section>
+
+        <section data-testid="gm-intervention-private-detail">
+          <h4 className="text-text-theme-secondary text-xs font-semibold uppercase">
+            GM Detail
+          </h4>
+          <PrivateMetadataRows privateMetadata={preview.privateMetadata} />
+        </section>
+
+        <section data-testid="gm-intervention-conflicts">
+          <h4 className="text-text-theme-secondary text-xs font-semibold uppercase">
+            Conflicts
+          </h4>
+          {preview.conflicts.length === 0 ? (
+            <p className="text-text-theme-secondary">None</p>
+          ) : (
+            <ul className="list-disc pl-4">
+              {preview.conflicts.map((conflict) => (
+                <li key={`${conflict.code}:${conflict.message}`}>
+                  {conflict.message}
+                  {conflict.requiresManualTakeover
+                    ? ' Manual takeover required.'
+                    : ''}
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      </div>
+
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          className="bg-surface-deep text-text-theme-primary rounded px-3 py-2 font-medium disabled:opacity-50"
+          onClick={onApprove}
+          disabled={approveDisabled}
+          data-testid="gm-intervention-approve"
+        >
+          Approve
+        </button>
+        <button
+          type="button"
+          className="border-border-theme text-text-theme-primary rounded border px-3 py-2 font-medium disabled:opacity-50"
+          onClick={onManualTakeover}
+          disabled={manualTakeoverDisabled}
+          data-testid="gm-intervention-manual-takeover"
+        >
+          Manual Takeover
+        </button>
+      </div>
+    </section>
+  );
+}
+
+export function GmInterventionPlayerLog({
+  records,
+}: {
+  readonly records: readonly IPlayerVisibleInterventionRecord<IGmPublicEffect>[];
+}): React.ReactElement | null {
+  if (records.length === 0) return null;
+
+  return (
+    <section
+      aria-label="Player-visible GM intervention log"
+      className="text-text-theme-secondary max-w-sm text-xs"
+      data-testid="gm-intervention-player-log"
+    >
+      {records.map((record) => (
+        <article key={record.id} data-gm-log-record-id={record.id}>
+          <span>{record.publicEffect.summary}</span>
+          {record.publicEffect.changedStateRefs.length > 0 && (
+            <span> {record.publicEffect.changedStateRefs.join(', ')}</span>
+          )}
+        </article>
+      ))}
+    </section>
+  );
+}
+
+function PrivateMetadataRows({
+  privateMetadata,
+}: {
+  readonly privateMetadata?: IGmPrivateMetadata;
+}): React.ReactElement {
+  if (!privateMetadata) {
+    return <p className="text-text-theme-secondary">Unavailable</p>;
+  }
+
+  const rows: Array<[string, string | undefined]> = [
+    ['Reason', privateMetadata.reason],
+    ['Default Outcome', privateMetadata.defaultOutcome],
+    ['Hidden Notes', privateMetadata.hiddenNotes],
+    ['Manual Takeover', privateMetadata.manualTakeoverNotes],
+  ];
+  const visibleRows = rows.filter(
+    (entry): entry is [string, string] =>
+      typeof entry[1] === 'string' && entry[1].length > 0,
+  );
+
+  if (visibleRows.length === 0) {
+    return <p className="text-text-theme-secondary">Unavailable</p>;
+  }
+
+  return (
+    <dl className="space-y-1">
+      {visibleRows.map(([label, value]) => (
+        <div key={label}>
+          <dt className="text-text-theme-secondary text-xs">{label}</dt>
+          <dd className="text-text-theme-primary">{value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}

--- a/src/components/gameplay/TacticalActionDock/TacticalActionDock.tsx
+++ b/src/components/gameplay/TacticalActionDock/TacticalActionDock.tsx
@@ -32,9 +32,16 @@ import type {
 } from '@/types/gameplay';
 import type { ShellMode } from '@/types/gameplay/TacticalShellInterfaces';
 
+import { isGmTacticalCommandId } from '@/lib/interventions';
 import { GamePhase } from '@/types/gameplay';
 
 import { CommandTooltip } from './CommandTooltip';
+import {
+  GmInterventionConfirmationPanel,
+  GmInterventionPlayerLog,
+  type IGmPreviewState,
+  type IGmTacticalInterventionSurface,
+} from './TacticalActionDock.gmIntervention';
 import { CommandPreviewPanel } from './TacticalActionDock.preview';
 import {
   useCommandPreview,
@@ -62,6 +69,8 @@ export interface TacticalActionDockProps {
   readonly infoText?: string;
   /** Rules-backed projection inputs for the active command preview. */
   readonly previewInputs?: ICommandPreviewInputs;
+  /** Optional GM intervention service for command previews and approval. */
+  readonly gmIntervention?: IGmTacticalInterventionSurface;
   /** Optional className for styling. */
   readonly className?: string;
 }
@@ -251,8 +260,12 @@ export function TacticalActionDock({
   trailingActions,
   infoText,
   previewInputs,
+  gmIntervention,
   className = '',
 }: TacticalActionDockProps): React.ReactElement {
+  const [gmPreviewState, setGmPreviewState] = useState<IGmPreviewState | null>(
+    null,
+  );
   const effectiveCtx = useMemo<ITacticalCommandContext>(() => {
     if (
       !previewInputs?.movementInfo &&
@@ -300,6 +313,19 @@ export function TacticalActionDock({
         // tooltip is the explanation surface — no secondary toast.
         return;
       }
+      if (
+        command.category === 'gm' &&
+        gmIntervention &&
+        isGmTacticalCommandId(command.id)
+      ) {
+        const preview = gmIntervention.preview({
+          commandId: command.id,
+          command,
+          ctx: effectiveCtx,
+        });
+        setGmPreviewState({ commandLabel: command.label, preview });
+        return;
+      }
       if (command.requiresConfirmation) {
         // Spec `End phase distinguishes no-op from unresolved
         // actions` — irreversible commits route through the
@@ -320,8 +346,27 @@ export function TacticalActionDock({
         onAction(result.actionId, result.payload);
       }
     },
-    [effectiveCtx, onAction],
+    [effectiveCtx, gmIntervention, onAction],
   );
+
+  const approveGmPreview = useCallback(() => {
+    if (!gmPreviewState || gmPreviewState.preview.status !== 'ready') return;
+    gmIntervention?.approve?.(gmPreviewState.preview);
+    setGmPreviewState(null);
+  }, [gmIntervention, gmPreviewState]);
+
+  const cancelGmPreview = useCallback(() => {
+    if (gmPreviewState) {
+      gmIntervention?.cancel?.(gmPreviewState.preview);
+    }
+    setGmPreviewState(null);
+  }, [gmIntervention, gmPreviewState]);
+
+  const takeManualControl = useCallback(() => {
+    if (!gmPreviewState) return;
+    gmIntervention?.manualTakeover?.(gmPreviewState.preview);
+    setGmPreviewState(null);
+  }, [gmIntervention, gmPreviewState]);
 
   return (
     <div
@@ -351,6 +396,19 @@ export function TacticalActionDock({
       </div>
       <div className="flex items-center gap-3">
         {commandPreview && <CommandPreviewPanel preview={commandPreview} />}
+        {gmPreviewState && (
+          <GmInterventionConfirmationPanel
+            previewState={gmPreviewState}
+            onApprove={gmIntervention?.approve ? approveGmPreview : undefined}
+            onCancel={cancelGmPreview}
+            onManualTakeover={
+              gmIntervention?.manualTakeover ? takeManualControl : undefined
+            }
+          />
+        )}
+        {gmIntervention?.playerLog && (
+          <GmInterventionPlayerLog records={gmIntervention.playerLog} />
+        )}
         {infoText && (
           <div className="text-text-theme-secondary text-sm">{infoText}</div>
         )}

--- a/src/components/gameplay/TacticalActionDock/__tests__/TacticalActionDock.04.gmIntervention.test.tsx
+++ b/src/components/gameplay/TacticalActionDock/__tests__/TacticalActionDock.04.gmIntervention.test.tsx
@@ -1,0 +1,206 @@
+import { within } from '@testing-library/react';
+
+import type {
+  IGmCascadePreview,
+  IGmPrivateMetadata,
+  IGmPublicEffect,
+  IPlayerVisibleInterventionRecord,
+} from '@/types/interventions';
+
+import * as H from './TacticalActionDock.test-helpers';
+
+const { GamePhase, TacticalActionDock, fireEvent, makeCtx, render, screen } = H;
+
+type GmPreview = IGmCascadePreview<IGmPrivateMetadata, IGmPublicEffect>;
+
+function makePreview(overrides: Partial<GmPreview> = {}): GmPreview {
+  return {
+    interventionId: 'gm-preview-1',
+    status: 'ready',
+    domain: 'combat',
+    kind: 'fix',
+    actorId: 'gm-1',
+    targetRefs: ['unit:atlas-1'],
+    affectedStateRefs: ['unit:atlas-1', 'unit:atlas-1:damage'],
+    privateMetadata: {
+      reason: 'Secret GM correction reason.',
+      defaultOutcome: 'The original hit would stand.',
+      hiddenNotes: 'Hidden ambush branch.',
+      manualTakeoverNotes: 'Use manual takeover if armor mapping changed.',
+    },
+    publicEffect: {
+      summary: 'Atlas damage corrected by the GM.',
+      changedStateRefs: ['unit:atlas-1:damage'],
+    },
+    projectedEvents: [],
+    conflicts: [],
+    ...overrides,
+  };
+}
+
+function makePlayerLogRecord(
+  overrides: Partial<IPlayerVisibleInterventionRecord<IGmPublicEffect>> = {},
+): IPlayerVisibleInterventionRecord<IGmPublicEffect> {
+  return {
+    id: 'record-1',
+    domain: 'combat',
+    kind: 'fix',
+    status: 'approved',
+    actorId: 'gm-1',
+    targetRefs: ['unit:atlas-1'],
+    publicEffect: {
+      summary: 'Atlas damage corrected by the GM.',
+      changedStateRefs: ['unit:atlas-1:damage'],
+    },
+    createdAt: '2026-06-20T07:00:00.000Z',
+    approvedAt: '2026-06-20T07:01:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('TacticalActionDock GM intervention surface', () => {
+  it('opens an accessible GM confirmation from the preview service', () => {
+    const onAction = jest.fn();
+    const approve = jest.fn();
+    const preview = jest.fn(() => makePreview());
+    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+
+    render(
+      <TacticalActionDock
+        ctx={makeCtx({ phase: GamePhase.Movement })}
+        shellMode="gm"
+        onAction={onAction}
+        gmIntervention={{ preview, approve }}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('command-btn-gm.set-damage'));
+
+    expect(preview).toHaveBeenCalledWith(
+      expect.objectContaining({ commandId: 'gm.set-damage' }),
+    );
+    expect(confirmSpy).not.toHaveBeenCalled();
+    expect(onAction).not.toHaveBeenCalled();
+
+    const dialog = screen.getByRole('dialog', {
+      name: 'Set Damage (GM)',
+    });
+    expect(dialog).toHaveAttribute('data-gm-preview-status', 'ready');
+    expect(
+      within(dialog).getByTestId('gm-intervention-private-detail'),
+    ).toHaveTextContent('Secret GM correction reason.');
+    expect(
+      within(dialog).getByTestId('gm-intervention-public-effect'),
+    ).toHaveTextContent('Atlas damage corrected by the GM.');
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Approve' }));
+    expect(approve).toHaveBeenCalledWith(
+      expect.objectContaining({
+        interventionId: 'gm-preview-1',
+      }),
+    );
+
+    confirmSpy.mockRestore();
+  });
+
+  it('shows service-level rejection and disables approval', () => {
+    const rejected = makePreview({
+      status: 'rejected',
+      privateMetadata: undefined,
+      publicEffect: undefined,
+      conflicts: [],
+      reason: 'Only the owning GM can request GM intervention previews.',
+    });
+
+    render(
+      <TacticalActionDock
+        ctx={makeCtx()}
+        shellMode="gm"
+        onAction={jest.fn()}
+        gmIntervention={{ preview: jest.fn(() => rejected) }}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('command-btn-gm.grant-resource'));
+
+    const dialog = screen.getByRole('dialog', {
+      name: 'Grant Resource (GM)',
+    });
+    expect(dialog).toHaveAttribute('data-gm-preview-status', 'rejected');
+    expect(dialog).toHaveTextContent(
+      'Only the owning GM can request GM intervention previews.',
+    );
+    expect(
+      within(dialog).getByRole('button', { name: 'Approve' }),
+    ).toBeDisabled();
+  });
+
+  it('shows manual takeover state and routes the manual takeover control', () => {
+    const manualTakeover = jest.fn();
+    const manualPreview = makePreview({
+      status: 'requires-manual-takeover',
+      conflicts: [
+        {
+          code: 'reload-conflict',
+          message: 'Armor mapping changed and needs GM resolution.',
+          affectedRefs: ['unit:atlas-1:armor'],
+          requiresManualTakeover: true,
+        },
+      ],
+    });
+
+    render(
+      <TacticalActionDock
+        ctx={makeCtx()}
+        shellMode="gm"
+        onAction={jest.fn()}
+        gmIntervention={{
+          preview: jest.fn(() => manualPreview),
+          manualTakeover,
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('command-btn-gm.set-damage'));
+
+    const dialog = screen.getByRole('dialog', {
+      name: 'Set Damage (GM)',
+    });
+    expect(dialog).toHaveAttribute(
+      'data-gm-preview-status',
+      'requires-manual-takeover',
+    );
+    expect(dialog).toHaveTextContent(
+      'Armor mapping changed and needs GM resolution.',
+    );
+    expect(
+      within(dialog).getByRole('button', { name: 'Approve' }),
+    ).toBeDisabled();
+
+    fireEvent.click(
+      within(dialog).getByRole('button', { name: 'Manual Takeover' }),
+    );
+    expect(manualTakeover).toHaveBeenCalledWith(manualPreview);
+  });
+
+  it('renders player-facing log entries without GM-private fields', () => {
+    render(
+      <TacticalActionDock
+        ctx={makeCtx()}
+        shellMode="gm"
+        onAction={jest.fn()}
+        gmIntervention={{
+          preview: jest.fn(() => makePreview()),
+          playerLog: [makePlayerLogRecord()],
+        }}
+      />,
+    );
+
+    const log = screen.getByTestId('gm-intervention-player-log');
+    expect(log).toHaveTextContent('Atlas damage corrected by the GM.');
+    expect(log).toHaveTextContent('unit:atlas-1:damage');
+    expect(log).not.toHaveTextContent('Hidden ambush branch.');
+    expect(log).not.toHaveTextContent('Secret GM correction reason.');
+    expect(log).not.toHaveTextContent('The original hit would stand.');
+  });
+});

--- a/src/components/gameplay/TacticalActionDock/commands/__tests__/gmReferralCommands.test.ts
+++ b/src/components/gameplay/TacticalActionDock/commands/__tests__/gmReferralCommands.test.ts
@@ -8,6 +8,7 @@
  * @spec openspec/changes/add-tactical-action-menu-system/specs/tactical-map-interface/spec.md
  */
 
+import { GM_TACTICAL_PREVIEW_ACTION_ID } from '@/lib/interventions';
 import { GamePhase, type ITacticalCommandContext } from '@/types/gameplay';
 
 import { buildGmReferralCommands } from '../gmReferralCommands';
@@ -57,5 +58,28 @@ describe('gmReferralCommands', () => {
       available: true,
     });
     expect(cmd.requiresConfirmation).toBe(true);
+  });
+
+  it('commits structured GM intervention preview intents instead of legacy stubs', () => {
+    const advance = commands.find((c) => c.id === 'gm.advance-phase')!;
+    const damage = commands.find((c) => c.id === 'gm.set-damage')!;
+    const resource = commands.find((c) => c.id === 'gm.grant-resource')!;
+
+    expect(advance.commit(makeCtx())).toEqual({
+      actionId: GM_TACTICAL_PREVIEW_ACTION_ID,
+      payload: {
+        commandId: 'gm.advance-phase',
+        activeUnitId: 'unit-a',
+        selectedUnitId: 'unit-a',
+        targetUnitId: null,
+        phase: GamePhase.Movement,
+      },
+    });
+    expect(damage.commit(makeCtx()).actionId).toBe(
+      GM_TACTICAL_PREVIEW_ACTION_ID,
+    );
+    expect(resource.commit(makeCtx()).actionId).toBe(
+      GM_TACTICAL_PREVIEW_ACTION_ID,
+    );
   });
 });

--- a/src/components/gameplay/TacticalActionDock/commands/gmReferralCommands.ts
+++ b/src/components/gameplay/TacticalActionDock/commands/gmReferralCommands.ts
@@ -2,14 +2,10 @@
  * GM / referee command family — advance phase by force, set damage,
  * grant resource.
  *
- * GM commands are filtered out of the registry for non-GM shellModes
- * (`combat`, `replay`, `spectator`). The registry hook reads
- * `shellMode` from the shell context and only includes this family
- * when `shellMode === 'gm'`.
- *
- * TODO(wave-8): when role-based gating lands the registry will gate
- * GM commands on `viewerPlayerId === matchOwnerId` AND `shellMode === 'gm'`,
- * not just shellMode.
+ * GM commands are filtered out of the registry for non-GM shellModes as an
+ * ergonomic visibility rule. Every command commits a GM intervention preview
+ * intent; the intervention service still owns authority, redaction, and
+ * approval.
  *
  * @spec openspec/changes/add-tactical-action-menu-system/specs/tactical-map-interface/spec.md
  * @see openspec/changes/add-tactical-action-menu-system/tasks.md §1.2
@@ -18,10 +14,12 @@
 import type { ITacticalCommand } from '@/types/gameplay';
 
 import {
-  ALL_GAME_PHASES,
-  alwaysAvailable,
-  commitStaticAction,
-} from './commandDescriptorHelpers';
+  buildGmTacticalCommandIntent,
+  GM_TACTICAL_PREVIEW_ACTION_ID,
+  type GmTacticalCommandId,
+} from '@/lib/interventions';
+
+import { ALL_GAME_PHASES, alwaysAvailable } from './commandDescriptorHelpers';
 
 export function buildGmReferralCommands(): readonly ITacticalCommand[] {
   return [GmAdvancePhaseCommand, GmSetDamageCommand, GmGrantResourceCommand];
@@ -35,7 +33,7 @@ const GmAdvancePhaseCommand: ITacticalCommand = {
   requiresConfirmation: true, // GM force-advance bypasses validation.
   undoable: false,
   availability: alwaysAvailable,
-  commit: commitStaticAction('gm-advance-phase'),
+  commit: commitGmPreviewIntent('gm.advance-phase'),
 };
 
 const GmSetDamageCommand: ITacticalCommand = {
@@ -55,7 +53,7 @@ const GmSetDamageCommand: ITacticalCommand = {
     }
     return { available: true };
   },
-  commit: commitStaticAction('gm-set-damage'),
+  commit: commitGmPreviewIntent('gm.set-damage'),
 };
 
 const GmGrantResourceCommand: ITacticalCommand = {
@@ -66,5 +64,12 @@ const GmGrantResourceCommand: ITacticalCommand = {
   requiresConfirmation: false,
   undoable: true,
   availability: alwaysAvailable,
-  commit: commitStaticAction('gm-grant-resource'),
+  commit: commitGmPreviewIntent('gm.grant-resource'),
 };
+
+function commitGmPreviewIntent(commandId: GmTacticalCommandId) {
+  return (ctx: Parameters<ITacticalCommand['commit']>[0]) => ({
+    actionId: GM_TACTICAL_PREVIEW_ACTION_ID,
+    payload: buildGmTacticalCommandIntent(commandId, ctx),
+  });
+}

--- a/src/components/gameplay/TacticalActionDock/index.ts
+++ b/src/components/gameplay/TacticalActionDock/index.ts
@@ -14,6 +14,11 @@ export {
   TacticalActionDock,
   type TacticalActionDockProps,
 } from './TacticalActionDock';
+export type {
+  IGmPreviewState,
+  IGmTacticalCommandPreviewRequest,
+  IGmTacticalInterventionSurface,
+} from './TacticalActionDock.gmIntervention';
 
 export {
   TokenContextMenu,

--- a/src/lib/interventions/GmTacticalCommandPreviewAdapter.ts
+++ b/src/lib/interventions/GmTacticalCommandPreviewAdapter.ts
@@ -1,0 +1,192 @@
+import type {
+  ITacticalCommandContext,
+  TacticalActionPayload,
+} from '@/types/gameplay';
+import type {
+  IGmAuthorityContext,
+  IGmCascadePreview,
+  IGmPrivateMetadata,
+  IGmPublicEffect,
+  IInterventionLedgerCommand,
+} from '@/types/interventions';
+
+import { GamePhase } from '@/types/gameplay';
+
+import type { InterventionLedger } from './InterventionLedger';
+
+import { createGmCascadePreview } from './GmCascadePreviewPipeline';
+
+export const GM_TACTICAL_PREVIEW_ACTION_ID = 'gm-intervention.preview';
+
+export type GmTacticalCommandId =
+  | 'gm.advance-phase'
+  | 'gm.set-damage'
+  | 'gm.grant-resource';
+
+export interface IGmTacticalCommandIntent {
+  readonly commandId: GmTacticalCommandId;
+  readonly activeUnitId: string | null;
+  readonly selectedUnitId: string | null;
+  readonly targetUnitId: string | null;
+  readonly phase: GamePhase;
+}
+
+export interface ICreateGmTacticalCommandPreviewInput<TState> {
+  readonly ledger: InterventionLedger<TState>;
+  readonly state: TState;
+  readonly authority: IGmAuthorityContext;
+  readonly commandId: GmTacticalCommandId;
+  readonly ctx: ITacticalCommandContext;
+  readonly reason?: string;
+  readonly defaultOutcome?: string;
+  readonly hiddenNotes?: string;
+  readonly manualTakeoverNotes?: string;
+  readonly publicSummary?: string;
+  readonly visibleToPlayerIds?: readonly string[];
+  readonly interventionId?: string;
+  readonly now?: () => string;
+}
+
+const PHASE_ORDER: readonly GamePhase[] = [
+  GamePhase.Initiative,
+  GamePhase.Movement,
+  GamePhase.WeaponAttack,
+  GamePhase.PhysicalAttack,
+  GamePhase.Heat,
+  GamePhase.End,
+];
+
+export function buildGmTacticalCommandIntent(
+  commandId: GmTacticalCommandId,
+  ctx: ITacticalCommandContext,
+): TacticalActionPayload {
+  return {
+    commandId,
+    activeUnitId: ctx.activeUnitId,
+    selectedUnitId: ctx.selectedUnitId,
+    targetUnitId: ctx.targetUnitId,
+    phase: ctx.phase,
+  };
+}
+
+export function isGmTacticalCommandId(
+  commandId: string,
+): commandId is GmTacticalCommandId {
+  return (
+    commandId === 'gm.advance-phase' ||
+    commandId === 'gm.set-damage' ||
+    commandId === 'gm.grant-resource'
+  );
+}
+
+export function createGmTacticalCommandPreview<TState>(
+  input: ICreateGmTacticalCommandPreviewInput<TState>,
+): IGmCascadePreview<IGmPrivateMetadata, IGmPublicEffect> {
+  const command = buildGmTacticalLedgerCommand(input);
+  return createGmCascadePreview({
+    ledger: input.ledger,
+    command,
+    state: input.state,
+    authority: input.authority,
+    interventionId: input.interventionId,
+    now: input.now,
+  }) as IGmCascadePreview<IGmPrivateMetadata, IGmPublicEffect>;
+}
+
+export function buildGmTacticalLedgerCommand<TState>(
+  input: ICreateGmTacticalCommandPreviewInput<TState>,
+): IInterventionLedgerCommand {
+  const { authority, commandId, ctx, visibleToPlayerIds } = input;
+  const privateMetadata = buildPrivateMetadata(input);
+
+  if (commandId === 'gm.advance-phase') {
+    return {
+      domain: 'combat',
+      kind: 'fix',
+      actorId: authority.actorId,
+      targetRefs: [`game:${authority.gameId}`, `phase:${ctx.phase}`],
+      payload: {
+        correction: {
+          family: 'turn-order',
+          phase: nextPhase(ctx.phase),
+          activeUnitId: ctx.activeUnitId,
+        },
+        privateMetadata,
+        publicSummary:
+          input.publicSummary ??
+          `GM preview requested for a combat phase correction.`,
+        visibleToPlayerIds,
+      },
+    };
+  }
+
+  if (commandId === 'gm.set-damage') {
+    const unitId = ctx.selectedUnitId ?? ctx.activeUnitId ?? 'unselected';
+    return {
+      domain: 'combat',
+      kind: 'fix',
+      actorId: authority.actorId,
+      targetRefs: [`unit:${unitId}`],
+      payload: {
+        correction: {
+          family: 'damage-critical',
+          unitId,
+        },
+        privateMetadata,
+        publicSummary:
+          input.publicSummary ??
+          `GM preview requested for a damage correction on ${unitId}.`,
+        visibleToPlayerIds,
+      },
+    };
+  }
+
+  return {
+    domain: 'economy',
+    kind: 'add',
+    actorId: authority.actorId,
+    targetRefs: [
+      authority.campaignId
+        ? `campaign:${authority.campaignId}`
+        : `game:${authority.gameId}`,
+      `economy:${authority.gameId}`,
+    ],
+    payload: {
+      privateMetadata,
+      publicSummary:
+        input.publicSummary ??
+        'GM preview requested for a resource correction.',
+      visibleToPlayerIds,
+    },
+  };
+}
+
+function buildPrivateMetadata<TState>(
+  input: ICreateGmTacticalCommandPreviewInput<TState>,
+): IGmPrivateMetadata {
+  return {
+    reason: input.reason ?? defaultReason(input.commandId),
+    defaultOutcome: input.defaultOutcome,
+    hiddenNotes: input.hiddenNotes,
+    manualTakeoverNotes: input.manualTakeoverNotes,
+  };
+}
+
+function defaultReason(commandId: GmTacticalCommandId): string {
+  switch (commandId) {
+    case 'gm.advance-phase':
+      return 'GM requested a tactical phase correction.';
+    case 'gm.set-damage':
+      return 'GM requested a tactical damage correction.';
+    case 'gm.grant-resource':
+      return 'GM requested a tactical resource correction.';
+  }
+}
+
+function nextPhase(phase: GamePhase): GamePhase {
+  const index = PHASE_ORDER.indexOf(phase);
+  if (index === -1 || index === PHASE_ORDER.length - 1) {
+    return GamePhase.Initiative;
+  }
+  return PHASE_ORDER[index + 1];
+}

--- a/src/lib/interventions/__tests__/GmTacticalCommandPreviewAdapter.test.ts
+++ b/src/lib/interventions/__tests__/GmTacticalCommandPreviewAdapter.test.ts
@@ -1,0 +1,164 @@
+import type {
+  IGmAuthorityContext,
+  IGmCombatInterventionState,
+  IGmCombatInterventionUnitState,
+} from '@/types/interventions';
+
+import {
+  GamePhase,
+  GameSide,
+  GameStatus,
+  LockState,
+  type ITacticalCommandContext,
+} from '@/types/gameplay';
+import { Facing, MovementType } from '@/types/gameplay/HexGridInterfaces';
+
+import {
+  buildGmTacticalCommandIntent,
+  createGmTacticalCommandPreview,
+  GM_TACTICAL_PREVIEW_ACTION_ID,
+  registerGmCombatInterventionImplementer,
+} from '../index';
+import { InterventionLedger } from '../InterventionLedger';
+
+const gmAuthority: IGmAuthorityContext = {
+  actorId: 'gm-1',
+  role: 'gm',
+  gameId: 'game-1',
+  campaignId: 'campaign-1',
+  ownedStateRefs: ['game:game-1', 'campaign:campaign-1'],
+};
+
+function makeCtx(
+  overrides: Partial<ITacticalCommandContext> = {},
+): ITacticalCommandContext {
+  return {
+    activeUnitId: 'atlas-1',
+    selectedUnitId: 'atlas-1',
+    targetUnitId: null,
+    hoveredHex: null,
+    phase: GamePhase.Movement,
+    canAct: true,
+    ...overrides,
+  };
+}
+
+function makeState(): IGmCombatInterventionState {
+  return {
+    gameId: 'game-1',
+    status: GameStatus.Active,
+    turn: 1,
+    phase: GamePhase.Movement,
+    initiativeWinner: GameSide.Player,
+    firstMover: GameSide.Player,
+    activationIndex: 0,
+    initiativeOrder: ['atlas-1'],
+    activeUnitId: 'atlas-1',
+    units: {
+      'atlas-1': makeUnit('atlas-1'),
+    },
+    turnEvents: [],
+  };
+}
+
+function makeUnit(id: string): IGmCombatInterventionUnitState {
+  return {
+    id,
+    side: GameSide.Player,
+    position: { q: 1, r: 1 },
+    facing: Facing.North,
+    heat: 0,
+    movementThisTurn: MovementType.Stationary,
+    hexesMovedThisTurn: 0,
+    armor: { head: 9, centerTorso: 30 },
+    structure: { head: 3, centerTorso: 20 },
+    destroyedLocations: [],
+    destroyedEquipment: [],
+    ammo: {},
+    pilotWounds: 0,
+    pilotConscious: true,
+    destroyed: false,
+    lockState: LockState.Pending,
+    componentDamage: {
+      engineHits: 0,
+      gyroHits: 0,
+      sensorHits: 0,
+      lifeSupport: 0,
+      cockpitHit: false,
+      actuators: {},
+      weaponsDestroyed: [],
+      heatSinksDestroyed: 0,
+      jumpJetsDestroyed: 0,
+    },
+  };
+}
+
+function makeLedger(): InterventionLedger<IGmCombatInterventionState> {
+  return registerGmCombatInterventionImplementer(
+    new InterventionLedger<IGmCombatInterventionState>(),
+  );
+}
+
+describe('GmTacticalCommandPreviewAdapter', () => {
+  it('builds structured preview intents for command descriptors', () => {
+    expect(buildGmTacticalCommandIntent('gm.set-damage', makeCtx())).toEqual({
+      commandId: 'gm.set-damage',
+      activeUnitId: 'atlas-1',
+      selectedUnitId: 'atlas-1',
+      targetUnitId: null,
+      phase: GamePhase.Movement,
+    });
+    expect(GM_TACTICAL_PREVIEW_ACTION_ID).toBe('gm-intervention.preview');
+  });
+
+  it('creates authorized combat previews through the cascade pipeline', () => {
+    const preview = createGmTacticalCommandPreview({
+      ledger: makeLedger(),
+      state: makeState(),
+      authority: gmAuthority,
+      commandId: 'gm.advance-phase',
+      ctx: makeCtx(),
+      interventionId: 'gm-tactical-1',
+      reason: 'Fix phase after table adjudication.',
+    });
+
+    expect(preview.status).toBe('ready');
+    expect(preview.domain).toBe('combat');
+    expect(preview.kind).toBe('fix');
+    expect(preview.privateMetadata?.reason).toBe(
+      'Fix phase after table adjudication.',
+    );
+    expect(preview.publicEffect?.summary).toContain('phase correction');
+  });
+
+  it('rejects shell-visible commands when service authority is not GM', () => {
+    const preview = createGmTacticalCommandPreview({
+      ledger: makeLedger(),
+      state: makeState(),
+      authority: { ...gmAuthority, role: 'player' },
+      commandId: 'gm.set-damage',
+      ctx: makeCtx(),
+    });
+
+    expect(preview.status).toBe('rejected');
+    expect(preview.reason).toBe(
+      'Only the owning GM can request GM intervention previews.',
+    );
+  });
+
+  it('defers economy/resource corrections until the campaign implementer exists', () => {
+    const state = makeState();
+    const preview = createGmTacticalCommandPreview({
+      ledger: makeLedger(),
+      state,
+      authority: gmAuthority,
+      commandId: 'gm.grant-resource',
+      ctx: makeCtx(),
+    });
+
+    expect(preview.status).toBe('deferred');
+    expect(preview.domain).toBe('economy');
+    expect(preview.projectedEvents).toEqual([]);
+    expect(state.turn).toBe(1);
+  });
+});

--- a/src/lib/interventions/index.ts
+++ b/src/lib/interventions/index.ts
@@ -4,6 +4,13 @@ export {
   createGmCascadePreview,
   logGmDeferredInterventionAttempt,
 } from './GmCascadePreviewPipeline';
+export {
+  buildGmTacticalCommandIntent,
+  buildGmTacticalLedgerCommand,
+  createGmTacticalCommandPreview,
+  GM_TACTICAL_PREVIEW_ACTION_ID,
+  isGmTacticalCommandId,
+} from './GmTacticalCommandPreviewAdapter';
 
 export type {
   GmDeferredInterventionLogger,
@@ -11,6 +18,11 @@ export type {
   ICreateGmCascadePreviewInput,
   IGmDeferredInterventionAttemptLog,
 } from './GmCascadePreviewPipeline';
+export type {
+  GmTacticalCommandId,
+  ICreateGmTacticalCommandPreviewInput,
+  IGmTacticalCommandIntent,
+} from './GmTacticalCommandPreviewAdapter';
 
 export {
   createGmCombatInterventionImplementer,


### PR DESCRIPTION
## Summary
- Add the missing `gm-tactical-command-surface` OpenSpec spec and complete the Tactical Command Surface checklist.
- Replace TacticalActionDock GM stub actions with structured `gm-intervention.preview` intents.
- Add a GM intervention preview adapter that delegates to the cascade preview pipeline, plus an accessible confirmation/manual-takeover panel and public-only log rendering.

## Verification
- npm.cmd test -- src/lib/interventions/__tests__ src/components/gameplay/TacticalActionDock src/lib/campaign/encounter/__tests__/launchCampaignEncounter.test.ts src/lib/multiplayer/server/__tests__/fogOfWar.test.ts src/lib/multiplayer/server/__tests__/ServerMatchHost.fogOfWarIntegration.test.ts src/components/gameplay/__tests__/GameplayLayout.viewModel.test.ts src/__tests__/unit/utils/gameplay/gameSession.test.ts src/utils/gameplay/gameState/__tests__/phaseManagement.test.ts
- npx.cmd tsc --noEmit --skipLibCheck --pretty false
- npx.cmd oxlint src/lib/interventions src/components/gameplay/TacticalActionDock src/types/interventions
- npx.cmd oxfmt --check src/lib/interventions/GmTacticalCommandPreviewAdapter.ts src/lib/interventions/index.ts src/lib/interventions/__tests__/GmTacticalCommandPreviewAdapter.test.ts src/components/gameplay/TacticalActionDock/TacticalActionDock.tsx src/components/gameplay/TacticalActionDock/TacticalActionDock.gmIntervention.tsx src/components/gameplay/TacticalActionDock/index.ts src/components/gameplay/TacticalActionDock/commands/gmReferralCommands.ts src/components/gameplay/TacticalActionDock/commands/__tests__/gmReferralCommands.test.ts src/components/gameplay/TacticalActionDock/__tests__/TacticalActionDock.04.gmIntervention.test.tsx openspec/changes/add-gm-intervention-control-plane/specs/gm-tactical-command-surface/spec.md openspec/changes/add-gm-intervention-control-plane/tasks.md
- cmd /c openspec validate add-gm-intervention-control-plane --strict
- commit hook: full npm run build

## Note
The host gameplay layout still needs to mount a real persisted ledger/state/authority source. This PR gives the dock a typed surface and proves shell mode alone does not authorize intervention approval.