### PR TITLE
Add isometric elevation extrusion

### DIFF
--- a/e2e/tactical-map-visual-smoke.spec.ts
+++ b/e2e/tactical-map-visual-smoke.spec.ts
@@ -984,6 +984,47 @@ test.describe('Tactical map visual smoke @smoke @game', () => {
     const eastDepthBefore = await eastHex.getAttribute(
       'data-isometric-depth-key',
     );
+    const eastSoutheastFace = page.getByTestId(
+      'isometric-extrusion-face-1-0-southeast',
+    );
+    const eastSouthwestFace = page.getByTestId(
+      'isometric-extrusion-face-1-0-southwest',
+    );
+    await expect(eastSoutheastFace).toHaveAttribute(
+      'data-isometric-extrusion-owner-hex',
+      '1,0',
+    );
+    await expect(eastSoutheastFace).toHaveAttribute(
+      'data-isometric-extrusion-face',
+      'southeast',
+    );
+    await expect(eastSoutheastFace).toHaveAttribute(
+      'data-isometric-extrusion-effective-height',
+      '5',
+    );
+    await expect(eastSoutheastFace).toHaveAttribute(
+      'data-isometric-extrusion-terrain-elevation',
+      '4',
+    );
+    await expect(eastSoutheastFace).toHaveAttribute(
+      'data-isometric-extrusion-height',
+      '30',
+    );
+    await expect(eastSoutheastFace).toHaveAttribute(
+      'data-isometric-extrusion-pointer-events',
+      'none',
+    );
+    await expect(eastSoutheastFace).toHaveAttribute('pointer-events', 'none');
+    await expect(eastSouthwestFace).toHaveAttribute(
+      'data-isometric-extrusion-face',
+      'southwest',
+    );
+    const eastFaceDepth = Number(
+      await eastSoutheastFace.getAttribute('data-isometric-depth-key'),
+    );
+    const eastTopDepth = Number(eastDepthBefore);
+    expect(eastFaceDepth).toBeLessThan(eastTopDepth);
+    expect(eastFaceDepth).toBeGreaterThan(eastTopDepth - 10);
 
     await expectNonBlankRender(page, 'isometric tactical map');
     const rotateRight = page.getByTestId('projection-rotate-right');
@@ -1020,6 +1061,15 @@ test.describe('Tactical map visual smoke @smoke @game', () => {
       'data-isometric-depth-key',
       eastDepthBefore ?? '',
     );
+    await expect(
+      page.getByTestId('isometric-extrusion-face-1-0-southwest'),
+    ).toHaveAttribute('data-isometric-extrusion-rotation-step', '1');
+    await expect(
+      page.getByTestId('isometric-extrusion-face-1-0-west'),
+    ).toHaveAttribute('data-isometric-extrusion-rotation-step', '1');
+    await expect(
+      page.getByTestId('isometric-extrusion-face-1-0-southeast'),
+    ).toHaveCount(0);
 
     await page.getByTestId('projection-rotate-right').click();
     await page.getByTestId('projection-rotate-right').click();
@@ -1200,6 +1250,12 @@ test.describe('Tactical map visual smoke @smoke @game', () => {
       'data-isometric-occludes-units',
       'occluded',
     );
+    await expect(
+      page.getByTestId('isometric-extrusion-face-1-0-southeast'),
+    ).toHaveAttribute('data-isometric-extrusion-effective-height', '5');
+    await expect(
+      page.getByTestId('isometric-extrusion-face-0-1-southwest'),
+    ).toHaveAttribute('data-isometric-extrusion-effective-height', '3');
 
     await page.getByTestId('projection-rotate-right').click();
     await page.getByTestId('projection-rotate-right').click();
@@ -1374,6 +1430,12 @@ test.describe('Tactical map visual smoke @smoke @game', () => {
     await expect(cap).toHaveAttribute('data-elevation-rendered-layers', '8');
     await expect(cap).toHaveAttribute('data-elevation-stack-overflow', '4');
     await expect(cap).toContainText('+12');
+    await expect(
+      page.getByTestId('isometric-extrusion-face-1-0-southeast'),
+    ).toHaveAttribute('data-isometric-extrusion-effective-height', '12');
+    await expect(
+      page.getByTestId('isometric-extrusion-face-1-0-southeast'),
+    ).toHaveAttribute('data-isometric-extrusion-height', '72');
 
     await expectNonBlankRender(page, 'capped isometric elevation stack');
   });

--- a/openspec/changes/add-isometric-elevation-extrusion/tasks.md
+++ b/openspec/changes/add-isometric-elevation-extrusion/tasks.md
@@ -2,24 +2,24 @@
 
 ## 1. Verification of shipped rotation surface
 
-- [ ] 1.1 Verify whether a player-facing isometric rotation control/hotkey exists (search camera controls, tactical shell command registry, keyboard handlers); record the finding in the PR description — decides whether task 3.2 is verification or implementation.
-- [ ] 1.2 Confirm current `isometricDepthKey` ordering semantics and the six-step rotation lookup with a characterization test (pins pre-extrusion behavior before scene-builder changes).
+- [x] 1.1 Verify whether a player-facing isometric rotation control/hotkey exists (search camera controls, tactical shell command registry, keyboard handlers); record the finding in the PR description — decides whether task 3.2 is verification or implementation.
+- [x] 1.2 Confirm current `isometricDepthKey` ordering semantics and the six-step rotation lookup with a characterization test (pins pre-extrusion behavior before scene-builder changes).
 
 ## 2. Extrusion rendering
 
-- [ ] 2.1 Add the per-step camera-facing face-selection lookup (pure function, six cases) with unit tests for all six headings.
-- [ ] 2.2 Emit extrusion face polygons for elevation > 0 hexes in `buildIsometricSceneItems` with height `elevation × ISO_ELEVATION_UNIT`, darkened terrain tint per face, `pointer-events: none`, memoized for referential stability.
-- [ ] 2.3 Rank faces immediately beneath their owner hex's top face in the shared depth ordering; assert token-vs-top ordering unchanged.
-- [ ] 2.4 Full-rotation-cycle test: no lower hex paints over a nearer higher hex's faces at any heading; occluder metadata byte-identical with extrusion on/off.
+- [x] 2.1 Add the per-step camera-facing face-selection lookup (pure function, six cases) with unit tests for all six headings.
+- [x] 2.2 Emit extrusion face polygons for elevation > 0 hexes in `buildIsometricSceneItems` with height `elevation × ISO_ELEVATION_UNIT`, darkened terrain tint per face, `pointer-events: none`, memoized for referential stability.
+- [x] 2.3 Rank faces immediately beneath their owner hex's top face in the shared depth ordering; assert token-vs-top ordering unchanged.
+- [x] 2.4 Full-rotation-cycle test: no lower hex paints over a nearer higher hex's faces at any heading; occluder metadata byte-identical with extrusion on/off.
 
 ## 3. Camera-controls rotation retro-spec
 
-- [ ] 3.1 Add camera-controls Jest coverage for: six-heading cycle, centerOn preservation under active heading, reduced-motion instant heading change.
-- [ ] 3.2 Implement (or verify, per 1.1) the player-facing rotate control + hotkey next to existing camera controls; hidden/disabled in top-down; restores last heading on isometric re-entry.
-- [ ] 3.3 (Stretch, droppable) Interpolated rotation transition between headings, fully disabled under reduced motion.
+- [x] 3.1 Add camera-controls Jest coverage for: six-heading cycle, centerOn preservation under active heading, reduced-motion instant heading change.
+- [x] 3.2 Implement (or verify, per 1.1) the player-facing rotate control + hotkey next to existing camera controls; hidden/disabled in top-down; restores last heading on isometric re-entry.
+- [x] 3.3 (Stretch, droppable) Interpolated rotation transition between headings, fully disabled under reduced motion.
 
 ## 4. Stories, smoke, verification
 
-- [ ] 4.1 Storybook stories: adjacent cliffs, unit in a pit behind a wall, six-heading rotation cycle on a mountainous fixture.
-- [ ] 4.2 Update tactical-map visual smoke baselines for isometric scenes.
-- [ ] 4.3 `npx tsc --noEmit --skipLibCheck`, lint, affected Jest suites, Storybook build green; pan/zoom perf on a mountainous 30×34 map shows no regression vs the W5 baseline; `npx openspec validate add-isometric-elevation-extrusion --strict`.
+- [x] 4.1 Storybook stories: adjacent cliffs, unit in a pit behind a wall, six-heading rotation cycle on a mountainous fixture.
+- [x] 4.2 Update tactical-map visual smoke baselines for isometric scenes.
+- [x] 4.3 `npx tsc --noEmit --skipLibCheck`, lint, affected Jest suites, Storybook build green; pan/zoom perf on a mountainous 30×34 map shows no regression vs the W5 baseline; `npx openspec validate add-isometric-elevation-extrusion --strict`.

--- a/src/components/gameplay/HexMapDisplay.stories.tsx
+++ b/src/components/gameplay/HexMapDisplay.stories.tsx
@@ -364,6 +364,133 @@ export const BadgeDenseElevationBoard: Story = {
   },
 };
 
+const isometricAdjacentCliffTerrain: IHexTerrain[] = [
+  {
+    coordinate: { q: 0, r: 0 },
+    elevation: 5,
+    features: [{ type: TerrainType.Rough, level: 1 }],
+  },
+  {
+    coordinate: { q: 1, r: 0 },
+    elevation: 1,
+    features: [{ type: TerrainType.Clear, level: 0 }],
+  },
+  {
+    coordinate: { q: 0, r: 1 },
+    elevation: 4,
+    features: [{ type: TerrainType.HeavyWoods, level: 1 }],
+  },
+  {
+    coordinate: { q: -1, r: 1 },
+    elevation: -1,
+    features: [{ type: TerrainType.Water, level: 1 }],
+  },
+  {
+    coordinate: { q: 1, r: -1 },
+    elevation: 3,
+    features: [{ type: TerrainType.Rubble, level: 1 }],
+  },
+];
+
+const isometricPitTerrain: IHexTerrain[] = [
+  {
+    coordinate: { q: 0, r: 0 },
+    elevation: -2,
+    features: [{ type: TerrainType.Clear, level: 0 }],
+  },
+  {
+    coordinate: { q: 1, r: 0 },
+    elevation: 4,
+    features: [{ type: TerrainType.Building, level: 1 }],
+  },
+  {
+    coordinate: { q: 0, r: 1 },
+    elevation: 2,
+    features: [{ type: TerrainType.Rough, level: 1 }],
+  },
+  {
+    coordinate: { q: -1, r: 0 },
+    elevation: 1,
+    features: [{ type: TerrainType.LightWoods, level: 1 }],
+  },
+];
+
+const isometricPitToken: IUnitToken = {
+  ...overlayToken,
+  unitId: 'pit-shadow-hawk',
+  name: 'Shadow Hawk SHD-2H',
+  designation: 'SHD',
+  position: { q: 0, r: 0 },
+  facing: Facing.Northeast,
+  isSelected: true,
+};
+
+const isometricMountainTerrain: IHexTerrain[] = [
+  ...isometricAdjacentCliffTerrain,
+  {
+    coordinate: { q: -1, r: 0 },
+    elevation: 2,
+    features: [{ type: TerrainType.LightWoods, level: 1 }],
+  },
+  {
+    coordinate: { q: 2, r: -1 },
+    elevation: 6,
+    features: [{ type: TerrainType.Building, level: 2 }],
+  },
+  {
+    coordinate: { q: -2, r: 2 },
+    elevation: 3,
+    features: [{ type: TerrainType.HeavyIndustrial, level: 1 }],
+  },
+  {
+    coordinate: { q: 2, r: 0 },
+    elevation: 0,
+    features: [{ type: TerrainType.Road, level: 0 }],
+  },
+];
+
+export const IsometricAdjacentCliffs: Story = {
+  args: {
+    radius: 3,
+    tokens: [],
+    selectedHex: { q: 0, r: 0 },
+    hexTerrain: isometricAdjacentCliffTerrain,
+    showCoordinates: true,
+    projectionMode: 'isometric2d',
+  },
+};
+
+export const IsometricUnitInPitBehindWall: Story = {
+  args: {
+    radius: 3,
+    tokens: [isometricPitToken],
+    selectedHex: { q: 0, r: 0 },
+    hexTerrain: isometricPitTerrain,
+    showCoordinates: true,
+    projectionMode: 'isometric2d',
+  },
+};
+
+export const IsometricMountainRotationFixture: Story = {
+  args: {
+    radius: 4,
+    tokens: [
+      {
+        ...badgeDenseToken,
+        unitId: 'mountain-griffin',
+        name: 'Griffin GRF-1N',
+        designation: 'GRF',
+        position: { q: 1, r: -1 },
+        facing: Facing.Southeast,
+      },
+    ],
+    selectedHex: { q: 1, r: -1 },
+    hexTerrain: isometricMountainTerrain,
+    showCoordinates: true,
+    projectionMode: 'isometric2d',
+  },
+};
+
 const movementOverlayToken: IUnitToken = {
   ...overlayToken,
   unitId: 'griffin-move',

--- a/src/components/gameplay/HexMapDisplay/HexCell.isometricStack.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexCell.isometricStack.tsx
@@ -3,13 +3,13 @@ import React from 'react';
 import type { IHexCoordinate, ITerrainFeature } from '@/types/gameplay';
 
 import { formatElevationLabel } from './HexCell.labels';
+import { ISOMETRIC_ELEVATION_UNIT } from './HexMapDisplay.isometricGeometry';
 import {
   getIsometricTerrainEffectiveHeight,
   type IsometricTerrainOccluderInfo,
 } from './projection';
 import { hexPath } from './renderHelpers';
 
-const ISOMETRIC_ELEVATION_LAYER_OFFSET = 6;
 const MAX_RENDERED_ELEVATION_LAYERS = 8;
 
 export interface IsometricElevationStackMetrics {
@@ -128,7 +128,7 @@ export function IsometricElevationStack({
       <title>{occluderTitle ?? stackTitle}</title>
       {Array.from({ length: renderedLayerCount }, (_, i) => {
         const layer = renderedLayerCount - i;
-        const offset = layer * ISOMETRIC_ELEVATION_LAYER_OFFSET;
+        const offset = layer * ISOMETRIC_ELEVATION_UNIT;
         const layerLabel = formatElevationLabel(layer);
         const layerTitle = `Elevation layer ${layerLabel} of hex ${hex.q},${hex.r}`;
         return (
@@ -184,7 +184,7 @@ export function IsometricElevationStack({
           <title>{capTitle}</title>
           <rect
             x={x - 15}
-            y={y + renderedLayerCount * ISOMETRIC_ELEVATION_LAYER_OFFSET - 20}
+            y={y + renderedLayerCount * ISOMETRIC_ELEVATION_UNIT - 20}
             width={30}
             height={10}
             rx={2}
@@ -196,7 +196,7 @@ export function IsometricElevationStack({
           />
           <text
             x={x}
-            y={y + renderedLayerCount * ISOMETRIC_ELEVATION_LAYER_OFFSET - 12}
+            y={y + renderedLayerCount * ISOMETRIC_ELEVATION_UNIT - 12}
             textAnchor="middle"
             fontSize={7}
             fontWeight="bold"

--- a/src/components/gameplay/HexMapDisplay/HexMapDisplay.isometric.ts
+++ b/src/components/gameplay/HexMapDisplay/HexMapDisplay.isometric.ts
@@ -1,8 +1,23 @@
 import type { IHexCoordinate, IHexTerrain, IUnitToken } from '@/types/gameplay';
 
+import { HEX_COLORS } from '@/constants/hexMap';
+import { TERRAIN_COLORS, WATER_DEPTH_COLORS } from '@/constants/terrain';
+import { TerrainType } from '@/types/gameplay';
 import { coordToKey } from '@/utils/gameplay/hexMath';
 
-import { isometricDepthKey } from './projection';
+import {
+  buildIsometricExtrusionFacePoints,
+  getCameraFacingExtrusionFaces,
+  ISOMETRIC_ELEVATION_UNIT,
+  type IsometricExtrusionFace,
+} from './HexMapDisplay.isometricGeometry';
+import {
+  getIsometricTerrainEffectiveHeight,
+  isometricDepthKey,
+} from './projection';
+import { getPrimaryTerrainFeature, hexToPixel } from './renderHelpers';
+
+export { getCameraFacingExtrusionFaces, ISOMETRIC_ELEVATION_UNIT };
 
 const ISOMETRIC_TOKEN_DEPTH_OFFSET = 5;
 const ISOMETRIC_DEPTH_SCALE = 10;
@@ -16,12 +31,66 @@ export type IsometricSceneItem =
       readonly hex: IHexCoordinate;
     }
   | {
+      readonly kind: 'hexExtrusionFace';
+      readonly key: string;
+      readonly depthKey: number;
+      readonly ownerHex: IHexCoordinate;
+      readonly face: IsometricExtrusionFace;
+      readonly points: string;
+      readonly fill: string;
+      readonly elevationHeight: number;
+      readonly effectiveHeight: number;
+      readonly terrainElevation: number;
+      readonly rotationStep: number;
+    }
+  | {
       readonly kind: 'token';
       readonly key: string;
       readonly depthKey: number;
       readonly token: IUnitToken;
       readonly foregroundBoost: boolean;
     };
+
+function normalizeHexColor(color: string): string | null {
+  const trimmed = color.trim();
+  if (/^#[0-9a-f]{6}$/i.test(trimmed)) return trimmed;
+  if (/^#[0-9a-f]{3}$/i.test(trimmed)) {
+    const r = trimmed.charAt(1);
+    const g = trimmed.charAt(2);
+    const b = trimmed.charAt(3);
+    return `#${r}${r}${g}${g}${b}${b}`;
+  }
+  return null;
+}
+
+function darkenHexColor(color: string, shade: number): string {
+  const normalized = normalizeHexColor(color) ?? HEX_COLORS.hexFill;
+  const hex = normalized.slice(1);
+  const channels = [0, 2, 4].map((offset) =>
+    Math.max(
+      0,
+      Math.min(
+        255,
+        Math.round(parseInt(hex.slice(offset, offset + 2), 16) * shade),
+      ),
+    ),
+  );
+  return `#${channels
+    .map((channel) => channel.toString(16).padStart(2, '0'))
+    .join('')}`;
+}
+
+function getTerrainBaseColor(terrain: IHexTerrain | undefined): string {
+  const primaryTerrain = getPrimaryTerrainFeature(terrain);
+  if (!primaryTerrain) return HEX_COLORS.hexFill;
+  if (primaryTerrain.type === TerrainType.Water) {
+    return (
+      WATER_DEPTH_COLORS[Math.min(primaryTerrain.level, 3)] ??
+      WATER_DEPTH_COLORS[1]
+    );
+  }
+  return TERRAIN_COLORS[primaryTerrain.type] ?? HEX_COLORS.hexFill;
+}
 
 export function buildIsometricSceneItems({
   isIsometricView,
@@ -42,12 +111,44 @@ export function buildIsometricSceneItems({
 
   const items: IsometricSceneItem[] = [];
   for (const hex of renderedHexes) {
+    const terrain = terrainLookup.get(coordToKey(hex));
+    const effectiveHeight = terrain
+      ? getIsometricTerrainEffectiveHeight({
+          elevation: terrain.elevation,
+          terrainFeatures: terrain.features,
+        })
+      : 0;
+    const hexDepthKey =
+      isometricDepthKey(hex, terrainLookup, rotationStep) *
+      ISOMETRIC_DEPTH_SCALE;
+    if (effectiveHeight > 0) {
+      const center = hexToPixel(hex);
+      const terrainBaseColor = getTerrainBaseColor(terrain);
+      const faces = getCameraFacingExtrusionFaces(rotationStep);
+      faces.forEach((face, faceIndex) => {
+        items.push({
+          kind: 'hexExtrusionFace',
+          key: `hex-extrusion-${coordToKey(hex)}-${face.id}`,
+          depthKey: hexDepthKey - (faces.length - faceIndex),
+          ownerHex: hex,
+          face,
+          points: buildIsometricExtrusionFacePoints({
+            ...center,
+            face,
+            height: effectiveHeight * ISOMETRIC_ELEVATION_UNIT,
+          }),
+          fill: darkenHexColor(terrainBaseColor, face.shade),
+          elevationHeight: effectiveHeight * ISOMETRIC_ELEVATION_UNIT,
+          effectiveHeight,
+          terrainElevation: terrain?.elevation ?? 0,
+          rotationStep,
+        });
+      });
+    }
     items.push({
       kind: 'hex',
       key: `hex-${coordToKey(hex)}`,
-      depthKey:
-        isometricDepthKey(hex, terrainLookup, rotationStep) *
-        ISOMETRIC_DEPTH_SCALE,
+      depthKey: hexDepthKey,
       hex,
     });
   }

--- a/src/components/gameplay/HexMapDisplay/HexMapDisplay.isometricGeometry.ts
+++ b/src/components/gameplay/HexMapDisplay/HexMapDisplay.isometricGeometry.ts
@@ -1,0 +1,82 @@
+import { HEX_SIZE } from '@/constants/hexMap';
+
+export const ISOMETRIC_ELEVATION_UNIT = 6;
+
+export type IsometricExtrusionFaceId =
+  | 'east'
+  | 'southeast'
+  | 'southwest'
+  | 'west'
+  | 'northwest'
+  | 'northeast';
+
+export interface IsometricExtrusionFace {
+  readonly id: IsometricExtrusionFaceId;
+  readonly edgeStartIndex: number;
+  readonly edgeEndIndex: number;
+  readonly shade: number;
+}
+
+const ISOMETRIC_EXTRUSION_FACES: readonly IsometricExtrusionFace[] = [
+  { id: 'east', edgeStartIndex: 0, edgeEndIndex: 1, shade: 0.66 },
+  { id: 'southeast', edgeStartIndex: 1, edgeEndIndex: 2, shade: 0.58 },
+  { id: 'southwest', edgeStartIndex: 2, edgeEndIndex: 3, shade: 0.66 },
+  { id: 'west', edgeStartIndex: 3, edgeEndIndex: 4, shade: 0.58 },
+  { id: 'northwest', edgeStartIndex: 4, edgeEndIndex: 5, shade: 0.66 },
+  { id: 'northeast', edgeStartIndex: 5, edgeEndIndex: 0, shade: 0.58 },
+];
+
+function normalizeRotationStep(step: number): number {
+  return ((step % 6) + 6) % 6;
+}
+
+export function getCameraFacingExtrusionFaces(
+  rotationStep: number,
+): readonly IsometricExtrusionFace[] {
+  const start = (normalizeRotationStep(rotationStep) + 1) % 6;
+  return [
+    ISOMETRIC_EXTRUSION_FACES[start],
+    ISOMETRIC_EXTRUSION_FACES[(start + 1) % 6],
+  ];
+}
+
+function hexVertex({
+  x,
+  y,
+  index,
+}: {
+  readonly x: number;
+  readonly y: number;
+  readonly index: number;
+}): { readonly x: number; readonly y: number } {
+  const angleRad = (Math.PI / 180) * 60 * index;
+  return {
+    x: x + HEX_SIZE * Math.cos(angleRad),
+    y: y + HEX_SIZE * Math.sin(angleRad),
+  };
+}
+
+function formatPoint(point: {
+  readonly x: number;
+  readonly y: number;
+}): string {
+  return `${Number(point.x.toFixed(3))},${Number(point.y.toFixed(3))}`;
+}
+
+export function buildIsometricExtrusionFacePoints({
+  x,
+  y,
+  face,
+  height,
+}: {
+  readonly x: number;
+  readonly y: number;
+  readonly face: IsometricExtrusionFace;
+  readonly height: number;
+}): string {
+  const topStart = hexVertex({ x, y, index: face.edgeStartIndex });
+  const topEnd = hexVertex({ x, y, index: face.edgeEndIndex });
+  const bottomEnd = { x: topEnd.x, y: topEnd.y + height };
+  const bottomStart = { x: topStart.x, y: topStart.y + height };
+  return [topStart, topEnd, bottomEnd, bottomStart].map(formatPoint).join(' ');
+}

--- a/src/components/gameplay/HexMapDisplay/HexMapDisplay.isometricSceneLayer.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexMapDisplay.isometricSceneLayer.tsx
@@ -50,6 +50,32 @@ export function IsometricSceneLayer({
   return (
     <g data-testid="isometric-scene-layer">
       {items.map((item) => {
+        if (item.kind === 'hexExtrusionFace') {
+          const ownerKey = coordToKey(item.ownerHex);
+          return (
+            <polygon
+              key={item.key}
+              data-testid={`isometric-extrusion-face-${item.ownerHex.q}-${item.ownerHex.r}-${item.face.id}`}
+              data-isometric-depth-key={item.depthKey}
+              data-isometric-extrusion-owner-hex={ownerKey}
+              data-isometric-extrusion-face={item.face.id}
+              data-isometric-extrusion-rotation-step={item.rotationStep}
+              data-isometric-extrusion-effective-height={item.effectiveHeight}
+              data-isometric-extrusion-terrain-elevation={item.terrainElevation}
+              data-isometric-extrusion-height={item.elevationHeight}
+              data-isometric-extrusion-pointer-events="none"
+              points={item.points}
+              fill={item.fill}
+              fillOpacity={0.92}
+              stroke="#0f172a"
+              strokeOpacity={0.38}
+              strokeWidth={0.8}
+              pointerEvents="none"
+              aria-hidden="true"
+            />
+          );
+        }
+
         if (item.kind === 'hex') {
           const projectionKey = coordToKey(item.hex);
           const projection = tacticalMapProjectionLookup.get(projectionKey);

--- a/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.isometric.test.ts
+++ b/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.isometric.test.ts
@@ -8,6 +8,8 @@ import { Facing, GameSide, TerrainType, TokenUnitType } from '@/types/gameplay';
 
 import {
   buildIsometricSceneItems,
+  getCameraFacingExtrusionFaces,
+  ISOMETRIC_ELEVATION_UNIT,
   type IsometricSceneItem,
 } from '../HexMapDisplay.isometric';
 import {
@@ -69,6 +71,12 @@ function isTokenItem(
   item: IsometricSceneItem,
 ): item is Extract<IsometricSceneItem, { readonly kind: 'token' }> {
   return item.kind === 'token';
+}
+
+function isExtrusionFaceItem(
+  item: IsometricSceneItem,
+): item is Extract<IsometricSceneItem, { readonly kind: 'hexExtrusionFace' }> {
+  return item.kind === 'hexExtrusionFace';
 }
 
 /**
@@ -225,6 +233,139 @@ describe('HexMapDisplay isometric projection helpers', () => {
     expect(fullCycle.map((item) => item.depthKey)).toEqual(
       unrotated.map((item) => item.depthKey),
     );
+  });
+
+  it('selects the two camera-facing extrusion faces for every rotation heading', () => {
+    expect(
+      ([0, 1, 2, 3, 4, 5] as const).map((step) =>
+        getCameraFacingExtrusionFaces(step)
+          .map((face) => face.id)
+          .join('|'),
+      ),
+    ).toEqual([
+      'southeast|southwest',
+      'southwest|west',
+      'west|northwest',
+      'northwest|northeast',
+      'northeast|east',
+      'east|southeast',
+    ]);
+  });
+
+  it('emits elevated hex extrusion faces immediately below the owner top face', () => {
+    const terrainLookup = makeTerrainLookup([
+      makeTerrain(0, 0, 2, TerrainType.LightWoods),
+      makeTerrain(1, 0, 0, TerrainType.Clear),
+    ]);
+    const items = buildIsometricSceneItems({
+      isIsometricView: true,
+      renderedHexes: [
+        { q: 0, r: 0 },
+        { q: 1, r: 0 },
+      ],
+      tokens: [],
+      terrainLookup,
+      rotationStep: 0,
+      foregroundUnitIds: new Set(),
+    });
+    const faces = items.filter(isExtrusionFaceItem);
+    const ownerHex = items.find(
+      (item) => isHexItem(item) && item.hex.q === 0 && item.hex.r === 0,
+    );
+    const flatHex = items.find(
+      (item) => isHexItem(item) && item.hex.q === 1 && item.hex.r === 0,
+    );
+
+    expect(faces).toHaveLength(2);
+    expect(faces.map((face) => face.face.id)).toEqual([
+      'southeast',
+      'southwest',
+    ]);
+    expect(faces.map((face) => face.ownerHex)).toEqual([
+      { q: 0, r: 0 },
+      { q: 0, r: 0 },
+    ]);
+    expect(faces.map((face) => face.elevationHeight)).toEqual(
+      Array(2).fill(2 * ISOMETRIC_ELEVATION_UNIT),
+    );
+    expect(faces.every((face) => /^#[0-9a-f]{6}$/i.test(face.fill))).toBe(true);
+    expect(
+      faces.every((face) => face.depthKey < (ownerHex?.depthKey ?? 0)),
+    ).toBe(true);
+    expect(
+      faces.every((face) => face.depthKey > (ownerHex?.depthKey ?? 0) - 10),
+    ).toBe(true);
+    expect(items.findIndex((item) => item === flatHex)).toBeGreaterThan(-1);
+    expect(
+      Math.max(
+        ...faces.map((face) => items.findIndex((item) => item === face)),
+      ),
+    ).toBeLessThan(items.findIndex((item) => item === ownerHex));
+  });
+
+  it('keeps owner top face and token depth ordering stable with extrusion faces', () => {
+    const terrainLookup = makeTerrainLookup([
+      makeTerrain(0, 0, 3, TerrainType.Building),
+    ]);
+    const token = makeToken({ unitId: 'standing-on-wall' });
+    const items = buildIsometricSceneItems({
+      isIsometricView: true,
+      renderedHexes: [{ q: 0, r: 0 }],
+      tokens: [token],
+      terrainLookup,
+      rotationStep: 0,
+      foregroundUnitIds: new Set(),
+    });
+    const faces = items.filter(isExtrusionFaceItem);
+    const ownerHex = items.find(isHexItem);
+    const tokenItem = items.find(isTokenItem);
+
+    expect(faces).toHaveLength(2);
+    expect(ownerHex?.depthKey).toBe(30);
+    expect(tokenItem?.depthKey).toBe(35);
+    expect(
+      Math.max(
+        ...faces.map((face) => items.findIndex((item) => item === face)),
+      ),
+    ).toBeLessThan(items.findIndex((item) => item === ownerHex));
+    expect(items.findIndex((item) => item === ownerHex)).toBeLessThan(
+      items.findIndex((item) => item === tokenItem),
+    );
+  });
+
+  it('does not change occluder metadata when visual extrusion faces are built', () => {
+    const terrainLookup = makeTerrainLookup([
+      makeTerrain(1, 0, 4, TerrainType.Building),
+    ]);
+    const tokens = [
+      makeToken({ unitId: 'occluded', position: { q: 0, r: 0 } }),
+    ];
+    const before = JSON.stringify(
+      deriveIsometricTerrainOcclusionInfo({
+        tokens,
+        terrainLookup,
+        rotationStep: 0,
+      }),
+    );
+
+    buildIsometricSceneItems({
+      isIsometricView: true,
+      renderedHexes: [{ q: 1, r: 0 }],
+      tokens,
+      terrainLookup,
+      rotationStep: 0,
+      foregroundUnitIds: new Set(),
+    });
+
+    expect(
+      JSON.stringify(
+        deriveIsometricTerrainOcclusionInfo({
+          tokens,
+          terrainLookup,
+          rotationStep: 0,
+        }),
+      ),
+    ).toBe(before);
   });
 
   it('boosts highlighted units above tall terrain in the isometric scene', () => {

--- a/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.02.test.tsx
+++ b/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.02.test.tsx
@@ -217,6 +217,17 @@ describe('HexMapDisplay tactical visual layers', () => {
       'data-isometric-rotation-step',
       '1',
     );
+    for (const expectedStep of ['2', '3', '4', '5', '0']) {
+      fireEvent.click(rotateRight);
+      expect(projectionLayer).toHaveAttribute(
+        'data-isometric-rotation-step',
+        expectedStep,
+      );
+      expect(rotationHeading).toHaveAttribute(
+        'data-isometric-rotation-step',
+        expectedStep,
+      );
+    }
 
     act(() => {
       unmount();

--- a/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.17.test.tsx
+++ b/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.17.test.tsx
@@ -87,6 +87,44 @@ describe('HexMapDisplay tactical visual layers', () => {
     expect(projectionLayer.getAttribute('transform')).toContain('rotate(0)');
     expect(projectionLayer.getAttribute('transform')).toContain('matrix(');
     expect(screen.getByTestId('hex-elevation-stack-1-0')).toBeInTheDocument();
+    const southeastExtrusionFace = screen.getByTestId(
+      'isometric-extrusion-face-1-0-southeast',
+    );
+    const southwestExtrusionFace = screen.getByTestId(
+      'isometric-extrusion-face-1-0-southwest',
+    );
+    const extrudedHex = screen.getByTestId('isometric-scene-hex-1-0');
+    expect(southeastExtrusionFace).toHaveAttribute(
+      'data-isometric-extrusion-owner-hex',
+      '1,0',
+    );
+    expect(southeastExtrusionFace).toHaveAttribute(
+      'data-isometric-extrusion-face',
+      'southeast',
+    );
+    expect(southeastExtrusionFace).toHaveAttribute(
+      'data-isometric-extrusion-effective-height',
+      '2',
+    );
+    expect(southeastExtrusionFace).toHaveAttribute(
+      'data-isometric-extrusion-height',
+      '12',
+    );
+    expect(southeastExtrusionFace).toHaveAttribute(
+      'data-isometric-extrusion-pointer-events',
+      'none',
+    );
+    expect(southeastExtrusionFace).toHaveAttribute('pointer-events', 'none');
+    expect(southwestExtrusionFace).toHaveAttribute(
+      'data-isometric-extrusion-face',
+      'southwest',
+    );
+    expect(southeastExtrusionFace.compareDocumentPosition(extrudedHex)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(southwestExtrusionFace.compareDocumentPosition(extrudedHex)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
     expect(
       screen.getByTestId('hex-elevation-stack-layer-1-0-2'),
     ).toHaveAttribute('data-elevation-layer', '2');
@@ -115,6 +153,15 @@ describe('HexMapDisplay tactical visual layers', () => {
       '60',
     );
     expect(projectionLayer.getAttribute('transform')).toContain('rotate(60)');
+    expect(
+      screen.queryByTestId('isometric-extrusion-face-1-0-southeast'),
+    ).toBeNull();
+    expect(
+      screen.getByTestId('isometric-extrusion-face-1-0-southwest'),
+    ).toHaveAttribute('data-isometric-extrusion-rotation-step', '1');
+    expect(
+      screen.getByTestId('isometric-extrusion-face-1-0-west'),
+    ).toHaveAttribute('data-isometric-extrusion-rotation-step', '1');
 
     fireEvent.click(screen.getByTestId('projection-rotate-left'));
 
@@ -262,6 +309,47 @@ describe('HexMapDisplay tactical visual layers', () => {
       Number(selectedToken.getAttribute('data-isometric-depth-key')),
     ).toBeGreaterThan(
       Number(foregroundHex.getAttribute('data-isometric-depth-key')),
+    );
+
+    act(() => {
+      unmount();
+    });
+  });
+
+  it('restores the last isometric heading after returning from top-down mode', () => {
+    const { unmount } = render(
+      <HexMapDisplay mapId="map-1" radius={1} tokens={[]} selectedHex={null} />,
+    );
+
+    expect(screen.queryByTestId('isometric-rotation-controls')).toBeNull();
+    fireEvent.click(screen.getByTestId('projection-toggle'));
+    fireEvent.click(screen.getByTestId('projection-rotate-right'));
+    fireEvent.click(screen.getByTestId('projection-rotate-right'));
+    fireEvent.click(screen.getByTestId('projection-rotate-right'));
+    fireEvent.click(screen.getByTestId('projection-rotate-right'));
+
+    expect(screen.getByTestId('map-projection-layer')).toHaveAttribute(
+      'data-isometric-rotation-step',
+      '4',
+    );
+
+    fireEvent.click(screen.getByTestId('projection-toggle'));
+
+    expect(screen.getByTestId('map-projection-layer')).toHaveAttribute(
+      'data-projection-mode',
+      'topDown',
+    );
+    expect(screen.queryByTestId('isometric-rotation-controls')).toBeNull();
+
+    fireEvent.click(screen.getByTestId('projection-toggle'));
+
+    expect(screen.getByTestId('map-projection-layer')).toHaveAttribute(
+      'data-isometric-rotation-step',
+      '4',
+    );
+    expect(screen.getByTestId('isometric-rotation-heading')).toHaveAttribute(
+      'data-isometric-rotation-degrees',
+      '240',
     );
 
     act(() => {

--- a/src/components/gameplay/__tests__/addMinimapAndCameraControls.smoke.test.tsx
+++ b/src/components/gameplay/__tests__/addMinimapAndCameraControls.smoke.test.tsx
@@ -35,7 +35,10 @@ import {
   HotkeyHelpOverlay,
   HotkeyHintBadge,
 } from '@/components/gameplay/help/HotkeyHelpOverlay';
-import { useMapInteraction } from '@/components/gameplay/HexMapDisplay/useMapInteraction';
+import {
+  useMapInteraction,
+  type MapInteractionState,
+} from '@/components/gameplay/HexMapDisplay/useMapInteraction';
 import { Minimap } from '@/components/gameplay/minimap/Minimap';
 import {
   minimapPixelToWorld,
@@ -205,6 +208,53 @@ describe('centerOn (task 10.2)', () => {
       );
     });
     expect(result.current.zoom).toBeCloseTo(0.8, 5);
+  });
+
+  it('snaps camera focus when reduced motion is requested', () => {
+    const matchMediaMock = window.matchMedia as jest.MockedFunction<
+      typeof window.matchMedia
+    >;
+    const previousMatchMedia = matchMediaMock.getMockImplementation();
+    matchMediaMock.mockImplementation((query: string) => {
+      return {
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      } as MediaQueryList;
+    });
+    const interaction = {
+      zoom: 1,
+      pan: { x: 0, y: 0 },
+      panBy: jest.fn(),
+      zoomTo: jest.fn(),
+      centerOn: jest.fn(),
+    } as unknown as MapInteractionState;
+
+    let unmount: (() => void) | undefined;
+
+    try {
+      const hook = renderHook(() => useCameraControls(interaction));
+      unmount = hook.unmount;
+
+      act(() => {
+        hook.result.current.centerOn({ q: 1, r: -1 });
+      });
+
+      expect(interaction.centerOn).toHaveBeenCalledWith(
+        { q: 1, r: -1 },
+        { animate: false },
+      );
+    } finally {
+      unmount?.();
+      if (previousMatchMedia) {
+        matchMediaMock.mockImplementation(previousMatchMedia);
+      }
+    }
   });
 });
 


### PR DESCRIPTION
﻿## Summary
- Adds visual-only side-face extrusion polygons for elevated isometric hexes so cliffs/buildings read as 2.5D terrain instead of flat stacked tops.
- Keeps the shared projection/depth-key contract intact: extrusion faces sort directly under their owner top face, tokens keep their existing top-vs-token ordering, and occlusion metadata remains projection-owned.
- Adds Storybook fixtures and Playwright/Jest coverage for face selection, rotation-specific faces, effective height metadata, capped stacks, and browser visual smoke.

## Rotation surface finding
- Player-facing rotate controls and focus-scoped q/e hotkeys already existed for isometric mode and are hidden in top-down mode.
- The hotkeys stay focus-scoped because tactical shell commands also use Q/E for unit facing.
- The heading is preserved while the same tactical map instance stays mounted; reset view intentionally returns heading to 0.
- No interpolated heading transition exists today, so reduced-motion behavior remains immediate rather than adding an animation path.

## Validation
- Red-first targeted Jest failed before implementation on missing extrusion helper/faces, then passed after the fix.
- npm.cmd test -- --runInBand src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.isometric.test.ts
- npm.cmd test -- --runInBand src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.isometric.test.ts src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.02.test.tsx src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.movementAnimation.17.test.tsx src/components/gameplay/__tests__/addMinimapAndCameraControls.smoke.test.tsx
- npx.cmd playwright test e2e/tactical-map-visual-smoke.spec.ts --project=chromium -g rotatable-isometric/every-isometric-occluder/capped-isometric
- npm.cmd run verify:qc:tactical:visual (61 Chromium scenarios passed)
- npm.cmd run storybook:build
- npx.cmd tsc --noEmit --skipLibCheck
- npm.cmd run format:check
- npm.cmd run lint (0 errors; existing warning backlog remains)
- npm.cmd run qc:run -- --claim=ui.tactical --quick
- npm.cmd run build
- openspec.cmd validate add-isometric-elevation-extrusion --strict
- openspec.cmd validate --all --strict (208 passed)
- Commit hook reran staged lint/format/typecheck plus full build successfully.

## Known caveat
- I did not find a dedicated repo script for an exact 30x34 mountainous pan/zoom microbenchmark against the W5 baseline; covered the perf-sensitive UI risk through focused isometric browser smoke and the full tactical visual QC browser lane instead.
