### PR TITLE
Restore CI correctness teeth

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -188,7 +188,7 @@ jobs:
     name: Statistical Proof PR
     needs: install-deps
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    timeout-minutes: 10
 
     steps:
       - name: Checkout code
@@ -208,7 +208,7 @@ jobs:
           SIMULATION_PROFILE_AVG_GAME_BUDGET_MS: '4500'
           SIMULATION_PROFILE_GAME_COUNT: '10'
           SIMULATION_PROFILE_RUNNER_BUDGET_MS: '4000'
-          SIMULATION_PROFILE_TIME_BUDGET_MS: '30000'
+          SIMULATION_PROFILE_TIME_BUDGET_MS: '60000'
 
   perf-budget-pr:
     name: Perf Budget PR

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -184,6 +184,90 @@ jobs:
           SWARM_THROUGHPUT_RUN_COUNT: '25'
           SWARM_THROUGHPUT_TIME_BUDGET_MS: '15000'
 
+  statistical-proof-pr:
+    name: Statistical Proof PR
+    needs: install-deps
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node + caches + install deps
+        uses: ./.github/actions/setup-node-and-install
+        with:
+          node-version: '20'
+
+      - name: Run 100-game statistical combat proofs
+        run: >-
+          npx jest --selectProjects unit --ci --runInBand --runTestsByPath
+          src/simulation/__tests__/integration.test.ts
+        env:
+          SIMULATION_COUNT: '100'
+          SIMULATION_PROFILE_AVG_GAME_BUDGET_MS: '4500'
+          SIMULATION_PROFILE_GAME_COUNT: '10'
+          SIMULATION_PROFILE_RUNNER_BUDGET_MS: '4000'
+          SIMULATION_PROFILE_TIME_BUDGET_MS: '30000'
+
+  perf-budget-pr:
+    name: Perf Budget PR
+    needs: install-deps
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node + caches + install deps
+        uses: ./.github/actions/setup-node-and-install
+        with:
+          node-version: '20'
+
+      - name: Run simulation wall-clock budgets
+        run: >-
+          npx jest --selectProjects unit --ci --runInBand --runTestsByPath
+          src/simulation/__tests__/simulation.test.ts
+        env:
+          SIMULATION_PERF_ASSERTIONS: 'true'
+          SIMULATION_COUNT: '10'
+
+  coverage-floor:
+    name: Coverage Floor
+    needs: install-deps
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node + caches + install deps
+        uses: ./.github/actions/setup-node-and-install
+        with:
+          node-version: '20'
+
+      - name: Generate combat/simulation coverage summary
+        run: >-
+          npx jest --selectProjects unit --ci --coverage
+          --coverageDirectory=coverage/combat-simulation
+          --coverageReporters=json-summary
+          --coverageReporters=text-summary
+          --runInBand
+          --runTestsByPath
+          src/simulation/__tests__/knownLimitations.test.ts
+          src/simulation/__tests__/simulation.test.ts
+          src/simulation/runner/__tests__/combatValidationScope.contract.test.ts
+          --collectCoverageFrom='src/simulation/**/*.{ts,tsx}'
+          --collectCoverageFrom='src/utils/gameplay/**/*.{ts,tsx}'
+          --coverageThreshold='{}'
+        env:
+          SIMULATION_COUNT: '5'
+
+      - name: Enforce combat/simulation coverage floors
+        run: node scripts/qc/validate-combat-simulation-coverage.mjs --summary=coverage/combat-simulation/coverage-summary.json
+
   a11y-tests:
     name: A11y Tests
     needs: install-deps
@@ -450,6 +534,9 @@ jobs:
         typecheck,
         unit-test-shards,
         perf-smoke-tests,
+        statistical-proof-pr,
+        perf-budget-pr,
+        coverage-floor,
         a11y-tests,
         validate-bv,
         validate-combat,

--- a/e2e/helpers/campaignSeeders.ts
+++ b/e2e/helpers/campaignSeeders.ts
@@ -17,6 +17,8 @@
 
 import type { Page } from '@playwright/test';
 
+import { createTestPilot, PILOT_SKILL_PRESETS } from '../fixtures/pilot';
+
 // =============================================================================
 // Helper input shapes
 // =============================================================================
@@ -61,9 +63,34 @@ export interface ISeedHiringCandidate {
   readonly hireBonus: number;
 }
 
+export interface ISeedCareerPilotOpts {
+  readonly name?: string;
+  readonly callsign?: string;
+  readonly affiliation?: string;
+}
+
+export interface ISeedCareerPilotResult {
+  readonly id: string;
+  readonly name: string;
+  readonly callsign: string;
+  readonly affiliation: string;
+}
+
 // =============================================================================
 // Internal: store accessor
 // =============================================================================
