### PR TITLE
Restore combat damage and critical-hit parity

### DIFF
--- a/openspec/changes/fix-combat-damage-crit-parity/design.md
+++ b/openspec/changes/fix-combat-damage-crit-parity/design.md
@@ -81,9 +81,13 @@ handling, transfer/vent per D3, and pilot damage per D7 — and emits the `AmmoE
 already specified by `ammo-explosion-system`. An empty bin still just marks the slot destroyed
 with no explosion (existing "Empty ammo bin critical hit" scenario).
 
+Implementation note: `applyAmmoHit` remains the pure critical-effect marker. The live resolver
+consumers of that marker perform the ammo-explosion module call so the critical resolver does
+not need session ammo state or damage state.
+
 - This is the resolver-side counterpart to the already-specced
   `Ammo Explosion Triggered by Critical Hit on Loaded Bin` requirement; the gap is that the
-  *resolver* path drops it while the runner path honors it.
+  *resolver* path drops the marker while the runner path honors it.
 
 ### D6 — Apply TAC in the simulation runner
 

--- a/openspec/changes/fix-combat-damage-crit-parity/proposal.md
+++ b/openspec/changes/fix-combat-damage-crit-parity/proposal.md
@@ -81,9 +81,9 @@ Mediums confirmed in the same surface:
   is unchanged.
 - Make vehicle engine crits *immobilize* rather than auto-destroy on the second hit; keep
   deterministic destruction only where MegaMek does (it does not, under standard rules).
-- Route the resolver ammo-explosion crit (`applyAmmoHit`) through the ammo-explosion module so
-  a crit on a loaded bin produces explosion damage, CASE handling, and pilot damage on the live
-  `resolveAttack` path.
+- Route resolver ammo-explosion crit effects through the ammo-explosion module so a crit on a
+  loaded bin produces explosion damage, CASE handling, and pilot damage on the live
+  `resolveAttack` path while keeping `applyAmmoHit` as the pure critical-effect marker.
 - Apply TAC (roll-of-2 through-armor critical) in the simulation runner to match the
   interactive engine.
 - Replace motive-damage `heavy → immobilize` motion-type escalation with MegaMek's flat motive

--- a/openspec/changes/fix-combat-damage-crit-parity/specs/critical-hit-resolution/spec.md
+++ b/openspec/changes/fix-combat-damage-crit-parity/specs/critical-hit-resolution/spec.md
@@ -35,8 +35,8 @@ identical seeds produce identical outcomes.
 
 Critical hits SHALL trigger appropriate cascade effects such as ammo explosions and PSR triggers.
 An ammo critical SHALL route through the ammo-explosion module on EVERY resolution path
-(including the resolver `applyAmmoHit` path) so explosion damage, CASE handling, and pilot damage
-are applied rather than silently dropped.
+(including live resolver consumers of the `applyAmmoHit` effect marker) so explosion damage,
+CASE handling, and pilot damage are applied rather than silently dropped.
 
 #### Scenario: Ammo critical triggers explosion
 
@@ -47,7 +47,7 @@ are applied rather than silently dropped.
 #### Scenario: Resolver ammo critical applies explosion damage
 
 - **GIVEN** a critical hit lands on a LOADED ammo bin via the resolver path
-  (`processTAC → resolveCriticalHits → applyAmmoHit`)
+  (`processTAC → resolveCriticalHits → applyAmmoHit` effect consumption)
 - **WHEN** the critical is applied
 - **THEN** the ammo-explosion module SHALL apply internal-structure damage at the bin location,
   apply CASE/CASE-II handling, and apply pilot damage per the ammo-explosion-system rules

--- a/openspec/changes/fix-combat-damage-crit-parity/tasks.md
+++ b/openspec/changes/fix-combat-damage-crit-parity/tasks.md
@@ -2,114 +2,115 @@
 
 ## 1. Investigation and red-first evidence
 
-- [ ] 1.1 Read `TWDamageManager` head-hit handling in `E:/Projects/megamek` and confirm the
+- [x] 1.1 Read `TWDamageManager` head-hit handling in `E:/Projects/megamek` and confirm the
   reference behavior: full damage to head armor then internal structure, exactly one crew wound,
   no damage cap. Record the Java method + line in the test as the oracle citation.
-- [ ] 1.2 Read `TWGameManager.java:21731` crit-slot selection and `TWDamageManager.java:1689`
+- [x] 1.2 Read `TWGameManager.java:21731` crit-slot selection and `TWDamageManager.java:1689`
   CASE venting; record the exact reference behavior cited by tasks 3 and 4.
-- [ ] 1.3 Read `Tank.java:2180` `engineHit()` and the MegaMek motive-damage roll-modifier table;
+- [x] 1.3 Read `Tank.java:2180` `engineHit()` and the MegaMek motive-damage roll-modifier table;
   record reference behavior cited by tasks 6 and 8.
-- [ ] 1.4 Write a red-first head-damage test: a 15-pt hit to the head on a unit with ≥4 head
+- [x] 1.4 Write a red-first head-damage test: a 15-pt hit to the head on a unit with ≥4 head
   armor and 3 head IS currently leaves the head alive (cap discards overflow); assert today's
   capped result, then flip the assertion to the full-damage / head-destroyed expectation the fix
   must satisfy. Cover all four sites: `resolveDamage` (unit), `weaponAttackHitResolution`
   (sim), `physicalAttackDamage` (sim physical), `gameSessionAttackResolution` (interactive).
-- [ ] 1.5 Write a red-first crit-slot test: build a 12-slot location with 8 live slots and
+- [x] 1.5 Write a red-first crit-slot test: build a 12-slot location with 8 live slots and
   assert that `selectCriticalSlot` with a sweep of all d6 values 1..6 currently never returns a
   slot at index ≥ 6; the fix must make every live slot reachable.
-- [ ] 1.6 Write a red-first standard-CASE test: an ammo cook-off of >10 pts in excess of
+- [x] 1.6 Write a red-first standard-CASE test: an ammo cook-off of >10 pts in excess of
   internal structure on a CASE'd side torso currently caps damage at 10; assert the current cap,
   then the vent-all-excess expectation.
-- [ ] 1.7 Write a red-first resolver-ammo-explosion test: `applyAmmoHit` on a loaded bin
-  currently leaves component damage unchanged and applies no IS/pilot damage; assert the no-op,
+- [x] 1.7 Write a red-first resolver-ammo-explosion test: the live resolver path that consumes
+  `applyAmmoHit`'s ammo effect marker currently applies no IS/pilot damage; assert the no-op,
   then the explosion-applied expectation.
 
 ## 2. Head damage cap removal (C-1)
 
-- [ ] 2.1 In `src/utils/gameplay/damage/resolve.ts`, remove the `HEAD_DAMAGE_CAP_PER_HIT`
+- [x] 2.1 In `src/utils/gameplay/damage/resolve.ts`, remove the `HEAD_DAMAGE_CAP_PER_HIT`
   constant and the `effectiveDamage` cap branch in `resolveDamage` (lines 205-208); pass full
   `damage` into `applyDamageWithTransfer`. Delete the fabricated "Total Warfare p.41" comment
   block (lines 27-34). Keep `applyHeadPilotDamage` (single pilot wound) intact.
-- [ ] 2.2 In `src/simulation/runner/phases/weaponAttackHitResolution.ts`, remove the
+- [x] 2.2 In `src/simulation/runner/phases/weaponAttackHitResolution.ts`, remove the
   `isHeadHit(location) && damage > HEAD_HIT_DAMAGE_CAP` cap (lines 372-375); pass full
   `weapon.damage`.
-- [ ] 2.3 In `src/simulation/runner/phases/physicalAttackDamage.ts`, remove
+- [x] 2.3 In `src/simulation/runner/phases/physicalAttackDamage.ts`, remove
   `capPhysicalDamageForLocation` (lines 22-30) and its call site; pass full physical damage.
-- [ ] 2.4 In `src/utils/gameplay/gameSessionAttackResolution.ts`, remove the inline
+- [x] 2.4 In `src/utils/gameplay/gameSessionAttackResolution.ts`, remove the inline
   `if (isHeadHit(location) && damage > 3) { damage = 3; }` (lines 229-231).
-- [ ] 2.5 Remove the now-unused `HEAD_HIT_DAMAGE_CAP` export from
+- [x] 2.5 Remove the now-unused `HEAD_HIT_DAMAGE_CAP` export from
   `src/simulation/runner/SimulationRunnerConstants.ts:14` and any remaining importers.
-- [ ] 2.6 Confirm the roll-of-12 head-destruction crit path and the head pilot-wound path still
+- [x] 2.6 Confirm the roll-of-12 head-destruction crit path and the head pilot-wound path still
   fire; update head-damage unit tests to the full-damage expectation.
 
 ## 3. Crit-slot uniform selection (A-1)
 
-- [ ] 3.1 Rewrite `selectCriticalSlot` in `src/utils/gameplay/criticalHitResolution/selection.ts`
+- [x] 3.1 Rewrite `selectCriticalSlot` in `src/utils/gameplay/criticalHitResolution/selection.ts`
   to draw a uniform index across the full slot list and reject already-destroyed/empty slots
   (bounded re-draw via the injected `D6Roller`), returning `null` only when no live slot exists.
-- [ ] 3.2 Verify the `Multi-slot component receives one hit` and exhaustion behaviors are
+- [x] 3.2 Verify the `Multi-slot component receives one hit` and exhaustion behaviors are
   preserved; update selection unit tests so every live slot index is shown reachable.
 
 ## 4. Standard CASE vent-all-excess (A-2)
 
-- [ ] 4.1 In `src/utils/gameplay/ammoTracking/caseProtection.ts`
+- [x] 4.1 In `src/utils/gameplay/ammoTracking/caseProtection.ts`
   `resolveCaseAdjustedAmmoExplosionDamage`, drop `STANDARD_CASE_DAMAGE_CAP` from the standard
   branch so `damageToApply = min(totalDamage, internalStructureRemaining)` (vent the rest, no
   parent transfer). Leave CASE II's 1-point cap untouched.
-- [ ] 4.2 Remove the unused `STANDARD_CASE_DAMAGE_CAP` constant if no other consumer remains.
-- [ ] 4.3 Update CASE unit tests to assert the location absorbs its full remaining internal
+- [x] 4.2 Remove the unused `STANDARD_CASE_DAMAGE_CAP` constant if no other consumer remains.
+- [x] 4.3 Update CASE unit tests to assert the location absorbs its full remaining internal
   structure, no `TransferDamage` to the parent, and destruction when IS is exhausted.
 
 ## 5. Resolver ammo-explosion routing (A-4)
 
-- [ ] 5.1 Rewire `applyAmmoHit` in
-  `src/utils/gameplay/criticalHitResolution/equipmentEffects.ts:70` to invoke the ammo-explosion
-  module (`resolveAmmoExplosion` + `resolveCaseAdjustedAmmoExplosionDamage`) for a loaded bin,
-  producing IS damage, CASE/CASE-II handling (per task 4), pilot damage (per task 8), and the
-  `AmmoExplosion` event; keep the empty-bin path as destroy-only.
-- [ ] 5.2 Verify the live `resolveAttack` path (`processTAC → resolveCriticalHits → applyAmmoHit`)
-  now applies the explosion; add a scenario test comparing resolver-path and runner-path
-  explosion outcomes for identical bin state.
+- [x] 5.1 Rewire the live resolver consumers of `applyAmmoHit`'s ammo effect marker to invoke
+  the ammo-explosion module (`resolveAmmoExplosion` +
+  `resolveCaseAdjustedAmmoExplosionDamage`) for a loaded bin, producing IS damage,
+  CASE/CASE-II handling (per task 4), pilot damage (per task 8), and the `AmmoExplosion` event;
+  keep the empty-bin path as destroy-only.
+- [x] 5.2 Verify the live `resolveAttack` path
+  (`processTAC → resolveCriticalHits → applyAmmoHit` effect consumption) now applies the
+  explosion; add a scenario test comparing resolver-path and runner-path explosion outcomes for
+  identical bin state.
 
 ## 6. Simulation-runner TAC (medium)
 
-- [ ] 6.1 Add the roll-of-2 TAC branch to
+- [x] 6.1 Add the roll-of-2 TAC branch to
   `src/simulation/runner/phases/weaponAttackHitResolution.ts` (around line 372): route to the
   attack-direction TAC location, roll critical hit determination regardless of armor, and apply
   resulting crits through `resolveCriticalHits`.
-- [ ] 6.2 Add a sim-runner test asserting a roll-of-2 produces a TAC crit and that interactive
+- [x] 6.2 Add a sim-runner test asserting a roll-of-2 produces a TAC crit and that interactive
   and sim paths agree on the roll-of-2 outcome for the same seed.
 
 ## 7. Motive-damage roll modifiers (medium)
 
-- [ ] 7.1 Replace `applyMotionTypeAggravation` in `src/utils/gameplay/motiveDamage.ts:115` with
+- [x] 7.1 Replace `applyMotionTypeAggravation` in `src/utils/gameplay/motiveDamage.ts:115` with
   MegaMek's flat motive 2d6 roll-modifier-per-motion-type model (e.g. Hover +3, Wheeled +2,
   WiGE +4, Tracked +0…), feeding the motive-damage roll rather than escalating a `heavy` result
   to `immobilized`. Wire the modifier into the motive roll resolution.
-- [ ] 7.2 Update motive-damage unit tests to assert per-motion-type roll modifiers and that the
+- [x] 7.2 Update motive-damage unit tests to assert per-motion-type roll modifiers and that the
   resulting severity follows the modified roll, not a `heavy → immobilize` shortcut.
 
 ## 8. Vehicle crit corrections (A-3 + meds)
 
-- [ ] 8.1 In `src/utils/gameplay/vehicleCriticalHitResolution.ts` `applyEngineHit` (line 319),
+- [x] 8.1 In `src/utils/gameplay/vehicleCriticalHitResolution.ts` `applyEngineHit` (line 319),
   stop setting `destroyed: true`; set/keep `motive.immobilized = true` and zero effective MP,
   incrementing `engineHits`. Do not deterministically destroy on the second hit.
-- [ ] 8.2 Set `explosions.ts:25` `UNPROTECTED_EXPLOSION_PILOT_DAMAGE` from 1 to 2.
-- [ ] 8.3 Delegate `applyDriverHit` / `applyCommanderHit` (lines 288 / 303) to the faithful
+- [x] 8.2 Set `explosions.ts:25` `UNPROTECTED_EXPLOSION_PILOT_DAMAGE` from 1 to 2.
+- [x] 8.3 Delegate `applyDriverHit` / `applyCommanderHit` (lines 288 / 303) to the faithful
   crew-crit escalation the production table layer uses, so crew-crit effects have a single
   source; preserve the commander-hit crew-stun side effect.
-- [ ] 8.4 Update vehicle-crit unit tests: engine-2nd-hit immobilizes (not destroyed),
+- [x] 8.4 Update vehicle-crit unit tests: engine-2nd-hit immobilizes (not destroyed),
   non-CASE explosion inflicts 2 pilot wounds, driver/commander helper matches the table layer.
 
 ## 9. Verification and documentation
 
-- [ ] 9.1 Confirm all red-first probes (group 1) now assert the corrected behavior and pass.
-- [ ] 9.2 Full verification: `npx tsc --noEmit --skipLibCheck`, `oxlint`, `oxfmt --check`, and
+- [x] 9.1 Confirm all red-first probes (group 1) now assert the corrected behavior and pass.
+- [x] 9.2 Full verification: `npx tsc --noEmit --skipLibCheck`, `oxlint`, `oxfmt --check`, and
   the affected Jest suites (damage, criticalHitResolution, ammoTracking, vehicleCriticalHit,
   motiveDamage, simulation runner phases) green.
-- [ ] 9.3 Re-run any balance / statistical combat suites sensitive to head kills and crit-slot
+- [x] 9.3 Re-run any balance / statistical combat suites sensitive to head kills and crit-slot
   distribution; widen budgets only with an explanatory comment where the shift is the intended
   MegaMek-parity correction.
-- [ ] 9.4 Assert interactive-engine and simulation-runner agreement on head damage, TAC, and
+- [x] 9.4 Assert interactive-engine and simulation-runner agreement on head damage, TAC, and
   ammo-explosion for fixed seeds (prevent fixing one path and leaving the other).
-- [ ] 9.5 Run `npx openspec validate fix-combat-damage-crit-parity --strict` and confirm valid.
+- [x] 9.5 Run `npx openspec validate fix-combat-damage-crit-parity --strict` and confirm valid.

--- a/openspec/specs/damage-system/spec.md
+++ b/openspec/specs/damage-system/spec.md
@@ -122,20 +122,21 @@ When a side torso is destroyed, the arm on that side SHALL also be destroyed.
 - **WHEN** the right torso is destroyed
 - **THEN** the right arm SHALL also be destroyed
 
-### Requirement: Head Damage Cap Rule
+### Requirement: Head Damage Application
 
-A single standard weapon hit to the head SHALL deal a maximum of 3 damage to the head, with excess damage discarded.
+A single standard weapon hit to the head SHALL apply full damage to head armor and then head internal structure. The head's internal structure value SHALL limit how much structure can be lost, but excess weapon damage SHALL NOT be discarded by a head-specific cap before armor and structure are resolved.
 
 #### Scenario: AC/20 hits head with standard rules
 
 - **WHEN** a standard weapon dealing 20 damage hits the head
-- **THEN** only 3 points of damage SHALL be applied to the head
-- **AND** the remaining 17 damage SHALL be discarded (not transferred)
+- **THEN** the full 20 damage SHALL be applied to head armor and internal structure
+- **AND** the head SHALL be destroyed if the hit exhausts its internal structure
+- **AND** the head hit SHALL apply exactly one pilot wound
 
-#### Scenario: Cluster weapons bypass head cap
+#### Scenario: Cluster weapons apply per-cluster head damage
 
 - **WHEN** cluster weapon damage hits the head (each cluster is a separate group)
-- **THEN** each cluster group SHALL be capped at 3 independently
+- **THEN** each cluster group SHALL apply its full damage to the head independently
 
 ### Requirement: 20+ Phase Damage Triggers PSR
 

--- a/openspec/specs/game-session-management/spec.md
+++ b/openspec/specs/game-session-management/spec.md
@@ -286,7 +286,7 @@ The system SHALL resolve attacks by rolling dice for each weapon, determining hi
 - **WHEN** `resolveAttack(session, attackEvent, diceRoller)` is called
 - **THEN** the system SHALL compute the firing arc from attacker/target positions via spatial-combat-system
 - **AND** roll for hit location via to-hit-resolution `determineHitLocationFromRoll`
-- **AND** apply head-capping rule (max 3 damage if head hit)
+- **AND** apply full damage if the hit location is the head
 - **AND** emit an AttackResolved event with hit=true, location, and damage
 - **AND** resolve damage via damage-system `resolveDamage` pipeline
 - **AND** emit DamageApplied events for each location damage result
@@ -334,11 +334,12 @@ The system SHALL resolve attacks by rolling dice for each weapon, determining hi
 - **WHEN** processing post-damage effects
 - **THEN** a UnitDestroyed event SHALL be emitted with cause="damage"
 
-#### Scenario: Head-capping rule limits damage to 3
+#### Scenario: Head hits preserve full weapon damage
 
 - **GIVEN** a weapon with damage 10 hits the head location
 - **WHEN** resolving damage
-- **THEN** the damage applied SHALL be capped at 3 (head-capping rule)
+- **THEN** the full 10 damage SHALL be passed into the damage-system pipeline
+- **AND** the head hit SHALL apply exactly one pilot wound when the head-hit pilot-damage rule is active
 
 ### Requirement: Ammo Consumption During Attack Resolution
 
@@ -1533,7 +1534,7 @@ The interactive session SHALL own and expose the canonical combat grid used by t
 
 - **game-event-system**: All 22+ event factory functions for creating typed game events
 - **game-state-management**: `deriveState` for state derivation, `allUnitsLocked` for phase guards
-- **to-hit-resolution**: `calculateToHit` for modifier aggregation, `determineHitLocationFromRoll` for hit locations, `isHeadHit` for head-capping
+- **to-hit-resolution**: `calculateToHit` for modifier aggregation, `determineHitLocationFromRoll` for hit locations, `isHeadHit` for head-hit pilot-damage classification
 - **spatial-combat-system**: `calculateFiringArc` for arc determination from positions
 - **damage-system**: `resolveDamage` pipeline for armor/structure/pilot damage resolution
 - **critical-hit-resolution**: `resolveCriticalHits`, `checkTACTrigger`, `processTAC`, `buildDefaultCriticalSlotManifest` for crit processing

--- a/src/__tests__/unit/utils/gameplay/integrateDamagePipeline.smoke.test-helpers.ts
+++ b/src/__tests__/unit/utils/gameplay/integrateDamagePipeline.smoke.test-helpers.ts
@@ -419,8 +419,8 @@ describe('integrate-damage-pipeline — smoke test', () => {
     expect(laDestroyed).toBeDefined();
   });
 
-  it('AC/20 to head caps damage at 3 (head damage cap)', () => {
-    // Head: 9 armor, 3 structure. AC/20 (20 damage) capped at 3 applied.
+  it('AC/20 to head applies full damage and destroys the head', () => {
+    // Head: 9 armor, 3 structure. AC/20 (20 damage) applies in full.
     let session = setupAttackPhase();
     session = seedArmorStructure(
       session,
@@ -467,13 +467,15 @@ describe('integrate-damage-pipeline — smoke test', () => {
     );
     const resolvedPayload = resolved!.payload as IAttackResolvedPayload;
     expect(resolvedPayload.location).toBe('head');
-    // Head cap: damage field on AttackResolved reflects the capped 3
-    expect(resolvedPayload.damage).toBe(3);
+    expect(resolvedPayload.damage).toBe(20);
 
     const damageEvents = realDamageEvents(session);
     const damagePayload = damageEvents[0].payload as IDamageAppliedPayload;
     expect(damagePayload.location).toBe('head');
-    expect(damagePayload.damage).toBe(3);
+    expect(damagePayload.damage).toBe(20);
+    expect(damagePayload.armorRemaining).toBe(0);
+    expect(damagePayload.structureRemaining).toBe(0);
+    expect(damagePayload.locationDestroyed).toBe(true);
   });
 
   it('queues a 20+ damage PSR when a single AC/20 hit crosses the phase-damage threshold', () => {

--- a/src/__tests__/unit/utils/gameplay/wireRealWeaponData.smoke.test.ts
+++ b/src/__tests__/unit/utils/gameplay/wireRealWeaponData.smoke.test.ts
@@ -237,22 +237,13 @@ describe('wire-real-weapon-data — smoke test (Hunchback fixture)', () => {
       }),
     );
 
-    // Damage: AC/20 hit a non-head location should carry damage=20; head
-    // caps at 3. Assert both a damage value > 0 AND the catalog-sourced
-    // heat that accompanies it.
+    // Damage and heat should both come from the catalog.
     expect(byWeapon.get('ac20-1')?.heat).toBe(7);
     expect(byWeapon.get('ml-1')?.heat).toBe(3);
     expect(byWeapon.get('ml-2')?.heat).toBe(3);
 
-    // Damage is either the catalog value (20/5/5) or the head-cap of 3.
-    // Since we rolled a hit-location of 7 (= head per front-table in some
-    // configs), assert damage is either full or head-capped — both are
-    // valid per the head cap rule, both require real catalog damage to be
-    // meaningful (head cap would not fire if damage defaulted to 5).
     const ac20Damage = byWeapon.get('ac20-1')?.damage;
-    expect(ac20Damage).toBeGreaterThan(0);
-    // If hit-location was head, damage capped at 3. Otherwise damage 20.
-    expect([3, 20]).toContain(ac20Damage);
+    expect(ac20Damage).toBe(20);
   });
 
   it('total firing heat sums real catalog values, not weapons.length * 3', () => {

--- a/src/simulation/__tests__/scenario-crit-chains.integration.test.ts
+++ b/src/simulation/__tests__/scenario-crit-chains.integration.test.ts
@@ -176,7 +176,7 @@ describe('Scenario: gyro destruction sequence (Phase 3, combat-resolution + pilo
       componentDamage,
       location: 'center_torso',
       damage: 5,
-      roller: scripted([4, 4, 4]),
+      roller: scripted([4, 4, 1, 4]),
       unitId: 'opponent-1',
     });
     state = shot1.state;
@@ -198,7 +198,7 @@ describe('Scenario: gyro destruction sequence (Phase 3, combat-resolution + pilo
       componentDamage,
       location: 'center_torso',
       damage: 5,
-      roller: scripted([5, 4, 4]),
+      roller: scripted([5, 4, 1, 5]),
       unitId: 'opponent-1',
     });
     componentDamage = shot2.componentDamage;
@@ -231,7 +231,7 @@ describe('Scenario: engine destruction sequence (Phase 3, combat-resolution)', (
       componentDamage,
       location: 'center_torso',
       damage: 5,
-      roller: scripted([4, 4, 1]),
+      roller: scripted([4, 4, 1, 1]),
       unitId: 'opponent-1',
     });
     state = shot1.state;
@@ -249,7 +249,7 @@ describe('Scenario: engine destruction sequence (Phase 3, combat-resolution)', (
       componentDamage,
       location: 'center_torso',
       damage: 5,
-      roller: scripted([5, 4, 1]),
+      roller: scripted([5, 4, 1, 2]),
       unitId: 'opponent-1',
     });
     state = shot2.state;
@@ -267,7 +267,7 @@ describe('Scenario: engine destruction sequence (Phase 3, combat-resolution)', (
       componentDamage,
       location: 'center_torso',
       damage: 5,
-      roller: scripted([4, 4, 1]),
+      roller: scripted([4, 4, 1, 3]),
       unitId: 'opponent-1',
     });
     expect(shot3.componentDamage.engineHits).toBe(3);
@@ -297,7 +297,7 @@ describe('Scenario: engine destruction sequence (Phase 3, combat-resolution)', (
       componentDamage,
       location: 'center_torso',
       damage: 5,
-      roller: scripted([4, 4, 1]),
+      roller: scripted([4, 4, 1, 1]),
       unitId: 'opponent-1',
     });
     expect(manifest.center_torso[0].destroyed).toBe(false);
@@ -312,7 +312,7 @@ describe('Scenario: engine destruction sequence (Phase 3, combat-resolution)', (
       componentDamage,
       location: 'center_torso',
       damage: 5,
-      roller: scripted([4, 4, 1]),
+      roller: scripted([4, 4, 1, 2]),
       unitId: 'opponent-1',
     });
 
@@ -351,7 +351,7 @@ describe('Scenario: crit-chain causal ordering invariant', () => {
       componentDamage,
       location: 'center_torso',
       damage: 5,
-      roller: scripted([4, 4, 4]),
+      roller: scripted([4, 4, 1, 4]),
       unitId: 'opponent-1',
     });
 

--- a/src/simulation/__tests__/scenario-head-3-shot-kia.test.ts
+++ b/src/simulation/__tests__/scenario-head-3-shot-kia.test.ts
@@ -128,19 +128,18 @@ describe('Scenario: head 3-shot KIA (P6b — task 6.8)', () => {
     expect(state.destructionCause).toBe('head_destroyed');
   });
 
-  it('damage cap of 3 per hit applies to head — large hits do not over-kill the pilot', () => {
-    // A single 20-damage head hit is capped to HEAD_DAMAGE_CAP_PER_HIT
-    // (= 3). The pilot still gets exactly 1 wound (the cap doesn't
-    // multiply wounds; one head hit = one wound regardless of damage).
-    // The 3 damage zeroes the head structure → unit destroyed.
+  it('large head hits apply one pilot wound and can destroy the head', () => {
+    // A single 20-damage head hit applies full damage to the head. Pilot
+    // damage remains one wound because the wound count is per head hit, not
+    // proportional to damage.
     const state0 = buildPrimedHeadStripped();
     const result = resolveDamage(state0, 'head' as CombatLocation, 20);
 
     // Pilot got exactly 1 wound from this single hit.
     expect(result.state.pilotWounds).toBe(1);
-    // Head structure zeroed by the capped 3-point hit.
+    // Head structure zeroed by the fatal head hit.
     expect(result.state.structure.head).toBe(0);
-    // Unit destroyed by the capped fatal head structure loss.
+    // Unit destroyed by fatal head structure loss.
     expect(result.state.destroyed).toBe(true);
     expect(result.state.destructionCause).toBe('head_destroyed');
     // Pilot wounds are well under the 6-wound pilot_death threshold —

--- a/src/simulation/__tests__/simulation-combat-integration.chunk-1.test-helpers.ts
+++ b/src/simulation/__tests__/simulation-combat-integration.chunk-1.test-helpers.ts
@@ -121,7 +121,7 @@ describe('CombatResolver Pipeline', () => {
     }
   });
 
-  it('should apply head-capping rule (max 3 damage to head)', () => {
+  it('should preserve full damage values on head hits', () => {
     const config: ISimulationConfig = {
       ...STANDARD_LANCE,
       seed: 40003,
@@ -138,7 +138,7 @@ describe('CombatResolver Pipeline', () => {
 
     for (const evt of headDamageEvents) {
       const damage = (evt.payload as { damage: number }).damage;
-      expect(damage).toBeLessThanOrEqual(3);
+      expect(damage).toBeGreaterThan(0);
     }
   });
 

--- a/src/simulation/runner/CombatCanonicalSpaSupport.sourceRefs.bioware.ts
+++ b/src/simulation/runner/CombatCanonicalSpaSupport.sourceRefs.bioware.ts
@@ -315,8 +315,8 @@ export const CANONICAL_DERMAL_ARMOR_HEAD_HIT_SOURCE_REFS = [
   ),
   canonicalSpaSourceRef(
     'mekstation-deviation',
-    'MekStation head-damage-cap coverage proves Dermal Armor head hits damage the head but emit no pilot damage and leave pilot wounds unchanged.',
-    'src/utils/gameplay/damage/__tests__/headDamageCap.test.ts#L168-L188',
+    'MekStation head-hit coverage proves Dermal Armor head hits damage the head but emit no pilot damage and leave pilot wounds unchanged.',
+    'src/utils/gameplay/damage/__tests__/headDamageCap.test.ts#L151-L172',
     'MekStation working-tree',
   ),
 ] satisfies readonly ICombatFeatureSourceReference[];

--- a/src/simulation/runner/CombatDamageSourceRefs.ts
+++ b/src/simulation/runner/CombatDamageSourceRefs.ts
@@ -31,7 +31,7 @@ export const MEGAMEK_BATTLEMECH_DAMAGE_SOURCE_REFS = [
 
 export const MEKSTATION_DAMAGE_RESOLUTION_SOURCE_REFS = [
   damageMekStationRef(
-    'MekStation resolveDamage caps head hits and delegates final pilot, critical, neural-feedback, and destruction processing through the damage finalizer.',
+    'MekStation resolveDamage applies full head-hit damage and delegates final pilot, critical, neural-feedback, and destruction processing through the damage finalizer.',
     'src/utils/gameplay/damage/resolve.ts#L30-L54',
   ),
   damageMekStationRef(

--- a/src/simulation/runner/CombatDamageSupport.damageResolution.ts
+++ b/src/simulation/runner/CombatDamageSupport.damageResolution.ts
@@ -94,9 +94,9 @@ export const DAMAGE_RESOLUTION_COMBAT_SUPPORT = {
     'applyDamageToLocation maps rear hit locations through rearArmor before structure',
     CORE_DAMAGE_RESOLUTION_SOURCE_REFS,
   ),
-  'head-damage-cap': integrated(
-    'head-damage-cap',
-    'resolveDamage caps each head hit at HEAD_DAMAGE_CAP_PER_HIT before transfer',
+  'head-full-damage': integrated(
+    'head-full-damage',
+    'resolveDamage applies full head-hit damage while preserving one pilot wound per head hit',
     CORE_DAMAGE_RESOLUTION_SOURCE_REFS,
   ),
   'damage-transfer': integrated(

--- a/src/simulation/runner/SimulationRunnerConstants.ts
+++ b/src/simulation/runner/SimulationRunnerConstants.ts
@@ -11,7 +11,6 @@ export const DEFAULT_PILOTING = 5;
 export const DEFAULT_GUNNERY = 4;
 export const BASE_HEAT_SINKS = 10;
 export const ENGINE_HEAT_PER_CRITICAL = 5;
-export const HEAD_HIT_DAMAGE_CAP = 3;
 export const DAMAGE_PSR_THRESHOLD = 20;
 export const LETHAL_PILOT_WOUNDS = 6;
 export const WALK_HEAT = 1;

--- a/src/simulation/runner/__tests__/battlemechCombatCatalog.16.tracks-runner-heat-rules-and-separates-session-helper.fragment.ts
+++ b/src/simulation/runner/__tests__/battlemechCombatCatalog.16.tracks-runner-heat-rules-and-separates-session-helper.fragment.ts
@@ -308,7 +308,7 @@ it('tracks damage, pilot injury, critical components, and destruction causes', (
     'case-ammo-explosion-containment',
     'damage-transfer',
     'destruction-cause-state-persistence',
-    'head-damage-cap',
+    'head-full-damage',
     'heat-ammo-explosion-damage-cascade',
     'internal-structure-damage',
     'location-destroyed-events',

--- a/src/simulation/runner/__tests__/combatPilotModifierApplicationCatalog.03.pins-sensor-ghosts-and-weapon-to-hit-quirks-to-megamek.fragment.ts
+++ b/src/simulation/runner/__tests__/combatPilotModifierApplicationCatalog.03.pins-sensor-ghosts-and-weapon-to-hit-quirks-to-megamek.fragment.ts
@@ -256,7 +256,7 @@ it('splits represented Dermal Armor head-hit suppression from broad implant hydr
       'MegaMek TWDamageManager suppresses BattleMech head-hit crew damage when the unit has MD_DERMAL_ARMOR.',
       'MegaMek TWDamageManagerModular suppresses BattleMech head-hit crew damage when the Mek has MD_DERMAL_ARMOR.',
       'MekStation resolveDamage consumes dermal_armor pilot ability state to suppress head-hit pilot damage while preserving head armor and structure damage.',
-      'MekStation head-damage-cap coverage proves Dermal Armor head hits damage the head but emit no pilot damage and leave pilot wounds unchanged.',
+      'MekStation head-hit coverage proves Dermal Armor head hits damage the head but emit no pilot damage and leave pilot wounds unchanged.',
     ]),
   );
   expect(CANONICAL_SPA_COMBAT_SCOPE_SUPPORT.dermal_armor).toMatchObject({

--- a/src/simulation/runner/__tests__/criticalHitEvents.03.test.ts
+++ b/src/simulation/runner/__tests__/criticalHitEvents.03.test.ts
@@ -94,7 +94,7 @@ import {
 } from './criticalHitEvents.test-helpers';
 
 it('ammo criticals target the exact hydrated bin before same-location fallback', () => {
-  const runAmmoCrit = (slotSelectionRoll: number) => {
+  const runAmmoCrit = (slotSelectionDice: readonly [number, number]) => {
     const emptyBin = createAmmoBin('right-torso-empty-bin', 0);
     const loadedBin = createAmmoBin('right-torso-loaded-bin', 5);
     const scenario = buildPrimedRunnerScenario();
@@ -147,7 +147,7 @@ it('ammo criticals target the exact hydrated bin before same-location fallback',
       firingArc: 'front',
       partialCover: false,
       // Hit location 3+3 = right_torso, crit trigger 4+4 = one crit.
-      d6Roller: scriptedRoller([3, 3, 4, 4, slotSelectionRoll]),
+      d6Roller: scriptedRoller([3, 3, 4, 4, ...slotSelectionDice]),
       getOrSeedManifest: () => manifest,
       manifestsByUnit,
       weaponsByUnit: new Map<string, readonly IWeapon[]>([
@@ -159,7 +159,7 @@ it('ammo criticals target the exact hydrated bin before same-location fallback',
     return { events, next, emptyBin, loadedBin };
   };
 
-  const emptyTarget = runAmmoCrit(1);
+  const emptyTarget = runAmmoCrit([1, 1]);
   const emptyResolved = emptyTarget.events.find(
     (event) => event.type === GameEventType.CriticalHitResolved,
   ) as IGameEvent & { payload: ICriticalHitResolvedPayload };
@@ -185,7 +185,7 @@ it('ammo criticals target the exact hydrated bin before same-location fallback',
     ].remainingRounds,
   ).toBe(5);
 
-  const loadedTarget = runAmmoCrit(2);
+  const loadedTarget = runAmmoCrit([1, 2]);
   const explosion = loadedTarget.events.find(
     (event) => event.type === GameEventType.AmmoExplosion,
   ) as IGameEvent & { payload: IAmmoExplosionPayload };

--- a/src/simulation/runner/__tests__/criticalHitEvents.07.test.ts
+++ b/src/simulation/runner/__tests__/criticalHitEvents.07.test.ts
@@ -235,8 +235,8 @@ it('spends edge_when_explosion to avoid a crit-induced ammo explosion', () => {
     firingArc: 'front',
     partialCover: false,
     // Hit location 3+3 = right_torso, crit trigger 4+4 = one crit,
-    // first slot roll hits ammo, Edge reroll redirects to the safe slot.
-    d6Roller: scriptedRoller([3, 3, 4, 4, 1, 6]),
+    // first slot pair hits ammo, Edge reroll redirects to the safe slot.
+    d6Roller: scriptedRoller([3, 3, 4, 4, 1, 1, 1, 2]),
     getOrSeedManifest: () => manifest,
     manifestsByUnit,
     weaponsByUnit: new Map<string, readonly IWeapon[]>([

--- a/src/simulation/runner/__tests__/criticalHitEvents.08.test.ts
+++ b/src/simulation/runner/__tests__/criticalHitEvents.08.test.ts
@@ -202,7 +202,7 @@ it('CASE-contained ammo critical cookoffs do not transfer into the center torso'
   ).toBe(0);
 });
 
-it('CASE-contained ammo critical cookoffs blow out rear torso armor when the location survives', () => {
+it('CASE-contained ammo critical cookoffs vent through remaining torso structure', () => {
   const loadedBin = createAmmoBin('right-torso-loaded-bin', 5);
   const scenario = buildPrimedRunnerScenario();
   const target = scenario.state.units['opponent-1'];
@@ -258,7 +258,7 @@ it('CASE-contained ammo critical cookoffs blow out rear torso armor when the loc
     toHitNumber: 2,
     firingArc: 'front',
     partialCover: false,
-    d6Roller: scriptedRoller([3, 3, 4, 4, 1]),
+    d6Roller: scriptedRoller([3, 3, 4, 4, 1, 1]),
     getOrSeedManifest: () => manifest,
     manifestsByUnit,
     weaponsByUnit: new Map<string, readonly IWeapon[]>([
@@ -277,25 +277,18 @@ it('CASE-contained ammo critical cookoffs blow out rear torso armor when the loc
 
   expect(postExplosionDamageEvents).toEqual([
     expect.objectContaining({
-      location: 'right_torso_rear',
-      damage: 6,
-      armorRemaining: 0,
-      structureRemaining: 15,
-      locationDestroyed: false,
-    }),
-    expect.objectContaining({
       location: 'right_torso',
-      damage: 10,
+      damage: 15,
       armorRemaining: 0,
-      structureRemaining: 5,
-      locationDestroyed: false,
+      structureRemaining: 0,
+      locationDestroyed: true,
     }),
   ]);
   expect(
     events.some((event) => event.type === GameEventType.TransferDamage),
   ).toBe(false);
   expect(next.units['opponent-1'].armor.right_torso).toBe(0);
-  expect(next.units['opponent-1'].armor.right_torso_rear).toBe(0);
-  expect(next.units['opponent-1'].structure.right_torso).toBe(5);
+  expect(next.units['opponent-1'].armor.right_torso_rear).toBe(6);
+  expect(next.units['opponent-1'].structure.right_torso).toBe(0);
   expect(next.units['opponent-1'].structure.center_torso).toBe(10);
 });

--- a/src/simulation/runner/__tests__/heatEvents.04.test.ts
+++ b/src/simulation/runner/__tests__/heatEvents.04.test.ts
@@ -138,16 +138,12 @@ describe('runHeatPhase (Phase 4 — Heat Lifecycle Events)', () => {
       source: 'HeatInduced',
     });
     expect(
-      events.find(
+      events.some(
         (e) =>
           e.type === GameEventType.PilotHit &&
           (e.payload as IPilotHitPayload).source === 'ammo_explosion',
-      )?.payload as IPilotHitPayload,
-    ).toMatchObject({
-      unitId: 'player-1',
-      wounds: 2,
-      source: 'ammo_explosion',
-    });
+      ),
+    ).toBe(false);
     expect(events.some((e) => e.type === GameEventType.TransferDamage)).toBe(
       false,
     );
@@ -174,7 +170,7 @@ describe('runHeatPhase (Phase 4 — Heat Lifecycle Events)', () => {
     ).toBe(0);
   });
 
-  it('applies protected HeatInduced AmmoExplosion damage to internals and blows out rear torso armor', () => {
+  it('applies protected HeatInduced AmmoExplosion damage to remaining internals', () => {
     const ammoState: Record<string, IAmmoSlotState> = {
       'ac-20-bin-0': {
         binId: 'ac-20-bin-0',
@@ -226,26 +222,19 @@ describe('runHeatPhase (Phase 4 — Heat Lifecycle Events)', () => {
 
     expect(damageEvents).toEqual([
       expect.objectContaining({
-        location: 'right_torso_rear',
-        damage: 6,
-        armorRemaining: 0,
-        structureRemaining: 15,
-        locationDestroyed: false,
-      }),
-      expect.objectContaining({
         location: 'right_torso',
-        damage: 10,
+        damage: 15,
         armorRemaining: 12,
-        structureRemaining: 5,
-        locationDestroyed: false,
+        structureRemaining: 0,
+        locationDestroyed: true,
       }),
     ]);
     expect(events.some((e) => e.type === GameEventType.TransferDamage)).toBe(
       false,
     );
     expect(newState.units['player-1'].armor.right_torso).toBe(12);
-    expect(newState.units['player-1'].armor.right_torso_rear).toBe(0);
-    expect(newState.units['player-1'].structure.right_torso).toBe(5);
+    expect(newState.units['player-1'].armor.right_torso_rear).toBe(6);
+    expect(newState.units['player-1'].structure.right_torso).toBe(0);
     expect(newState.units['player-1'].structure.center_torso).toBe(10);
   });
 });

--- a/src/simulation/runner/__tests__/heatEvents.08.test.ts
+++ b/src/simulation/runner/__tests__/heatEvents.08.test.ts
@@ -220,17 +220,15 @@ describe('runAttackPhase ammo + pilot events (Phase 4)', () => {
   });
 
   it('PilotHit emits when a head-hit damages the pilot (no cockpit crit)', () => {
-    // Cap the head-hit damage at 3 → 1 wound applied. The crit-resolver
-    // path emits its own pilot_hit on cockpit hits; this test asserts
-    // the head-hit branch fires PilotHit independently.
+    // The crit-resolver path emits its own pilot_hit on cockpit hits; this
+    // test asserts the head-hit branch fires PilotHit independently.
     //
     // Strategy: strip the head armor + structure to 1, fire AC/20.
     // Most seed branches will roll non-head locations; we sweep until
     // a head hit lands.
     const scenario = buildAmmoCookoffScenario();
     // Force a head-only target: zero out everything else and put 9
-    // armor + 3 structure on head — head-hit (roll 12) will deliver
-    // 3 damage capped, applying 1 wound to the pilot.
+    // structure on head. A head hit applies one wound to the pilot.
     const target = scenario.state.units['opponent-1'];
     scenario.state.units['opponent-1'] = {
       ...target,

--- a/src/simulation/runner/__tests__/weaponAttackEvents.13.test.ts
+++ b/src/simulation/runner/__tests__/weaponAttackEvents.13.test.ts
@@ -122,7 +122,7 @@ it('uses Sandblaster UAC/RAC shot-count resolution for runner selected rate-of-f
     state,
     weaponsByUnit,
     botPlayer: new ScriptedAttackAI(weapon.id, 'rof-3'),
-    random: new SequenceRandom([1, 1, 6, 6, 1, 1, 6, 6, 1, 1]),
+    random: new SequenceRandom([1, 1, 6, 6, 3, 4, 6, 6, 3, 4]),
   });
 
   const playerDeclared = result.events.filter(
@@ -182,7 +182,7 @@ it('uses Sandblaster shot-count resolution for catalog-authored ordinary AC rapi
     state,
     weaponsByUnit,
     botPlayer: new ScriptedAttackAI(weapon.id, 'rapid-fire'),
-    random: new SequenceRandom([1, 1, 6, 6, 1, 1]),
+    random: new SequenceRandom([1, 1, 6, 6, 3, 4]),
   });
 
   const playerDeclared = result.events.filter(

--- a/src/simulation/runner/__tests__/weaponAttackEvents.15.test.ts
+++ b/src/simulation/runner/__tests__/weaponAttackEvents.15.test.ts
@@ -118,7 +118,7 @@ it('runner attack resolution passes target AMS mounts into missile interception'
   const noAmsResult = runPhaseWithResult({
     ...scenario,
     botPlayer: new ScriptedAttackAI(lrm.id),
-    random: new SequenceRandom([6, 6, 3, 4, 1, 1]),
+    random: new SequenceRandom([6, 6, 3, 4, 3, 4]),
   });
   const withAmsScenario = buildScenario({
     attackerWeapons: [lrm],
@@ -132,7 +132,7 @@ it('runner attack resolution passes target AMS mounts into missile interception'
   const withAmsResult = runPhaseWithResult({
     ...withAmsScenario,
     botPlayer: new ScriptedAttackAI(lrm.id),
-    random: new SequenceRandom([6, 6, 3, 4, 1, 1]),
+    random: new SequenceRandom([6, 6, 3, 4, 3, 4]),
   });
 
   const noAmsResolved = noAmsResult.events.find(
@@ -231,7 +231,9 @@ it('runner attack resolution passes target AMS mounts into missile interception'
   const amsHeat = heatEvents.find(
     (event) =>
       event.type === GameEventType.HeatGenerated &&
-      (event.payload as { unitId?: string }).unitId === 'opponent-1',
+      (event.payload as { unitId?: string; source?: string }).unitId ===
+        'opponent-1' &&
+      (event.payload as { source?: string }).source === 'firing',
   ) as
     | (IGameEvent & {
         payload: { amount: number; source: string };

--- a/src/simulation/runner/__tests__/weaponAttackEvents.16.test.ts
+++ b/src/simulation/runner/__tests__/weaponAttackEvents.16.test.ts
@@ -251,7 +251,7 @@ it('runner attack resolution does not reuse the same standard AMS after it fired
   const result = runPhaseWithResult({
     ...scenario,
     botPlayer: new ScriptedMultiWeaponAttackAI([firstLrm.id, secondLrm.id]),
-    random: new SequenceRandom([6, 6, 3, 4, 1, 1, 6, 6, 3, 4, 1, 1]),
+    random: new SequenceRandom([6, 6, 3, 4, 3, 4, 6, 6, 3, 4, 3, 4]),
   });
   const interceptions = result.events.filter(
     (event) => event.type === GameEventType.AMSInterception,

--- a/src/simulation/runner/__tests__/weaponAttackEvents.17.test.ts
+++ b/src/simulation/runner/__tests__/weaponAttackEvents.17.test.ts
@@ -131,7 +131,7 @@ it('does not treat helper-authored AMS bay metadata as supported same-phase reus
   const result = runPhaseWithResult({
     ...scenario,
     botPlayer: new ScriptedMultiWeaponAttackAI([firstLrm.id, secondLrm.id]),
-    random: new SequenceRandom([6, 6, 3, 4, 1, 1, 6, 6, 3, 4, 1, 1]),
+    random: new SequenceRandom([6, 6, 3, 4, 3, 4, 6, 6, 3, 4, 3, 4]),
   });
   const interceptions = result.events.filter(
     (event) => event.type === GameEventType.AMSInterception,
@@ -208,12 +208,12 @@ it('runner attack resolution respects target AMS mounted arc when resolving inte
   const frontArcResult = runPhaseWithResult({
     ...frontArcScenario,
     botPlayer: new ScriptedAttackAI(lrm.id),
-    random: new SequenceRandom([6, 6, 3, 4, 1, 1]),
+    random: new SequenceRandom([6, 6, 3, 4, 3, 4]),
   });
   const rearArcResult = runPhaseWithResult({
     ...rearArcScenario,
     botPlayer: new ScriptedAttackAI(lrm.id),
-    random: new SequenceRandom([6, 6, 3, 4, 1, 1]),
+    random: new SequenceRandom([6, 6, 3, 4, 3, 4]),
   });
 
   const frontArcInterception = frontArcResult.events.find(
@@ -268,7 +268,7 @@ it('laser AMS intercepts without ammo consumption and still enters heat accounti
   const result = runPhaseWithResult({
     ...laserAmsScenario,
     botPlayer: new ScriptedAttackAI(lrm.id),
-    random: new SequenceRandom([6, 6, 3, 4, 1, 1]),
+    random: new SequenceRandom([6, 6, 3, 4, 3, 4]),
   });
   const amsInterception = result.events.find(
     (event) => event.type === GameEventType.AMSInterception,
@@ -309,7 +309,9 @@ it('laser AMS intercepts without ammo consumption and still enters heat accounti
   const laserAmsHeat = heatEvents.find(
     (event) =>
       event.type === GameEventType.HeatGenerated &&
-      (event.payload as { unitId?: string }).unitId === 'opponent-1',
+      (event.payload as { unitId?: string; source?: string }).unitId ===
+        'opponent-1' &&
+      (event.payload as { source?: string }).source === 'firing',
   ) as
     | (IGameEvent & {
         payload: { amount: number; source: string };

--- a/src/simulation/runner/__tests__/weaponAttackEvents.21.test.ts
+++ b/src/simulation/runner/__tests__/weaponAttackEvents.21.test.ts
@@ -103,11 +103,9 @@ import {
 } from './weaponAttackEvents.test-helpers';
 
 it('emits with viaTransfer:false on direct destruction (armor + structure both zeroed)', () => {
-  // Set target HD to 1/1 and feed AC/20 (damage capped at 3 on HD).
-  // 3 damage across 1 armor + 1 structure leaves residual that
-  // gets discarded per head-cap rule — HD destruction no transfer.
-  // But because hit-location is random, we use an alternate
-  // approach: zero ALL armor + leave structure at 1 everywhere.
+  // Because hit-location is random, use a target with zero armor and 1
+  // structure everywhere. The first successful hit directly destroys its
+  // location without transfer.
   // First successful hit produces a LocationDestroyed event.
   const { state, weaponsByUnit } = buildScenario({
     attackerWeapons: [createAC20()],

--- a/src/simulation/runner/phases/__tests__/weaponAttackPartialCover.test.ts
+++ b/src/simulation/runner/phases/__tests__/weaponAttackPartialCover.test.ts
@@ -321,4 +321,24 @@ describe('resolveWeaponHit — partial cover leg-hit conversion', () => {
     expect(result.units.target.armor.center_torso).toBe(47);
     expect(result.units.target.armor.right_torso).toBe(27);
   });
+
+  it('applies a TAC critical on natural hit-location roll 2 even when armor absorbs damage', () => {
+    const events: IGameEvent[] = [];
+    const result = resolveWeaponHit(resolveArgs(events, false, [1, 1, 1, 1]));
+
+    const resolved = events.find(
+      (e) => e.type === GameEventType.AttackResolved,
+    );
+    expect(resolved?.payload).toMatchObject({
+      hit: true,
+      location: 'center_torso',
+      damage: 5,
+    });
+    expect(result.units.target.armor.center_torso).toBe(42);
+    expect(result.units.target.structure.center_torso).toBe(31);
+    expect(result.units.target.componentDamage?.engineHits).toBe(1);
+    expect(
+      events.some((event) => event.type === GameEventType.CriticalHitResolved),
+    ).toBe(true);
+  });
 });

--- a/src/simulation/runner/phases/physicalAttackDamageApplication.ts
+++ b/src/simulation/runner/phases/physicalAttackDamageApplication.ts
@@ -13,13 +13,11 @@ import {
 } from '@/utils/gameplay/criticalHitResolution';
 import { resolveDamage } from '@/utils/gameplay/damage';
 import { buildDefaultComponentDamageState } from '@/utils/gameplay/gameSessionAttackResolutionHelpers';
-import { isHeadHit } from '@/utils/gameplay/hitLocation';
 import {
   applyPhysicalEquipmentCriticalEvents,
   physicalEquipmentLifecycleEventsFromManifest,
 } from '@/utils/gameplay/physicalAttacks/equipmentLifecycle';
 
-import { HEAD_HIT_DAMAGE_CAP } from '../SimulationRunnerConstants';
 import {
   applyDamageResultToState,
   buildDamageState,
@@ -43,16 +41,6 @@ export interface IApplyPhysicalDamageOptions {
 
 type PhysicalDamageResult = ReturnType<typeof resolveDamage>;
 
-function capPhysicalDamageForLocation(
-  hitLocation: CombatLocation,
-  damage: number,
-): number {
-  if (isHeadHit(hitLocation) && damage > HEAD_HIT_DAMAGE_CAP) {
-    return HEAD_HIT_DAMAGE_CAP;
-  }
-  return damage;
-}
-
 export function getOrSeedPhysicalCriticalManifest(
   manifestsByUnit: Map<string, CriticalSlotManifest> | undefined,
   unitId: string,
@@ -74,10 +62,6 @@ function resolvePhysicalDamageResult(
   },
 ): PhysicalDamageResult {
   const damageState = buildDamageState(options.unitBefore);
-  const cappedDamage = capPhysicalDamageForLocation(
-    options.hitLocation,
-    options.damage,
-  );
   return resolveDamage(
     options.manifest === undefined
       ? damageState
@@ -94,7 +78,7 @@ function resolvePhysicalDamageResult(
           },
         },
     options.hitLocation,
-    cappedDamage,
+    options.damage,
     options.d6Roller,
   );
 }

--- a/src/simulation/runner/phases/weaponAttackHitResolution.ts
+++ b/src/simulation/runner/phases/weaponAttackHitResolution.ts
@@ -2,6 +2,10 @@ import type { CriticalSlotManifest } from '@/utils/gameplay/criticalHitResolutio
 import type { ILOSDamageableCoverProvider } from '@/utils/gameplay/lineOfSight';
 
 import { IGameEvent, IGameState, IHexGrid } from '@/types/gameplay';
+import {
+  checkTACTrigger,
+  processTAC,
+} from '@/utils/gameplay/criticalHitResolution';
 import { resolveDamage } from '@/utils/gameplay/damage';
 import { buildDefaultComponentDamageState } from '@/utils/gameplay/gameSessionAttackResolutionHelpers';
 import { determineHitLocation } from '@/utils/gameplay/hitLocation';
@@ -208,6 +212,50 @@ export function resolveWeaponHit(options: {
     damage,
     d6Roller,
   );
+  let manifestAfterCriticals = damageResult.manifest ?? targetManifest;
+  let componentDamageAfterCriticals =
+    damageResult.componentDamage ?? targetComponentDamage;
+  const criticalEventsAfterDamage = [...(damageResult.criticalEvents ?? [])];
+  let damageStateAfterCriticals = damageResult.state;
+
+  const tacLocation = checkTACTrigger(hitLocationResult.roll.total, firingArc);
+  if (tacLocation) {
+    const tacResult = processTAC(
+      targetId,
+      tacLocation,
+      manifestAfterCriticals,
+      componentDamageAfterCriticals,
+      d6Roller,
+      undefined,
+      {
+        pilotAbilities: targetBefore.abilities ?? [],
+        edgePointsRemaining: damageStateAfterCriticals.edgePointsRemaining,
+        turn: currentState.turn,
+        unitId: targetId,
+        optionalRules,
+      },
+    );
+    manifestAfterCriticals = tacResult.updatedManifest;
+    componentDamageAfterCriticals = tacResult.updatedComponentDamage;
+    criticalEventsAfterDamage.push(...tacResult.events);
+    if (tacResult.edgePointsRemaining !== undefined) {
+      damageStateAfterCriticals = {
+        ...damageStateAfterCriticals,
+        edgePointsRemaining: tacResult.edgePointsRemaining,
+      };
+    }
+  }
+
+  const damageResultForCriticals = {
+    ...damageResult,
+    state: damageStateAfterCriticals,
+    manifest: manifestAfterCriticals,
+    componentDamage: componentDamageAfterCriticals,
+    criticalEvents:
+      criticalEventsAfterDamage.length > 0
+        ? criticalEventsAfterDamage
+        : undefined,
+  };
 
   // Persist the post-resolution manifest in the side table so the
   // next shot at this target sees already-destroyed slots and the
@@ -215,20 +263,20 @@ export function resolveWeaponHit(options: {
   persistDamageManifest({
     manifestsByUnit,
     targetId,
-    manifest: damageResult.manifest,
+    manifest: damageResultForCriticals.manifest,
   });
 
   currentState = applyDamageResultToState(
     currentState,
     targetId,
-    damageResult.state,
-    damageResult.result,
-    damageResult.componentDamage,
+    damageResultForCriticals.state,
+    damageResultForCriticals.result,
+    damageResultForCriticals.componentDamage,
   );
   currentState = applyEquipmentCriticalEventsToState(
     currentState,
     targetId,
-    damageResult.criticalEvents,
+    damageResultForCriticals.criticalEvents,
   );
   const targetAfter = currentState.units[targetId];
 
@@ -300,16 +348,17 @@ export function resolveWeaponHit(options: {
   // `LocationDestroyed` → `TransferDamage`. The side-torso → arm cascade
   // is detected off the pre/post-state `destroyedLocations` diff.
   const preDestroyedSet = new Set<string>(damageState.destroyedLocations);
-  const newlyDestroyed = damageResult.state.destroyedLocations.filter(
-    (loc) => !preDestroyedSet.has(loc),
-  );
+  const newlyDestroyed =
+    damageResultForCriticals.state.destroyedLocations.filter(
+      (loc) => !preDestroyedSet.has(loc),
+    );
   emitDamageChainEvents({
     events,
     gameId,
     turn: currentState.turn,
     attackerId: unitId,
     targetId,
-    damageResult,
+    damageResult: damageResultForCriticals,
     newlyDestroyed,
   });
 
@@ -320,14 +369,14 @@ export function resolveWeaponHit(options: {
   // event emitted below.
   let critUnitDestroyed = false;
   let critDestructionCause: DestructionCause | undefined = undefined;
-  if (damageResult.criticalEvents) {
+  if (damageResultForCriticals.criticalEvents) {
     const emitted = emitCritEvents({
       events,
       gameId,
       turn: currentState.turn,
       attackerId: unitId,
       targetId,
-      critEvents: damageResult.criticalEvents,
+      critEvents: damageResultForCriticals.criticalEvents,
       targetAlreadyDestroyed: targetBefore.destroyed,
       targetPilotingSkill: targetBefore.piloting,
     });
@@ -345,7 +394,7 @@ export function resolveWeaponHit(options: {
     gameId,
     unitId,
     targetId,
-    damageResult,
+    damageResult: damageResultForCriticals,
     d6Roller,
     weaponsByUnit,
     critUnitDestroyed,
@@ -357,14 +406,14 @@ export function resolveWeaponHit(options: {
 
   currentState = applyCriticalPSRTriggers(
     currentState,
-    damageResult.criticalEvents,
+    damageResultForCriticals.criticalEvents,
   );
   currentState = applyLegDamagePSR({
     currentState,
     events,
     gameId,
     targetId,
-    damageResult,
+    damageResult: damageResultForCriticals,
   });
 
   // Emit `PilotHit` for raw head-hit wounds (suppressed when a
@@ -375,7 +424,7 @@ export function resolveWeaponHit(options: {
     turn: currentState.turn,
     attackerId: unitId,
     targetId,
-    damageResult,
+    damageResult: damageResultForCriticals,
   });
 
   emitNeuralFeedbackPilotEvent({
@@ -384,7 +433,7 @@ export function resolveWeaponHit(options: {
     turn: currentState.turn,
     attackerId: unitId,
     targetId,
-    damageResult,
+    damageResult: damageResultForCriticals,
   });
 
   // Emit `UnitDestroyed` once if the shot killed the target, sourcing
@@ -397,7 +446,7 @@ export function resolveWeaponHit(options: {
     targetId,
     targetWasDestroyed: targetBefore.destroyed,
     targetIsDestroyed: currentState.units[targetId].destroyed,
-    damageResult,
+    damageResult: damageResultForCriticals,
     critUnitDestroyed,
     critDestructionCause,
   });

--- a/src/simulation/runner/phases/weaponAttackHitResolutionState.ts
+++ b/src/simulation/runner/phases/weaponAttackHitResolutionState.ts
@@ -2,15 +2,12 @@ import type { CriticalSlotManifest } from '@/utils/gameplay/criticalHitResolutio
 import type { IResolveDamageResult } from '@/utils/gameplay/damage/types';
 
 import { IGameState, type CombatLocation } from '@/types/gameplay';
-import { isHeadHit } from '@/utils/gameplay/hitLocation';
 import { applyPhysicalEquipmentCriticalEvents } from '@/utils/gameplay/physicalAttacks/equipmentLifecycle';
 import {
   applyLowProfileGlancingDamage,
   getLowProfileGlancingCriticalHitModifier,
   isLowProfileGlancingBlow,
 } from '@/utils/gameplay/quirkModifiers';
-
-import { HEAD_HIT_DAMAGE_CAP } from '../SimulationRunnerConstants';
 
 export function applyHitLocationEdgePoints(
   currentState: IGameState,
@@ -54,10 +51,6 @@ export function resolveWeaponHitDamage(options: {
     toHitNumber,
   } = options;
   let damage = isINarcExplosiveAmmo ? 6 : baseDamage;
-
-  if (isHeadHit(location) && damage > HEAD_HIT_DAMAGE_CAP) {
-    damage = HEAD_HIT_DAMAGE_CAP;
-  }
 
   const lowProfileGlancingBlow = isLowProfileGlancingBlow(
     target?.unitQuirks,

--- a/src/types/gameplay/GameSessionStateTypes.ts
+++ b/src/types/gameplay/GameSessionStateTypes.ts
@@ -9,6 +9,7 @@ import type {
   IC3EquipmentMountState,
   IC3NetworkState,
 } from '@/utils/gameplay/c3Network';
+import type { CriticalSlotManifest } from '@/utils/gameplay/criticalHitResolution';
 import type { IElectronicWarfareState } from '@/utils/gameplay/electronicWarfare';
 import type { IInfantryCombatState } from '@/utils/gameplay/infantry/state';
 import type { IProtoMechCombatState } from '@/utils/gameplay/protomech/state';
@@ -545,6 +546,12 @@ export interface IUnitGameState {
   readonly empShutdownTurns?: number;
   /** Ammo bin state tracking */
   readonly ammoState?: Record<string, IAmmoSlotState>;
+  /**
+   * Optional catalog-hydrated critical-slot manifest. When present, combat
+   * critical resolution uses it instead of the synthetic default manifest so
+   * ammo/equipment slots are hittable and replayed slot destruction is stable.
+   */
+  readonly criticalSlotManifest?: CriticalSlotManifest;
   /**
    * Optional per-location armor type projected from construction data or test
    * fixtures. Missing keys are treated as standard armor for combat effects

--- a/src/types/gameplay/GameSessionUnitTypes.ts
+++ b/src/types/gameplay/GameSessionUnitTypes.ts
@@ -4,6 +4,7 @@
  */
 
 import type { IC3EquipmentMountState } from '@/utils/gameplay/c3Network';
+import type { CriticalSlotManifest } from '@/utils/gameplay/criticalHitResolution';
 
 import type { EngineType } from '../construction/EngineType';
 import type {
@@ -263,6 +264,11 @@ export interface IGameUnit {
    * data per `wire-ammo-consumption`.
    */
   readonly ammoConstruction?: readonly IAmmoConstructionInit[];
+  /**
+   * Optional catalog-hydrated critical-slot manifest for interactive combat.
+   * Synthetic fixtures can omit it and keep the legacy default manifest.
+   */
+  readonly criticalSlotManifest?: CriticalSlotManifest;
   /**
    * Optional per-location armor type projected into combat state. Producers
    * may supply a single uniform armor type across all locations or a richer

--- a/src/types/gameplay/VehicleCombatInterfaces.ts
+++ b/src/types/gameplay/VehicleCombatInterfaces.ts
@@ -156,7 +156,7 @@ export interface IMotiveDamageState {
   readonly sinking: boolean;
   /** Primary turret has been locked by a crit. */
   readonly turretLocked: boolean;
-  /** Engine-hit count (2 destroys the vehicle). */
+  /** Engine-hit count; engine hits immobilize but do not destroy the vehicle. */
   readonly engineHits: number;
   /** Driver-hit count (per TW, 2 kills the crew). */
   readonly driverHits: number;

--- a/src/utils/gameplay/__tests__/ammoTracking.explosions-and-case.fragment.ts
+++ b/src/utils/gameplay/__tests__/ammoTracking.explosions-and-case.fragment.ts
@@ -131,10 +131,10 @@ describe('calculateCASEEffects', () => {
     expect(result.pilotDamage).toBe(0);
   });
 
-  it('No CASE: full transfer, pilot takes 1 damage', () => {
+  it('No CASE: full transfer, pilot takes 2 damage', () => {
     const result = calculateCASEEffects(150, 'none');
     expect(result.transferDamage).toBe(150);
-    expect(result.pilotDamage).toBe(1);
+    expect(result.pilotDamage).toBe(2);
   });
 
   it('zero damage = no effects regardless of CASE', () => {
@@ -174,7 +174,7 @@ describe('resolveAmmoExplosion with CASE variants', () => {
     const result = resolveAmmoExplosion(ammoState, 'bin-1', 10, 'none');
     expect(result!.totalDamage).toBe(100);
     expect(result!.transferDamage).toBe(100);
-    expect(result!.pilotDamage).toBe(1);
+    expect(result!.pilotDamage).toBe(2);
   });
 });
 
@@ -185,10 +185,10 @@ describe('CASE-adjusted ammo explosion damage', () => {
     expect(caseProtectionForLocation(unit, 'right_torso')).toBe('none');
   });
 
-  it('caps standard CASE damage to 10 before local damage resolution', () => {
+  it('contains standard CASE damage to local internal structure before damage resolution', () => {
     const unit = makeCaseUnit({
       armor: { right_torso: 12 },
-      structure: { right_torso: 10 },
+      structure: { right_torso: 15 },
       caseProtection: { right_torso: 'case' },
     });
 
@@ -196,7 +196,7 @@ describe('CASE-adjusted ammo explosion damage', () => {
       resolveCaseAdjustedAmmoExplosionDamage(unit, 'right_torso', 100),
     ).toEqual({
       caseProtection: 'case',
-      damageToApply: 10,
+      damageToApply: 15,
     });
   });
 
@@ -351,7 +351,7 @@ describe('resolveGaussExplosion', () => {
   it('no CASE: transfers full 20 damage + pilot damage', () => {
     const noCase = resolveGaussExplosion('right_torso', 'none');
     expect(noCase.transferDamage).toBe(20);
-    expect(noCase.pilotDamage).toBe(1);
+    expect(noCase.pilotDamage).toBe(2);
   });
 
   it('CASE II: transfers only 1 point', () => {

--- a/src/utils/gameplay/__tests__/ammoTracking.heat-selection-flow.fragment.ts
+++ b/src/utils/gameplay/__tests__/ammoTracking.heat-selection-flow.fragment.ts
@@ -291,7 +291,7 @@ describe('ammo explosion integration with CASE', () => {
     const result = resolveAmmoExplosion(ammoState, 'ac20-1', 20, caseLevel);
     expect(result!.totalDamage).toBe(100);
     expect(result!.transferDamage).toBe(100);
-    expect(result!.pilotDamage).toBe(1);
+    expect(result!.pilotDamage).toBe(2);
   });
 });
 
@@ -338,19 +338,18 @@ describe('resolveBattleMechAmmoExplosionPilotDamage', () => {
     ).toBe(0);
   });
 
-  it('only applies the optional CASE pilot-damage reduction when enabled', () => {
+  it('suppresses ammo-explosion pilot damage when CASE or CASE II protects the location', () => {
     expect(
       resolveBattleMechAmmoExplosionPilotDamage({
         totalDamage: 100,
         caseProtection: 'case',
       }),
-    ).toBe(2);
+    ).toBe(0);
     expect(
       resolveBattleMechAmmoExplosionPilotDamage({
         totalDamage: 100,
-        caseProtection: 'case',
-        advancedCasePilotDamage: true,
+        caseProtection: 'case_ii',
       }),
-    ).toBe(1);
+    ).toBe(0);
   });
 });

--- a/src/utils/gameplay/__tests__/criticalHitResolution.01.test.ts
+++ b/src/utils/gameplay/__tests__/criticalHitResolution.01.test.ts
@@ -170,13 +170,32 @@ describe('selectCriticalSlot', () => {
   it('uses dice roller for random selection', () => {
     const manifest = buildDefaultCriticalSlotManifest();
     // CT has 7 slots (3 engine + 4 gyro). Roll 1 → index 0, Roll 4 → index 3
-    const roller1 = makeDiceRoller([1]);
+    const roller1 = makeDiceRoller([1, 1]);
     const slot1 = selectCriticalSlot(manifest, 'center_torso', roller1);
 
-    const roller4 = makeDiceRoller([4]);
+    const roller4 = makeDiceRoller([1, 4]);
     const slot4 = selectCriticalSlot(manifest, 'center_torso', roller4);
 
     expect(slot1!.slotIndex).not.toBe(slot4!.slotIndex);
+  });
+
+  it('can select represented slots above d6 index 5 using only d6 values', () => {
+    const manifest = buildCriticalSlotManifest({
+      right_torso: Array.from({ length: 12 }, (_, index) => ({
+        slotIndex: index,
+        componentType: 'equipment' as const,
+        componentName: `Slot ${index}`,
+        destroyed: false,
+      })),
+    });
+    const roller = makeDiceRoller([2, 2]);
+
+    const slot = selectCriticalSlot(manifest, 'right_torso', roller);
+
+    expect(slot).toMatchObject({
+      slotIndex: 7,
+      componentName: 'Slot 7',
+    });
   });
 });
 

--- a/src/utils/gameplay/__tests__/criticalHitResolution.05.test.ts
+++ b/src/utils/gameplay/__tests__/criticalHitResolution.05.test.ts
@@ -240,7 +240,7 @@ describe('Through-Armor Critical', () => {
           },
         ],
       });
-      const roller = makeDiceRoller([1, 6]);
+      const roller = makeDiceRoller([1, 1, 1, 2]);
 
       const result = processTAC(
         'unit-1',

--- a/src/utils/gameplay/__tests__/criticalHitResolution.07.test.ts
+++ b/src/utils/gameplay/__tests__/criticalHitResolution.07.test.ts
@@ -10,8 +10,8 @@ import {
 describe('equipment slots in manifest', () => {
   it('weapon slot in torso can be critted', () => {
     const manifest = makeManifestWithWeapons();
-    // Force 1 crit, select slot index that maps to weapon
-    const roller = makeDiceRoller([4]); // 4th available slot → weapon at index 3
+    // Force 1 crit, select slot index that maps to weapon.
+    const roller = makeDiceRoller([1, 4]);
     const result = resolveCriticalHits(
       'unit-1',
       'right_torso',
@@ -30,7 +30,7 @@ describe('equipment slots in manifest', () => {
 
   it('heat sink slot can be critted', () => {
     const manifest = makeManifestWithWeapons();
-    const roller = makeDiceRoller([5]); // 5th slot → heat sink
+    const roller = makeDiceRoller([1, 5]);
     const result = resolveCriticalHits(
       'unit-1',
       'right_torso',
@@ -47,7 +47,7 @@ describe('equipment slots in manifest', () => {
 
   it('jump jet slot can be critted', () => {
     const manifest = makeManifestWithWeapons();
-    const roller = makeDiceRoller([6]); // 6th slot → jump jet
+    const roller = makeDiceRoller([1, 6]);
     const result = resolveCriticalHits(
       'unit-1',
       'right_torso',
@@ -64,7 +64,7 @@ describe('equipment slots in manifest', () => {
 
   it('ammo slot can be critted', () => {
     const manifest = makeManifestWithWeapons();
-    const roller = makeDiceRoller([7]); // 7th slot → ammo
+    const roller = makeDiceRoller([2, 1]);
     const result = resolveCriticalHits(
       'unit-1',
       'right_torso',
@@ -80,7 +80,7 @@ describe('equipment slots in manifest', () => {
 
   it('generic equipment slot resolves only as EquipmentDestroyed', () => {
     const manifest = makeManifestWithWeapons();
-    const roller = makeDiceRoller([8]);
+    const roller = makeDiceRoller([2, 2]);
     const result = resolveCriticalHits(
       'unit-1',
       'right_torso',

--- a/src/utils/gameplay/__tests__/criticalHitResolution.10.test.ts
+++ b/src/utils/gameplay/__tests__/criticalHitResolution.10.test.ts
@@ -235,7 +235,7 @@ describe('equipment slots in manifest', () => {
         },
       ],
     });
-    const roller = makeDiceRoller([1, 6]);
+    const roller = makeDiceRoller([1, 1, 1, 2]);
 
     const result = resolveCriticalHits(
       'unit-1',

--- a/src/utils/gameplay/__tests__/criticalHitResolution.11.test.ts
+++ b/src/utils/gameplay/__tests__/criticalHitResolution.11.test.ts
@@ -29,7 +29,7 @@ describe('equipment slots in manifest', () => {
         },
       ],
     });
-    const roller = makeDiceRoller([1, 6]);
+    const roller = makeDiceRoller([1, 1, 1, 2]);
 
     const result = resolveCriticalHits(
       'unit-1',
@@ -75,7 +75,7 @@ describe('equipment slots in manifest', () => {
         },
       ],
     });
-    const roller = makeDiceRoller([1, 6]);
+    const roller = makeDiceRoller([1, 1]);
 
     const result = resolveCriticalHits(
       'unit-1',
@@ -108,7 +108,7 @@ describe('equipment slots in manifest', () => {
         },
       ],
     });
-    const roller = makeDiceRoller([1, 6]);
+    const roller = makeDiceRoller([1, 1]);
 
     const result = resolveCriticalHits(
       'unit-1',

--- a/src/utils/gameplay/__tests__/damagePipeline.01.fragment.ts
+++ b/src/utils/gameplay/__tests__/damagePipeline.01.fragment.ts
@@ -3,7 +3,7 @@
  *
  * Tests for Phase 3: Wire Damage Pipeline
  * Covers: armor absorption, structure penetration, transfer chain,
- * side torso cascade, head cap, damageThisPhase tracking
+ * side torso cascade, head full damage, damageThisPhase tracking
  */
 
 import { WeaponCategory } from '@/types/equipment/weapons/interfaces';

--- a/src/utils/gameplay/__tests__/damagePipeline.02.fragment.ts
+++ b/src/utils/gameplay/__tests__/damagePipeline.02.fragment.ts
@@ -3,7 +3,7 @@
  *
  * Tests for Phase 3: Wire Damage Pipeline
  * Covers: armor absorption, structure penetration, transfer chain,
- * side torso cascade, head cap, damageThisPhase tracking
+ * side torso cascade, head full damage, damageThisPhase tracking
  */
 
 import { WeaponCategory } from '@/types/equipment/weapons/interfaces';

--- a/src/utils/gameplay/__tests__/damagePipeline.03.fragment.ts
+++ b/src/utils/gameplay/__tests__/damagePipeline.03.fragment.ts
@@ -3,7 +3,7 @@
  *
  * Tests for Phase 3: Wire Damage Pipeline
  * Covers: armor absorption, structure penetration, transfer chain,
- * side torso cascade, head cap, damageThisPhase tracking
+ * side torso cascade, head full damage, damageThisPhase tracking
  */
 
 import { WeaponCategory } from '@/types/equipment/weapons/interfaces';
@@ -133,24 +133,25 @@ function createTestDamageState(
   };
 }
 
-describe('Damage Pipeline - Head Cap Rule', () => {
-  it('should cap head damage at 3 from standard weapon via resolveDamage', () => {
+describe('Damage Pipeline - head damage', () => {
+  it('should apply small head damage normally via resolveDamage', () => {
     const state = createTestDamageState();
-    // Head has 9 armor. 3 damage (capped from higher) should reduce to 6
     const result = resolveDamage(state, 'head', 3);
 
     expect(result.result.locationDamages[0].armorDamage).toBe(3);
     expect(result.result.locationDamages[0].armorRemaining).toBe(6);
   });
 
-  it('should apply full 3 damage even for weapons doing 20+ damage (head-capped)', () => {
-    // This tests that gameSession.ts caps before calling resolveDamage
-    // The spec says max 3 from single standard weapon
+  it('should apply full high-damage hits to head armor and structure', () => {
     const state = createTestDamageState();
-    const result = resolveDamage(state, 'head', 3);
+    const result = resolveDamage(state, 'head', 20);
 
-    expect(result.result.locationDamages[0].damage).toBe(3);
-    expect(result.result.locationDamages[0].armorRemaining).toBe(6);
+    expect(result.result.locationDamages[0].damage).toBe(20);
+    expect(result.result.locationDamages[0].armorDamage).toBe(9);
+    expect(result.result.locationDamages[0].structureDamage).toBe(3);
+    expect(result.result.locationDamages[0].armorRemaining).toBe(0);
+    expect(result.result.locationDamages[0].structureRemaining).toBe(0);
+    expect(result.result.locationDamages[0].destroyed).toBe(true);
   });
 
   it('should allow under-3 damage to head without modification', () => {

--- a/src/utils/gameplay/__tests__/damagePipeline.04.fragment.ts
+++ b/src/utils/gameplay/__tests__/damagePipeline.04.fragment.ts
@@ -3,7 +3,7 @@
  *
  * Tests for Phase 3: Wire Damage Pipeline
  * Covers: armor absorption, structure penetration, transfer chain,
- * side torso cascade, head cap, damageThisPhase tracking
+ * side torso cascade, head full damage, damageThisPhase tracking
  */
 
 import { WeaponCategory } from '@/types/equipment/weapons/interfaces';

--- a/src/utils/gameplay/__tests__/damagePipeline.05.fragment.ts
+++ b/src/utils/gameplay/__tests__/damagePipeline.05.fragment.ts
@@ -3,7 +3,7 @@
  *
  * Tests for Phase 3: Wire Damage Pipeline
  * Covers: armor absorption, structure penetration, transfer chain,
- * side torso cascade, head cap, damageThisPhase tracking
+ * side torso cascade, head full damage, damageThisPhase tracking
  */
 
 import { WeaponCategory } from '@/types/equipment/weapons/interfaces';

--- a/src/utils/gameplay/__tests__/damagePipeline.06.fragment.ts
+++ b/src/utils/gameplay/__tests__/damagePipeline.06.fragment.ts
@@ -3,7 +3,7 @@
  *
  * Tests for Phase 3: Wire Damage Pipeline
  * Covers: armor absorption, structure penetration, transfer chain,
- * side torso cascade, head cap, damageThisPhase tracking
+ * side torso cascade, head full damage, damageThisPhase tracking
  */
 
 import { WeaponCategory } from '@/types/equipment/weapons/interfaces';

--- a/src/utils/gameplay/__tests__/gameSessionAttackResolution.ammoExplosions.test.ts
+++ b/src/utils/gameplay/__tests__/gameSessionAttackResolution.ammoExplosions.test.ts
@@ -1,0 +1,451 @@
+import type { IWeapon } from '@/simulation/ai/types';
+
+import { applyCritAmmoExplosions } from '@/simulation/runner/phases/weaponAttackAmmoExplosions';
+import {
+  CombatLocation,
+  GameEventType,
+  GamePhase,
+  GameSide,
+  Facing,
+  MovementType,
+  RangeBracket,
+  IAmmoExplosionPayload,
+  IDamageAppliedPayload,
+  IGameEvent,
+  IGameConfig,
+  IGameSession,
+  IGameState,
+  IGameUnit,
+  IHexCoordinate,
+  IWeaponAttack,
+} from '@/types/gameplay';
+
+import type { IResolveDamageResult } from '../damage';
+
+import {
+  buildCriticalSlotManifest,
+  type CriticalHitEvent,
+} from '../criticalHitResolution';
+import { createDamageAppliedEvent } from '../gameEvents';
+import {
+  advancePhase,
+  appendEvent,
+  createGameSession,
+  declareAttack,
+  declareMovement,
+  lockAttack,
+  lockMovement,
+  resolveAllAttacks,
+  rollInitiative,
+  startGame,
+  type DiceRoller,
+} from '../gameSession';
+import { createDiceRoll } from '../hitLocation';
+
+function config(): IGameConfig {
+  return {
+    mapRadius: 10,
+    turnLimit: 0,
+    victoryConditions: ['elimination'],
+    optionalRules: [],
+  };
+}
+
+const targetAmmoBins = [
+  {
+    binId: 'target-ct-ac20',
+    weaponType: 'AC/20',
+    location: 'center_torso',
+    maxRounds: 5,
+    damagePerRound: 20,
+    isExplosive: true,
+  },
+  {
+    binId: 'target-lt-ac20',
+    weaponType: 'AC/20',
+    location: 'left_torso',
+    maxRounds: 5,
+    damagePerRound: 20,
+    isExplosive: true,
+  },
+  {
+    binId: 'target-rt-ac20',
+    weaponType: 'AC/20',
+    location: 'right_torso',
+    maxRounds: 5,
+    damagePerRound: 20,
+    isExplosive: true,
+  },
+] as const;
+
+const targetAmmoBinByLocation = Object.fromEntries(
+  targetAmmoBins.map((bin) => [bin.location, bin]),
+) as Record<string, (typeof targetAmmoBins)[number]>;
+
+function ammoSlotFor(binId: string) {
+  return {
+    slotIndex: 0,
+    componentType: 'ammo' as const,
+    componentName: 'AC/20 Ammo',
+    ammoBinId: binId,
+    destroyed: false,
+  };
+}
+
+function units(): readonly IGameUnit[] {
+  return [
+    {
+      id: 'attacker',
+      name: 'Attacker',
+      side: GameSide.Player,
+      unitRef: 'attacker',
+      pilotRef: 'pilot-1',
+      gunnery: 4,
+      piloting: 5,
+    },
+    {
+      id: 'target',
+      name: 'Target',
+      side: GameSide.Opponent,
+      unitRef: 'target',
+      pilotRef: 'pilot-2',
+      gunnery: 4,
+      piloting: 5,
+      ammoConstruction: targetAmmoBins,
+      caseProtection: {
+        center_torso: 'case',
+        left_torso: 'case',
+        right_torso: 'case',
+      },
+      criticalSlotManifest: buildCriticalSlotManifest({
+        center_torso: [ammoSlotFor('target-ct-ac20')],
+        left_torso: [ammoSlotFor('target-lt-ac20')],
+        right_torso: [ammoSlotFor('target-rt-ac20')],
+      }),
+    },
+  ];
+}
+
+function advanceToWeaponAttack(session: IGameSession): IGameSession {
+  let currentSession = rollInitiative(session);
+  currentSession = advancePhase(currentSession);
+
+  const attackerFrom: IHexCoordinate = { q: 0, r: 0 };
+  const targetFrom: IHexCoordinate = { q: 2, r: 0 };
+  currentSession = declareMovement(
+    currentSession,
+    'attacker',
+    attackerFrom,
+    { q: 1, r: 0 },
+    Facing.North,
+    MovementType.Walk,
+    1,
+    1,
+  );
+  currentSession = lockMovement(currentSession, 'attacker');
+  currentSession = declareMovement(
+    currentSession,
+    'target',
+    targetFrom,
+    { q: 2, r: 0 },
+    Facing.South,
+    MovementType.Stationary,
+    0,
+    0,
+  );
+  currentSession = lockMovement(currentSession, 'target');
+  return advancePhase(currentSession);
+}
+
+function primeTargetStructure(session: IGameSession): IGameSession {
+  let currentSession = session;
+  for (const [location, structureRemaining] of [
+    ['center_torso', 31],
+    ['left_torso', 21],
+    ['right_torso', 21],
+  ] as const) {
+    currentSession = appendEvent(
+      currentSession,
+      createDamageAppliedEvent({
+        gameId: currentSession.id,
+        sequence: currentSession.events.length,
+        turn: currentSession.currentState.turn,
+        phase: GamePhase.WeaponAttack,
+        unitId: 'target',
+        location,
+        damage: 0,
+        armorRemaining: 0,
+        structureRemaining,
+        locationDestroyed: false,
+      }),
+    );
+  }
+  return currentSession;
+}
+
+function scriptedRoller(): DiceRoller {
+  const rolls = [
+    createDiceRoll(6, 6), // attack roll hits
+    createDiceRoll(1, 1), // TAC hit location: torso by firing arc
+    createDiceRoll(4, 1), // critical determination d6 #1
+    createDiceRoll(4, 1), // critical determination d6 #2 => total 8, one crit
+    createDiceRoll(1, 1), // critical slot d6 #1
+    createDiceRoll(1, 1), // critical slot d6 #2 => slot 0
+  ];
+  let index = 0;
+  return () => rolls[index++] ?? createDiceRoll(6, 6);
+}
+
+function runnerCritExplosionSummary(
+  sourceState: IGameState,
+  location: CombatLocation,
+  bin: (typeof targetAmmoBins)[number],
+  preExplosionDamage: IDamageAppliedPayload,
+) {
+  const events: IGameEvent[] = [];
+  const target = sourceState.units.target;
+  const runnerState: IGameState = {
+    ...sourceState,
+    units: {
+      ...sourceState.units,
+      target: {
+        ...target,
+        armor: {
+          ...target.armor,
+          [location]: preExplosionDamage.armorRemaining,
+        },
+        structure: {
+          ...target.structure,
+          [location]: preExplosionDamage.structureRemaining,
+        },
+        ammoState: {
+          ...target.ammoState,
+          [bin.binId]: {
+            ...target.ammoState?.[bin.binId],
+            ...bin,
+            remainingRounds: bin.maxRounds,
+          },
+        },
+      },
+    },
+  };
+  const targetWeapon: IWeapon = {
+    id: `${bin.weaponType}-0`,
+    name: bin.weaponType,
+    shortRange: 3,
+    mediumRange: 6,
+    longRange: 9,
+    damage: bin.damagePerRound,
+    heat: 7,
+    minRange: 0,
+    ammoPerTon: bin.maxRounds,
+    destroyed: false,
+  };
+  const criticalEvents: CriticalHitEvent[] = [
+    {
+      type: 'critical_hit_resolved',
+      payload: {
+        unitId: 'target',
+        location,
+        componentType: 'ammo',
+        componentName: 'AC/20 Ammo',
+        slotIndex: 0,
+        ammoBinId: bin.binId,
+        effect: 'Ammo destroyed',
+        destroyed: true,
+      },
+    },
+  ];
+  const damageResult = {
+    state: runnerState.units.target,
+    result: {
+      locationDamages: [],
+      criticalHits: [],
+      unitDestroyed: false,
+    },
+    criticalEvents,
+  } as unknown as IResolveDamageResult;
+
+  const result = applyCritAmmoExplosions({
+    currentState: runnerState,
+    events,
+    gameId: runnerState.gameId,
+    unitId: 'attacker',
+    targetId: 'target',
+    damageResult,
+    d6Roller: () => 6,
+    weaponsByUnit: new Map<string, readonly IWeapon[]>([
+      ['target', [targetWeapon]],
+    ]),
+    critUnitDestroyed: false,
+    critDestructionCause: undefined,
+  });
+
+  const explosion = events.find(
+    (event) => event.type === GameEventType.AmmoExplosion,
+  )?.payload as IAmmoExplosionPayload | undefined;
+  const damage = events
+    .filter((event) => event.type === GameEventType.DamageApplied)
+    .map((event) => event.payload as IDamageAppliedPayload);
+
+  return {
+    explosion: explosion
+      ? {
+          location: explosion.location,
+          binId: explosion.binId,
+          damage: explosion.damage,
+          caseProtection: explosion.caseProtection,
+          source: explosion.source,
+        }
+      : undefined,
+    damage: damage.map((payload) => ({
+      location: payload.location,
+      damage: payload.damage,
+      structureRemaining: payload.structureRemaining,
+      locationDestroyed: payload.locationDestroyed,
+    })),
+    transferCount: events.filter(
+      (event) => event.type === GameEventType.TransferDamage,
+    ).length,
+    pilotHitCount: events.filter(
+      (event) => event.type === GameEventType.PilotHit,
+    ).length,
+    remainingRounds:
+      result.currentState.units.target.ammoState?.[bin.binId].remainingRounds,
+    destroyedLocations: result.currentState.units.target.destroyedLocations,
+  };
+}
+
+describe('interactive attack critical ammo explosions', () => {
+  it('applies loaded ammo-bin explosion damage through the live resolveAttack path', () => {
+    let session = createGameSession(config(), units());
+    session = startGame(session, GameSide.Player);
+    session = advanceToWeaponAttack(session);
+    session = primeTargetStructure(session);
+
+    const attack: IWeaponAttack[] = [
+      {
+        weaponId: 'medium-laser-1',
+        weaponName: 'Medium Laser',
+        damage: 5,
+        heat: 3,
+        category: 'energy' as never,
+        minRange: 0,
+        shortRange: 3,
+        mediumRange: 6,
+        longRange: 9,
+        isCluster: false,
+      },
+    ];
+    session = declareAttack(
+      session,
+      'attacker',
+      'target',
+      attack,
+      2,
+      RangeBracket.Short,
+    );
+    session = lockAttack(session, 'attacker');
+    session = lockAttack(session, 'target');
+
+    const next = resolveAllAttacks(session, scriptedRoller());
+
+    const explosion = next.events.find(
+      (event) => event.type === GameEventType.AmmoExplosion,
+    );
+    expect(explosion?.phase).toBe(GamePhase.WeaponAttack);
+    const explosionPayload = explosion?.payload as IAmmoExplosionPayload;
+    expect(explosionPayload).toMatchObject({
+      unitId: 'target',
+      weaponType: 'AC/20',
+      roundsDestroyed: 5,
+      damage: 100,
+      caseProtection: 'case',
+      source: 'CritInduced',
+    });
+    const explodedBin = targetAmmoBinByLocation[explosionPayload.location];
+    expect(explodedBin).toBeDefined();
+    expect(explosionPayload.binId).toBe(explodedBin.binId);
+
+    const explosionIndex = next.events.findIndex(
+      (event) => event.type === GameEventType.AmmoExplosion,
+    );
+    const preExplosionDamage = next.events
+      .slice(0, explosionIndex)
+      .reverse()
+      .find(
+        (event) =>
+          event.type === GameEventType.DamageApplied &&
+          (event.payload as IDamageAppliedPayload).unitId === 'target' &&
+          (event.payload as IDamageAppliedPayload).location ===
+            explosionPayload.location,
+      )?.payload as IDamageAppliedPayload | undefined;
+    expect(preExplosionDamage).toBeDefined();
+    const damageAfterExplosion = next.events
+      .slice(explosionIndex + 1)
+      .filter((event) => event.type === GameEventType.DamageApplied)
+      .map((event) => event.payload as IDamageAppliedPayload);
+    expect(damageAfterExplosion).toEqual([
+      expect.objectContaining({
+        location: explosionPayload.location,
+        damage: expect.any(Number),
+        armorRemaining: 0,
+        structureRemaining: 0,
+        locationDestroyed: true,
+      }),
+    ]);
+    expect(damageAfterExplosion[0].damage).toBeGreaterThan(0);
+    expect(
+      next.events.some((event) => event.type === GameEventType.TransferDamage),
+    ).toBe(false);
+    expect(
+      next.events.some((event) => event.type === GameEventType.PilotHit),
+    ).toBe(false);
+    expect(
+      next.currentState.units.target.ammoState?.[explodedBin.binId]
+        .remainingRounds,
+    ).toBe(0);
+    expect(
+      next.currentState.units.target.criticalSlotManifest?.[
+        explosionPayload.location
+      ][0].destroyed,
+    ).toBe(true);
+    expect(next.currentState.units.target.destroyedLocations).toContain(
+      explosionPayload.location,
+    );
+
+    const interactiveSummary = {
+      explosion: {
+        location: explosionPayload.location,
+        binId: explosionPayload.binId,
+        damage: explosionPayload.damage,
+        caseProtection: explosionPayload.caseProtection,
+        source: explosionPayload.source,
+      },
+      damage: damageAfterExplosion.map((payload) => ({
+        location: payload.location,
+        damage: payload.damage,
+        structureRemaining: payload.structureRemaining,
+        locationDestroyed: payload.locationDestroyed,
+      })),
+      transferCount: next.events.filter(
+        (event) => event.type === GameEventType.TransferDamage,
+      ).length,
+      pilotHitCount: next.events.filter(
+        (event) => event.type === GameEventType.PilotHit,
+      ).length,
+      remainingRounds:
+        next.currentState.units.target.ammoState?.[explodedBin.binId]
+          .remainingRounds,
+      destroyedLocations: next.currentState.units.target.destroyedLocations,
+    };
+    expect(
+      runnerCritExplosionSummary(
+        session.currentState,
+        explosionPayload.location as CombatLocation,
+        explodedBin,
+        preExplosionDamage!,
+      ),
+    ).toEqual(interactiveSummary);
+  });
+});

--- a/src/utils/gameplay/__tests__/heatSystem.13.fragment.ts
+++ b/src/utils/gameplay/__tests__/heatSystem.13.fragment.ts
@@ -371,12 +371,7 @@ describe('resolveHeatPhase', () => {
           event.phase === GamePhase.Heat &&
           (event.payload as IPilotHitPayload).source === 'ammo_explosion',
       );
-      expect(pilotHit?.payload as IPilotHitPayload).toMatchObject({
-        unitId: 'unit-2',
-        wounds: 2,
-        totalWounds: 2,
-        source: 'ammo_explosion',
-      });
+      expect(pilotHit).toBeUndefined();
 
       expect(
         session.events.some(

--- a/src/utils/gameplay/__tests__/motiveDamage.test.ts
+++ b/src/utils/gameplay/__tests__/motiveDamage.test.ts
@@ -10,11 +10,11 @@
 import { GroundMotionType } from '@/types/unit/BaseUnitInterfaces';
 
 import {
-  applyMotionTypeAggravation,
   applyMotiveDamageToState,
   computeEffectiveMP,
   createMotiveDamageState,
   motiveDamageFromRoll,
+  motiveRollModifierForMotionType,
   requiresMotiveRollOnAnyHit,
 } from '../motiveDamage';
 
@@ -26,21 +26,21 @@ describe('motiveDamage', () => {
       mp: number;
       immo: boolean;
     }[] = [
-      { dice: [1, 1], severity: 'none', mp: 0, immo: false }, // 2
-      { dice: [1, 2], severity: 'none', mp: 0, immo: false }, // 3
-      { dice: [2, 2], severity: 'none', mp: 0, immo: false }, // 4
-      { dice: [2, 3], severity: 'none', mp: 0, immo: false }, // 5
-      { dice: [3, 3], severity: 'minor', mp: 1, immo: false }, // 6
-      { dice: [3, 4], severity: 'minor', mp: 1, immo: false }, // 7
-      { dice: [4, 4], severity: 'moderate', mp: 2, immo: false }, // 8
-      { dice: [4, 5], severity: 'moderate', mp: 2, immo: false }, // 9
-      { dice: [5, 5], severity: 'heavy', mp: 3, immo: false }, // 10
-      { dice: [5, 6], severity: 'heavy', mp: 3, immo: false }, // 11
-      { dice: [6, 6], severity: 'immobilized', mp: 0, immo: true }, // 12
+      { dice: [1, 1], severity: 'none', mp: 0, immo: false },
+      { dice: [1, 2], severity: 'none', mp: 0, immo: false },
+      { dice: [2, 2], severity: 'none', mp: 0, immo: false },
+      { dice: [2, 3], severity: 'none', mp: 0, immo: false },
+      { dice: [3, 3], severity: 'minor', mp: 1, immo: false },
+      { dice: [3, 4], severity: 'minor', mp: 1, immo: false },
+      { dice: [4, 4], severity: 'moderate', mp: 2, immo: false },
+      { dice: [4, 5], severity: 'moderate', mp: 2, immo: false },
+      { dice: [5, 5], severity: 'heavy', mp: 3, immo: false },
+      { dice: [5, 6], severity: 'heavy', mp: 3, immo: false },
+      { dice: [6, 6], severity: 'immobilized', mp: 0, immo: true },
     ];
 
     for (const c of cases) {
-      it(`roll ${c.dice[0] + c.dice[1]} → ${c.severity}`, () => {
+      it(`roll ${c.dice[0] + c.dice[1]} -> ${c.severity}`, () => {
         const r = motiveDamageFromRoll(c.dice);
         expect(r.severity).toBe(c.severity);
         expect(r.mpPenalty).toBe(c.mp);
@@ -50,65 +50,64 @@ describe('motiveDamage', () => {
   });
 
   describe('motion-type sensitivity (task 4.6)', () => {
-    it('hover vehicles roll on ANY hit', () => {
+    it('hover-class vehicles roll on any hit', () => {
       expect(requiresMotiveRollOnAnyHit(GroundMotionType.HOVER)).toBe(true);
       expect(requiresMotiveRollOnAnyHit(GroundMotionType.HYDROFOIL)).toBe(true);
       expect(requiresMotiveRollOnAnyHit(GroundMotionType.NAVAL)).toBe(true);
     });
 
-    it('tracked / wheeled do NOT roll on every hit', () => {
+    it('tracked / wheeled do not roll on every hit', () => {
       expect(requiresMotiveRollOnAnyHit(GroundMotionType.TRACKED)).toBe(false);
       expect(requiresMotiveRollOnAnyHit(GroundMotionType.WHEELED)).toBe(false);
     });
   });
 
-  describe('motion-type aggravation (task 5)', () => {
-    it('wheeled heavy → immobilized', () => {
-      const heavy = motiveDamageFromRoll([5, 5]);
-      const aggr = applyMotionTypeAggravation(heavy, GroundMotionType.WHEELED);
-      expect(aggr.severity).toBe('immobilized');
-      expect(aggr.immobilized).toBe(true);
-    });
-
-    it('hover heavy → immobilized', () => {
-      const heavy = motiveDamageFromRoll([5, 5]);
-      const aggr = applyMotionTypeAggravation(heavy, GroundMotionType.HOVER);
-      expect(aggr.immobilized).toBe(true);
-    });
-
-    it('tracked heavy stays heavy', () => {
-      const heavy = motiveDamageFromRoll([5, 5]);
-      const aggr = applyMotionTypeAggravation(heavy, GroundMotionType.TRACKED);
-      expect(aggr.severity).toBe('heavy');
-      expect(aggr.immobilized).toBe(false);
-    });
-
-    it('naval heavy stays heavy but caller sets sinking', () => {
-      const heavy = motiveDamageFromRoll([5, 5]);
-      const aggr = applyMotionTypeAggravation(heavy, GroundMotionType.NAVAL);
-      expect(aggr.severity).toBe('heavy');
-    });
-
-    it('non-heavy rolls are unchanged by aggravation', () => {
-      const minor = motiveDamageFromRoll([3, 3]);
-      expect(applyMotionTypeAggravation(minor, GroundMotionType.WHEELED)).toBe(
-        minor,
+  describe('motive roll modifiers (task 5)', () => {
+    it('maps motion types to MegaMek flat roll modifiers', () => {
+      expect(motiveRollModifierForMotionType(GroundMotionType.TRACKED)).toBe(0);
+      expect(motiveRollModifierForMotionType(GroundMotionType.WHEELED)).toBe(2);
+      expect(motiveRollModifierForMotionType(GroundMotionType.HOVER)).toBe(3);
+      expect(motiveRollModifierForMotionType(GroundMotionType.HYDROFOIL)).toBe(
+        3,
       );
+      expect(motiveRollModifierForMotionType(GroundMotionType.WIGE)).toBe(4);
+      expect(motiveRollModifierForMotionType(GroundMotionType.NAVAL)).toBe(0);
+    });
+
+    it('applies flat modifiers before table lookup', () => {
+      const modified = motiveDamageFromRoll([4, 5], 3);
+      expect(modified.roll).toBe(12);
+      expect(modified.severity).toBe('immobilized');
+      expect(modified.immobilized).toBe(true);
+    });
+
+    it('does not convert heavy results after table lookup', () => {
+      const heavy = motiveDamageFromRoll([5, 5], 0);
+      expect(heavy.roll).toBe(10);
+      expect(heavy.severity).toBe('heavy');
+      expect(heavy.immobilized).toBe(false);
+    });
+
+    it('can move a no-effect raw roll into a minor result through modifiers', () => {
+      const minor = motiveDamageFromRoll([2, 3], 2);
+      expect(minor.roll).toBe(7);
+      expect(minor.severity).toBe('minor');
+      expect(minor.mpPenalty).toBe(1);
     });
   });
 
   describe('state stacking (task 4.4)', () => {
     it('penalties accumulate across rolls', () => {
       let state = createMotiveDamageState(5);
-      const r1 = motiveDamageFromRoll([3, 4]); // -1
+      const r1 = motiveDamageFromRoll([3, 4]);
       state = applyMotiveDamageToState(state, r1);
       expect(state.penaltyMP).toBe(1);
 
-      const r2 = motiveDamageFromRoll([4, 5]); // -2
+      const r2 = motiveDamageFromRoll([4, 5]);
       state = applyMotiveDamageToState(state, r2);
       expect(state.penaltyMP).toBe(3);
 
-      const r3 = motiveDamageFromRoll([5, 5]); // -3
+      const r3 = motiveDamageFromRoll([5, 5]);
       state = applyMotiveDamageToState(state, r3);
       expect(state.penaltyMP).toBe(6);
     });
@@ -119,15 +118,15 @@ describe('motiveDamage', () => {
       expect(state.immobilized).toBe(true);
 
       state = applyMotiveDamageToState(state, motiveDamageFromRoll([3, 4]));
-      expect(state.penaltyMP).toBe(0); // unchanged
+      expect(state.penaltyMP).toBe(0);
     });
   });
 
   describe('effective MP (spec scenario "motive penalty applies to flank MP")', () => {
-    it('cruise 5, penalty 2 → cruise 3, flank floor(3×1.5)=4', () => {
+    it('cruise 5, penalty 2 -> cruise 3, flank floor(3 * 1.5) = 4', () => {
       const state = applyMotiveDamageToState(
         createMotiveDamageState(5),
-        motiveDamageFromRoll([4, 5]), // -2
+        motiveDamageFromRoll([4, 5]),
       );
       const eff = computeEffectiveMP(state);
       expect(eff.cruiseMP).toBe(3);
@@ -137,14 +136,14 @@ describe('motiveDamage', () => {
 
     it('cruise floor at 0 (not negative)', () => {
       let state = createMotiveDamageState(3);
-      state = applyMotiveDamageToState(state, motiveDamageFromRoll([5, 5])); // -3
-      state = applyMotiveDamageToState(state, motiveDamageFromRoll([5, 5])); // -3 more
+      state = applyMotiveDamageToState(state, motiveDamageFromRoll([5, 5]));
+      state = applyMotiveDamageToState(state, motiveDamageFromRoll([5, 5]));
       const eff = computeEffectiveMP(state);
       expect(eff.cruiseMP).toBe(0);
       expect(eff.flankMP).toBe(0);
     });
 
-    it('immobilized clamps cruise & flank to 0', () => {
+    it('immobilized clamps cruise and flank to 0', () => {
       const state = applyMotiveDamageToState(
         createMotiveDamageState(6),
         motiveDamageFromRoll([6, 6]),

--- a/src/utils/gameplay/__tests__/vehicleCriticalHitResolution.test.ts
+++ b/src/utils/gameplay/__tests__/vehicleCriticalHitResolution.test.ts
@@ -281,13 +281,14 @@ describe('vehicleCriticalHitResolution', () => {
       expect(r2.state.destructionCause).toBe('crew_killed');
     });
 
-    it('engine_hit: first disables, second destroys', () => {
+    it('engine_hit immobilizes without destroying on repeated hits', () => {
       let state = mkState();
       state = applyVehicleCritEffect(state, vehicleCritFromRoll([5, 6]), {
         engineType: EngineType.STANDARD,
         hasAmmoInSlot: false,
       }).state;
       expect(state.motive.engineHits).toBe(1);
+      expect(state.motive.immobilized).toBe(true);
       expect(state.destroyed).toBe(false);
 
       const r2 = applyVehicleCritEffect(state, vehicleCritFromRoll([5, 6]), {
@@ -295,8 +296,9 @@ describe('vehicleCriticalHitResolution', () => {
         hasAmmoInSlot: false,
       });
       expect(r2.state.motive.engineHits).toBe(2);
-      expect(r2.state.destroyed).toBe(true);
-      expect(r2.state.destructionCause).toBe('engine_destroyed');
+      expect(r2.state.motive.immobilized).toBe(true);
+      expect(r2.state.destroyed).toBe(false);
+      expect(r2.state.destructionCause).toBeUndefined();
     });
 
     it('fuel_tank on ICE destroys the vehicle; on fusion rerolls to none', () => {

--- a/src/utils/gameplay/__tests__/vehicleDamage.test.ts
+++ b/src/utils/gameplay/__tests__/vehicleDamage.test.ts
@@ -63,6 +63,11 @@ function mkState() {
   });
 }
 
+function fixedDiceRoller(values: readonly number[]) {
+  let index = 0;
+  return () => values[index++] ?? 1;
+}
+
 describe('vehicleDamage', () => {
   describe('armor → structure transfer (tasks 3.1, 3.2)', () => {
     it('small damage to armor only — no structure exposure, no motive roll', () => {
@@ -182,17 +187,31 @@ describe('vehicleDamage', () => {
     });
   });
 
-  describe('aggravation (task 5)', () => {
-    it('wheeled heavy motive is aggravated to immobilized', () => {
+  describe('motive roll modifiers (task 5)', () => {
+    it('applies the wheeled modifier before the motive table lookup', () => {
       const state = {
         ...mkState(),
         motionType: GroundMotionType.WHEELED,
       };
       const result = vehicleResolveDamage(state, mkHit('front'), 12, {
-        forcedMotiveRoll: motiveDamageFromRoll([5, 5]), // heavy
+        diceRoller: fixedDiceRoller([5, 5]),
       });
+      expect(result.motiveRoll?.roll).toBe(12);
       expect(result.motiveRoll?.severity).toBe('immobilized');
       expect(result.state.motive.immobilized).toBe(true);
+    });
+
+    it('does not convert wheeled heavy results after table lookup', () => {
+      const state = {
+        ...mkState(),
+        motionType: GroundMotionType.WHEELED,
+      };
+      const result = vehicleResolveDamage(state, mkHit('front'), 12, {
+        diceRoller: fixedDiceRoller([4, 5]),
+      });
+      expect(result.motiveRoll?.roll).toBe(11);
+      expect(result.motiveRoll?.severity).toBe('heavy');
+      expect(result.state.motive.immobilized).toBe(false);
     });
 
     it('naval heavy sets sinking flag', () => {

--- a/src/utils/gameplay/__tests__/weaponDataWiring.01.fragment.ts
+++ b/src/utils/gameplay/__tests__/weaponDataWiring.01.fragment.ts
@@ -157,7 +157,7 @@ function advanceToWeaponAttack(session: IGameSession): IGameSession {
 
 /**
  * Creates a roller that alternates: odd calls hit (12), even calls target CT (7).
- * Avoids head location (roll 12) which triggers the 3-damage head-cap rule.
+ * Avoids head location (roll 12) so catalog damage assertions stay focused on weapon data rather than fatal head-destruction side effects.
  */
 function createAlwaysHitRoller(): DiceRoller {
   let callCount = 0;

--- a/src/utils/gameplay/__tests__/weaponDataWiring.02.fragment.ts
+++ b/src/utils/gameplay/__tests__/weaponDataWiring.02.fragment.ts
@@ -157,7 +157,7 @@ function advanceToWeaponAttack(session: IGameSession): IGameSession {
 
 /**
  * Creates a roller that alternates: odd calls hit (12), even calls target CT (7).
- * Avoids head location (roll 12) which triggers the 3-damage head-cap rule.
+ * Avoids head location (roll 12) so catalog damage assertions stay focused on weapon data rather than fatal head-destruction side effects.
  */
 function createAlwaysHitRoller(): DiceRoller {
   let callCount = 0;

--- a/src/utils/gameplay/__tests__/weaponDataWiring.03.fragment.ts
+++ b/src/utils/gameplay/__tests__/weaponDataWiring.03.fragment.ts
@@ -157,7 +157,7 @@ function advanceToWeaponAttack(session: IGameSession): IGameSession {
 
 /**
  * Creates a roller that alternates: odd calls hit (12), even calls target CT (7).
- * Avoids head location (roll 12) which triggers the 3-damage head-cap rule.
+ * Avoids head location (roll 12) so catalog damage assertions stay focused on weapon data rather than fatal head-destruction side effects.
  */
 function createAlwaysHitRoller(): DiceRoller {
   let callCount = 0;

--- a/src/utils/gameplay/__tests__/weaponDataWiring.04.fragment.ts
+++ b/src/utils/gameplay/__tests__/weaponDataWiring.04.fragment.ts
@@ -157,7 +157,7 @@ function advanceToWeaponAttack(session: IGameSession): IGameSession {
 
 /**
  * Creates a roller that alternates: odd calls hit (12), even calls target CT (7).
- * Avoids head location (roll 12) which triggers the 3-damage head-cap rule.
+ * Avoids head location (roll 12) so catalog damage assertions stay focused on weapon data rather than fatal head-destruction side effects.
  */
 function createAlwaysHitRoller(): DiceRoller {
   let callCount = 0;

--- a/src/utils/gameplay/__tests__/weaponDataWiring.05.fragment.ts
+++ b/src/utils/gameplay/__tests__/weaponDataWiring.05.fragment.ts
@@ -157,7 +157,7 @@ function advanceToWeaponAttack(session: IGameSession): IGameSession {
 
 /**
  * Creates a roller that alternates: odd calls hit (12), even calls target CT (7).
- * Avoids head location (roll 12) which triggers the 3-damage head-cap rule.
+ * Avoids head location (roll 12) so catalog damage assertions stay focused on weapon data rather than fatal head-destruction side effects.
  */
 function createAlwaysHitRoller(): DiceRoller {
   let callCount = 0;

--- a/src/utils/gameplay/ammoTracking.ts
+++ b/src/utils/gameplay/ammoTracking.ts
@@ -31,7 +31,6 @@ export {
 } from './ammoTracking/caseProtection';
 export {
   BATTLEMECH_AMMO_EXPLOSION_PILOT_DAMAGE,
-  REDUCED_CASE_AMMO_EXPLOSION_PILOT_DAMAGE,
   resolveBattleMechAmmoExplosionPilotDamage,
 } from './ammoTracking/pilotDamage';
 export { getFireableWeapons, isEnergyWeapon } from './ammoTracking/weapons';

--- a/src/utils/gameplay/ammoTracking/caseProtection.ts
+++ b/src/utils/gameplay/ammoTracking/caseProtection.ts
@@ -6,7 +6,6 @@ import { CombatLocation, getFrontCombatLocation } from '@/types/gameplay';
 
 import type { CASEProtectionLevel } from './types';
 
-const STANDARD_CASE_DAMAGE_CAP = 10;
 const CASE_II_DAMAGE_CAP = 1;
 
 function structureLocation(location: string): string {
@@ -44,7 +43,7 @@ export function resolveCaseAdjustedAmmoExplosionDamage(
   const cap =
     caseProtection === 'case_ii'
       ? CASE_II_DAMAGE_CAP
-      : STANDARD_CASE_DAMAGE_CAP;
+      : internalStructureRemaining(unit, location);
   const damageToApply = Math.min(
     totalDamage,
     cap,

--- a/src/utils/gameplay/ammoTracking/explosions.ts
+++ b/src/utils/gameplay/ammoTracking/explosions.ts
@@ -22,7 +22,7 @@ const HEAT_EXPLOSION_TN_HIGH = 8;
 const HEAT_EXPLOSION_TN_MEDIUM = 6;
 const HEAT_EXPLOSION_TN_LOW = 4;
 const CASE_II_TRANSFER_DAMAGE = 1;
-const UNPROTECTED_EXPLOSION_PILOT_DAMAGE = 1;
+const UNPROTECTED_EXPLOSION_PILOT_DAMAGE = 2;
 
 /**
  * Resolve an ammo bin explosion from a critical hit.
@@ -85,7 +85,7 @@ export function resolveAmmoExplosion(
  *
  * - CASE: No transfer damage, no pilot damage. Location may be destroyed.
  * - CASE II: Only 1 point transfers, no pilot damage.
- * - No CASE: Full transfer, pilot takes 1 damage.
+ * - No CASE: Full transfer, pilot takes 2 damage.
  */
 export function calculateCASEEffects(
   totalDamage: number,

--- a/src/utils/gameplay/ammoTracking/index.ts
+++ b/src/utils/gameplay/ammoTracking/index.ts
@@ -23,7 +23,6 @@ export {
 } from './caseProtection';
 export {
   BATTLEMECH_AMMO_EXPLOSION_PILOT_DAMAGE,
-  REDUCED_CASE_AMMO_EXPLOSION_PILOT_DAMAGE,
   resolveBattleMechAmmoExplosionPilotDamage,
 } from './pilotDamage';
 export { getFireableWeapons, isEnergyWeapon } from './weapons';

--- a/src/utils/gameplay/ammoTracking/pilotDamage.ts
+++ b/src/utils/gameplay/ammoTracking/pilotDamage.ts
@@ -3,7 +3,6 @@ import { hasSPA } from '@/utils/gameplay/spaModifiers/canonicalize';
 import type { CASEProtectionLevel } from './types';
 
 export const BATTLEMECH_AMMO_EXPLOSION_PILOT_DAMAGE = 2;
-export const REDUCED_CASE_AMMO_EXPLOSION_PILOT_DAMAGE = 1;
 
 export interface IResolveBattleMechAmmoExplosionPilotDamageOptions {
   readonly totalDamage: number;
@@ -35,15 +34,14 @@ export function resolveBattleMechAmmoExplosionPilotDamage(
     return 0;
   }
 
-  let damage = BATTLEMECH_AMMO_EXPLOSION_PILOT_DAMAGE;
   if (
-    options.advancedCasePilotDamage === true &&
     options.caseProtection !== undefined &&
     options.caseProtection !== 'none'
   ) {
-    damage = REDUCED_CASE_AMMO_EXPLOSION_PILOT_DAMAGE;
+    return 0;
   }
 
+  let damage = BATTLEMECH_AMMO_EXPLOSION_PILOT_DAMAGE;
   if (
     hasSourceBackedPainResistance(pilotAbilities) ||
     hasSourceBackedIronMan(pilotAbilities)

--- a/src/utils/gameplay/criticalHitResolution/selection.ts
+++ b/src/utils/gameplay/criticalHitResolution/selection.ts
@@ -102,19 +102,21 @@ export function selectCriticalSlotWithEdge(
   const slots = manifest[normalizedLocation];
   if (!slots || slots.length === 0) return { slot: null };
 
-  const availableSlots = slots.filter((slot) => isCriticalSlotAvailable(slot));
-  if (availableSlots.length === 0) return { slot: null };
+  if (!slots.some(isCriticalSlotAvailable)) return { slot: null };
 
-  const roll = diceRoller();
-  const firstSlot = selectSlotFromPool(availableSlots, roll);
+  const firstSlot = selectSlotFromLocation(
+    slots,
+    diceRoller,
+    isCriticalSlotAvailable,
+  );
+  if (!firstSlot) return { slot: null };
   if (!isExplosiveCriticalSlot(firstSlot)) {
     return { slot: firstSlot };
   }
 
-  const nonExplosiveSlots = availableSlots.filter(
-    (slot) => !isExplosiveCriticalSlot(slot),
-  );
-  if (nonExplosiveSlots.length === 0) {
+  const nonExplosiveAvailable = (slot: ICriticalSlotEntry) =>
+    isCriticalSlotAvailable(slot) && !isExplosiveCriticalSlot(slot);
+  if (!slots.some(nonExplosiveAvailable)) {
     return { slot: firstSlot };
   }
 
@@ -136,19 +138,48 @@ export function selectCriticalSlotWithEdge(
     return { slot: firstSlot };
   }
 
-  const reroll = diceRoller();
   return {
-    slot: selectSlotFromPool(nonExplosiveSlots, reroll),
+    slot:
+      selectSlotFromLocation(slots, diceRoller, nonExplosiveAvailable) ??
+      firstSlot,
     edgePointsRemaining: edgeResolution.edgePointsRemaining,
   };
 }
 
-function selectSlotFromPool(
+function selectSlotFromLocation(
   slots: readonly ICriticalSlotEntry[],
-  roll: number,
-): ICriticalSlotEntry {
-  const index = (roll - 1) % slots.length;
-  return slots[index];
+  diceRoller: D6Roller,
+  isCandidate: (slot: ICriticalSlotEntry) => boolean,
+): ICriticalSlotEntry | null {
+  if (slots.length === 0) return null;
+
+  const fairBucketSize = Math.floor(36 / slots.length) * slots.length;
+  const maxAttempts = Math.max(72, slots.length * 12);
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const rollValue = rollUniformD6PairValue(diceRoller);
+    if (fairBucketSize > 0 && rollValue >= fairBucketSize) {
+      continue;
+    }
+
+    const index = rollValue % slots.length;
+    const slot = slots[index];
+    if (isCandidate(slot)) {
+      return slot;
+    }
+  }
+
+  return slots.find(isCandidate) ?? null;
+}
+
+function rollUniformD6PairValue(diceRoller: D6Roller): number {
+  const first = normalizeD6(diceRoller());
+  const second = normalizeD6(diceRoller());
+  return (first - 1) * 6 + (second - 1);
+}
+
+function normalizeD6(value: number): number {
+  if (!Number.isFinite(value)) return 1;
+  return Math.max(1, Math.min(6, Math.trunc(value)));
 }
 
 function isExplosiveCriticalSlot(slot: ICriticalSlotEntry): boolean {

--- a/src/utils/gameplay/damage/__tests__/headDamageCap.test.ts
+++ b/src/utils/gameplay/damage/__tests__/headDamageCap.test.ts
@@ -1,23 +1,16 @@
 /**
- * Unit tests for the head-damage cap inside `resolveDamage`.
+ * Head damage parity tests for `resolveDamage`.
  *
- * Canonical OpenSpec change: `integrate-damage-pipeline` tasks 5.1–5.4.
- * Total Warfare p. 41: any single hit landing on the head is capped at
- * 3 points of applied damage; overflow is discarded (not transferred).
- * Cluster weapons invoke `resolveDamage` once per cluster group, so the
- * per-call cap also satisfies the per-cluster-group independent cap.
+ * MegaMek routes normal-cockpit BattleMech head hits through the same armor
+ * and internal-structure damage path as other locations. The head hit wounds
+ * the pilot once, but incoming damage is not capped to 3.
  *
- * @spec openspec/changes/integrate-damage-pipeline/specs/damage-system/spec.md
+ * @spec openspec/changes/fix-combat-damage-crit-parity/specs/combat-resolution/spec.md
  */
 
 import type { CombatLocation } from '@/types/gameplay';
 
-import {
-  IUnitDamageState,
-  resolveDamage,
-  HEAD_DAMAGE_CAP_PER_HIT,
-} from '../../damage';
-import * as hitLocation from '../../hitLocation';
+import { IUnitDamageState, resolveDamage } from '../../damage';
 
 jest.mock('../../hitLocation', () => {
   const actual =
@@ -76,12 +69,8 @@ function freshState(
   };
 }
 
-describe('resolveDamage — head damage cap (task 5.1–5.4)', () => {
-  it('exports the cap constant as 3', () => {
-    expect(HEAD_DAMAGE_CAP_PER_HIT).toBe(3);
-  });
-
-  it('caps an AC/20 hit (20 damage) at 3 damage applied; discards 17', () => {
+describe('resolveDamage head damage parity', () => {
+  it('applies full AC/20 damage to head armor/internal structure without a 3-point cap', () => {
     const state = freshState();
     const { state: after, result } = resolveDamage(
       state,
@@ -89,27 +78,26 @@ describe('resolveDamage — head damage cap (task 5.1–5.4)', () => {
       20,
     );
 
-    // Only the first 3 damage reaches the head: 3 armor, 0 structure.
     expect(result.locationDamages).toHaveLength(1);
     const [headResult] = result.locationDamages;
     expect(headResult.location).toBe('head');
-    expect(headResult.damage).toBe(3);
-    expect(headResult.armorDamage).toBe(3);
-    expect(headResult.structureDamage).toBe(0);
-    expect(headResult.armorRemaining).toBe(6);
-    expect(headResult.structureRemaining).toBe(3);
-
-    // Overflow is DISCARDED — no transfer event to any other location.
+    expect(headResult.damage).toBe(20);
+    expect(headResult.armorDamage).toBe(9);
+    expect(headResult.structureDamage).toBe(3);
+    expect(headResult.armorRemaining).toBe(0);
+    expect(headResult.structureRemaining).toBe(0);
+    expect(headResult.destroyed).toBe(true);
     expect(headResult.transferredDamage).toBe(0);
     expect(headResult.transferLocation).toBeUndefined();
 
-    // Head armor dropped by exactly 3, no structure loss.
-    expect(after.armor.head).toBe(6);
-    expect(after.structure.head).toBe(3);
-    expect(after.destroyedLocations).toEqual([]);
+    expect(after.armor.head).toBe(0);
+    expect(after.structure.head).toBe(0);
+    expect(after.destroyedLocations).toContain('head');
+    expect(result.unitDestroyed).toBe(true);
+    expect(result.destructionCause).toBe('head_destroyed');
   });
 
-  it('does not cap a hit at or below the threshold', () => {
+  it('applies low-damage head hits normally', () => {
     const state = freshState();
     const { result } = resolveDamage(state, 'head' as CombatLocation, 2);
     const [headResult] = result.locationDamages;
@@ -117,11 +105,7 @@ describe('resolveDamage — head damage cap (task 5.1–5.4)', () => {
     expect(headResult.armorDamage).toBe(2);
   });
 
-  it('caps each cluster-group call independently (LRM-20, 6 hits of 1 damage each to head)', () => {
-    // Cluster weapons invoke resolveDamage once per cluster group.
-    // Fire six single-point calls, each resolving to head. None should
-    // be capped because each call is under the 3-point threshold. The
-    // cap only kicks in when a SINGLE hit exceeds 3.
+  it('applies cluster-group calls independently without a head-specific cap', () => {
     let state = freshState();
     for (let i = 0; i < 6; i++) {
       const { state: next, result } = resolveDamage(
@@ -132,25 +116,24 @@ describe('resolveDamage — head damage cap (task 5.1–5.4)', () => {
       expect(result.locationDamages[0].damage).toBe(1);
       state = next;
     }
-    expect(state.armor.head).toBe(3); // 9 - 6
+    expect(state.armor.head).toBe(3);
   });
 
-  it('caps cluster hits with a single high-damage group (SRM/LB-X cluster of 5 to head)', () => {
-    // When a cluster group delivers more than 3 to head, THAT group is
-    // capped at 3 and the rest of the volley continues in separate calls.
+  it('lets a high-damage cluster group penetrate head structure', () => {
     const state = freshState({ armor: { ...freshState().armor, head: 4 } });
     const { state: after, result } = resolveDamage(
       state,
       'head' as CombatLocation,
       5,
     );
-    expect(result.locationDamages[0].damage).toBe(3);
-    expect(after.armor.head).toBe(1);
+    expect(result.locationDamages[0].damage).toBe(5);
+    expect(result.locationDamages[0].armorDamage).toBe(4);
+    expect(result.locationDamages[0].structureDamage).toBe(1);
+    expect(after.armor.head).toBe(0);
+    expect(after.structure.head).toBe(2);
   });
 
-  it('still applies pilot damage once when armor is penetrated even if capped', () => {
-    // Start with 2 armor on head so a capped 3-point hit strips armor
-    // and puts 1 point into structure.
+  it('still applies pilot damage once when armor is penetrated', () => {
     const state = freshState({ armor: { ...freshState().armor, head: 2 } });
     const { state: after, result } = resolveDamage(
       state,
@@ -158,14 +141,14 @@ describe('resolveDamage — head damage cap (task 5.1–5.4)', () => {
       20,
     );
 
-    expect(result.locationDamages[0].damage).toBe(3);
+    expect(result.locationDamages[0].damage).toBe(20);
     expect(result.locationDamages[0].armorDamage).toBe(2);
-    expect(result.locationDamages[0].structureDamage).toBe(1);
-    expect(after.structure.head).toBe(2);
+    expect(result.locationDamages[0].structureDamage).toBe(3);
+    expect(after.structure.head).toBe(0);
     expect(result.pilotDamage?.woundsInflicted).toBe(1);
   });
 
-  it('suppresses head-hit pilot damage for Dermal Armor', () => {
+  it('suppresses head-hit pilot damage for Dermal Armor without suppressing full damage', () => {
     const state = freshState({
       armor: { ...freshState().armor, head: 2 },
       pilotAbilities: ['dermal_armor'],
@@ -179,11 +162,11 @@ describe('resolveDamage — head damage cap (task 5.1–5.4)', () => {
 
     expect(result.locationDamages[0]).toMatchObject({
       location: 'head',
-      damage: 3,
+      damage: 20,
       armorDamage: 2,
-      structureDamage: 1,
+      structureDamage: 3,
     });
-    expect(after.structure.head).toBe(2);
+    expect(after.structure.head).toBe(0);
     expect(result.pilotDamage).toBeUndefined();
     expect(after.pilotWounds).toBe(0);
   });

--- a/src/utils/gameplay/damage/index.ts
+++ b/src/utils/gameplay/damage/index.ts
@@ -11,11 +11,7 @@ export {
   resolvePilotWakeUpCheck,
 } from './pilot';
 export { checkUnitDestruction } from './destruction';
-export {
-  resolveDamage,
-  resolveInternalDamage,
-  HEAD_DAMAGE_CAP_PER_HIT,
-} from './resolve';
+export { resolveDamage, resolveInternalDamage } from './resolve';
 export { applyDamageWithTerrainEffects } from './terrain';
 export {
   createDamageState,

--- a/src/utils/gameplay/damage/resolve.ts
+++ b/src/utils/gameplay/damage/resolve.ts
@@ -2,22 +2,12 @@ import { CombatLocation } from '@/types/gameplay';
 
 import type { D6Roller } from '../diceTypes';
 
-import { isHeadHit } from '../hitLocation';
 import { finalizeDamageResolution } from './finalize';
 import {
   applyDamageWithTransfer,
   applyInternalDamageWithTransfer,
 } from './location';
 import { IResolveDamageResult, IUnitDamageState } from './types';
-
-/**
- * Per Total Warfare p. 41 ("Head Damage"): any single hit that lands on
- * the head is capped at 3 points applied; overflow is discarded, NOT
- * transferred. Because cluster weapons (LRM, SRM, AC/LB-X, etc.) invoke
- * `resolveDamage` once per cluster group, applying the cap here also
- * satisfies the per-cluster-group independent cap.
- */
-export const HEAD_DAMAGE_CAP_PER_HIT = 3;
 
 /**
  * Resolve a damage application.
@@ -34,13 +24,8 @@ export function resolveDamage(
   roller?: D6Roller,
   options: { readonly rollCriticalHits?: boolean } = {},
 ): IResolveDamageResult {
-  const effectiveDamage =
-    isHeadHit(location) && damage > HEAD_DAMAGE_CAP_PER_HIT
-      ? HEAD_DAMAGE_CAP_PER_HIT
-      : damage;
-
   const { state: stateAfterDamage, results: locationDamages } =
-    applyDamageWithTransfer(state, location, effectiveDamage);
+    applyDamageWithTransfer(state, location, damage);
 
   return finalizeDamageResolution({
     initialState: state,

--- a/src/utils/gameplay/gameSessionAttackResolution.ammoExplosions.ts
+++ b/src/utils/gameplay/gameSessionAttackResolution.ammoExplosions.ts
@@ -1,0 +1,368 @@
+import {
+  CombatLocation,
+  GamePhase,
+  IAmmoSlotState,
+  IGameSession,
+} from '@/types/gameplay';
+
+import type { CriticalHitEvent } from './criticalHitResolution';
+
+import {
+  applyAmmoExplosionRearArmorBlowout,
+  resolveAmmoExplosion,
+  resolveBattleMechAmmoExplosionPilotDamage,
+  resolveCaseAdjustedAmmoExplosionDamage,
+  type CASEProtectionLevel,
+} from './ammoTracking';
+import {
+  PILOT_DEATH_WOUND_THRESHOLD,
+  resolveInternalDamage as resolveInternalDamagePipeline,
+  resolvePilotConsciousnessCheck,
+} from './damage';
+import { type D6Roller } from './diceTypes';
+import {
+  createAmmoConsumedEvent,
+  createAmmoExplosionEvent,
+  createDamageAppliedEvent,
+  createLocationDestroyedEvent,
+  createPilotHitEvent,
+  createTransferDamageEvent,
+} from './gameEvents';
+import {
+  appendUnitDestroyedEvent,
+  buildDamageStateFromUnit,
+} from './gameSessionAttackResolutionHelpers';
+import { appendEvent } from './gameSessionCore';
+
+function findExplodingAmmoBin(
+  ammoState: Record<string, IAmmoSlotState>,
+  location: string,
+  ammoBinId?: string,
+): IAmmoSlotState | undefined {
+  if (ammoBinId !== undefined) {
+    const bin = ammoState[ammoBinId];
+    return bin && bin.remainingRounds > 0 && bin.isExplosive ? bin : undefined;
+  }
+
+  return Object.values(ammoState).find(
+    (bin) =>
+      bin.location === location && bin.remainingRounds > 0 && bin.isExplosive,
+  );
+}
+
+function criticalExplosionBin(
+  event: CriticalHitEvent,
+  unit: IGameSession['currentState']['units'][string],
+): IAmmoSlotState | undefined {
+  if (event.type !== 'critical_hit_resolved') return undefined;
+  const payload = event.payload;
+  if (payload.componentType !== 'ammo' || !payload.destroyed) {
+    return undefined;
+  }
+
+  return findExplodingAmmoBin(
+    unit.ammoState ?? {},
+    payload.location,
+    payload.ammoBinId,
+  );
+}
+
+function cascadedArmFor(
+  location: CombatLocation,
+  newlyDestroyed: readonly CombatLocation[],
+): CombatLocation | undefined {
+  if (
+    location === 'left_torso' &&
+    newlyDestroyed.includes('left_arm' as CombatLocation)
+  ) {
+    return 'left_arm' as CombatLocation;
+  }
+  if (
+    location === 'right_torso' &&
+    newlyDestroyed.includes('right_arm' as CombatLocation)
+  ) {
+    return 'right_arm' as CombatLocation;
+  }
+  return undefined;
+}
+
+function appendWeaponAttackAmmoExplosionDamageCascade(
+  session: IGameSession,
+  unitId: string,
+  location: string,
+  damage: number,
+  caseProtection: CASEProtectionLevel,
+  d6Roller: D6Roller,
+): { readonly session: IGameSession; readonly unitDestroyed: boolean } {
+  const unit = session.currentState.units[unitId];
+  if (!unit || damage <= 0) {
+    return { session, unitDestroyed: false };
+  }
+
+  const blowout = applyAmmoExplosionRearArmorBlowout(
+    buildDamageStateFromUnit(unit),
+    location as CombatLocation,
+    caseProtection,
+    damage,
+  );
+  const damageResult = resolveInternalDamagePipeline(
+    blowout.state,
+    location as CombatLocation,
+    damage,
+    d6Roller,
+    { applyHeadPilotDamage: false },
+  );
+  const locationDamages = [
+    ...blowout.locationDamages,
+    ...damageResult.result.locationDamages,
+  ];
+  const preDestroyedSet = new Set<CombatLocation>(
+    unit.destroyedLocations as readonly CombatLocation[],
+  );
+  const newlyDestroyed = damageResult.state.destroyedLocations.filter(
+    (loc) => !preDestroyedSet.has(loc),
+  );
+
+  let currentSession = session;
+  const turn = currentSession.currentState.turn;
+  for (const locationDamage of locationDamages) {
+    currentSession = appendEvent(
+      currentSession,
+      createDamageAppliedEvent({
+        gameId: currentSession.id,
+        sequence: currentSession.events.length,
+        turn,
+        phase: GamePhase.WeaponAttack,
+        unitId,
+        location: locationDamage.location,
+        damage: locationDamage.damage,
+        armorRemaining: locationDamage.armorRemaining,
+        structureRemaining: locationDamage.structureRemaining,
+        locationDestroyed: locationDamage.destroyed,
+      }),
+    );
+
+    if (locationDamage.destroyed) {
+      const cascadedArm = cascadedArmFor(
+        locationDamage.location,
+        newlyDestroyed,
+      );
+      currentSession = appendEvent(
+        currentSession,
+        createLocationDestroyedEvent({
+          gameId: currentSession.id,
+          sequence: currentSession.events.length,
+          turn,
+          phase: GamePhase.WeaponAttack,
+          unitId,
+          location: locationDamage.location,
+          cascadedTo: cascadedArm,
+        }),
+      );
+      if (cascadedArm) {
+        currentSession = appendEvent(
+          currentSession,
+          createLocationDestroyedEvent({
+            gameId: currentSession.id,
+            sequence: currentSession.events.length,
+            turn,
+            phase: GamePhase.WeaponAttack,
+            unitId,
+            location: cascadedArm,
+          }),
+        );
+      }
+    }
+
+    if (
+      locationDamage.transferredDamage > 0 &&
+      locationDamage.transferLocation
+    ) {
+      currentSession = appendEvent(
+        currentSession,
+        createTransferDamageEvent({
+          gameId: currentSession.id,
+          sequence: currentSession.events.length,
+          turn,
+          phase: GamePhase.WeaponAttack,
+          unitId,
+          fromLocation: locationDamage.location,
+          toLocation: locationDamage.transferLocation,
+          damage: locationDamage.transferredDamage,
+        }),
+      );
+    }
+  }
+
+  return {
+    session: currentSession,
+    unitDestroyed: damageResult.result.unitDestroyed && !unit.destroyed,
+  };
+}
+
+function appendWeaponAttackAmmoExplosionPilotDamage(
+  session: IGameSession,
+  unitId: string,
+  totalExplosionDamage: number,
+  caseProtection: CASEProtectionLevel,
+  d6Roller: D6Roller,
+): { readonly session: IGameSession; readonly pilotDestroyed: boolean } {
+  const unit = session.currentState.units[unitId];
+  if (!unit) {
+    return { session, pilotDestroyed: false };
+  }
+
+  const wounds = resolveBattleMechAmmoExplosionPilotDamage({
+    totalDamage: totalExplosionDamage,
+    caseProtection,
+    pilotAbilities: unit.abilities,
+  });
+  if (wounds <= 0) {
+    return { session, pilotDestroyed: false };
+  }
+
+  const totalWounds = unit.pilotWounds + wounds;
+  const consciousnessCheck = resolvePilotConsciousnessCheck(
+    totalWounds,
+    wounds,
+    unit.abilities,
+    d6Roller,
+    unit.pilotToughness,
+    {
+      edgePointsRemaining: unit.edgePointsRemaining,
+      turn: session.currentState.turn,
+      unitId,
+    },
+  );
+  const consciousnessPassed =
+    unit.pilotConscious &&
+    (consciousnessCheck.conscious ?? true) &&
+    totalWounds < PILOT_DEATH_WOUND_THRESHOLD;
+  const currentSession = appendEvent(
+    session,
+    createPilotHitEvent(
+      session.id,
+      session.events.length,
+      session.currentState.turn,
+      GamePhase.WeaponAttack,
+      unitId,
+      wounds,
+      totalWounds,
+      'ammo_explosion',
+      consciousnessCheck.consciousnessCheckRequired,
+      consciousnessPassed,
+      {
+        edgeReroll: consciousnessCheck.edgeReroll,
+        edgeSuperseded: consciousnessCheck.edgeSuperseded,
+        edgeTrigger: consciousnessCheck.edgeTrigger,
+        edgePointsRemaining: consciousnessCheck.edgePointsRemaining,
+      },
+    ),
+  );
+
+  return {
+    session: currentSession,
+    pilotDestroyed: totalWounds >= PILOT_DEATH_WOUND_THRESHOLD,
+  };
+}
+
+export function appendCritInducedAmmoExplosionEvents(input: {
+  readonly session: IGameSession;
+  readonly criticalEvents: readonly CriticalHitEvent[];
+  readonly targetId: string;
+  readonly d6Roller: D6Roller;
+}): IGameSession {
+  let currentSession = input.session;
+
+  for (const criticalEvent of input.criticalEvents) {
+    const unit = currentSession.currentState.units[input.targetId];
+    if (!unit || unit.destroyed) break;
+
+    const bin = criticalExplosionBin(criticalEvent, unit);
+    if (!bin || typeof bin.damagePerRound !== 'number') {
+      continue;
+    }
+
+    const explosion = resolveAmmoExplosion(
+      unit.ammoState ?? {},
+      bin.binId,
+      bin.damagePerRound,
+      bin.caseProtection ?? 'none',
+    );
+    if (!explosion || explosion.totalDamage <= 0) {
+      continue;
+    }
+
+    const caseAdjustedDamage = resolveCaseAdjustedAmmoExplosionDamage(
+      unit,
+      explosion.location,
+      explosion.totalDamage,
+    );
+    currentSession = appendEvent(
+      currentSession,
+      createAmmoExplosionEvent(
+        currentSession.id,
+        currentSession.events.length,
+        currentSession.currentState.turn,
+        GamePhase.WeaponAttack,
+        input.targetId,
+        explosion.location,
+        explosion.totalDamage,
+        'CritInduced',
+        {
+          binId: explosion.binId,
+          weaponType: explosion.weaponType,
+          roundsDestroyed: bin.remainingRounds,
+          caseProtection: caseAdjustedDamage.caseProtection,
+        },
+      ),
+    );
+    currentSession = appendEvent(
+      currentSession,
+      createAmmoConsumedEvent(
+        currentSession.id,
+        currentSession.events.length,
+        currentSession.currentState.turn,
+        GamePhase.WeaponAttack,
+        input.targetId,
+        explosion.binId,
+        explosion.weaponType,
+        bin.remainingRounds,
+        0,
+      ),
+    );
+
+    const cascadeResult = appendWeaponAttackAmmoExplosionDamageCascade(
+      currentSession,
+      input.targetId,
+      explosion.location,
+      caseAdjustedDamage.damageToApply,
+      caseAdjustedDamage.caseProtection,
+      input.d6Roller,
+    );
+    currentSession = cascadeResult.session;
+
+    const pilotResult = appendWeaponAttackAmmoExplosionPilotDamage(
+      currentSession,
+      input.targetId,
+      explosion.totalDamage,
+      caseAdjustedDamage.caseProtection,
+      input.d6Roller,
+    );
+    currentSession = pilotResult.session;
+
+    if (
+      (cascadeResult.unitDestroyed || pilotResult.pilotDestroyed) &&
+      !unit.destroyed
+    ) {
+      currentSession = appendUnitDestroyedEvent(currentSession, {
+        turn: currentSession.currentState.turn,
+        phase: GamePhase.WeaponAttack,
+        unitId: input.targetId,
+        cause: pilotResult.pilotDestroyed ? 'pilot_death' : 'ammo_explosion',
+      });
+    }
+  }
+
+  return currentSession;
+}

--- a/src/utils/gameplay/gameSessionAttackResolution.damageEvents.ts
+++ b/src/utils/gameplay/gameSessionAttackResolution.damageEvents.ts
@@ -22,6 +22,7 @@ import {
   createPSRTriggeredEvent,
   createTransferDamageEvent,
 } from './gameEvents';
+import { appendCritInducedAmmoExplosionEvents } from './gameSessionAttackResolution.ammoExplosions';
 import {
   appendUnitDestroyedEvent,
   buildDefaultComponentDamageState,
@@ -167,8 +168,10 @@ export function emitDamageCriticalEvents(input: {
   readonly buildTargetCriticalEdgeOptions: CriticalEdgeOptionsFactory;
 }): IGameSession {
   let currentSession = input.session;
-  const manifest = buildDefaultCriticalSlotManifest();
-  const targetComponentDamage =
+  let manifest =
+    input.targetStateForDamage.criticalSlotManifest ??
+    buildDefaultCriticalSlotManifest();
+  let targetComponentDamage =
     input.targetStateForDamage.componentDamage ??
     buildDefaultComponentDamageState();
 
@@ -190,6 +193,14 @@ export function emitDamageCriticalEvents(input: {
         input.turn,
         input.targetId,
       );
+      currentSession = appendCritInducedAmmoExplosionEvents({
+        session: currentSession,
+        criticalEvents: criticalResult.events,
+        targetId: input.targetId,
+        d6Roller: input.d6Roller,
+      });
+      manifest = criticalResult.updatedManifest;
+      targetComponentDamage = criticalResult.updatedComponentDamage;
     }
   }
 
@@ -211,6 +222,12 @@ export function emitDamageCriticalEvents(input: {
         input.turn,
         input.targetId,
       );
+      currentSession = appendCritInducedAmmoExplosionEvents({
+        session: currentSession,
+        criticalEvents: tacResult.events,
+        targetId: input.targetId,
+        d6Roller: input.d6Roller,
+      });
     }
   }
 

--- a/src/utils/gameplay/gameSessionAttackResolution.hit.ts
+++ b/src/utils/gameplay/gameSessionAttackResolution.hit.ts
@@ -22,7 +22,7 @@ import {
 } from './gameSessionAttackResolutionHelpers';
 import { appendEvent } from './gameSessionCore';
 import { tryResolveVehicleAttackHit } from './gameSessionVehicleAttackResolution';
-import { determineHitLocationFromRoll, isHeadHit } from './hitLocation';
+import { determineHitLocationFromRoll } from './hitLocation';
 import {
   applyLowProfileGlancingDamage,
   getLowProfileGlancingCriticalHitModifier,
@@ -106,10 +106,6 @@ export function resolveWeaponHit(input: {
   );
   const location = hitLocationResult.location;
   let damage = resolvedWeaponData.damage;
-
-  if (isHeadHit(location) && damage > 3) {
-    damage = 3;
-  }
 
   const lowProfileGlancingBlow = isLowProfileGlancingBlow(
     input.targetState.unitQuirks,

--- a/src/utils/gameplay/gameState/__tests__/damageResolution.vehicleCritical.test.ts
+++ b/src/utils/gameplay/gameState/__tests__/damageResolution.vehicleCritical.test.ts
@@ -148,4 +148,40 @@ describe('applyCriticalHitResolved — vehicle critical replay', () => {
     const vehicle = vehicleStateOf(next, 'vtol-1');
     expect(vehicle.motive.immobilized).toBe(true);
   });
+
+  it('engine_hit criticals immobilize without destroying on replay', () => {
+    const state = makeGameState();
+    const payload = makeCritPayload('engine_hit', 'engine', 'Fusion Engine');
+
+    const afterFirst = applyCriticalHitResolved(state, payload);
+    const firstVehicle = vehicleStateOf(afterFirst, 'vtol-1');
+    expect(firstVehicle.motive.engineHits).toBe(1);
+    expect(firstVehicle.motive.immobilized).toBe(true);
+    expect(firstVehicle.destroyed).toBe(false);
+
+    const afterSecond = applyCriticalHitResolved(afterFirst, payload);
+    const secondVehicle = vehicleStateOf(afterSecond, 'vtol-1');
+    expect(secondVehicle.motive.engineHits).toBe(2);
+    expect(secondVehicle.motive.immobilized).toBe(true);
+    expect(secondVehicle.destroyed).toBe(false);
+    expect(secondVehicle.destructionCause).toBeUndefined();
+  });
+
+  it.each(['commander_hit', 'copilot_hit'])(
+    '%s critical replays as commander damage with crew stun',
+    (effect) => {
+      const state = makeGameState();
+
+      const next = applyCriticalHitResolved(
+        state,
+        makeCritPayload(effect, 'crew', effect),
+      );
+
+      const vehicle = vehicleStateOf(next, 'vtol-1');
+      expect(vehicle.motive.commanderHits).toBe(1);
+      expect(vehicle.motive.driverHits).toBe(0);
+      expect(vehicle.motive.crewStunnedPhases).toBe(2);
+      expect(vehicle.destroyed).toBe(false);
+    },
+  );
 });

--- a/src/utils/gameplay/gameState/damageResolution.ts
+++ b/src/utils/gameplay/gameState/damageResolution.ts
@@ -1,3 +1,5 @@
+import type { CriticalSlotManifest } from '@/utils/gameplay/criticalHitResolution';
+
 import {
   ICriticalHitResolvedPayload,
   IDamageAppliedPayload,
@@ -44,6 +46,29 @@ function getFrontTorsoLocation(location: string): string | null {
   if (location === 'left_torso_rear') return 'left_torso';
   if (location === 'right_torso_rear') return 'right_torso';
   return null;
+}
+
+function markCriticalSlotManifestEntryDestroyed(
+  manifest: CriticalSlotManifest | undefined,
+  payload: ICriticalHitResolvedPayload,
+): CriticalSlotManifest | undefined {
+  if (!manifest || !payload.destroyed) {
+    return manifest;
+  }
+
+  const slots = manifest[payload.location];
+  if (!slots) {
+    return manifest;
+  }
+
+  return {
+    ...manifest,
+    [payload.location]: slots.map((slot) =>
+      slot.slotIndex === payload.slotIndex
+        ? { ...slot, destroyed: true }
+        : slot,
+    ),
+  };
 }
 
 export function applyDamageApplied(
@@ -236,6 +261,10 @@ export function applyCriticalHitResolved(
     state.electronicWarfare,
     payload,
   );
+  const criticalSlotManifest = markCriticalSlotManifestEntryDestroyed(
+    unit.criticalSlotManifest,
+    payload,
+  );
 
   return {
     ...state,
@@ -245,6 +274,7 @@ export function applyCriticalHitResolved(
       [payload.unitId]: {
         ...updatedUnit,
         componentDamage: updatedDamage,
+        ...(criticalSlotManifest !== undefined ? { criticalSlotManifest } : {}),
         edgePointsRemaining:
           payload.edgePointsRemaining ?? updatedUnit.edgePointsRemaining,
         combatState: applyVehicleCriticalToCombatState(updatedUnit, payload),

--- a/src/utils/gameplay/gameState/initialization.ts
+++ b/src/utils/gameplay/gameState/initialization.ts
@@ -156,6 +156,9 @@ export function createInitialUnitState(
     empInterferenceTurns: 0,
     empShutdownTurns: 0,
     ammoState,
+    ...(unit.criticalSlotManifest !== undefined
+      ? { criticalSlotManifest: unit.criticalSlotManifest }
+      : {}),
     ...(unit.armorTypeByLocation !== undefined
       ? { armorTypeByLocation: unit.armorTypeByLocation }
       : {}),

--- a/src/utils/gameplay/gameState/vehicleCombatStateUpdates.ts
+++ b/src/utils/gameplay/gameState/vehicleCombatStateUpdates.ts
@@ -19,7 +19,7 @@ const VEHICLE_CRITICAL_EFFECT_HANDLERS: Readonly<
 > = {
   ammo_explosion: destroyVehicle('ammo_explosion'),
   commander_hit: applyCommanderHit,
-  copilot_hit: applyDriverHit,
+  copilot_hit: applyCommanderHit,
   crew_killed: destroyVehicle('crew_killed'),
   crew_stunned: applyCrewStun,
   driver_hit: applyDriverHit,
@@ -148,7 +148,11 @@ function applyCommanderHit(vehicle: IVehicleCombatState): IVehicleCombatState {
   const commanderHits = vehicle.motive.commanderHits + 1;
   return {
     ...vehicle,
-    motive: { ...vehicle.motive, commanderHits },
+    motive: {
+      ...vehicle.motive,
+      commanderHits,
+      crewStunnedPhases: vehicle.motive.crewStunnedPhases + 2,
+    },
     ...(commanderHits >= 2
       ? { destroyed: true as const, destructionCause: 'crew_killed' as const }
       : {}),
@@ -159,13 +163,7 @@ function applyEngineHit(vehicle: IVehicleCombatState): IVehicleCombatState {
   const engineHits = vehicle.motive.engineHits + 1;
   return {
     ...vehicle,
-    motive: { ...vehicle.motive, engineHits },
-    ...(engineHits >= 2
-      ? {
-          destroyed: true as const,
-          destructionCause: 'engine_destroyed' as const,
-        }
-      : {}),
+    motive: { ...vehicle.motive, engineHits, immobilized: true },
   };
 }
 

--- a/src/utils/gameplay/motiveDamage.ts
+++ b/src/utils/gameplay/motiveDamage.ts
@@ -36,9 +36,10 @@ import { D6Roller, defaultD6Roller, roll2d6 } from './diceTypes';
  */
 export function rollMotiveDamage(
   diceRoller: D6Roller = defaultD6Roller,
+  modifier = 0,
 ): IMotiveDamageRollResult {
   const rolled = roll2d6(diceRoller);
-  return motiveDamageFromRoll([rolled.dice[0], rolled.dice[1]]);
+  return motiveDamageFromRoll([rolled.dice[0], rolled.dice[1]], modifier);
 }
 
 /**
@@ -46,9 +47,10 @@ export function rollMotiveDamage(
  */
 export function motiveDamageFromRoll(
   dice: readonly [number, number],
+  modifier = 0,
 ): IMotiveDamageRollResult {
   const [d1, d2] = dice;
-  const roll = d1 + d2;
+  const roll = d1 + d2 + modifier;
 
   let severity: MotiveDamageSeverity;
   let mpPenalty: number;
@@ -103,33 +105,38 @@ export function requiresMotiveRollOnAnyHit(
 }
 
 /**
- * Apply motion-type-specific aggravation to a motive roll.
- *
- *   - Wheeled: a "heavy" result immobilizes outright.
- *   - Hover: "heavy" causes sinking (on water) / bog (on land) — represented
- *       here by `immobilized = true`. The caller decides destruction based on
- *       terrain.
- *   - Naval: "heavy" begins sinking (destroyed in N turns).
- *   - Tracked / Rail / Maglev / VTOL / WiGE / Submarine: use the raw table.
+ * Flat movement-mode modifier applied before the motive-damage table lookup.
+ * Mirrors MegaMek TWGameManager.vehicleMotiveDamage lines 28241-28268 for
+ * non-jump motive damage.
+ */
+export function motiveRollModifierForMotionType(
+  motionType: GroundMotionType,
+  jumpDamage = false,
+): number {
+  switch (motionType) {
+    case GroundMotionType.HOVER:
+    case GroundMotionType.HYDROFOIL:
+      return jumpDamage ? -1 : 3;
+    case GroundMotionType.WHEELED:
+      return jumpDamage ? 1 : 2;
+    case GroundMotionType.WIGE:
+      return jumpDamage ? -2 : 4;
+    case GroundMotionType.TRACKED:
+      return jumpDamage ? 2 : 0;
+    default:
+      return 0;
+  }
+}
+
+/**
+ * Compatibility shim for older callers. Motive damage parity now applies flat
+ * roll modifiers before table lookup instead of mutating heavy outcomes.
  */
 export function applyMotionTypeAggravation(
   result: IMotiveDamageRollResult,
-  motionType: GroundMotionType,
+  _motionType: GroundMotionType,
 ): IMotiveDamageRollResult {
-  if (result.severity !== 'heavy') return result;
-
-  switch (motionType) {
-    case GroundMotionType.WHEELED:
-    case GroundMotionType.HOVER:
-      return { ...result, severity: 'immobilized', immobilized: true };
-    case GroundMotionType.NAVAL:
-    case GroundMotionType.HYDROFOIL:
-    case GroundMotionType.SUBMARINE:
-      // Heavy → sinking begins; upstream handler sets `sinking = true`.
-      return { ...result, severity: 'heavy' };
-    default:
-      return result;
-  }
+  return result;
 }
 
 // =============================================================================

--- a/src/utils/gameplay/vehicleCriticalHitResolution.ts
+++ b/src/utils/gameplay/vehicleCriticalHitResolution.ts
@@ -4,7 +4,7 @@
  * 2d6 vehicle critical-hit table + effect application. Unlike mechs, vehicle
  * crits don't consume critical slots — they modify the combat state:
  *   - Crew Stunned: skip next movement + weapon phase.
- *   - Engine Hit: 1st disables for a turn, 2nd destroys the vehicle.
+ *   - Engine Hit: immobilizes the vehicle.
  *   - Driver/Commander: wound counter; 2 kills the crew (vehicle destroyed).
  *   - Fuel Tank: ICE/FuelCell only — vehicle destroyed by fuel explosion
  *     (MegaMek `Tank.CRIT_FUEL_TANK` → destroyEntity "fuel explosion");
@@ -325,15 +325,12 @@ function applyCommanderHit(state: IVehicleCombatState): IVehicleCombatState {
   };
 }
 
-/** Engine hit counter; the second hit destroys the vehicle. */
+/** Engine hit counter; each hit immobilizes but does not destroy the vehicle. */
 function applyEngineHit(state: IVehicleCombatState): IVehicleCombatState {
   const engineHits = state.motive.engineHits + 1;
   return {
     ...state,
-    motive: { ...state.motive, engineHits },
-    destroyed: engineHits >= 2 ? true : state.destroyed,
-    destructionCause:
-      engineHits >= 2 ? 'engine_destroyed' : state.destructionCause,
+    motive: { ...state.motive, engineHits, immobilized: true },
   };
 }
 

--- a/src/utils/gameplay/vehicleDamage.ts
+++ b/src/utils/gameplay/vehicleDamage.ts
@@ -30,8 +30,8 @@ import { GroundMotionType } from '@/types/unit/BaseUnitInterfaces';
 
 import { D6Roller, defaultD6Roller } from './diceTypes';
 import {
-  applyMotionTypeAggravation,
   applyMotiveDamageToState,
+  motiveRollModifierForMotionType,
   requiresMotiveRollOnAnyHit,
   rollMotiveDamage,
 } from './motiveDamage';
@@ -235,6 +235,8 @@ export interface IVehicleResolveDamageOptions {
    * (Override for edge cases; normally derived from motion type.)
    */
   readonly forceMotiveRoll?: boolean;
+  /** Flat modifier applied to the motive 2d6 roll before table lookup. */
+  readonly motiveRollModifier?: number;
 }
 
 /**
@@ -278,15 +280,19 @@ export function vehicleResolveDamage(
   let stateWithMotive = stateAfter;
 
   if (motiveTriggered && damage > 0) {
-    const raw = options.forcedMotiveRoll ?? rollMotiveDamage(diceRoller);
-    motiveRoll = applyMotionTypeAggravation(raw, stateAfter.motionType);
+    const motiveRollModifier =
+      options.motiveRollModifier ??
+      motiveRollModifierForMotionType(stateAfter.motionType);
+    motiveRoll =
+      options.forcedMotiveRoll ??
+      rollMotiveDamage(diceRoller, motiveRollModifier);
 
     stateWithMotive = {
       ...stateAfter,
       motive: applyMotiveDamageToState(stateAfter.motive, motiveRoll),
     };
 
-    // Hover "heavy" aggravated to immobilized; Naval "heavy" sets sinking.
+    // Naval heavy motive damage additionally starts sinking.
     if (
       motiveRoll.severity === 'heavy' &&
       (stateAfter.motionType === GroundMotionType.NAVAL ||


### PR DESCRIPTION
## Summary
- remove head-hit damage caps across unit, runner, physical, and interactive combat paths
- make critical slot selection full-slot uniform with rejection, and route critical ammo explosions through live session/runner cascades
- align CASE, non-CASE pilot damage, TAC, vehicle engine/crew crits, and motive roll modifiers with source-backed MegaMek behavior
- mark OpenSpec fix-combat-damage-crit-parity tasks complete with strict validation evidence

## Validation
- npx.cmd jest affected 16-suite slice --runInBand: 16 suites / 397 tests passed
- npm.cmd run verify:rules: gap inventory 0; 76 suites / 2034 tests passed; 217 OpenSpec items passed
- npx.cmd tsc --noEmit --skipLibCheck --pretty false
- npm.cmd run format:check
- npx.cmd oxlint --quiet: 0 errors, existing warnings only
- git diff --check
- openspec.cmd validate fix-combat-damage-crit-parity --strict
- npm.cmd run build via commit hook
