### PR TITLE
Keep top-down map readable under dense tactical overlays

### DIFF
--- a/e2e/tactical-map-visual-smoke.spec.ts
+++ b/e2e/tactical-map-visual-smoke.spec.ts
@@ -320,6 +320,32 @@ test.describe('Tactical map visual smoke @smoke @game', () => {
         /terrain-elevation:mekstation:MekStation terrain\/elevation grid state/,
       );
     }
+    const elevationToggle = page.getByTestId('overlay-toggle-elevation');
+    await expect(elevationToggle).toHaveAttribute('aria-pressed', 'true');
+    await expect(elevationToggle).toHaveAttribute(
+      'data-map-layer-id',
+      'elevation',
+    );
+    await expect(elevationToggle).toHaveAttribute(
+      'data-map-layer-projection-channel',
+      'terrain-elevation',
+    );
+    await expect(elevationToggle).toHaveAttribute(
+      'data-map-layer-rules-surface',
+      'terrain-elevation',
+    );
+    await elevationToggle.click();
+    await expect(elevationToggle).toHaveAttribute('aria-pressed', 'false');
+    await expect(page.getByTestId('hex-elevation-label-1-0')).toHaveCount(0);
+    await expect(topDownTerrainLabel).toHaveAttribute(
+      'data-terrain-features',
+      'building',
+    );
+    await elevationToggle.click();
+    await expect(elevationToggle).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.getByTestId('hex-elevation-label-1-0')).toContainText(
+      '+4',
+    );
     const movementBadge = page.getByTestId('hex-movement-badge-0-1');
     await expect(movementBadge).toContainText('W3/R4/J3 MP');
     await expect(movementBadge).toHaveAttribute(
@@ -467,6 +493,17 @@ test.describe('Tactical map visual smoke @smoke @game', () => {
       'data-invalid-badge-reason',
       'Jump elevation rise of 4 exceeds jump MP 3',
     );
+    await expect(page.getByTestId('hex-overlay-1-0')).toHaveAttribute(
+      'data-movement-non-color-encoding',
+      'blocked-cross-hatch',
+    );
+    await expect(
+      page.getByTestId('blocked-movement-pattern-1-0'),
+    ).toHaveAttribute('fill', 'url(#pattern-blocked-movement)');
+    await expect(page.getByTestId('blocked-movement-glyph-1-0')).toContainText(
+      '!',
+    );
+    await expect(page.getByTestId('jump-pattern-1-0')).toHaveCount(0);
     await expect(page.getByTestId('hex-combat-badge-0-0')).toHaveAttribute(
       'data-combat-badge-distance',
       '1',
@@ -1067,6 +1104,49 @@ test.describe('Tactical map visual smoke @smoke @game', () => {
       'data-isometric-rotation-step',
       '0',
     );
+  });
+
+  test('keeps top-down elevation badges readable on a large board in browser', async ({
+    page,
+  }) => {
+    await page.goto('/e2e/tactical-map?scenario=large-topdown-legibility');
+
+    const projectionLayer = page.getByTestId('map-projection-layer');
+    const hexGrid = page.getByTestId('hex-grid');
+    await expect(projectionLayer).toHaveAttribute(
+      'data-projection-mode',
+      'topDown',
+    );
+    await expect(page.getByTestId('hex-17-0')).toBeAttached();
+    await expect(page.getByTestId('hex--17-0')).toBeAttached();
+
+    const centralElevationLabel = page.getByTestId('hex-elevation-label-1-0');
+    await expect(centralElevationLabel).toContainText('+4');
+    const defaultBadgeBox = await centralElevationLabel.boundingBox();
+    expect(
+      defaultBadgeBox?.height ?? 0,
+      'large-board default zoom should leave the central elevation badge measurable',
+    ).toBeGreaterThan(3);
+
+    const initialViewBox = await hexGrid.getAttribute('viewBox');
+    await dragMouseOnLocator(hexGrid, 80, -60);
+    await expect(hexGrid).not.toHaveAttribute('viewBox', initialViewBox ?? '');
+    await expectNonBlankRender(page, 'large top-down tactical map after pan');
+
+    await page.getByTestId('zoom-out-btn').click();
+    await page.getByTestId('zoom-out-btn').click();
+    await expect(page.getByTestId('hex-elevation-label-1-0')).toHaveCount(0);
+    await expectNonBlankRender(
+      page,
+      'large top-down tactical map below badge readability zoom',
+    );
+
+    await page.getByTestId('zoom-in-btn').click();
+    await page.getByTestId('zoom-in-btn').click();
+    await expect(page.getByTestId('hex-elevation-label-1-0')).toContainText(
+      '+4',
+    );
+    await expectNonBlankRender(page, 'large top-down tactical map after zoom');
   });
 
   test('renders every isometric occluder layer that may hide one unit in browser', async ({
@@ -1768,7 +1848,23 @@ test.describe('Tactical map visual smoke @smoke @game', () => {
       'aria-pressed',
       'true',
     );
+    await expect(page.getByTestId('mp-legend')).toHaveAttribute(
+      'data-non-color-encodings',
+      'blocked:cross-hatch|run:dashed-border|jump:diagonal-hatch',
+    );
+    await expect(page.getByTestId('mp-legend-run')).toHaveAttribute(
+      'data-non-color-encoding',
+      'dashed-border',
+    );
     await expect(optionHex).toHaveAttribute('data-movement-type', 'run');
+    await expect(page.getByTestId('hex-overlay-0-1')).toHaveAttribute(
+      'data-movement-non-color-encoding',
+      'run-dashed-border',
+    );
+    await expect(page.getByTestId('run-range-outline-0-1')).toHaveAttribute(
+      'stroke-dasharray',
+      '5 3',
+    );
     await expect(optionHex).toHaveAttribute('data-mp-cost', '3');
     await expect(optionHex).toHaveAttribute('data-heat-generated', '2');
     await expect(movementBadge).toHaveAttribute(

--- a/openspec/changes/add-topdown-tactical-legibility/design.md
+++ b/openspec/changes/add-topdown-tactical-legibility/design.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Top-down hexes render as SVG polygons (`HexCell.tsx`) with terrain tints and overlay layers composed in `HexMapDisplay.layers.tsx`. `formatElevationLabel` ("+N"/"-N") exists in `HexCell.labels.tsx` but is consumed only by tooltips and the isometric label path. The movement overlay (`MovementCostOverlay` + reachable-hex tinting) encodes state primarily by hue: walk cyan, run yellow, jump red (with diagonal pattern), blocked dark gray; MP cost text renders per tile. The spec's readability requirement already mandates an on-hex elevation number; this design closes the implementation gap and strengthens the non-color encodings, Antiyoy-style legibility without an art rewrite.
+Top-down hexes render as SVG polygons (`HexCell.tsx`) with terrain tints and overlay layers composed in `HexMapDisplay.layers.tsx`. `ElevationBadge` now exists in the `HexCell` badge stack, but current behavior renders it unconditionally, including elevation 0 and isometric mode, without the layer toggle or zoom cutoff this change requires. The movement overlay (`MovementCostOverlay` + reachable-hex tinting) encodes state primarily by hue: walk cyan, run yellow, jump red (with diagonal pattern), blocked dark gray; MP cost text renders per tile. The spec's readability requirement already mandates an on-hex elevation number; this design turns the current always-on badge into a governed top-down layer and strengthens the non-color encodings, Antiyoy-style legibility without an art rewrite.
 
 ## Goals / Non-Goals
 
@@ -18,26 +18,26 @@ Top-down hexes render as SVG polygons (`HexCell.tsx`) with terrain tints and ove
 
 ## Decisions
 
-**D1 — Elevation badge is a dedicated SVG text layer on `HexCell`, not a new overlay component.**
-Badge renders inside the existing hex cell group (same transform), positioned at a corner anchor so unit tokens and MP cost text stay unobstructed. Zero-elevation hexes render no badge (noise reduction); negative elevations always render (water depth/ditches are tactically critical). Alternative — separate `<ElevationBadgeLayer>` over the board: rejected, doubles per-hex node count and complicates the isometric depth path for no benefit since badges are per-hex static.
+**D1 - Elevation badge remains a dedicated SVG text layer on `HexCell`, not a new overlay component.**
+Badge renders inside the existing hex cell group (same transform), positioned at a corner anchor so unit tokens and MP cost text stay unobstructed. Zero-elevation hexes render no badge (noise reduction); negative elevations always render (water depth/ditches are tactically critical). Alternative - separate `<ElevationBadgeLayer>` over the board: rejected, doubles per-hex node count and complicates the isometric depth path for no benefit since badges are per-hex static.
 
-**D2 — Zoom behavior: badge hides below a readability threshold instead of scaling indefinitely.**
-Below the zoom level where badge text would render under ~8px effective, the badge layer hides (single CSS class toggle driven by the existing zoom state) — matching the spec's "at playable zoom levels" wording. Alternative — always render and let text shrink: rejected, produces unreadable smudges that defeat the legibility goal.
+**D2 - Zoom behavior: badge hides below a readability threshold instead of scaling indefinitely.**
+Below the zoom level where badge text would render under ~8px effective, the badge layer hides (single CSS class toggle driven by the existing zoom state) - matching the spec's "at playable zoom levels" wording. Alternative - always render and let text shrink: rejected, produces unreadable smudges that defeat the legibility goal.
 
-**D3 — Toggle lives with the existing overlay toggles (`interaction.showElevationBadges`, default ON in top-down).**
+**D3 - Toggle lives with the existing overlay toggles (`interaction.showElevationBadges`, default ON in top-down).**
 Reuses the established `interaction.show*Overlay` state shape in the map interaction store; persisted with the same mechanism as other overlay toggles. Isometric mode ignores the flag (it has its own elevation presentation).
 
-**D4 — Non-color encodings extend the existing SVG `<pattern>` approach.**
-Jump already uses a diagonal pattern; blocked tiles add a cross-hatch pattern + a small "blocked" glyph at the badge anchor opposite corner; run tiles add a dashed border stroke while walk keeps solid fill. Patterns are defined once in the SVG `<defs>` and referenced per tile — no per-tile pattern instantiation. Alternative — icon sprites per state: rejected for node-count and visual noise at small zoom.
+**D4 - Non-color encodings extend the existing SVG `<pattern>` approach.**
+Jump already uses a diagonal pattern; blocked tiles add a cross-hatch pattern + a small "blocked" glyph at the badge anchor opposite corner; run tiles add a dashed border stroke while walk keeps solid fill. Patterns are defined once in the SVG `<defs>` and referenced per tile - no per-tile pattern instantiation. Alternative - icon sprites per state: rejected for node-count and visual noise at small zoom.
 
-**D5 — Single data source: badges read `terrain.elevation` from the same hex model the projection consumes.**
+**D5 - Single data source: badges read `terrain.elevation` from the same hex model the projection consumes.**
 No second elevation lookup; the badge component receives the already-loaded hex terrain object. Replay/recovery surfaces get badges for free since they render through the same `HexMapDisplay`.
 
 ## Risks / Trade-offs
 
-- [Per-hex text nodes increase SVG node count on 30×34 boards (~1000 hexes)] → Badges skip elevation-0 hexes (majority on most maps); layer hides at low zoom; reuse the W5 memoization patterns (`HexCell` memo + handler identity) so badge props stay referentially stable.
-- [Badge collides visually with MP cost text or unit tokens on busy hexes] → Fixed corner anchor + collision priority rule (unit token > MP cost > badge); verified in Storybook stress states.
-- [Pattern fills can flicker on pan/zoom in some browsers] → Patterns in shared `<defs>` with `patternUnits="userSpaceOnUse"`, the same approach the jump pattern already ships.
+- [Per-hex text nodes increase SVG node count on 30x34 boards (~1000 hexes)] -> Badges skip elevation-0 hexes (majority on most maps); layer hides at low zoom; reuse the W5 memoization patterns (`HexCell` memo + handler identity) so badge props stay referentially stable.
+- [Badge collides visually with MP cost text or unit tokens on busy hexes] -> Fixed corner anchor + collision priority rule (unit token > MP cost > badge); verified in Storybook stress states.
+- [Pattern fills can flicker on pan/zoom in some browsers] -> Patterns in shared `<defs>` with `patternUnits="userSpaceOnUse"`, the same approach the jump pattern already ships.
 
 ## Migration Plan
 

--- a/openspec/changes/add-topdown-tactical-legibility/proposal.md
+++ b/openspec/changes/add-topdown-tactical-legibility/proposal.md
@@ -2,11 +2,11 @@
 
 ## Why
 
-The spec already requires elevation to be "visible as a readable number on or near the hex" (tactical-map-interface → Top-Down Terrain And Elevation Readability), but the shipped top-down view only exposes elevation through hover tooltips and isometric labels — there is no persistent per-hex elevation badge, so players cannot read the battlefield's height profile at a glance (council decision 2026-06-12, verified: `formatElevationLabel` exists in `HexCell.labels.tsx` but is not wired to a flat-view badge overlay). Movement overlay states also lean on color tints alone for the walk/run and blocked distinctions, which fails the goal that overlays communicate "without relying only on color."
+The spec already requires elevation to be "visible as a readable number on or near the hex" (tactical-map-interface -> Top-Down Terrain And Elevation Readability). Current code now has an `ElevationBadge` path, but it is always-on, renders noisy elevation-0 badges, lacks a layer toggle and zoom readability threshold, and is not constrained to top-down mode. Players still need a controllable, playable-zoom elevation layer that reads cleanly on dense maps. Movement overlay states also lean on color tints alone for the walk/run and blocked distinctions, which fails the goal that overlays communicate "without relying only on color."
 
 ## What Changes
 
-- Render a persistent, toggleable per-hex elevation badge in top-down mode at playable zoom levels, fed by the same terrain seed the projection uses (no new data source).
+- Refine the existing per-hex elevation badge into a persistent, toggleable top-down layer that renders only non-zero elevations at playable zoom levels, fed by the same terrain seed the projection uses (no new data source).
 - Add non-color-only encodings to the movement overlay: a distinct hatch/icon for blocked tiles and a secondary (non-hue) encoding distinguishing walk from run reach, complementing the existing jump diagonal pattern and MP cost text.
 - Keep terrain glyphs/labels distinguishable under the new badge layer (legibility constraint, not a redesign).
 
@@ -24,7 +24,7 @@ The spec already requires elevation to be "visible as a readable number on or ne
 
 - `src/components/gameplay/HexMapDisplay/HexCell.labels.tsx`, `HexCell.tsx` (badge layer), `HexMapDisplay.layers.tsx` / `Overlays.tsx` (movement overlay encodings), overlay legend components.
 - Visual smoke (`tactical-map-visual-smoke`) and Storybook stories for HexMapDisplay states.
-- No engine, projection, or rules changes; no combat-resolution delta — does not change the
+- No engine, projection, or rules changes; no combat-resolution delta - does not change the
   archived `add-battlemech-combat-validation-suite` baseline or the current `validate:combat` /
   `validate:combat:gaps` accounting.
 
@@ -32,5 +32,5 @@ The spec already requires elevation to be "visible as a readable number on or ne
 
 - No isometric work (separate change: `add-isometric-elevation-extrusion`).
 - No projection/engine agreement work (separate change: `fix-tactical-projection-agreement-gaps`).
-- No new per-hex to-hit surfacing — combined hover explanation and combat tooltip requirements already cover combat context per hex.
+- No new per-hex to-hit surfacing - combined hover explanation and combat tooltip requirements already cover combat context per hex.
 - No terrain art overhaul; existing terrain visuals stay, badges layer on top.

--- a/openspec/changes/add-topdown-tactical-legibility/tasks.md
+++ b/openspec/changes/add-topdown-tactical-legibility/tasks.md
@@ -2,24 +2,24 @@
 
 ## 1. Elevation badge layer
 
-- [ ] 1.1 Add the elevation badge render path to `HexCell` (corner-anchored SVG text inside the existing hex group), fed by the hex's terrain elevation, skipping elevation-0 hexes, signed formatting via `formatElevationLabel`.
-- [ ] 1.2 Add `showElevationBadges` to the map interaction store following the existing overlay-toggle shape (default ON in top-down, ignored in isometric), persisted like the other overlay toggles.
-- [ ] 1.3 Implement the zoom readability threshold: hide the badge layer below the cutoff via the existing zoom state; restore on zoom-in without re-toggle.
-- [ ] 1.4 Enforce collision priority (unit token > MP cost text > badge) at the fixed anchor; verify against Storybook stress states with tokens + overlays + badges on one hex.
+- [x] 1.1 Refine the existing elevation badge render path in `HexCell` (corner-anchored SVG text inside the existing hex group), fed by the hex's terrain elevation, skipping elevation-0 hexes, signed formatting via `formatElevationLabel`.
+- [x] 1.2 Add `showElevationBadges` to the map interaction store following the existing overlay-toggle shape (default ON in top-down, ignored in isometric), persisted like the other overlay toggles.
+- [x] 1.3 Implement the zoom readability threshold: hide the badge layer below the cutoff via the existing zoom state; restore on zoom-in without re-toggle.
+- [x] 1.4 Enforce collision priority (unit token > MP cost text > badge) at the fixed anchor; verify against Storybook stress states with tokens + overlays + badges on one hex.
 
 ## 2. Non-color overlay encodings
 
-- [ ] 2.1 Add the blocked-tile cross-hatch pattern + blocked glyph to the shared SVG `<defs>` and reference it from blocked movement tiles (alongside the existing dark gray tint), visually distinct from the jump diagonal pattern.
-- [ ] 2.2 Add the run-only dashed-border encoding distinguishing run tiles from walk tiles without hue.
-- [ ] 2.3 Update the overlay legend to document the non-color encodings alongside the palette colors.
+- [x] 2.1 Add the blocked-tile cross-hatch pattern + blocked glyph to the shared SVG `<defs>` and reference it from blocked movement tiles (alongside the existing dark gray tint), visually distinct from the jump diagonal pattern.
+- [x] 2.2 Add the run-only dashed-border encoding distinguishing run tiles from walk tiles without hue.
+- [x] 2.3 Update the overlay legend to document the non-color encodings alongside the palette colors.
 
 ## 3. Tests and stories
 
-- [ ] 3.1 Unit tests: badge renders signed values on non-zero hexes, no badge at elevation 0, toggle off removes badges, zoom threshold hides/restores the layer, badge data source equals the projection's hex terrain object.
-- [ ] 3.2 Unit tests: blocked tiles render the cross-hatch encoding, run-only tiles render the dashed border, legend lists both.
-- [ ] 3.3 Storybook stories for badge-dense boards (negative elevations, water depths) and encoding combinations; update tactical-map visual smoke baselines.
+- [x] 3.1 Unit tests: badge renders signed values on non-zero hexes, no badge at elevation 0, toggle off removes badges, zoom threshold hides/restores the layer, badge data source equals the projection's hex terrain object.
+- [x] 3.2 Unit tests: blocked tiles render the cross-hatch encoding, run-only tiles render the dashed border, legend lists both.
+- [x] 3.3 Storybook stories for badge-dense boards (negative elevations, water depths) and encoding combinations; update tactical-map visual smoke baselines.
 
 ## 4. Verification
 
-- [ ] 4.1 `npx tsc --noEmit --skipLibCheck`, lint, affected Jest suites, Storybook build, and visual smoke green; `npx openspec validate add-topdown-tactical-legibility --strict`.
-- [ ] 4.2 Manual dev-browser pass on a 30×34 map: badges readable at default zoom, no perf regression on pan/zoom (compare against the W5 occlusion-sweep baseline behavior).
+- [x] 4.1 `npx tsc --noEmit --skipLibCheck`, lint, affected Jest suites, Storybook build, and visual smoke green; `npx openspec validate add-topdown-tactical-legibility --strict`.
+- [x] 4.2 Manual dev-browser pass on a 30x34 map: badges readable at default zoom, no perf regression on pan/zoom (compare against the W5 occlusion-sweep baseline behavior).

--- a/src/components/gameplay/GameplayLayout.sections.tsx
+++ b/src/components/gameplay/GameplayLayout.sections.tsx
@@ -36,6 +36,8 @@ export const noopInteraction: MapInteractionState = {
   setLayerVisibility: () => {},
   showMovementOverlay: false,
   setShowMovementOverlay: () => {},
+  showElevationBadges: true,
+  setShowElevationBadges: () => {},
   showCoverOverlay: false,
   setShowCoverOverlay: () => {},
   showFiringArcOverlay: true,

--- a/src/components/gameplay/HexMapDisplay.stories.tsx
+++ b/src/components/gameplay/HexMapDisplay.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import {
   TerrainType,
   IHexTerrain,
+  IMovementRangeHex,
   Facing,
   GameSide,
   IUnitToken,
@@ -234,6 +235,98 @@ const overlayToken: IUnitToken = {
   unitType: TokenUnitType.Mech,
 };
 
+const badgeDenseTerrain: IHexTerrain[] = [
+  {
+    coordinate: { q: 0, r: 0 },
+    elevation: 0,
+    features: [{ type: TerrainType.Clear, level: 0 }],
+  },
+  {
+    coordinate: { q: 1, r: 0 },
+    elevation: 4,
+    features: [{ type: TerrainType.Building, level: 2 }],
+  },
+  {
+    coordinate: { q: 0, r: 1 },
+    elevation: -1,
+    features: [{ type: TerrainType.Water, level: 1 }],
+  },
+  {
+    coordinate: { q: -1, r: 1 },
+    elevation: -2,
+    features: [{ type: TerrainType.Water, level: 3 }],
+  },
+  {
+    coordinate: { q: 1, r: -1 },
+    elevation: 2,
+    features: [{ type: TerrainType.Rough, level: 1 }],
+  },
+  {
+    coordinate: { q: 2, r: -1 },
+    elevation: 3,
+    features: [{ type: TerrainType.HeavyWoods, level: 2 }],
+  },
+  {
+    coordinate: { q: -1, r: 0 },
+    elevation: 1,
+    features: [{ type: TerrainType.Rubble, level: 1 }],
+  },
+  {
+    coordinate: { q: 0, r: -1 },
+    elevation: -1,
+    features: [{ type: TerrainType.Swamp, level: 1 }],
+  },
+];
+
+const badgeDenseToken: IUnitToken = {
+  ...overlayToken,
+  unitId: 'shadow-hawk-badge-density',
+  name: 'Shadow Hawk SHD-2H',
+  designation: 'SHD',
+  position: { q: 1, r: 0 },
+  facing: Facing.Southwest,
+  isSelected: false,
+};
+
+const badgeDenseMovementRange: readonly IMovementRangeHex[] = [
+  {
+    hex: { q: 1, r: 0 },
+    mpCost: 3,
+    terrainCost: 0,
+    elevationDelta: 1,
+    elevationCost: 1,
+    heatGenerated: 0,
+    movementMode: 'biped',
+    reachable: true,
+    movementType: MovementType.Walk,
+  },
+  {
+    hex: { q: 2, r: -1 },
+    mpCost: 5,
+    terrainCost: 2,
+    elevationDelta: 1,
+    elevationCost: 1,
+    heatGenerated: 2,
+    movementMode: 'biped',
+    reachable: true,
+    movementType: MovementType.Run,
+  },
+  {
+    hex: { q: -1, r: 1 },
+    mpCost: 6,
+    terrainCost: 0,
+    elevationDelta: -2,
+    elevationCost: 0,
+    heatGenerated: 3,
+    movementMode: 'jump',
+    reachable: false,
+    movementType: MovementType.Jump,
+    blockedReason: 'Water depth exceeds safe landing profile',
+    movementInvalidReason: 'TerrainBlocked',
+    movementInvalidDetails: 'Water depth exceeds safe landing profile',
+  },
+];
+
 export const WithOverlays: Story = {
   args: {
     radius: 3,
@@ -252,6 +345,25 @@ export const WithOverlays: Story = {
   },
 };
 
+export const BadgeDenseElevationBoard: Story = {
+  args: {
+    radius: 3,
+    tokens: [badgeDenseToken],
+    selectedHex: { q: 0, r: 0 },
+    hexTerrain: badgeDenseTerrain,
+    movementRange: badgeDenseMovementRange,
+    showCoordinates: true,
+    mpLegend: {
+      active: 'run',
+      movementMode: 'biped',
+      walkMP: 4,
+      runMP: 6,
+      jumpMP: 3,
+      jumpAvailable: true,
+    },
+  },
+};
+
 const movementOverlayToken: IUnitToken = {
   ...overlayToken,
   unitId: 'griffin-move',
@@ -260,6 +372,84 @@ const movementOverlayToken: IUnitToken = {
   position: { q: -1, r: 0 },
   facing: Facing.Northeast,
 };
+
+const movementEncodingTerrain: IHexTerrain[] = [
+  {
+    coordinate: { q: -1, r: 0 },
+    elevation: 0,
+    features: [{ type: TerrainType.Clear, level: 0 }],
+  },
+  {
+    coordinate: { q: 0, r: 0 },
+    elevation: 0,
+    features: [{ type: TerrainType.Clear, level: 0 }],
+  },
+  {
+    coordinate: { q: 1, r: 0 },
+    elevation: 1,
+    features: [{ type: TerrainType.Rough, level: 1 }],
+  },
+  {
+    coordinate: { q: 2, r: 0 },
+    elevation: 2,
+    features: [{ type: TerrainType.Building, level: 1 }],
+  },
+  {
+    coordinate: { q: 0, r: 1 },
+    elevation: -1,
+    features: [{ type: TerrainType.Water, level: 2 }],
+  },
+];
+
+const movementEncodingRange: readonly IMovementRangeHex[] = [
+  {
+    hex: { q: 0, r: 0 },
+    mpCost: 1,
+    terrainCost: 0,
+    elevationDelta: 0,
+    elevationCost: 0,
+    heatGenerated: 0,
+    movementMode: 'biped',
+    reachable: true,
+    movementType: MovementType.Walk,
+  },
+  {
+    hex: { q: 1, r: 0 },
+    mpCost: 4,
+    terrainCost: 1,
+    elevationDelta: 1,
+    elevationCost: 1,
+    heatGenerated: 2,
+    movementMode: 'biped',
+    reachable: true,
+    movementType: MovementType.Run,
+  },
+  {
+    hex: { q: 2, r: 0 },
+    mpCost: 7,
+    terrainCost: 2,
+    elevationDelta: 2,
+    elevationCost: 2,
+    heatGenerated: 0,
+    movementMode: 'biped',
+    reachable: false,
+    movementType: MovementType.Run,
+    blockedReason: 'Destination exceeds remaining MP',
+    movementInvalidReason: 'InsufficientMP',
+    movementInvalidDetails: 'Destination exceeds remaining MP',
+  },
+  {
+    hex: { q: 0, r: 1 },
+    mpCost: 3,
+    terrainCost: 0,
+    elevationDelta: -1,
+    elevationCost: 0,
+    heatGenerated: 3,
+    movementMode: 'jump',
+    reachable: true,
+    movementType: MovementType.Jump,
+  },
+];
 
 const attackOverlayTokens: IUnitToken[] = [
   {
@@ -344,6 +534,25 @@ export const MovementAndPathOverlay: Story = {
     hoverMpCost: 4,
     mpLegend: {
       active: 'run',
+      jumpAvailable: true,
+    },
+  },
+};
+
+export const MovementEncodingCombinations: Story = {
+  args: {
+    radius: 3,
+    tokens: [movementOverlayToken],
+    selectedHex: { q: -1, r: 0 },
+    hexTerrain: movementEncodingTerrain,
+    movementRange: movementEncodingRange,
+    showCoordinates: true,
+    mpLegend: {
+      active: 'run',
+      movementMode: 'biped',
+      walkMP: 4,
+      runMP: 6,
+      jumpMP: 3,
       jumpAvailable: true,
     },
   },

--- a/src/components/gameplay/HexMapDisplay/HexCell.badgeStack.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexCell.badgeStack.tsx
@@ -58,6 +58,7 @@ export function HexCellBadgeStack({
   movementOptions,
   pathIndex,
   projectionMode,
+  showElevationBadge,
   tacticalProjectionBlockedReasons,
   tacticalProjectionCombatStatus,
   tacticalProjectionExplanation,
@@ -85,6 +86,7 @@ export function HexCellBadgeStack({
   >[number][];
   readonly pathIndex?: number;
   readonly projectionMode: MapProjectionMode;
+  readonly showElevationBadge?: boolean;
   readonly tacticalProjectionBlockedReasons?: readonly string[];
   readonly tacticalProjectionCombatStatus?: TacticalMapCombatProjectionStatus;
   readonly tacticalProjectionExplanation?: string;
@@ -102,17 +104,21 @@ export function HexCellBadgeStack({
 }): React.ReactElement {
   return (
     <>
-      <ElevationBadge
-        x={x}
-        y={y}
-        hex={hex}
-        elevation={elevation}
-        label={elevationLabel}
-        projectionMode={projectionMode}
-        projectionIntent={tacticalProjectionIntent}
-        projectionStatus={tacticalProjectionStatus}
-        sourceReferences={tacticalProjectionSourceReferences}
-      />
+      {showElevationBadge &&
+        projectionMode === 'topDown' &&
+        elevation !== 0 && (
+          <ElevationBadge
+            x={x}
+            y={y}
+            hex={hex}
+            elevation={elevation}
+            label={elevationLabel}
+            projectionMode={projectionMode}
+            projectionIntent={tacticalProjectionIntent}
+            projectionStatus={tacticalProjectionStatus}
+            sourceReferences={tacticalProjectionSourceReferences}
+          />
+        )}
       <ProjectionStatusBadge
         x={x}
         y={y}

--- a/src/components/gameplay/HexMapDisplay/HexCell.overlayAttributes.ts
+++ b/src/components/gameplay/HexMapDisplay/HexCell.overlayAttributes.ts
@@ -78,6 +78,7 @@ export function buildOverlayAttributes({
     role: 'img',
     'aria-label': overlayLabel,
     'data-hex-overlay-kind': overlayState.kind ?? undefined,
+    'data-movement-non-color-encoding': overlayState.movementNonColorEncoding,
     'data-hex-overlay-status': tacticalProjectionStatus,
     'data-hex-overlay-movement-status': tacticalProjectionMovementStatus,
     'data-hex-overlay-movement-cost-status':

--- a/src/components/gameplay/HexMapDisplay/HexCell.overlayModel.ts
+++ b/src/components/gameplay/HexMapDisplay/HexCell.overlayModel.ts
@@ -22,6 +22,9 @@ export interface HexOverlayState {
   readonly hasOverlay: boolean;
   readonly isLegacyAttackRangeFallback: boolean;
   readonly kind: HexOverlayKind | null;
+  readonly movementNonColorEncoding?:
+    | 'blocked-cross-hatch'
+    | 'run-dashed-border';
   readonly opacity: number;
 }
 
@@ -86,6 +89,7 @@ export function deriveHexOverlayState({
         : HEX_COLORS.movementRangeUnreachable,
       isLegacyAttackRangeFallback,
       kind: movementInfo.reachable ? 'movement-legal' : 'movement-blocked',
+      movementNonColorEncoding: movementNonColorEncodingFor(movementInfo),
       opacity: 0.5,
     });
   }
@@ -148,6 +152,20 @@ function colorForMovementType(type: MovementType): string {
       return HEX_COLORS.movementRangeJump;
     default:
       return HEX_COLORS.movementRange;
+  }
+}
+
+function movementNonColorEncodingFor(
+  movementInfo: IMovementRangeHex,
+): HexOverlayState['movementNonColorEncoding'] {
+  if (!movementInfo.reachable) return 'blocked-cross-hatch';
+  switch (movementInfo.movementType) {
+    case MovementType.Run:
+    case MovementType.Sprint:
+    case MovementType.Evade:
+      return 'run-dashed-border';
+    default:
+      return undefined;
   }
 }
 

--- a/src/components/gameplay/HexMapDisplay/HexCell.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexCell.tsx
@@ -45,12 +45,26 @@ import { hexToPixel, hexPath, getTerrainFill } from './renderHelpers';
  * reference it by URL.
  */
 const JUMP_PATTERN_URL = 'url(#pattern-jump-range)';
+const BLOCKED_MOVEMENT_PATTERN_URL = 'url(#pattern-blocked-movement)';
 
 function isJumpRangeTile(movementInfo?: IMovementRangeHex): boolean {
   return (
     movementInfo?.reachable === true &&
     movementInfo.movementType === MovementType.Jump
   );
+}
+
+function isRunRangeTile(movementInfo?: IMovementRangeHex): boolean {
+  return (
+    movementInfo?.reachable === true &&
+    (movementInfo.movementType === MovementType.Run ||
+      movementInfo.movementType === MovementType.Sprint ||
+      movementInfo.movementType === MovementType.Evade)
+  );
+}
+
+function isBlockedMovementTile(movementInfo?: IMovementRangeHex): boolean {
+  return movementInfo !== undefined && movementInfo.reachable === false;
 }
 
 function hasRenderableIsometricOccluder(
@@ -100,6 +114,7 @@ export interface HexCellProps {
   tacticalProjectionExplanation?: string;
   isometricOccluderInfo?: IsometricTerrainOccluderInfo;
   showCoordinate: boolean;
+  showElevationBadge?: boolean;
   projectionMode?: MapProjectionMode;
   /**
    * Per `add-movement-phase-ui` § 4.3: when the user hovers a
@@ -157,6 +172,7 @@ export const HexCell = React.memo(function HexCell({
   tacticalProjectionExplanation,
   isometricOccluderInfo,
   showCoordinate,
+  showElevationBadge = true,
   projectionMode = 'topDown',
   hoverMpCost,
   isUnreachableHover,
@@ -194,6 +210,8 @@ export const HexCell = React.memo(function HexCell({
   const overlayKind = overlayState.kind;
   const isLegacyAttackRangeFallback = overlayState.isLegacyAttackRangeFallback;
   const isJumpTile = isJumpRangeTile(movementInfo);
+  const isRunTile = isRunRangeTile(movementInfo);
+  const isBlockedTile = isBlockedMovementTile(movementInfo);
   const isIsometricOccluder = hasRenderableIsometricOccluder(
     isIsometricTile,
     isometricOccluderInfo,
@@ -329,6 +347,57 @@ export const HexCell = React.memo(function HexCell({
           data-testid={`jump-pattern-${hex.q}-${hex.r}`}
         />
       )}
+      {isBlockedTile && !isInPath && (
+        <>
+          <path
+            d={pathD}
+            fill={BLOCKED_MOVEMENT_PATTERN_URL}
+            opacity={0.72}
+            pointerEvents="none"
+            data-testid={`blocked-movement-pattern-${hex.q}-${hex.r}`}
+          />
+          <g
+            pointerEvents="none"
+            data-testid={`blocked-movement-glyph-${hex.q}-${hex.r}`}
+            aria-label={`Blocked movement marker for hex ${hex.q},${hex.r}`}
+          >
+            <rect
+              x={x - 28}
+              y={y + 11}
+              width={16}
+              height={14}
+              rx={3}
+              fill="#0f172a"
+              fillOpacity={0.88}
+              stroke="#f8fafc"
+              strokeWidth={0.75}
+            />
+            <text
+              x={x - 20}
+              y={y + 21}
+              textAnchor="middle"
+              fontSize={10}
+              fontWeight="bold"
+              fill="#f8fafc"
+            >
+              !
+            </text>
+          </g>
+        </>
+      )}
+      {isRunTile && !isInPath && (
+        <path
+          d={pathD}
+          fill="none"
+          stroke="#854d0e"
+          strokeWidth={2}
+          strokeDasharray="5 3"
+          opacity={0.92}
+          pointerEvents="none"
+          data-testid={`run-range-outline-${hex.q}-${hex.r}`}
+          aria-label={`Run-only movement marker for hex ${hex.q},${hex.r}`}
+        />
+      )}
       {isIsometricOccluder && (
         <g
           pointerEvents="none"
@@ -386,6 +455,7 @@ export const HexCell = React.memo(function HexCell({
         elevation={elevation}
         elevationLabel={elevationLabel}
         terrainFeatures={terrainFeatures}
+        showElevationBadge={showElevationBadge}
         projectionMode={projectionMode}
         movementInfo={movementInfo}
         movementOptions={movementOptions}

--- a/src/components/gameplay/HexMapDisplay/HexMapDisplay.controlIcons.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexMapDisplay.controlIcons.tsx
@@ -79,6 +79,18 @@ export function CoverIcon(): React.ReactElement {
   );
 }
 
+export function ElevationIcon(): React.ReactElement {
+  return (
+    <ControlIcon>
+      <path d="M5 17h14" />
+      <path d="M7 13h10" />
+      <path d="M9 9h6" />
+      <path d="M12 5v12" />
+      <path d="M9 8 12 5l3 3" />
+    </ControlIcon>
+  );
+}
+
 export function FiringArcIcon(): React.ReactElement {
   return (
     <ControlIcon>

--- a/src/components/gameplay/HexMapDisplay/HexMapDisplay.controls.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexMapDisplay.controls.tsx
@@ -6,6 +6,7 @@ import type { MapInteractionState } from './useMapInteraction';
 
 import {
   CoverIcon,
+  ElevationIcon,
   FiringArcIcon,
   IsometricIcon,
   LosIcon,
@@ -32,12 +33,14 @@ interface MapControlsProps {
 
 type OverlayToggleProjectionChannel =
   | 'movement'
+  | 'terrain-elevation'
   | 'cover'
   | 'firing-arc'
   | 'line-of-sight';
 
 type OverlayToggleRulesSurface =
   | 'movement-cost'
+  | 'terrain-elevation'
   | 'cover-level'
   | 'firing-arc'
   | 'line-of-sight';
@@ -211,6 +214,32 @@ export function MapControls({
           )}
         >
           <MovementIcon />
+        </button>
+        <button
+          type="button"
+          onClick={() => interaction.setShowElevationBadges((v) => !v)}
+          className={`flex min-h-[44px] min-w-[44px] items-center justify-center rounded p-2 text-xs font-medium shadow transition-colors ${
+            interaction.showElevationBadges
+              ? 'bg-sky-600 text-white hover:bg-sky-700'
+              : 'bg-white text-slate-700 hover:bg-gray-100'
+          }`}
+          title="Toggle terrain elevation badges"
+          aria-label={formatLayerToggleLabel(
+            'Toggle terrain elevation badges',
+            interaction.showElevationBadges,
+            'terrain-elevation',
+            'terrain-elevation',
+          )}
+          aria-pressed={interaction.showElevationBadges}
+          data-testid="overlay-toggle-elevation"
+          {...layerToggleProjectionAttributes(
+            interaction,
+            'elevation',
+            'terrain-elevation',
+            'terrain-elevation',
+          )}
+        >
+          <ElevationIcon />
         </button>
         <button
           type="button"

--- a/src/components/gameplay/HexMapDisplay/HexMapDisplay.mpLegend.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexMapDisplay.mpLegend.tsx
@@ -14,6 +14,8 @@ interface MapMovementPointLegendProps extends MapMovementPointLegendState {
 interface MovementLegendKindConfig {
   readonly kind: MapMovementKind;
   readonly label: string;
+  readonly nonColorEncoding?: string;
+  readonly nonColorEncodingLabel?: string;
   readonly swatchClassName: string;
 }
 
@@ -28,8 +30,20 @@ interface MovementLegendButtonProps {
 
 const MOVEMENT_LEGEND_KINDS: readonly MovementLegendKindConfig[] = [
   { kind: 'walk', label: 'Walk', swatchClassName: 'bg-cyan-400' },
-  { kind: 'run', label: 'Run', swatchClassName: 'bg-yellow-500' },
-  { kind: 'jump', label: 'Jump', swatchClassName: 'bg-red-500' },
+  {
+    kind: 'run',
+    label: 'Run',
+    nonColorEncoding: 'dashed-border',
+    nonColorEncodingLabel: 'dashed border for run-only tiles',
+    swatchClassName: 'bg-yellow-500',
+  },
+  {
+    kind: 'jump',
+    label: 'Jump',
+    nonColorEncoding: 'diagonal-hatch',
+    nonColorEncodingLabel: 'diagonal hatch',
+    swatchClassName: 'bg-red-500',
+  },
 ];
 
 function movementLegendDisabledReason(
@@ -44,12 +58,14 @@ function movementLegendStateLabel({
   isActive,
   label,
   movementModeLabel,
+  nonColorEncodingLabel,
   mp,
 }: {
   readonly disabledReason?: string;
   readonly isActive: boolean;
   readonly label: string;
   readonly movementModeLabel?: string;
+  readonly nonColorEncodingLabel?: string;
   readonly mp?: number;
 }): string {
   const stateParts = [
@@ -58,6 +74,9 @@ function movementLegendStateLabel({
   ];
   if (mp !== undefined) stateParts.push(`${mp} MP`);
   if (movementModeLabel) stateParts.push(`motive ${movementModeLabel}`);
+  if (nonColorEncodingLabel) {
+    stateParts.push(`non-color encoding ${nonColorEncodingLabel}`);
+  }
   if (disabledReason) stateParts.push(`disabled: ${disabledReason}`);
   return stateParts.join('; ');
 }
@@ -80,6 +99,7 @@ function MovementLegendButton({
     isActive,
     label,
     movementModeLabel,
+    nonColorEncodingLabel: config.nonColorEncodingLabel,
     mp,
   });
 
@@ -93,6 +113,7 @@ function MovementLegendButton({
       data-active={isActive ? 'true' : undefined}
       data-disabled={disabledReason ? 'true' : undefined}
       data-disabled-reason={disabledReason}
+      data-non-color-encoding={config.nonColorEncoding}
       data-selectable={isSelectable ? 'true' : undefined}
       data-mp={mp}
       aria-pressed={isActive}
@@ -132,6 +153,7 @@ export function MapMovementPointLegend({
     <div
       className="pointer-events-none absolute bottom-4 left-4 flex flex-col gap-1 rounded bg-white/90 p-2 text-xs shadow"
       data-testid="mp-legend"
+      data-non-color-encodings="blocked:cross-hatch|run:dashed-border|jump:diagonal-hatch"
       data-movement-mode={movementMode}
       data-walk-mp={walkMP}
       data-run-mp={runMP}
@@ -159,6 +181,15 @@ export function MapMovementPointLegend({
           onMovementModeSelect={onMovementModeSelect}
         />
       ))}
+      <div
+        className="pointer-events-auto flex items-center gap-2 rounded px-1 py-0.5 text-slate-700"
+        data-testid="mp-legend-blocked"
+        data-non-color-encoding="cross-hatch"
+        aria-label="Blocked movement projection; non-color encoding cross-hatch and blocked marker"
+      >
+        <span className="inline-block h-3 w-3 rounded-sm border border-slate-700 bg-slate-500" />
+        <span>Blocked</span>
+      </div>
     </div>
   );
 }

--- a/src/components/gameplay/HexMapDisplay/HexMapDisplay.renderHexCell.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexMapDisplay.renderHexCell.tsx
@@ -27,6 +27,7 @@ export interface RenderHexCellInput {
   readonly projectionMode: MapProjectionMode;
   readonly selectedHex: IHexCoordinate | null;
   readonly showCoordinates: boolean;
+  readonly showElevationBadges: boolean;
   readonly tacticalMapProjectionLookup: ReadonlyMap<
     string,
     ITacticalMapHexProjection
@@ -47,6 +48,7 @@ export function renderHexCell(
     projectionMode,
     selectedHex,
     showCoordinates,
+    showElevationBadges,
     tacticalMapProjectionLookup,
     terrainLookup,
   }: RenderHexCellInput,
@@ -89,6 +91,7 @@ export function renderHexCell(
       tacticalProjectionExplanation={projection?.explanation}
       isometricOccluderInfo={isometricOccluderInfo || undefined}
       showCoordinate={showCoordinates}
+      showElevationBadge={showElevationBadges}
       projectionMode={projectionMode}
       hoverMpCost={
         isHovered && hoverMpCost !== undefined && movementInfo?.reachable

--- a/src/components/gameplay/HexMapDisplay/HexMapDisplay.state.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexMapDisplay.state.tsx
@@ -46,6 +46,8 @@ import { getMapProjectionTransform, isIsometricProjection } from './projection';
 import { generateHexesInRadius } from './renderHelpers';
 import { useMapInteraction } from './useMapInteraction';
 
+const ELEVATION_BADGE_MIN_ZOOM = 0.75;
+
 // Stable empty defaults (audit 2026-06-09 G, W5.1a): inline `= []` /
 // `= {}` default parameters mint a FRESH identity on every render when
 // the prop is omitted, which invalidates every downstream useMemo
@@ -98,6 +100,10 @@ export function useHexMapDisplayState({
     interaction.isometricRotationStep,
   );
   const isIsometricView = isIsometricProjection(interaction.projectionMode);
+  const showElevationBadges =
+    !isIsometricView &&
+    interaction.showElevationBadges &&
+    interaction.zoom >= ELEVATION_BADGE_MIN_ZOOM;
   const hexes = useMemo(() => generateHexesInRadius(radius), [radius]);
   const terrainLookup = useTerrainLookup(hexTerrain);
   const movementRangeLookup = useMovementRangeLookup(movementRange);
@@ -307,6 +313,7 @@ export function useHexMapDisplayState({
         projectionMode: interaction.projectionMode,
         selectedHex,
         showCoordinates,
+        showElevationBadges,
         tacticalMapProjectionLookup,
         terrainLookup,
       });
@@ -322,6 +329,7 @@ export function useHexMapDisplayState({
       isometricTerrainOccluderInfoByHex,
       selectedHex,
       showCoordinates,
+      showElevationBadges,
       tacticalMapProjectionLookup,
       terrainLookup,
     ],

--- a/src/components/gameplay/HexMapDisplay/Overlays.tsx
+++ b/src/components/gameplay/HexMapDisplay/Overlays.tsx
@@ -326,6 +326,26 @@ export function TerrainPatternDefs(): React.ReactElement {
         />
       </pattern>
       <pattern
+        id="pattern-blocked-movement"
+        patternUnits="userSpaceOnUse"
+        width="8"
+        height="8"
+      >
+        <rect width="8" height="8" fill="transparent" />
+        <path
+          d="M0 0 8 8 M8 0 0 8"
+          stroke="#0f172a"
+          strokeWidth="1.25"
+          opacity="0.65"
+        />
+        <path
+          d="M4 0v8 M0 4h8"
+          stroke="#f8fafc"
+          strokeWidth="0.75"
+          opacity="0.55"
+        />
+      </pattern>
+      <pattern
         id="pattern-light-woods"
         patternUnits="userSpaceOnUse"
         width="12"

--- a/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.04.test.tsx
+++ b/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.04.test.tsx
@@ -49,6 +49,10 @@ describe('HexMapDisplay tactical visual layers', () => {
     );
 
     expect(screen.getByTestId('mp-legend')).toHaveClass('pointer-events-none');
+    expect(screen.getByTestId('mp-legend')).toHaveAttribute(
+      'data-non-color-encodings',
+      'blocked:cross-hatch|run:dashed-border|jump:diagonal-hatch',
+    );
     expect(screen.getByTestId('mp-legend-walk')).toHaveAttribute(
       'aria-disabled',
       'true',
@@ -76,7 +80,7 @@ describe('HexMapDisplay tactical visual layers', () => {
     ).toHaveClass('bg-yellow-500');
     expect(screen.getByTestId('mp-legend-run')).toHaveAttribute(
       'aria-label',
-      'Run movement range; active',
+      'Run movement range; active; non-color encoding dashed border for run-only tiles',
     );
     expect(screen.getByTestId('mp-legend-jump')).toHaveClass(
       'pointer-events-auto',
@@ -98,7 +102,14 @@ describe('HexMapDisplay tactical visual layers', () => {
     );
     expect(screen.getByTestId('mp-legend-jump')).toHaveAttribute(
       'aria-label',
-      'Jump movement range; inactive; disabled: No jump capability',
+      'Jump movement range; inactive; non-color encoding diagonal hatch; disabled: No jump capability',
+    );
+    expect(screen.getByTestId('mp-legend-blocked')).toHaveAttribute(
+      'data-non-color-encoding',
+      'cross-hatch',
+    );
+    expect(screen.getByTestId('mp-legend-blocked')).toHaveTextContent(
+      'Blocked',
     );
 
     act(() => {
@@ -194,12 +205,12 @@ describe('HexMapDisplay tactical visual layers', () => {
     expect(screen.getByTestId('mp-legend-run')).toHaveAttribute('data-mp', '5');
     expect(screen.getByTestId('mp-legend-run')).toHaveAttribute(
       'aria-label',
-      'Run movement range; active; 5 MP; motive VTOL',
+      'Run movement range; active; 5 MP; motive VTOL; non-color encoding dashed border for run-only tiles',
     );
     expect(screen.getByTestId('mp-legend-jump')).toHaveTextContent('Jump 0MP');
     expect(screen.getByTestId('mp-legend-jump')).toHaveAttribute(
       'aria-label',
-      'Jump movement range; inactive; 0 MP; motive VTOL; disabled: No jump capability',
+      'Jump movement range; inactive; 0 MP; motive VTOL; non-color encoding diagonal hatch; disabled: No jump capability',
     );
 
     act(() => {

--- a/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.08.test.tsx
+++ b/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.08.test.tsx
@@ -334,4 +334,85 @@ describe('HexMapDisplay tactical visual layers', () => {
       unmount();
     });
   });
+
+  it('renders blocked and run movement states with non-color encodings', () => {
+    const blockedReason = 'Destination occupied by hostile unit';
+
+    const { unmount } = render(
+      <HexMapDisplay
+        mapId="movement-non-color-encodings"
+        radius={1}
+        tokens={[]}
+        selectedHex={null}
+        movementRange={[
+          {
+            hex: { q: -1, r: 0 },
+            mpCost: 1,
+            reachable: true,
+            movementType: MovementType.Walk,
+          },
+          {
+            hex: { q: 0, r: 1 },
+            mpCost: 4,
+            reachable: true,
+            movementType: MovementType.Run,
+          },
+          {
+            hex: { q: 1, r: 0 },
+            mpCost: 5,
+            reachable: false,
+            movementType: MovementType.Run,
+            blockedReason,
+            movementInvalidReason: 'DestinationOccupied',
+            movementInvalidDetails: blockedReason,
+          },
+        ]}
+      />,
+    );
+
+    const walkOverlay = screen.getByTestId('hex-overlay--1-0');
+    const runOverlay = screen.getByTestId('hex-overlay-0-1');
+    const blockedOverlay = screen.getByTestId('hex-overlay-1-0');
+
+    expect(walkOverlay).toHaveAttribute(
+      'data-hex-overlay-kind',
+      'movement-legal',
+    );
+    expect(walkOverlay).not.toHaveAttribute('data-movement-non-color-encoding');
+    expect(screen.queryByTestId('run-range-outline--1-0')).toBeNull();
+
+    expect(runOverlay).toHaveAttribute(
+      'data-hex-overlay-kind',
+      'movement-legal',
+    );
+    expect(runOverlay).toHaveAttribute(
+      'data-movement-non-color-encoding',
+      'run-dashed-border',
+    );
+    expect(screen.getByTestId('run-range-outline-0-1')).toHaveAttribute(
+      'stroke-dasharray',
+      '5 3',
+    );
+
+    expect(blockedOverlay).toHaveAttribute(
+      'data-hex-overlay-kind',
+      'movement-blocked',
+    );
+    expect(blockedOverlay).toHaveAttribute(
+      'data-movement-non-color-encoding',
+      'blocked-cross-hatch',
+    );
+    expect(screen.getByTestId('blocked-movement-pattern-1-0')).toHaveAttribute(
+      'fill',
+      'url(#pattern-blocked-movement)',
+    );
+    expect(screen.getByTestId('blocked-movement-glyph-1-0')).toHaveTextContent(
+      '!',
+    );
+    expect(screen.queryByTestId('jump-pattern-1-0')).toBeNull();
+
+    act(() => {
+      unmount();
+    });
+  });
 });

--- a/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.14.test.tsx
+++ b/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.14.test.tsx
@@ -75,9 +75,7 @@ describe('HexMapDisplay tactical visual layers', () => {
     expect(screen.getByTestId('hex-elevation-label-0-0')).toHaveTextContent(
       '+2',
     );
-    expect(screen.getByTestId('hex-elevation-label-1-0')).toHaveTextContent(
-      'Elevation 0',
-    );
+    expect(screen.queryByTestId('hex-elevation-label-1-0')).toBeNull();
     expect(movementHex).toHaveAttribute('data-elevation-delta', '-2');
     expect(movementHex).toHaveAttribute('data-elevation-cost', '2');
     expect(screen.getByTestId('hex-movement-cost-badge-1-0')).toHaveTextContent(

--- a/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.terrainLabels.01.test.tsx
+++ b/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.terrainLabels.01.test.tsx
@@ -49,7 +49,7 @@ describe('HexMapDisplay terrain and elevation labels', () => {
     });
   });
 
-  it('renders the full terrain vocabulary with readable elevation labels in top-down and isometric modes', () => {
+  it('renders the full terrain vocabulary with readable top-down elevation badges and isometric stacks', () => {
     const terrainMatrix = buildTerrainMatrix();
     const tallHex = terrainMatrix.find((terrain) => terrain.elevation > 0);
 
@@ -114,7 +114,7 @@ describe('HexMapDisplay terrain and elevation labels', () => {
     ): void => {
       const hex = screen.getByTestId('hex-1-0');
       const terrainBadge = screen.getByTestId('hex-terrain-label-1-0');
-      const elevationBadge = screen.getByTestId('hex-elevation-label-1-0');
+      const elevationBadge = screen.queryByTestId('hex-elevation-label-1-0');
 
       expect(hex).toHaveAttribute(
         'aria-label',
@@ -148,7 +148,13 @@ describe('HexMapDisplay terrain and elevation labels', () => {
         'data-projection-mode',
         projectionMode,
       );
-      for (const badge of [terrainBadge, elevationBadge]) {
+      const projectionBadges =
+        projectionMode === 'topDown'
+          ? [terrainBadge, elevationBadge]
+          : [terrainBadge];
+      for (const badge of projectionBadges) {
+        expect(badge).not.toBeNull();
+        if (!badge) throw new Error('Expected terrain projection badge');
         assertTerrainElevationProjectionMetadata(badge, layeredTerrain);
         expect(badge).toHaveAttribute(
           'data-tactical-projection-sources',
@@ -162,6 +168,9 @@ describe('HexMapDisplay terrain and elevation labels', () => {
           'data-tactical-projection-sources',
           expect.stringContaining('building level 3'),
         );
+      }
+      if (projectionMode === 'isometric2d') {
+        expect(elevationBadge).toBeNull();
       }
     };
 

--- a/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.terrainLabels.02.test.tsx
+++ b/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.terrainLabels.02.test.tsx
@@ -111,7 +111,7 @@ describe('HexMapDisplay terrain and elevation labels', () => {
     });
   });
 
-  it('keeps top-down terrain and elevation badges exposed across playable zoom levels', () => {
+  it('hides top-down elevation badges below the readability zoom threshold and restores them on zoom-in', () => {
     const roughRise: IHexTerrain = {
       coordinate: { q: 1, r: 0 },
       elevation: 2,
@@ -139,23 +139,83 @@ describe('HexMapDisplay terrain and elevation labels', () => {
       return interaction;
     };
 
-    const assertTopDownLabels = (): void => {
+    const assertTopDownMode = (): void => {
       expect(screen.getByTestId('map-projection-layer')).toHaveAttribute(
         'data-projection-mode',
         'topDown',
       );
-      assertTerrainAndElevationBadges([roughRise]);
+    };
+    const assertTerrainBadgeStillReadable = (): void => {
+      expect(screen.getByTestId('hex-terrain-label-1-0')).toHaveTextContent(
+        'RGH',
+      );
     };
 
-    assertTopDownLabels();
+    assertTopDownMode();
+    assertTerrainAndElevationBadges([roughRise]);
 
-    for (const zoom of [ZOOM_MIN, FOCUS_BUMP_ZOOM, ZOOM_MAX]) {
+    act(() => {
+      requireInteraction().setZoom(ZOOM_MIN);
+    });
+    expect(requireInteraction().zoom).toBe(ZOOM_MIN);
+    assertTopDownMode();
+    assertTerrainBadgeStillReadable();
+    expect(screen.queryByTestId('hex-elevation-label-1-0')).toBeNull();
+
+    for (const zoom of [FOCUS_BUMP_ZOOM, ZOOM_MAX]) {
       act(() => {
         requireInteraction().setZoom(zoom);
       });
       expect(requireInteraction().zoom).toBe(zoom);
-      assertTopDownLabels();
+      assertTopDownMode();
+      assertTerrainAndElevationBadges([roughRise]);
     }
+
+    act(() => {
+      unmount();
+    });
+  });
+
+  it('allows top-down elevation badges to be toggled off while preserving terrain hover elevation context', () => {
+    const roughRise: IHexTerrain = {
+      coordinate: { q: 1, r: 0 },
+      elevation: 2,
+      features: [{ type: TerrainType.Rough, level: 1 }],
+    };
+
+    const { unmount } = render(
+      <HexMapDisplay
+        mapId="terrain-elevation-toggle"
+        radius={1}
+        tokens={[]}
+        selectedHex={null}
+        hexTerrain={[roughRise]}
+      />,
+    );
+
+    const elevationToggle = screen.getByTestId('overlay-toggle-elevation');
+    expect(elevationToggle).toHaveAttribute('aria-pressed', 'true');
+    expect(elevationToggle).toHaveAttribute(
+      'data-map-layer-projection-channel',
+      'terrain-elevation',
+    );
+    expect(elevationToggle).toHaveAccessibleName(
+      expect.stringContaining('Toggle terrain elevation badges; visible'),
+    );
+    expect(screen.getByTestId('hex-elevation-label-1-0')).toHaveTextContent(
+      '+2',
+    );
+
+    fireEvent.click(elevationToggle);
+
+    expect(elevationToggle).toHaveAttribute('aria-pressed', 'false');
+    expect(elevationToggle).toHaveAttribute('data-map-layer-visible', 'false');
+    expect(screen.queryByTestId('hex-elevation-label-1-0')).toBeNull();
+
+    fireEvent.mouseEnter(screen.getByTestId('hex-1-0'));
+    expect(
+      screen.getByTestId('hex-terrain-tooltip-elevation'),
+    ).toHaveTextContent('Elevation: +2');
 
     act(() => {
       unmount();

--- a/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.terrainLabels.test-helpers.ts
+++ b/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.terrainLabels.test-helpers.ts
@@ -231,37 +231,44 @@ function assertTerrainAndElevationBadges(
       screen.getByTestId(`hex-terrain-label-${q}-${r}`).querySelector('text'),
     ).toHaveAttribute('font-size', '7');
 
-    expect(
-      screen.getByTestId(`hex-elevation-label-${q}-${r}`),
-    ).toHaveTextContent(elevationLabel);
-    expect(screen.getByTestId(`hex-elevation-label-${q}-${r}`)).toHaveAttribute(
+    const elevationBadgeTestId = `hex-elevation-label-${q}-${r}`;
+    const shouldRenderElevationBadge =
+      projectionMode === 'topDown' && terrain.elevation !== 0;
+
+    if (!shouldRenderElevationBadge) {
+      expect(screen.queryByTestId(elevationBadgeTestId)).toBeNull();
+      continue;
+    }
+
+    const elevationBadge = screen.getByTestId(elevationBadgeTestId);
+    expect(elevationBadge).toHaveTextContent(elevationLabel);
+    expect(elevationBadge).toHaveAttribute(
       'aria-label',
       expect.stringContaining(
         `Elevation ${elevationLabel} (level ${terrain.elevation})`,
       ),
     );
-    expect(screen.getByTestId(`hex-elevation-label-${q}-${r}`)).toHaveAttribute(
+    expect(elevationBadge).toHaveAttribute(
       'data-elevation-value',
       `${terrain.elevation}`,
     );
-    expect(screen.getByTestId(`hex-elevation-label-${q}-${r}`)).toHaveAttribute(
+    expect(elevationBadge).toHaveAttribute(
       'data-elevation-sign',
       elevationSign,
     );
-    expect(screen.getByTestId(`hex-elevation-label-${q}-${r}`)).toHaveAttribute(
+    expect(elevationBadge).toHaveAttribute(
       'data-projection-mode',
       projectionMode,
     );
-    assertTerrainElevationProjectionMetadata(
-      screen.getByTestId(`hex-elevation-label-${q}-${r}`),
-      terrain,
+    assertTerrainElevationProjectionMetadata(elevationBadge, terrain);
+    expect(elevationBadge.querySelector('rect')).toHaveAttribute(
+      'height',
+      '14',
     );
-    expect(
-      screen.getByTestId(`hex-elevation-label-${q}-${r}`).querySelector('rect'),
-    ).toHaveAttribute('height', '14');
-    expect(
-      screen.getByTestId(`hex-elevation-label-${q}-${r}`).querySelector('text'),
-    ).toHaveAttribute('font-size', '10');
+    expect(elevationBadge.querySelector('text')).toHaveAttribute(
+      'font-size',
+      '10',
+    );
   }
 }
 

--- a/src/components/gameplay/HexMapDisplay/useMapLayerState.ts
+++ b/src/components/gameplay/HexMapDisplay/useMapLayerState.ts
@@ -28,6 +28,8 @@ export interface IMapLayerInteractionState {
   ) => void;
   showMovementOverlay: boolean;
   setShowMovementOverlay: React.Dispatch<React.SetStateAction<boolean>>;
+  showElevationBadges: boolean;
+  setShowElevationBadges: React.Dispatch<React.SetStateAction<boolean>>;
   showCoverOverlay: boolean;
   setShowCoverOverlay: React.Dispatch<React.SetStateAction<boolean>>;
   showFiringArcOverlay: boolean;
@@ -71,6 +73,10 @@ export function useMapLayerState(
     React.Dispatch<React.SetStateAction<boolean>>
   >((next) => setLayerVisibility('movement', next), [setLayerVisibility]);
 
+  const setShowElevationBadges = useCallback<
+    React.Dispatch<React.SetStateAction<boolean>>
+  >((next) => setLayerVisibility('elevation', next), [setLayerVisibility]);
+
   const setShowCoverOverlay = useCallback<
     React.Dispatch<React.SetStateAction<boolean>>
   >((next) => setLayerVisibility('cover', next), [setLayerVisibility]);
@@ -103,6 +109,8 @@ export function useMapLayerState(
       setLayerVisibility,
       showMovementOverlay: layerState.movement.visible,
       setShowMovementOverlay,
+      showElevationBadges: layerState.elevation.visible,
+      setShowElevationBadges,
       showCoverOverlay: layerState.cover.visible,
       setShowCoverOverlay,
       showFiringArcOverlay: layerState.firingArcs.visible,
@@ -118,6 +126,7 @@ export function useMapLayerState(
       rotateIsometricRight,
       setLayerVisibility,
       setShowMovementOverlay,
+      setShowElevationBadges,
       setShowCoverOverlay,
       setShowFiringArcOverlay,
       setShowLOSOverlay,

--- a/src/testing/tactical-map.e2e-harness-map-config.ts
+++ b/src/testing/tactical-map.e2e-harness-map-config.ts
@@ -18,6 +18,7 @@ import * as hoverWater from './tactical-map.hover-water-scenario';
 import * as immobileCombat from './tactical-map.immobile-combat-scenario';
 import * as lamAirborneFighter from './tactical-map.lam-airborne-fighter-scenario';
 import * as lamConversion from './tactical-map.lam-conversion-scenario';
+import * as largeTopdown from './tactical-map.large-topdown-legibility-scenario';
 import * as movementCombat from './tactical-map.movement-combat-scenario';
 import * as movement from './tactical-map.movement-scenarios';
 import * as multiOccluders from './tactical-map.multi-isometric-occluders-scenario';
@@ -211,6 +212,8 @@ export const selectedHexByScenario = {
   'frogman-deep-water': frogman.tacticalMapFrogmanSelectedHex,
   'prone-stand-up': standUp.tacticalMapStandUpSelectedHex,
   'impossible-stand-up': standUp.tacticalMapStandUpSelectedHex,
+  'large-topdown-legibility':
+    largeTopdown.tacticalMapLargeTopdownLegibilitySelectedHex,
 } satisfies Record<string, { readonly q: number; readonly r: number }>;
 
 export const hexTerrainByScenario = {
@@ -260,8 +263,12 @@ export const hexTerrainByScenario = {
     cappedStack.tacticalMapCappedIsometricStackHexTerrain,
   'multi-isometric-occluders':
     multiOccluders.tacticalMapMultiIsometricOccludersHexTerrain,
+  'large-topdown-legibility':
+    largeTopdown.tacticalMapLargeTopdownLegibilityHexTerrain,
 } satisfies Record<string, typeof tacticalMapHexTerrain>;
 
 export const mapRadiusByScenario = {
   'lam-airmek-long-cruise-heat': 6,
+  'large-topdown-legibility':
+    largeTopdown.tacticalMapLargeTopdownLegibilityRadius,
 } satisfies Record<string, number>;

--- a/src/testing/tactical-map.large-topdown-legibility-scenario.ts
+++ b/src/testing/tactical-map.large-topdown-legibility-scenario.ts
@@ -1,0 +1,54 @@
+import type { IHexTerrain } from '@/types/gameplay';
+
+import { TerrainType } from '@/types/gameplay';
+
+export const tacticalMapLargeTopdownLegibilityRadius = 17;
+
+export const tacticalMapLargeTopdownLegibilitySelectedHex = {
+  q: 0,
+  r: 0,
+} as const;
+
+export const tacticalMapLargeTopdownLegibilityHexTerrain: readonly IHexTerrain[] =
+  [
+    {
+      coordinate: { q: 0, r: 0 },
+      elevation: 0,
+      features: [{ type: TerrainType.Clear, level: 0 }],
+    },
+    {
+      coordinate: { q: 1, r: 0 },
+      elevation: 4,
+      features: [{ type: TerrainType.Building, level: 2 }],
+    },
+    {
+      coordinate: { q: 0, r: 1 },
+      elevation: -1,
+      features: [{ type: TerrainType.Water, level: 1 }],
+    },
+    {
+      coordinate: { q: -1, r: 1 },
+      elevation: -2,
+      features: [{ type: TerrainType.Water, level: 2 }],
+    },
+    {
+      coordinate: { q: 2, r: -1 },
+      elevation: 3,
+      features: [{ type: TerrainType.HeavyWoods, level: 2 }],
+    },
+    {
+      coordinate: { q: -2, r: 2 },
+      elevation: 2,
+      features: [{ type: TerrainType.Rough, level: 1 }],
+    },
+    {
+      coordinate: { q: 5, r: -3 },
+      elevation: 1,
+      features: [{ type: TerrainType.LightWoods, level: 1 }],
+    },
+    {
+      coordinate: { q: -5, r: 3 },
+      elevation: -1,
+      features: [{ type: TerrainType.Swamp, level: 1 }],
+    },
+  ];


### PR DESCRIPTION
## Summary
- add a layer-controlled top-down elevation badge toggle with zoom readability gating
- add non-color movement encodings for blocked and run-only tiles plus legend metadata
- add Storybook stress boards and Playwright coverage for dense top-down boards, badge toggles, and non-color SVG marks
- mark add-topdown-tactical-legibility OpenSpec tasks complete after validation

## Validation
- npx.cmd tsc --noEmit --skipLibCheck
- npm.cmd run lint
- npm.cmd run format:check
- targeted HexMapDisplay Jest suites: 5 passed / 14 tests
- npx.cmd playwright test e2e/tactical-map-visual-smoke.spec.ts --project=chromium: 61 passed
- npm.cmd run storybook:build
- openspec.cmd validate add-topdown-tactical-legibility --strict
- git diff --check
- commit hook: lint-staged, staged TypeScript typecheck, and npm run build