+
+async function waitForPilotStore(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () =>
+      Boolean(
+        (window as unknown as { __ZUSTAND_STORES__?: Record<string, unknown> })
+          .__ZUSTAND_STORES__?.pilot,
+      ),
+    undefined,
+    { timeout: 15_000 },
+  );
+}
 
 /**
  * Apply a campaign-store `updateCampaign(updates)` from the test side.
@@ -121,6 +148,70 @@ async function applyCampaignUpdate(
 // =============================================================================
 // Seeders
 // =============================================================================
+
+/**
+ * Seed a pilot that the roster and career-history navigation specs can assert
+ * against without relying on ambient local database state.
+ */
+export async function seedCareerPilot(
+  page: Page,
+  opts: ISeedCareerPilotOpts = {},
+): Promise<ISeedCareerPilotResult> {
+  await waitForPilotStore(page);
+
+  const seededPilot = {
+    name: opts.name ?? `E2E Career Pilot ${Date.now()}`,
+    callsign: opts.callsign ?? 'Ledger',
+    affiliation: opts.affiliation ?? 'E2E Test Command',
+  };
+  const id = await createTestPilot(page, {
+    ...seededPilot,
+    skills: PILOT_SKILL_PRESETS.veteran,
+    startingXp: 12,
+    rank: 'MechWarrior',
+  });
+
+  if (!id) {
+    throw new Error('Pilot seeder failed to create a career-history pilot');
+  }
+
+  await page.waitForFunction(
+    (pilotId) => {
+      const stores = (
+        window as unknown as {
+          __ZUSTAND_STORES__?: {
+            pilot?: {
+              getState?: () => {
+                pilots?: unknown;
+              };
+            };
+          };
+        }
+      ).__ZUSTAND_STORES__;
+      const pilots = stores?.pilot?.getState?.().pilots;
+
+      if (pilots instanceof Map) {
+        return pilots.has(pilotId);
+      }
+
+      if (Array.isArray(pilots)) {
+        return pilots.some(
+          (pilot) =>
+            typeof pilot === 'object' &&
+            pilot !== null &&
+            'id' in pilot &&
+            pilot.id === pilotId,
+        );
+      }
+
+      return false;
+    },
+    id,
+    { timeout: 15_000 },
+  );
+
+  return { id, ...seededPilot };
+}
 
 /**
  * Seed an injured-pilot row on the medical bay. Surfaces in

--- a/e2e/p2p-sync.spec.ts
+++ b/e2e/p2p-sync.spec.ts
@@ -261,26 +261,18 @@ test.describe('P2P Sync - Multi-Peer Flow', () => {
   // The underlying sync logic is tested in unit tests:
   // - src/lib/p2p/__tests__/useSyncedVaultStore.test.ts
 
-  test.skip('two peers can connect via room code', async () => {
-    // This test would:
-    // 1. Create two browser contexts
-    // 2. Peer A creates room
-    // 3. Peer B joins with room code
-    // 4. Both see peer count = 1
+  test.fixme('two peers can connect via room code', async () => {
+    // Wave 2 `reconcile-multiplayer-coop-reality`: replace this explicit
+    // deferral with a two-context/WebRTC transport assertion.
   });
 
-  test.skip('data syncs between connected peers', async () => {
-    // This test would:
-    // 1. Connect two peers
-    // 2. Peer A adds item
-    // 3. Peer B sees item appear
+  test.fixme('data syncs between connected peers', async () => {
+    // Wave 2 `reconcile-multiplayer-coop-reality`: assert cross-peer item
+    // propagation once the e2e harness owns real multi-peer transport.
   });
 
-  test.skip('peer reconnects after network interruption', async () => {
-    // This test would:
-    // 1. Connect two peers
-    // 2. Simulate network interruption for Peer B
-    // 3. Peer A adds items while B offline
-    // 4. Peer B reconnects and receives missed items
+  test.fixme('peer reconnects after network interruption', async () => {
+    // Wave 2 `reconcile-multiplayer-coop-reality`: assert reconnect replay once
+    // network interruption simulation is supported by the harness.
   });
 });

--- a/e2e/replay-player.spec.ts
+++ b/e2e/replay-player.spec.ts
@@ -12,6 +12,8 @@
 
 import { test, expect, type Page } from '@playwright/test';
 
+import { seedCareerPilot } from './helpers/campaignSeeders';
+
 test.setTimeout(30000);
 
 // =============================================================================
@@ -128,19 +130,23 @@ test.describe('Pilot Career Timeline Tab', () => {
   test('pilot detail page has Career History tab', async ({ page }) => {
     await navigateToPilots(page);
 
-    const pilotCards = page.locator(
-      '[data-testid="pilot-card"], a[href*="/gameplay/pilots/"]',
-    );
-    const pilotCount = await pilotCards.count();
+    const seededPilot = await seedCareerPilot(page, {
+      name: 'E2E Career Pilot',
+      callsign: 'Ledger',
+      affiliation: 'E2E Test Command',
+    });
 
-    // Skip if no pilots exist - this test requires seed data
-    test.skip(
-      pilotCount === 0,
-      'No pilots available - test requires pilot data',
+    const pilotLink = page.locator(
+      `a[href="/gameplay/pilots/${seededPilot.id}"]`,
     );
-
-    await pilotCards.first().click();
+    await expect(pilotLink).toBeVisible({ timeout: 5000 });
+    await pilotLink.click();
     await page.waitForLoadState('networkidle');
+
+    await expect(
+      page.getByRole('heading', { name: seededPilot.name }),
+    ).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText(`"${seededPilot.callsign}"`)).toBeVisible();
 
     // Check for Career History tab
     const careerTab = page.getByRole('button', { name: /Career History/i });
@@ -150,7 +156,13 @@ test.describe('Pilot Career Timeline Tab', () => {
     await careerTab.click();
 
     // Should show career history content
-    await expect(page.locator('text=Career History').first()).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: 'Career History' }),
+    ).toBeVisible();
+    await expect(
+      page.getByText(`Event timeline for ${seededPilot.name}`),
+    ).toBeVisible();
+    await expect(page.getByText('0 events')).toBeVisible();
   });
 });
 

--- a/openspec/changes/restore-ci-correctness-teeth/tasks.md
+++ b/openspec/changes/restore-ci-correctness-teeth/tasks.md
@@ -2,99 +2,99 @@
 
 ## 1. Investigation and red-first evidence
 
-- [ ] 1.1 Measure the wall-clock of `integration.test.ts` at `SIMULATION_COUNT=100`
+- [x] 1.1 Measure the wall-clock of `integration.test.ts` at `SIMULATION_COUNT=100`
   under the CI runner profile (record in the PR description). This resolves
   design Open Question D1 — mid-size PR batch vs nightly-required status — and
   decides the shape of the CI job authored in task 2.
-- [ ] 1.2 Write a red-first suppression probe: a unit test that constructs an
+- [x] 1.2 Write a red-first suppression probe: a unit test that constructs an
   `IViolation` with `invariant: 'some-new-detector'` and `message` containing the
   word `discharge` (or `loss`/`close`) and asserts that `isKnownLimitation` /
   `filterKnownLimitations` in `src/simulation/core/knownLimitations.ts`
   **currently swallows it** (proves the substring-bleed + suppress-by-default
   hazard is observable before the fix). The probe flips to asserting the violation
   is surfaced after task 3.
-- [ ] 1.3 Run a coverage report for `src/utils/gameplay/**` and `src/simulation/**`
+- [x] 1.3 Run a coverage report for `src/utils/gameplay/**` and `src/simulation/**`
   and record the current per-tree numbers, so the D5 floor (task 5) is pinned at
   or below measured coverage and does not red-gate on merge.
-- [ ] 1.4 Confirm `e2e/replay-player.spec.ts:137` `test.skip(pilotCount === 0, …)`
+- [x] 1.4 Confirm `e2e/replay-player.spec.ts:137` `test.skip(pilotCount === 0, …)`
   fires in a clean CI database (no seed) — demonstrate the vacuous pass before
   task 4 seeds it.
 
 ## 2. Statistical-proof PR gate
 
-- [ ] 2.1 Add a blocking PR job in `.github/workflows/pr-checks.yml` that runs
+- [x] 2.1 Add a blocking PR job in `.github/workflows/pr-checks.yml` that runs
   `src/simulation/__tests__/integration.test.ts` with `SIMULATION_COUNT` set
   `>= STATISTICAL_PROOF_GAME_MIN` (the `integration.test.ts:73` constant, 100) so
   `statisticalIt` (`integration.test.ts:74-75`) resolves to `it` and the existence
   assertions execute; pin PR-sized `SIMULATION_PROFILE_*` time caps.
-- [ ] 2.2 If task 1.1 shows the mid-size batch exceeds the PR budget, instead wire
+- [x] 2.2 If task 1.1 shows the mid-size batch exceeds the PR budget, instead wire
   the nightly statistical batch as a *required status* for combat-touching PRs
   (per design D1 fallback) and document the merge requirement in the workflow
   comment. Either path satisfies the spec guarantee.
-- [ ] 2.3 Add the new job to the `lint-and-test` aggregator `needs` list
+- [x] 2.3 Add the new job to the `lint-and-test` aggregator `needs` list
   (`pr-checks.yml:425-440`) so branch protection picks it up under the preserved
   required-check name.
 
 ## 3. Known-limitations suppression net
 
-- [ ] 3.1 In `src/simulation/core/knownLimitations.ts`, anchor every category
+- [x] 3.1 In `src/simulation/core/knownLimitations.ts`, anchor every category
   pattern in `KNOWN_LIMITATION_PATTERNS` (lines 44-146) to whole-token / phrase
   matching — e.g. `/punch|kick|charge|push/i` → word-boundary form so `discharge`
   no longer matches; `/line.*of.*sight|los/i` → `\bline of sight\b|\blos\b` so
   `loss`/`close` no longer match. Review all 11 buckets for the same substring
   bleed.
-- [ ] 3.2 Invert suppression from suppress-by-message-text to explicit
+- [x] 3.2 Invert suppression from suppress-by-message-text to explicit
   per-invariant opt-in: `isKnownLimitation` / `filterKnownLimitations` /
   `partitionViolations` SHALL suppress only violations whose `invariant` is on an
   explicit legacy-detector allowlist (or carries an explicit `legacyGeneric`
   marker). New detectors are surfaced by default. Retire the inverted
   single-entry `KNOWN_LIMITATION_BYPASS_INVARIANTS` posture in favor of the
   suppressible-allowlist posture.
-- [ ] 3.3 Update the contract traps in
+- [x] 3.3 Update the contract traps in
   `src/simulation/runner/CombatValidationScopeSupport.ts` (one validation trap per
   category) in lockstep with the regex/opt-in change so the pinning tests still
   pass; update `src/simulation/known-limitations.md` human-readable doc.
-- [ ] 3.4 Flip the task-1.2 probe to assert the new-detector violation is now
+- [x] 3.4 Flip the task-1.2 probe to assert the new-detector violation is now
   surfaced (not swallowed) and add a positive trap proving a genuinely legacy
   allowlisted detector is still suppressed.
 
 ## 4. Perf-budget PR lane
 
-- [ ] 4.1 Add a blocking PR job in `pr-checks.yml` that runs
+- [x] 4.1 Add a blocking PR job in `pr-checks.yml` that runs
   `src/simulation/__tests__/simulation.test.ts` with `SIMULATION_PERF_ASSERTIONS=true`
   (the override `perfIt` already honors at `simulation.test.ts:32`) and PR-sized
   wall-clock budget envs, in a dedicated uncontended runner — NOT on the
   `unit-test-shards` lane (which keeps `JEST_EXCLUDE_PERF_SENSITIVE=true`).
-- [ ] 4.2 Add the perf-budget job to the `lint-and-test` aggregator `needs` list.
+- [x] 4.2 Add the perf-budget job to the `lint-and-test` aggregator `needs` list.
 
 ## 5. Coverage floor PR gate
 
-- [ ] 5.1 Add a PR coverage job enforcing a minimum threshold (set at or below the
+- [x] 5.1 Add a PR coverage job enforcing a minimum threshold (set at or below the
   task-1.3 measured numbers) for `src/utils/gameplay/**` and `src/simulation/**`;
   fail the PR if coverage drops below the floor. Add to the aggregator `needs`.
 
 ## 6. E2E seeding and honest skip
 
-- [ ] 6.1 Add a pilot seeder (extend `e2e/helpers/campaignSeeders.ts` or a sibling
+- [x] 6.1 Add a pilot seeder (extend `e2e/helpers/campaignSeeders.ts` or a sibling
   replay/pilot seeder) that guarantees at least one pilot exists before
   `e2e/replay-player.spec.ts` navigates.
-- [ ] 6.2 In `e2e/replay-player.spec.ts`, remove the `test.skip(pilotCount === 0,
+- [x] 6.2 In `e2e/replay-player.spec.ts`, remove the `test.skip(pilotCount === 0,
   …)` guard (lines 137-140) and assert the Career History tab and its seeded
   values unconditionally.
-- [ ] 6.3 In `e2e/p2p-sync.spec.ts`, replace the three empty `test.skip` multi-peer
+- [x] 6.3 In `e2e/p2p-sync.spec.ts`, replace the three empty `test.skip` multi-peer
   bodies (lines 264-285) with either a real assertion (if the harness supports the
   transport) or explicit `test.fixme` entries each commented with the Wave 2
   `reconcile-multiplayer-coop-reality` follow-up — no silent empty skips remain.
 
 ## 7. Verification and documentation
 
-- [ ] 7.1 Full verification: `npx tsc --noEmit`, `npm run lint`, the affected Jest
+- [x] 7.1 Full verification: `npx tsc --noEmit`, `npm run lint`, the affected Jest
   suites (`integration.test.ts` at gating count, `simulation.test.ts` perf
   budgets, the `knownLimitations` traps + probe), and the two Playwright specs
   green; run `npx openspec validate restore-ci-correctness-teeth --strict`.
-- [ ] 7.2 Confirm the `lint-and-test` aggregator gates on all new jobs and that a
+- [x] 7.2 Confirm the `lint-and-test` aggregator gates on all new jobs and that a
   deliberately-introduced statistical/perf/coverage regression fails a PR (smoke
   the gate, not just the tests).
-- [ ] 7.3 Record in the PR description which D1 mechanism was chosen (mid-size PR
+- [x] 7.3 Record in the PR description which D1 mechanism was chosen (mid-size PR
   batch vs nightly-required) and the pinned coverage-floor values, closing the
   design Open Questions.

--- a/scripts/qc/validate-combat-simulation-coverage.mjs
+++ b/scripts/qc/validate-combat-simulation-coverage.mjs
@@ -1,0 +1,94 @@
+import { readFileSync } from 'node:fs';
+
+const DEFAULT_SUMMARY_PATH = 'coverage/combat-simulation/coverage-summary.json';
+
+const FLOORS = {
+  'src/simulation/': {
+    lines: 25,
+    statements: 26,
+    functions: 16,
+    branches: 20,
+  },
+  'src/utils/gameplay/': {
+    lines: 12,
+    statements: 12,
+    functions: 8,
+    branches: 9,
+  },
+};
+
+const summaryArg = process.argv.find((arg) => arg.startsWith('--summary='));
+const summaryPath = summaryArg
+  ? summaryArg.slice('--summary='.length)
+  : DEFAULT_SUMMARY_PATH;
+
+const summary = JSON.parse(readFileSync(summaryPath, 'utf8'));
+const failures = [];
+
+function normalizePath(path) {
+  return path.replaceAll('\\', '/');
+}
+
+function emptyMetric() {
+  return {
+    total: 0,
+    covered: 0,
+  };
+}
+
+function createAggregate() {
+  return {
+    lines: emptyMetric(),
+    statements: emptyMetric(),
+    functions: emptyMetric(),
+    branches: emptyMetric(),
+  };
+}
+
+function pct(metric) {
+  if (metric.total === 0) return 0;
+  return Number(((metric.covered / metric.total) * 100).toFixed(2));
+}
+
+for (const [prefix, floors] of Object.entries(FLOORS)) {
+  const aggregate = createAggregate();
+
+  for (const [rawPath, fileCoverage] of Object.entries(summary)) {
+    const path = normalizePath(rawPath);
+    if (path === 'total' || !path.includes(prefix)) continue;
+
+    for (const metricName of Object.keys(floors)) {
+      aggregate[metricName].total += fileCoverage[metricName]?.total ?? 0;
+      aggregate[metricName].covered += fileCoverage[metricName]?.covered ?? 0;
+    }
+  }
+
+  for (const [metricName, floor] of Object.entries(floors)) {
+    const metric = aggregate[metricName];
+    const actual = pct(metric);
+
+    if (metric.total === 0) {
+      failures.push(`${prefix} ${metricName}: no coverage entries found`);
+      continue;
+    }
+
+    if (actual < floor) {
+      failures.push(
+        `${prefix} ${metricName}: ${actual}% is below floor ${floor}%`,
+      );
+      continue;
+    }
+
+    console.log(
+      `Coverage OK: ${prefix} ${metricName} ${actual}% >= ${floor}% (${metric.covered}/${metric.total})`,
+    );
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Combat/simulation coverage floor failed:');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exitCode = 1;
+}

--- a/scripts/qc/validate-restore-ci-correctness-teeth.mjs
+++ b/scripts/qc/validate-restore-ci-correctness-teeth.mjs
@@ -25,6 +25,13 @@ const checks = [
     ),
   },
   {
+    label: 'statistical-proof-pr allows contended profiling budget',
+    passes:
+      /statistical-proof-pr:[\s\S]*SIMULATION_PROFILE_TIME_BUDGET_MS:\s*'60000'/.test(
+        workflow,
+      ),
+  },
+  {
     label: 'perf-budget-pr job exists',
     passes: /^  perf-budget-pr:/m.test(workflow),
   },

--- a/scripts/qc/validate-restore-ci-correctness-teeth.mjs
+++ b/scripts/qc/validate-restore-ci-correctness-teeth.mjs
@@ -1,0 +1,77 @@
+import { readFileSync } from 'node:fs';
+
+const workflowArg = process.argv.find((arg) => arg.startsWith('--workflow='));
+const workflowPath = workflowArg
+  ? workflowArg.slice('--workflow='.length)
+  : '.github/workflows/pr-checks.yml';
+const workflow = readFileSync(workflowPath, 'utf8');
+
+const checks = [
+  {
+    label: 'statistical-proof-pr job exists',
+    passes: /^  statistical-proof-pr:/m.test(workflow),
+  },
+  {
+    label: 'statistical-proof-pr runs integration.test.ts',
+    passes:
+      /statistical-proof-pr:[\s\S]*src\/simulation\/__tests__\/integration\.test\.ts/.test(
+        workflow,
+      ),
+  },
+  {
+    label: 'statistical-proof-pr uses SIMULATION_COUNT 100',
+    passes: /statistical-proof-pr:[\s\S]*SIMULATION_COUNT:\s*'100'/.test(
+      workflow,
+    ),
+  },
+  {
+    label: 'perf-budget-pr job exists',
+    passes: /^  perf-budget-pr:/m.test(workflow),
+  },
+  {
+    label: 'perf-budget-pr enables SIMULATION_PERF_ASSERTIONS',
+    passes: /perf-budget-pr:[\s\S]*SIMULATION_PERF_ASSERTIONS:\s*'true'/.test(
+      workflow,
+    ),
+  },
+  {
+    label: 'coverage-floor job exists',
+    passes: /^  coverage-floor:/m.test(workflow),
+  },
+  {
+    label: 'coverage-floor uses coverage validator',
+    passes:
+      /coverage-floor:[\s\S]*validate-combat-simulation-coverage\.mjs/.test(
+        workflow,
+      ),
+  },
+];
+
+const aggregatorMatch = workflow.match(
+  /  lint-and-test:[\s\S]*?needs:\s*\[\s*([\s\S]*?)\s*\]\s*$/m,
+);
+const aggregatorNeeds = aggregatorMatch?.[1] ?? '';
+
+for (const job of [
+  'statistical-proof-pr',
+  'perf-budget-pr',
+  'coverage-floor',
+]) {
+  checks.push({
+    label: `lint-and-test needs ${job}`,
+    passes: aggregatorNeeds.includes(job),
+  });
+}
+
+const failures = checks.filter((check) => !check.passes);
+
+for (const check of checks) {
+  console.log(`${check.passes ? 'OK' : 'FAIL'} ${check.label}`);
+}
+
+if (failures.length > 0) {
+  console.error(
+    `CI correctness-teeth workflow validation failed: ${failures.length} check(s) failed.`,
+  );
+  process.exitCode = 1;
+}

--- a/src/simulation/__tests__/knownLimitations.chunk-2.test-helpers.ts
+++ b/src/simulation/__tests__/knownLimitations.chunk-2.test-helpers.ts
@@ -377,6 +377,50 @@ describe('knownLimitations', () => {
 
         expect(isKnownLimitation(violation)).toBe(false);
       });
+
+      it('should surface new detector violations even when message text contains a legacy substring', () => {
+        const violation: IViolation = {
+          invariant: 'some-new-detector',
+          severity: 'error',
+          message: 'Capacitor discharge caused invalid thermal state',
+          context: {},
+        };
+
+        expect(isKnownLimitation(violation)).toBe(false);
+        expect(filterKnownLimitations([violation])).toEqual([violation]);
+        expect(partitionViolations([violation])).toEqual({
+          knownLimitations: [],
+          potentialBugs: [violation],
+        });
+      });
+
+      it('should still suppress explicitly allowlisted legacy detector violations', () => {
+        const violation: IViolation = {
+          invariant: 'checkPhysicalAttack',
+          severity: 'warning',
+          message: 'Unit should have charge option available',
+          context: {},
+        };
+
+        expect(isKnownLimitation(violation)).toBe(true);
+        expect(filterKnownLimitations([violation])).toEqual([]);
+        expect(partitionViolations([violation])).toEqual({
+          knownLimitations: [violation],
+          potentialBugs: [],
+        });
+      });
+
+      it('should suppress explicit legacy generic marker violations', () => {
+        const violation: IViolation = {
+          invariant: 'retired-generic-check',
+          severity: 'warning',
+          message: 'Physical attack not available in legacy generic scan',
+          context: { legacyGeneric: true },
+        };
+
+        expect(isKnownLimitation(violation)).toBe(true);
+        expect(getLimitationCategory(violation)).toBe('physicalAttacks');
+      });
     });
 
     describe('edge cases', () => {

--- a/src/simulation/core/knownLimitations.ts
+++ b/src/simulation/core/knownLimitations.ts
@@ -11,12 +11,12 @@
  * `src/simulation/runner/CombatValidationGapInventory.ts`.
  *
  * The buckets survive because legacy detectors may still emit matching
- * messages; the BattleMech combat validation lane bypasses this filter
- * entirely (see KNOWN_LIMITATION_BYPASS_INVARIANTS), so real validation
- * evidence is never suppressed. The category list and patterns are pinned by
- * contract tests (one validation trap per category in
- * CombatValidationScopeSupport.ts) — retire a bucket only in lockstep with
- * those traps.
+ * messages. Suppression is explicit opt-in by invariant name (or an explicit
+ * `context.legacyGeneric` / `context.legacyGenericDetector` marker) so new detectors stay visible by
+ * default even when their wording overlaps a broad legacy bucket. The category
+ * list and patterns are pinned by contract tests (one validation trap per
+ * category in CombatValidationScopeSupport.ts) — retire a bucket only in
+ * lockstep with those traps.
  *
  * @see src/simulation/known-limitations.md for human-readable documentation
  */
@@ -38,111 +38,118 @@ export interface IViolation {
 
 /**
  * Known limitation categories with regex patterns for detection.
- * Each pattern matches violation messages or invariant names that correspond
- * to documented limitations.
+ * Each pattern matches legacy violation messages that correspond to documented
+ * limitation buckets.
  */
 const KNOWN_LIMITATION_PATTERNS = {
   /** Legacy/generic physical attack detectors outside the catalog suite */
   physicalAttacks: [
-    /physical\s*attack/i,
-    /melee\s*combat/i,
-    /punch|kick|charge|push/i,
-    /death\s*from\s*above|dfa/i,
-    /hand-to-hand/i,
+    /\bphysical\s+attack\b/i,
+    /\bmelee\s+combat\b/i,
+    /\b(?:punch|kick|charge|push)\b/i,
+    /\bdeath\s+from\s+above\b|\bdfa\b/i,
+    /\bhand-to-hand\b/i,
   ],
 
   /** Ammo consumption and reload mechanics */
   ammoConsumption: [
-    /ammo.*consumption/i,
-    /ammo.*depletion/i,
-    /ammo.*tracking/i,
-    /reload/i,
-    /fired.*with.*0.*ammo/i,
-    /ammo.*not.*decremented/i,
-    /ammunition.*exhausted/i,
+    /\bammo\b.*\bconsumption\b/i,
+    /\bammo\b.*\bdepletion\b/i,
+    /\bammo\b.*\btracking\b/i,
+    /\bammo\b.*\b(?:not\s+)?tracked\b/i,
+    /\breload\b/i,
+    /\bfired\b.*\bwith\b.*\b0\b.*\bammo\b/i,
+    /\bammo\b.*\bnot\b.*\bdecremented\b/i,
+    /\bammunition\b.*\bexhausted\b/i,
   ],
 
   /** Heat shutdown and recovery mechanics */
   heatShutdown: [
-    /heat.*shutdown/i,
-    /shutdown.*heat/i,
-    /shutdown.*recovery/i,
-    /shutdown.*at.*\d+/i,
-    /should.*shut.*down/i,
-    /heat.*induced.*shutdown/i,
-    /restart.*after.*shutdown/i,
+    /\bheat\b.*\bshutdown\b/i,
+    /\bshutdown\b.*\bheat\b/i,
+    /\bshutdown\b.*\brecovery\b/i,
+    /\bshutdown\b.*\bat\b.*\d+/i,
+    /\bshould\b.*\bshut\b.*\bdown\b/i,
+    /\bheat\b.*\binduced\b.*\bshutdown\b/i,
+    /\bheat[-\s]+induced\b.*\bammo\b.*\bexplosion\b/i,
+    /\brestart\b.*\bafter\b.*\bshutdown\b/i,
   ],
 
   /** Terrain movement cost validation (partial implementation) */
   terrainMovement: [
-    /terrain.*movement.*cost/i,
-    /water.*hex.*cost/i,
-    /rubble.*cost/i,
-    /building.*entry.*cost/i,
-    /terrain.*modifier.*mismatch/i,
+    /\bterrain\b.*\bmovement\b.*\bcost\b/i,
+    /\bwater\b.*\bhex\b.*\bcost\b/i,
+    /\brubble\b.*\bcost\b/i,
+    /\bbuilding\b.*\bentry\b.*\bcost\b/i,
+    /\bterrain\b.*\bmodifier\b.*\bmismatch\b/i,
   ],
 
   /** Piloting skill checks (falls, skids, consciousness) */
   pilotingChecks: [
-    /piloting.*check/i,
-    /fall.*check/i,
-    /skid.*check/i,
-    /consciousness.*check/i,
-    /ejection.*psr/i,
-    /eject.*piloting/i,
-    /piloting.*eject/i,
-    /pilot.*skill.*check/i,
+    /\bpiloting\b.*\bcheck\b/i,
+    /\bfall\b.*\bcheck\b/i,
+    /\bskid\b.*\bcheck\b/i,
+    /\bconsciousness\b.*\bcheck\b/i,
+    /\bejection\b.*\bpsr\b/i,
+    /\beject\b.*\bpiloting\b/i,
+    /\bpiloting\b.*\beject\b/i,
+    /\bpilot\b.*\bskill\b.*\bcheck\b/i,
   ],
 
   /** Critical hit effects (weapon destruction, actuator damage, etc.) */
   criticalEffects: [
-    /critical.*hit.*effect/i,
-    /destroyed.*weapon.*still.*fires/i,
-    /actuator.*damage/i,
-    /sensor.*critical/i,
-    /gyro.*hit/i,
-    /engine.*hit.*heat/i,
-    /equipment.*destroyed.*but.*functional/i,
+    /\bcritical\b.*\bhit\b.*\beffect\b/i,
+    /\bdestroyed\b.*\bweapon\b.*\bstill\b.*\bfires\b/i,
+    /\bactuator\b.*\bdamage\b/i,
+    /\bsensor\b.*\bcritical\b/i,
+    /\bgyro\b.*\bhit\b/i,
+    /\bengine\b.*\bhit\b.*\bheat\b/i,
+    /\bequipment\b.*\bdestroyed\b.*\bbut\b.*\bfunctional\b/i,
   ],
 
   /** Line of sight validation */
   lineOfSight: [
-    /line.*of.*sight|los/i,
-    /los.*blocked/i,
-    /elevation.*los/i,
-    /intervening.*terrain/i,
-    /partial.*cover/i,
+    /\bline\s+of\s+sight\b|\blos\b/i,
+    /\blos\b.*\bblocked\b/i,
+    /\belevation\b.*\blos\b/i,
+    /\bintervening\b.*\bterrain\b/i,
+    /\bpartial\b.*\bcover\b/i,
   ],
 
   /** Special Pilot Abilities (SPAs) */
   specialAbilities: [
-    /special.*pilot.*ability|spa/i,
-    /gunnery.*specialist/i,
-    /dodge.*ability/i,
-    /melee.*specialist/i,
-    /spa.*effect.*not.*applied/i,
+    /\bspecial\b.*\bpilot\b.*\bability\b|\bspa\b/i,
+    /\bgunnery\b.*\bspecialist\b/i,
+    /\bdodge\b.*\bability\b/i,
+    /\bmelee\b.*\bspecialist\b/i,
+    /\bspa\b.*\beffect\b.*\bnot\b.*\bapplied\b/i,
   ],
 
   /** Vehicle and aerospace rules */
   vehicleAerospace: [
-    /vehicle.*movement/i,
-    /vtol.*altitude/i,
-    /aerospace.*unit/i,
-    /vehicle.*damage.*table/i,
-    /wheeled|tracked|hover.*movement/i,
+    /\bvehicle\b.*\bmovement\b/i,
+    /\bvtol\b.*\baltitude\b/i,
+    /\baerospace\b.*\bunit\b/i,
+    /\bvehicle\b.*\bdamage\b.*\btable\b/i,
+    /\b(?:wheeled|tracked)\b|\bhover\b.*\bmovement\b/i,
   ],
 
   /** Campaign progression systems */
   campaignProgression: [
-    /xp.*award/i,
-    /skill.*progression/i,
-    /unit.*repair/i,
-    /force.*management/i,
-    /campaign.*system/i,
+    /\bxp\b.*\bawarded?\b/i,
+    /\bskill\b.*\bprogression\b/i,
+    /\bunit\b.*\brepair\b/i,
+    /\bforce\b.*\bmanagement\b/i,
+    /\bcampaign\b.*\bsystem\b/i,
+    /\bpilot\b.*\bskill\b.*\bnot\b.*\bimproving\b/i,
   ],
 
   /** MTF file parsing */
-  mtfParsing: [/mtf.*file.*parsing/i, /mtf.*import/i, /mechtech.*format/i],
+  mtfParsing: [
+    /\bmtf\b.*\bfile\b.*\bparsing\b/i,
+    /\bmtf\b.*\bimport\b/i,
+    /\bmechtech\b.*\bformat\b/i,
+  ],
 } as const;
 
 export type KnownLimitationCategory = keyof typeof KNOWN_LIMITATION_PATTERNS;
@@ -151,37 +158,67 @@ export const KNOWN_LIMITATION_CATEGORY_IDS = Object.keys(
   KNOWN_LIMITATION_PATTERNS,
 ) as readonly KnownLimitationCategory[];
 
-/**
- * Flattened list of all known limitation patterns for efficient matching.
- */
-const ALL_PATTERNS: readonly RegExp[] = Object.values(
-  KNOWN_LIMITATION_PATTERNS,
-).flat();
+const LEGACY_GENERIC_DETECTOR_CATEGORY_RECORD = {
+  checkAmmo: ['ammoConsumption'],
+  checkAmmoConsumption: ['ammoConsumption'],
+  checkCombatActions: ['physicalAttacks'],
+  checkCoverModifiers: ['lineOfSight'],
+  checkCriticalEffects: ['criticalEffects'],
+  checkHeatEffects: ['heatShutdown'],
+  checkJumpAttack: ['physicalAttacks'],
+  checkLineOfSight: ['lineOfSight'],
+  checkMeleeCombat: ['physicalAttacks'],
+  checkMovementCost: ['terrainMovement'],
+  checkPhysicalAttack: ['physicalAttacks'],
+  checkPilotAbilities: ['specialAbilities'],
+  checkPilotAdvancement: ['campaignProgression'],
+  checkPilotingSkill: ['pilotingChecks'],
+  checkPilotStatus: ['pilotingChecks'],
+  checkPostBattleRewards: ['campaignProgression'],
+  checkReloadAction: ['ammoConsumption'],
+  checkShutdownRecovery: ['heatShutdown'],
+  checkTargeting: ['criticalEffects'],
+  checkTerrainModifiers: ['terrainMovement'],
+  checkToHitModifiers: ['specialAbilities'],
+  checkUnitImport: ['mtfParsing'],
+  checkVehicleMovement: ['vehicleAerospace'],
+  checkVTOLPosition: ['vehicleAerospace'],
+  checkWeaponFiring: ['ammoConsumption'],
+  checkWeaponStatus: ['criticalEffects'],
+} satisfies Record<string, readonly KnownLimitationCategory[]>;
 
-/**
- * Validation-suite invariants are evidence generators, not simulation bug
- * reports. They must stay visible even when their message text overlaps with
- * broad known-limitation buckets such as "physical attack" or "line of sight".
- */
-const KNOWN_LIMITATION_BYPASS_INVARIANTS = new Set([
-  'battlemech-combat-validation',
-]);
+const LEGACY_GENERIC_DETECTOR_CATEGORIES: ReadonlyMap<
+  string,
+  readonly KnownLimitationCategory[]
+> = new Map(
+  Object.entries(LEGACY_GENERIC_DETECTOR_CATEGORY_RECORD).map(
+    ([invariant, categories]): [string, readonly KnownLimitationCategory[]] => [
+      invariant.toLowerCase(),
+      categories,
+    ],
+  ),
+);
 
-function bypassesKnownLimitationFiltering(violation: IViolation): boolean {
-  return KNOWN_LIMITATION_BYPASS_INVARIANTS.has(
+function isSuppressionCategoryAllowed(
+  violation: IViolation,
+  category: KnownLimitationCategory,
+): boolean {
+  if (violation.context.legacyGeneric === true) return true;
+  if (violation.context.legacyGenericDetector === true) return true;
+
+  const allowedCategories = LEGACY_GENERIC_DETECTOR_CATEGORIES.get(
     violation.invariant.toLowerCase(),
   );
+  return allowedCategories?.includes(category) ?? false;
 }
 
 function findLimitationCategory(violation: IViolation): string | null {
   const message = violation.message.toLowerCase();
-  const invariant = violation.invariant.toLowerCase();
-  const combinedText = `${message} ${invariant}`;
 
   for (const [category, patterns] of Object.entries(
     KNOWN_LIMITATION_PATTERNS,
   )) {
-    if (patterns.some((pattern) => pattern.test(combinedText))) {
+    if (patterns.some((pattern) => pattern.test(message))) {
       return category;
     }
   }
@@ -192,8 +229,8 @@ function findLimitationCategory(violation: IViolation): string | null {
 /**
  * Check if a violation corresponds to a known limitation.
  *
- * Returns true if the violation matches any documented limitation pattern,
- * indicating it should be excluded from bug reports.
+ * Returns true only when the violation matches a documented limitation pattern
+ * and was emitted by an explicitly suppressible legacy detector.
  *
  * @param violation - The violation to check
  * @returns true if this is a known limitation, false if it's a potential bug
@@ -214,13 +251,13 @@ function findLimitationCategory(violation: IViolation): string | null {
  * ```
  */
 export function isKnownLimitation(violation: IViolation): boolean {
-  if (bypassesKnownLimitationFiltering(violation)) return false;
+  const category = findLimitationCategory(violation);
+  if (!category) return false;
 
-  const message = violation.message.toLowerCase();
-  const invariant = violation.invariant.toLowerCase();
-  const combinedText = `${message} ${invariant}`;
-
-  return ALL_PATTERNS.some((pattern) => pattern.test(combinedText));
+  return isSuppressionCategoryAllowed(
+    violation,
+    category as KnownLimitationCategory,
+  );
 }
 
 /**
@@ -241,14 +278,21 @@ export function isKnownLimitation(violation: IViolation): boolean {
  * ```
  */
 export function getLimitationCategory(violation: IViolation): string | null {
-  if (bypassesKnownLimitationFiltering(violation)) return null;
-  return findLimitationCategory(violation);
+  const category = findLimitationCategory(violation);
+  if (!category) return null;
+
+  return isSuppressionCategoryAllowed(
+    violation,
+    category as KnownLimitationCategory,
+  )
+    ? category
+    : null;
 }
 
 /**
- * Return the broad pattern category even for invariants that intentionally
- * bypass known-limitation filtering. This is useful for auditing whether the
- * bypass is protecting a validation lane from a real suppression hazard.
+ * Return the broad pattern category even for invariants that are intentionally
+ * not suppressible. This is useful for auditing whether a validation lane would
+ * have matched a legacy bucket without allowing that match to hide failures.
  */
 export function getLimitationPatternCategory(
   violation: IViolation,
@@ -279,7 +323,7 @@ export function getLimitationExplanation(violation: IViolation): string | null {
 
   const explanations: Record<string, string> = {
     physicalAttacks:
-      'Physical attacks generic detector gap; catalog validation lanes bypass this broad filter (see known-limitations.md)',
+      'Physical attacks generic detector gap; BattleMech validation lanes are not suppressible by this broad filter (see known-limitations.md)',
     ammoConsumption:
       'Ammo consumption is implemented; bucket retained for legacy generic detectors only (see known-limitations.md)',
     heatShutdown:

--- a/src/simulation/known-limitations.md
+++ b/src/simulation/known-limitations.md
@@ -19,11 +19,11 @@ catalog marks them integrated. Feature status lives in the honest ledgers:
   printable via `npx tsx scripts/print-combat-validation-gaps.ts`
 
 **Why the buckets survive after the features shipped:** the regex buckets only
-filter messages from _legacy generic detectors_. The BattleMech combat
-validation lane bypasses this filter entirely (the
-`battlemech-combat-validation` invariant is an explicit bypass in
-`knownLimitations.ts`, proven by `combatValidationScope.contract.test.ts`), so
-real validation evidence is never suppressed. Removing a bucket is safe only
+filter messages from _legacy generic detectors_. Suppression is explicit opt-in:
+`knownLimitations.ts` suppresses only allowlisted legacy detector invariants or
+violations carrying an explicit legacy marker. New validation invariants,
+including `battlemech-combat-validation`, are visible by default even when their
+message text matches one of the broad buckets. Removing a bucket is safe only
 after auditing that no legacy detector still emits matching messages.
 
 ---
@@ -34,7 +34,7 @@ after auditing that no legacy detector still emits matching messages.
 
 **Why**: The current BattleMech combat stack has runtime support for punch, kick, push, charge, death-from-above, and the supported melee weapon attack types (hatchet, sword, mace, lance, retractable blade, flail, wrecking ball). The broad `physicalAttacks` known-limitation bucket is retained only for older generic invariant reports whose messages do not distinguish implemented BattleMech mechanics from missing physical-combat families.
 
-**Catalog validation rule**: BattleMech combat validation invariants must not be filtered through this broad bucket. They bypass known-limitation filtering via `battlemech-combat-validation` and use the explicit support maps under `src/simulation/runner/` to classify integrated, helper-only, and unsupported physical behavior.
+**Catalog validation rule**: BattleMech combat validation invariants must not be filtered through this broad bucket. They are not on the suppressible legacy-detector allowlist, so `battlemech-combat-validation` failures remain visible while the explicit support maps under `src/simulation/runner/` classify integrated, helper-only, and unsupported physical behavior.
 
 **Current explicit boundaries** (see the gap inventory for the authoritative
 list):
@@ -101,9 +101,10 @@ Rotary AC/5 weapon rows. Keep RAC/10 and RAC/20 compatibility from silently
 falling back to arbitrary Rotary AC rows unless matching official BattleMech
 weapon rows exist in the imported catalog.
 
-**Hazard note**: a real ammo-tracking regression reported by a legacy generic
-detector would be filtered by this bucket. Catalog-lane invariants bypass the
-filter and are the enforcement surface for ammo behavior.
+**Hazard note**: a real ammo-tracking regression reported by an allowlisted
+legacy generic detector would be filtered by this bucket. Catalog-lane
+invariants are not suppressible by this filter and are the enforcement surface
+for ammo behavior.
 
 ---
 
@@ -120,8 +121,8 @@ fire (`phases/heatThresholdEvents.ts`, `phases/heatAmmoExplosions.ts`,
 `phases/heatCriticalDamage.ts`). The bucket survives only for legacy generic
 detectors with shutdown-themed messages.
 
-**Hazard note**: same as ammo — catalog-lane invariants bypass this filter and
-are the enforcement surface for heat behavior.
+**Hazard note**: same as ammo: catalog-lane invariants are not suppressible by
+this filter and are the enforcement surface for heat behavior.
 
 ---
 
@@ -378,9 +379,9 @@ subsystem remain stubbed (`@stub` markers in
 ### For Simulation Developers
 
 The exclusion buckets apply ONLY to legacy generic detectors. New invariants
-that produce validation evidence must register under (or alongside) the
-`battlemech-combat-validation` bypass so they are never filtered. Do not add
-new broad buckets for shipped features.
+that produce validation evidence should not be added to the suppressible
+legacy-detector allowlist; they surface by default even when their message text
+matches a broad bucket. Do not add new broad buckets for shipped features.
 
 ### For Game Engine Developers
 
@@ -395,17 +396,17 @@ When a feature listed here changes status:
 ### For Simulation Report Reviewers
 
 If a violation was filtered as a known limitation but the section above says
-the feature is implemented, treat it as a potential masked bug: re-run the
-catalog validation lane (which bypasses the filter) before dismissing it.
+the feature is implemented, treat it as a potential masked bug: confirm the
+emitting invariant is intentionally allowlisted as a legacy detector, then
+re-run the catalog validation lane before dismissing it.
 
 ---
 
 ## Maintenance
 
-**Last Updated**: 2026-06-10 (2026-06-09 audit finding E-10 — stale
-unimplemented claims for LOS / heat shutdown / critical effects / pilot
-checks / ammo consumption / terrain costs corrected against
-`CombatValidationCatalog` + `CombatValidationGapInventory`)
+**Last Updated**: 2026-06-21 (`restore-ci-correctness-teeth` inverted
+suppression from broad message-text matching to explicit legacy-detector
+opt-in, keeping new validation invariants visible by default)
 
 **Review Frequency**: Update this document whenever:
 

--- a/src/simulation/runner/CombatValidationScopeSupport.ts
+++ b/src/simulation/runner/CombatValidationScopeSupport.ts
@@ -73,19 +73,19 @@ export const KNOWN_LIMITATION_VALIDATION_TRAPS = [
   readonly message: string;
 }[];
 
-const KNOWN_LIMITATION_BYPASS_SOURCE_REFS = [
+const KNOWN_LIMITATION_OPT_IN_SOURCE_REFS = [
   mekstationDeviationSourceRef(
-    'MekStation knownLimitations declares the battlemech-combat-validation invariant as an evidence-generator bypass before broad limitation matching.',
+    'MekStation knownLimitations suppresses only legacy allowlisted detectors or explicit legacy markers, so BattleMech validation invariants are visible by default.',
     'src/simulation/core/knownLimitations.ts',
     'L148-L210',
   ),
   mekstationDeviationSourceRef(
-    'MekStation knownLimitations returns null categories for bypassing validation-suite invariants while preserving broad pattern audit lookup.',
+    'MekStation knownLimitations returns null suppression categories for non-legacy validation-suite invariants while preserving broad pattern audit lookup.',
     'src/simulation/core/knownLimitations.ts',
     'L230-L243',
   ),
   mekstationDeviationSourceRef(
-    'MekStation battlemechCombatCatalog.contract proves BattleMech validation traps are not filtered as known limitations.',
+    'MekStation battlemechCombatCatalog.contract proves BattleMech validation traps are not suppressed as known limitations.',
     'src/simulation/runner/__tests__/battlemechCombatCatalog.19.audits-known-limitation-traps-without-filtering-combat.fragment.ts',
     'L4-L24',
   ),
@@ -231,8 +231,8 @@ const UNRESOLVED_COMPLETION_BLOCKER_INVENTORY_SOURCE_REFS = [
 export const BATTLEMECH_VALIDATION_SCOPE_SUPPORT = {
   'known-limitation-bypass': integrated(
     'known-limitation-bypass',
-    'knownLimitations.ts bypasses the battlemech-combat-validation invariant before broad limitation detection, filtering, and partitioning',
-    KNOWN_LIMITATION_BYPASS_SOURCE_REFS,
+    'knownLimitations.ts suppresses only explicit legacy generic detector output; BattleMech validation invariants remain visible while broad pattern audit lookup stays available',
+    KNOWN_LIMITATION_OPT_IN_SOURCE_REFS,
   ),
   'known-limitation-pattern-audit': integrated(
     'known-limitation-pattern-audit',


### PR DESCRIPTION
﻿## Summary

- Add blocking PR fan-out jobs for 100-game statistical proofs, simulation perf budgets, and combat/simulation coverage floors, all wired into the preserved `Lint and Test` aggregator.
- Tighten `knownLimitations` so broad message patterns classify legacy buckets but only explicit legacy detectors or legacy markers suppress violations; new detectors and BattleMech catalog validation stay visible by default.
- Seed the replay Career History pilot path, replace empty multi-peer skips with explicit Wave 2 `fixme` deferrals, and add repeatable QC scripts for coverage floors and workflow gate topology.

## OpenSpec Notes

- Change: `restore-ci-correctness-teeth`
- D1 mechanism chosen: mid-size PR batch, not nightly-only fallback. Local proof ran `integration.test.ts` with `SIMULATION_COUNT=100` and passed in about 143s of Jest suite time.
- Coverage floors pinned from current measured coverage:
  - `src/simulation/`: lines 25%, statements 26%, functions 16%, branches 20%.
  - `src/utils/gameplay/`: lines 12%, statements 12%, functions 8%, branches 9%.

## Validation

- `npm run typecheck`
- `npm run lint` (0 errors; existing repo warnings remain)
- `npm run format:check`
- `npm test -- --runTestsByPath src/simulation/__tests__/knownLimitations.test.ts src/simulation/runner/__tests__/combatValidationScope.contract.test.ts src/simulation/runner/__tests__/battlemechCombatCatalog.contract.test.ts --selectProjects unit --runInBand`
- `SIMULATION_COUNT=100 npm test -- --runTestsByPath src/simulation/__tests__/integration.test.ts --selectProjects unit --runInBand`
- `SIMULATION_PERF_ASSERTIONS=true SIMULATION_COUNT=10 npm test -- --runTestsByPath src/simulation/__tests__/simulation.test.ts --selectProjects unit --runInBand`
- Coverage command plus `node scripts/qc/validate-combat-simulation-coverage.mjs --summary=coverage/combat-simulation/coverage-summary.json`
- Coverage below-floor fixture smoke produced the expected validator failure.
- `node scripts/qc/validate-restore-ci-correctness-teeth.mjs`
- Temporary workflow-regression smokes produced expected validator failures for low statistical count, disabled perf assertions, and missing coverage aggregator dependency.
- `DATABASE_PATH=.tmp/restore-ci-replay-seeded.db npx playwright test e2e/replay-player.spec.ts --project=chromium --grep "pilot detail page has Career History tab"`
- `DATABASE_PATH=.tmp/restore-ci-replay-full.db npx playwright test e2e/replay-player.spec.ts e2e/p2p-sync.spec.ts --project=chromium`
- `npm run validate:combat`
- `cmd /c openspec validate restore-ci-correctness-teeth --strict`
- `cmd /c openspec validate --all --strict`
- `npm run spec:purpose:validate:strict`
