### PR TITLE
Reduce maintenance source gate debt

### DIFF
--- a/src/components/gameplay/HexMapDisplay.stories.fixture.ts
+++ b/src/components/gameplay/HexMapDisplay.stories.fixture.ts
@@ -1,0 +1,501 @@
+import {
+  TerrainType,
+  IHexTerrain,
+  IMovementRangeHex,
+  Facing,
+  GameSide,
+  IUnitToken,
+  MovementType,
+  TokenUnitType,
+} from '@/types/gameplay';
+
+const allTerrainTypeCoordinates = [
+  { q: 0, r: -2 },
+  { q: 1, r: -2 },
+  { q: 2, r: -2 },
+  { q: -1, r: -1 },
+  { q: 0, r: -1 },
+  { q: 1, r: -1 },
+  { q: 2, r: -1 },
+  { q: -2, r: 0 },
+  { q: -1, r: 0 },
+  { q: 0, r: 0 },
+  { q: 1, r: 0 },
+  { q: 2, r: 0 },
+  { q: -2, r: 1 },
+  { q: -1, r: 1 },
+  { q: 0, r: 1 },
+  { q: 1, r: 1 },
+  { q: -2, r: 2 },
+  { q: -1, r: 2 },
+  { q: 0, r: 2 },
+];
+
+export const terrainWithSelectionMovementRange: readonly IMovementRangeHex[] = [
+  {
+    hex: { q: 0, r: 1 },
+    mpCost: 2,
+    reachable: true,
+    movementType: MovementType.Walk,
+  },
+  {
+    hex: { q: 1, r: 1 },
+    mpCost: 2,
+    reachable: true,
+    movementType: MovementType.Walk,
+  },
+  {
+    hex: { q: 2, r: 0 },
+    mpCost: 3,
+    reachable: true,
+    movementType: MovementType.Walk,
+  },
+  {
+    hex: { q: 2, r: -1 },
+    mpCost: 4,
+    reachable: false,
+    movementType: MovementType.Run,
+  },
+];
+
+export const allTerrainTypesTerrain: IHexTerrain[] = Object.values(
+  TerrainType,
+).map((type, index) => ({
+  coordinate: allTerrainTypeCoordinates[index],
+  elevation: (index % 7) - 3,
+  features: [
+    {
+      type,
+      level: type === TerrainType.Clear ? 0 : 1,
+    },
+  ],
+}));
+
+export const overlayTerrain: IHexTerrain[] = [
+  {
+    coordinate: { q: 0, r: 0 },
+    elevation: 0,
+    features: [{ type: TerrainType.Clear, level: 0 }],
+  },
+  {
+    coordinate: { q: 1, r: 0 },
+    elevation: 0,
+    features: [{ type: TerrainType.LightWoods, level: 1 }],
+  },
+  {
+    coordinate: { q: 2, r: 0 },
+    elevation: 0,
+    features: [{ type: TerrainType.HeavyWoods, level: 2 }],
+  },
+  {
+    coordinate: { q: -1, r: 0 },
+    elevation: 0,
+    features: [{ type: TerrainType.Water, level: 1 }],
+  },
+  {
+    coordinate: { q: 0, r: 1 },
+    elevation: 0,
+    features: [{ type: TerrainType.Rough, level: 1 }],
+  },
+  {
+    coordinate: { q: 1, r: 1 },
+    elevation: 0,
+    features: [{ type: TerrainType.Building, level: 2 }],
+  },
+  {
+    coordinate: { q: -1, r: 1 },
+    elevation: 0,
+    features: [{ type: TerrainType.Swamp, level: 1 }],
+  },
+  {
+    coordinate: { q: 0, r: -1 },
+    elevation: 0,
+    features: [{ type: TerrainType.Pavement, level: 0 }],
+  },
+  {
+    coordinate: { q: 1, r: -1 },
+    elevation: 0,
+    features: [{ type: TerrainType.Road, level: 0 }],
+  },
+  {
+    coordinate: { q: -1, r: -1 },
+    elevation: 0,
+    features: [{ type: TerrainType.Rubble, level: 1 }],
+  },
+  {
+    coordinate: { q: 2, r: -1 },
+    elevation: 0,
+    features: [{ type: TerrainType.Smoke, level: 1 }],
+  },
+];
+
+export const overlayToken: IUnitToken = {
+  unitId: 'atlas-overlay',
+  name: 'Atlas AS7-D',
+  designation: 'A1',
+  position: { q: 0, r: 0 },
+  facing: Facing.North,
+  side: GameSide.Player,
+  isDestroyed: false,
+  isSelected: true,
+  isValidTarget: false,
+  unitType: TokenUnitType.Mech,
+};
+
+export const badgeDenseTerrain: IHexTerrain[] = [
+  {
+    coordinate: { q: 0, r: 0 },
+    elevation: 0,
+    features: [{ type: TerrainType.Clear, level: 0 }],
+  },
+  {
+    coordinate: { q: 1, r: 0 },
+    elevation: 4,
+    features: [{ type: TerrainType.Building, level: 2 }],
+  },
+  {
+    coordinate: { q: 0, r: 1 },
+    elevation: -1,
+    features: [{ type: TerrainType.Water, level: 1 }],
+  },
+  {
+    coordinate: { q: -1, r: 1 },
+    elevation: -2,
+    features: [{ type: TerrainType.Water, level: 3 }],
+  },
+  {
+    coordinate: { q: 1, r: -1 },
+    elevation: 2,
+    features: [{ type: TerrainType.Rough, level: 1 }],
+  },
+  {
+    coordinate: { q: 2, r: -1 },
+    elevation: 3,
+    features: [{ type: TerrainType.HeavyWoods, level: 2 }],
+  },
+  {
+    coordinate: { q: -1, r: 0 },
+    elevation: 1,
+    features: [{ type: TerrainType.Rubble, level: 1 }],
+  },
+  {
+    coordinate: { q: 0, r: -1 },
+    elevation: -1,
+    features: [{ type: TerrainType.Swamp, level: 1 }],
+  },
+];
+
+export const badgeDenseToken: IUnitToken = {
+  ...overlayToken,
+  unitId: 'shadow-hawk-badge-density',
+  name: 'Shadow Hawk SHD-2H',
+  designation: 'SHD',
+  position: { q: 1, r: 0 },
+  facing: Facing.Southwest,
+  isSelected: false,
+};
+
+export const badgeDenseMovementRange: readonly IMovementRangeHex[] = [
+  {
+    hex: { q: 1, r: 0 },
+    mpCost: 3,
+    terrainCost: 0,
+    elevationDelta: 1,
+    elevationCost: 1,
+    heatGenerated: 0,
+    movementMode: 'biped',
+    reachable: true,
+    movementType: MovementType.Walk,
+  },
+  {
+    hex: { q: 2, r: -1 },
+    mpCost: 5,
+    terrainCost: 2,
+    elevationDelta: 1,
+    elevationCost: 1,
+    heatGenerated: 2,
+    movementMode: 'biped',
+    reachable: true,
+    movementType: MovementType.Run,
+  },
+  {
+    hex: { q: -1, r: 1 },
+    mpCost: 6,
+    terrainCost: 0,
+    elevationDelta: -2,
+    elevationCost: 0,
+    heatGenerated: 3,
+    movementMode: 'jump',
+    reachable: false,
+    movementType: MovementType.Jump,
+    blockedReason: 'Water depth exceeds safe landing profile',
+    movementInvalidReason: 'TerrainBlocked',
+    movementInvalidDetails: 'Water depth exceeds safe landing profile',
+  },
+];
+
+export const isometricAdjacentCliffTerrain: IHexTerrain[] = [
+  {
+    coordinate: { q: 0, r: 0 },
+    elevation: 5,
+    features: [{ type: TerrainType.Rough, level: 1 }],
+  },
+  {
+    coordinate: { q: 1, r: 0 },
+    elevation: 1,
+    features: [{ type: TerrainType.Clear, level: 0 }],
+  },
+  {
+    coordinate: { q: 0, r: 1 },
+    elevation: 4,
+    features: [{ type: TerrainType.HeavyWoods, level: 1 }],
+  },
+  {
+    coordinate: { q: -1, r: 1 },
+    elevation: -1,
+    features: [{ type: TerrainType.Water, level: 1 }],
+  },
+  {
+    coordinate: { q: 1, r: -1 },
+    elevation: 3,
+    features: [{ type: TerrainType.Rubble, level: 1 }],
+  },
+];
+
+export const isometricPitTerrain: IHexTerrain[] = [
+  {
+    coordinate: { q: 0, r: 0 },
+    elevation: -2,
+    features: [{ type: TerrainType.Clear, level: 0 }],
+  },
+  {
+    coordinate: { q: 1, r: 0 },
+    elevation: 4,
+    features: [{ type: TerrainType.Building, level: 1 }],
+  },
+  {
+    coordinate: { q: 0, r: 1 },
+    elevation: 2,
+    features: [{ type: TerrainType.Rough, level: 1 }],
+  },
+  {
+    coordinate: { q: -1, r: 0 },
+    elevation: 1,
+    features: [{ type: TerrainType.LightWoods, level: 1 }],
+  },
+];
+
+export const isometricPitToken: IUnitToken = {
+  ...overlayToken,
+  unitId: 'pit-shadow-hawk',
+  name: 'Shadow Hawk SHD-2H',
+  designation: 'SHD',
+  position: { q: 0, r: 0 },
+  facing: Facing.Northeast,
+  isSelected: true,
+};
+
+export const isometricMountainTerrain: IHexTerrain[] = [
+  ...isometricAdjacentCliffTerrain,
+  {
+    coordinate: { q: -1, r: 0 },
+    elevation: 2,
+    features: [{ type: TerrainType.LightWoods, level: 1 }],
+  },
+  {
+    coordinate: { q: 2, r: -1 },
+    elevation: 6,
+    features: [{ type: TerrainType.Building, level: 2 }],
+  },
+  {
+    coordinate: { q: -2, r: 2 },
+    elevation: 3,
+    features: [{ type: TerrainType.HeavyIndustrial, level: 1 }],
+  },
+  {
+    coordinate: { q: 2, r: 0 },
+    elevation: 0,
+    features: [{ type: TerrainType.Road, level: 0 }],
+  },
+];
+
+export const mountainRotationToken: IUnitToken = {
+  ...badgeDenseToken,
+  unitId: 'mountain-griffin',
+  name: 'Griffin GRF-1N',
+  designation: 'GRF',
+  position: { q: 1, r: -1 },
+  facing: Facing.Southeast,
+};
+
+export const movementOverlayToken: IUnitToken = {
+  ...overlayToken,
+  unitId: 'griffin-move',
+  name: 'Griffin GRF-1N',
+  designation: 'G1',
+  position: { q: -1, r: 0 },
+  facing: Facing.Northeast,
+};
+
+export const movementEncodingTerrain: IHexTerrain[] = [
+  {
+    coordinate: { q: -1, r: 0 },
+    elevation: 0,
+    features: [{ type: TerrainType.Clear, level: 0 }],
+  },
+  {
+    coordinate: { q: 0, r: 0 },
+    elevation: 0,
+    features: [{ type: TerrainType.Clear, level: 0 }],
+  },
+  {
+    coordinate: { q: 1, r: 0 },
+    elevation: 1,
+    features: [{ type: TerrainType.Rough, level: 1 }],
+  },
+  {
+    coordinate: { q: 2, r: 0 },
+    elevation: 2,
+    features: [{ type: TerrainType.Building, level: 1 }],
+  },
+  {
+    coordinate: { q: 0, r: 1 },
+    elevation: -1,
+    features: [{ type: TerrainType.Water, level: 2 }],
+  },
+];
+
+export const movementEncodingRange: readonly IMovementRangeHex[] = [
+  {
+    hex: { q: 0, r: 0 },
+    mpCost: 1,
+    terrainCost: 0,
+    elevationDelta: 0,
+    elevationCost: 0,
+    heatGenerated: 0,
+    movementMode: 'biped',
+    reachable: true,
+    movementType: MovementType.Walk,
+  },
+  {
+    hex: { q: 1, r: 0 },
+    mpCost: 4,
+    terrainCost: 1,
+    elevationDelta: 1,
+    elevationCost: 1,
+    heatGenerated: 2,
+    movementMode: 'biped',
+    reachable: true,
+    movementType: MovementType.Run,
+  },
+  {
+    hex: { q: 2, r: 0 },
+    mpCost: 7,
+    terrainCost: 2,
+    elevationDelta: 2,
+    elevationCost: 2,
+    heatGenerated: 0,
+    movementMode: 'biped',
+    reachable: false,
+    movementType: MovementType.Run,
+    blockedReason: 'Destination exceeds remaining MP',
+    movementInvalidReason: 'InsufficientMP',
+    movementInvalidDetails: 'Destination exceeds remaining MP',
+  },
+  {
+    hex: { q: 0, r: 1 },
+    mpCost: 3,
+    terrainCost: 0,
+    elevationDelta: -1,
+    elevationCost: 0,
+    heatGenerated: 3,
+    movementMode: 'jump',
+    reachable: true,
+    movementType: MovementType.Jump,
+  },
+];
+
+export const movementAndPathMovementRange: readonly IMovementRangeHex[] = [
+  {
+    hex: { q: 0, r: 0 },
+    mpCost: 1,
+    reachable: true,
+    movementType: MovementType.Walk,
+  },
+  {
+    hex: { q: 1, r: 0 },
+    mpCost: 2,
+    reachable: true,
+    movementType: MovementType.Walk,
+  },
+  {
+    hex: { q: 2, r: 0 },
+    mpCost: 4,
+    reachable: true,
+    movementType: MovementType.Run,
+  },
+  {
+    hex: { q: 2, r: -1 },
+    mpCost: 5,
+    reachable: false,
+    movementType: MovementType.Run,
+  },
+  {
+    hex: { q: 0, r: 2 },
+    mpCost: 3,
+    reachable: true,
+    movementType: MovementType.Jump,
+  },
+];
+
+export const movementAndPathHighlightPath = [
+  { q: -1, r: 0 },
+  { q: 0, r: 0 },
+  { q: 1, r: 0 },
+  { q: 2, r: 0 },
+];
+
+export const attackOverlayTokens: IUnitToken[] = [
+  {
+    ...overlayToken,
+    unitId: 'warhammer-attacker',
+    name: 'Warhammer WHM-6R',
+    designation: 'W6',
+    position: { q: 0, r: 0 },
+    facing: Facing.Northeast,
+    isSelected: true,
+  },
+  {
+    ...overlayToken,
+    unitId: 'hunchback-target',
+    name: 'Hunchback HBK-4G',
+    designation: 'H4',
+    position: { q: 3, r: -1 },
+    facing: Facing.Southwest,
+    side: GameSide.Opponent,
+    isSelected: false,
+    isValidTarget: true,
+    isActiveTarget: true,
+  },
+  {
+    ...overlayToken,
+    unitId: 'locust-target',
+    name: 'Locust LCT-1V',
+    designation: 'L1',
+    position: { q: 2, r: 1 },
+    facing: Facing.Northwest,
+    side: GameSide.Opponent,
+    isSelected: false,
+    isValidTarget: true,
+  },
+];
+
+export const attackOverlayRange = [
+  { q: 1, r: 0 },
+  { q: 2, r: 0 },
+  { q: 3, r: -1 },
+  { q: 2, r: 1 },
+  { q: 1, r: -1 },
+  { q: 0, r: 1 },
+  { q: -1, r: 1 },
+];

--- a/src/components/gameplay/HexMapDisplay.stories.tsx
+++ b/src/components/gameplay/HexMapDisplay.stories.tsx
@@ -1,17 +1,27 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import {
-  TerrainType,
-  IHexTerrain,
-  IMovementRangeHex,
-  Facing,
-  GameSide,
-  IUnitToken,
-  MovementType,
-  TokenUnitType,
-} from '@/types/gameplay';
-
 import { HexMapDisplay } from './HexMapDisplay';
+import {
+  allTerrainTypesTerrain,
+  attackOverlayRange,
+  attackOverlayTokens,
+  badgeDenseMovementRange,
+  badgeDenseTerrain,
+  badgeDenseToken,
+  isometricAdjacentCliffTerrain,
+  isometricMountainTerrain,
+  isometricPitTerrain,
+  isometricPitToken,
+  mountainRotationToken,
+  movementAndPathHighlightPath,
+  movementAndPathMovementRange,
+  movementEncodingRange,
+  movementEncodingTerrain,
+  movementOverlayToken,
+  overlayTerrain,
+  overlayToken,
+  terrainWithSelectionMovementRange,
+} from './HexMapDisplay.stories.fixture';
 import {
   sampleTerrain,
   sampleToken,
@@ -93,239 +103,20 @@ export const TerrainWithSelection: Story = {
     tokens: [sampleToken],
     selectedHex: { q: 1, r: 0 },
     hexTerrain: sampleTerrain,
-    movementRange: [
-      {
-        hex: { q: 0, r: 1 },
-        mpCost: 2,
-        reachable: true,
-        movementType: MovementType.Walk,
-      },
-      {
-        hex: { q: 1, r: 1 },
-        mpCost: 2,
-        reachable: true,
-        movementType: MovementType.Walk,
-      },
-      {
-        hex: { q: 2, r: 0 },
-        mpCost: 3,
-        reachable: true,
-        movementType: MovementType.Walk,
-      },
-      {
-        hex: { q: 2, r: -1 },
-        mpCost: 4,
-        reachable: false,
-        movementType: MovementType.Run,
-      },
-    ],
+    movementRange: terrainWithSelectionMovementRange,
     showCoordinates: true,
   },
 };
-
-const allTerrainTypeCoordinates = [
-  { q: 0, r: -2 },
-  { q: 1, r: -2 },
-  { q: 2, r: -2 },
-  { q: -1, r: -1 },
-  { q: 0, r: -1 },
-  { q: 1, r: -1 },
-  { q: 2, r: -1 },
-  { q: -2, r: 0 },
-  { q: -1, r: 0 },
-  { q: 0, r: 0 },
-  { q: 1, r: 0 },
-  { q: 2, r: 0 },
-  { q: -2, r: 1 },
-  { q: -1, r: 1 },
-  { q: 0, r: 1 },
-  { q: 1, r: 1 },
-  { q: -2, r: 2 },
-  { q: -1, r: 2 },
-  { q: 0, r: 2 },
-];
 
 export const AllTerrainTypes: Story = {
   args: {
     radius: 2,
     tokens: [],
     selectedHex: null,
-    hexTerrain: Object.values(TerrainType).map((type, index) => ({
-      coordinate: allTerrainTypeCoordinates[index],
-      elevation: (index % 7) - 3,
-      features: [
-        {
-          type,
-          level: type === TerrainType.Clear ? 0 : 1,
-        },
-      ],
-    })),
+    hexTerrain: allTerrainTypesTerrain,
     showCoordinates: true,
   },
 };
-
-const overlayTerrain: IHexTerrain[] = [
-  {
-    coordinate: { q: 0, r: 0 },
-    elevation: 0,
-    features: [{ type: TerrainType.Clear, level: 0 }],
-  },
-  {
-    coordinate: { q: 1, r: 0 },
-    elevation: 0,
-    features: [{ type: TerrainType.LightWoods, level: 1 }],
-  },
-  {
-    coordinate: { q: 2, r: 0 },
-    elevation: 0,
-    features: [{ type: TerrainType.HeavyWoods, level: 2 }],
-  },
-  {
-    coordinate: { q: -1, r: 0 },
-    elevation: 0,
-    features: [{ type: TerrainType.Water, level: 1 }],
-  },
-  {
-    coordinate: { q: 0, r: 1 },
-    elevation: 0,
-    features: [{ type: TerrainType.Rough, level: 1 }],
-  },
-  {
-    coordinate: { q: 1, r: 1 },
-    elevation: 0,
-    features: [{ type: TerrainType.Building, level: 2 }],
-  },
-  {
-    coordinate: { q: -1, r: 1 },
-    elevation: 0,
-    features: [{ type: TerrainType.Swamp, level: 1 }],
-  },
-  {
-    coordinate: { q: 0, r: -1 },
-    elevation: 0,
-    features: [{ type: TerrainType.Pavement, level: 0 }],
-  },
-  {
-    coordinate: { q: 1, r: -1 },
-    elevation: 0,
-    features: [{ type: TerrainType.Road, level: 0 }],
-  },
-  {
-    coordinate: { q: -1, r: -1 },
-    elevation: 0,
-    features: [{ type: TerrainType.Rubble, level: 1 }],
-  },
-  {
-    coordinate: { q: 2, r: -1 },
-    elevation: 0,
-    features: [{ type: TerrainType.Smoke, level: 1 }],
-  },
-];
-
-const overlayToken: IUnitToken = {
-  unitId: 'atlas-overlay',
-  name: 'Atlas AS7-D',
-  designation: 'A1',
-  position: { q: 0, r: 0 },
-  facing: Facing.North,
-  side: GameSide.Player,
-  isDestroyed: false,
-  isSelected: true,
-  isValidTarget: false,
-  unitType: TokenUnitType.Mech,
-};
-
-const badgeDenseTerrain: IHexTerrain[] = [
-  {
-    coordinate: { q: 0, r: 0 },
-    elevation: 0,
-    features: [{ type: TerrainType.Clear, level: 0 }],
-  },
-  {
-    coordinate: { q: 1, r: 0 },
-    elevation: 4,
-    features: [{ type: TerrainType.Building, level: 2 }],
-  },
-  {
-    coordinate: { q: 0, r: 1 },
-    elevation: -1,
-    features: [{ type: TerrainType.Water, level: 1 }],
-  },
-  {
-    coordinate: { q: -1, r: 1 },
-    elevation: -2,
-    features: [{ type: TerrainType.Water, level: 3 }],
-  },
-  {
-    coordinate: { q: 1, r: -1 },
-    elevation: 2,
-    features: [{ type: TerrainType.Rough, level: 1 }],
-  },
-  {
-    coordinate: { q: 2, r: -1 },
-    elevation: 3,
-    features: [{ type: TerrainType.HeavyWoods, level: 2 }],
-  },
-  {
-    coordinate: { q: -1, r: 0 },
-    elevation: 1,
-    features: [{ type: TerrainType.Rubble, level: 1 }],
-  },
-  {
-    coordinate: { q: 0, r: -1 },
-    elevation: -1,
-    features: [{ type: TerrainType.Swamp, level: 1 }],
-  },
-];
-
-const badgeDenseToken: IUnitToken = {
-  ...overlayToken,
-  unitId: 'shadow-hawk-badge-density',
-  name: 'Shadow Hawk SHD-2H',
-  designation: 'SHD',
-  position: { q: 1, r: 0 },
-  facing: Facing.Southwest,
-  isSelected: false,
-};
-
-const badgeDenseMovementRange: readonly IMovementRangeHex[] = [
-  {
-    hex: { q: 1, r: 0 },
-    mpCost: 3,
-    terrainCost: 0,
-    elevationDelta: 1,
-    elevationCost: 1,
-    heatGenerated: 0,
-    movementMode: 'biped',
-    reachable: true,
-    movementType: MovementType.Walk,
-  },
-  {
-    hex: { q: 2, r: -1 },
-    mpCost: 5,
-    terrainCost: 2,
-    elevationDelta: 1,
-    elevationCost: 1,
-    heatGenerated: 2,
-    movementMode: 'biped',
-    reachable: true,
-    movementType: MovementType.Run,
-  },
-  {
-    hex: { q: -1, r: 1 },
-    mpCost: 6,
-    terrainCost: 0,
-    elevationDelta: -2,
-    elevationCost: 0,
-    heatGenerated: 3,
-    movementMode: 'jump',
-    reachable: false,
-    movementType: MovementType.Jump,
-    blockedReason: 'Water depth exceeds safe landing profile',
-    movementInvalidReason: 'TerrainBlocked',
-    movementInvalidDetails: 'Water depth exceeds safe landing profile',
-  },
-];
 
 export const WithOverlays: Story = {
   args: {
@@ -364,91 +155,6 @@ export const BadgeDenseElevationBoard: Story = {
   },
 };
 
-const isometricAdjacentCliffTerrain: IHexTerrain[] = [
-  {
-    coordinate: { q: 0, r: 0 },
-    elevation: 5,
-    features: [{ type: TerrainType.Rough, level: 1 }],
-  },
-  {
-    coordinate: { q: 1, r: 0 },
-    elevation: 1,
-    features: [{ type: TerrainType.Clear, level: 0 }],
-  },
-  {
-    coordinate: { q: 0, r: 1 },
-    elevation: 4,
-    features: [{ type: TerrainType.HeavyWoods, level: 1 }],
-  },
-  {
-    coordinate: { q: -1, r: 1 },
-    elevation: -1,
-    features: [{ type: TerrainType.Water, level: 1 }],
-  },
-  {
-    coordinate: { q: 1, r: -1 },
-    elevation: 3,
-    features: [{ type: TerrainType.Rubble, level: 1 }],
-  },
-];
-
-const isometricPitTerrain: IHexTerrain[] = [
-  {
-    coordinate: { q: 0, r: 0 },
-    elevation: -2,
-    features: [{ type: TerrainType.Clear, level: 0 }],
-  },
-  {
-    coordinate: { q: 1, r: 0 },
-    elevation: 4,
-    features: [{ type: TerrainType.Building, level: 1 }],
-  },
-  {
-    coordinate: { q: 0, r: 1 },
-    elevation: 2,
-    features: [{ type: TerrainType.Rough, level: 1 }],
-  },
-  {
-    coordinate: { q: -1, r: 0 },
-    elevation: 1,
-    features: [{ type: TerrainType.LightWoods, level: 1 }],
-  },
-];
-
-const isometricPitToken: IUnitToken = {
-  ...overlayToken,
-  unitId: 'pit-shadow-hawk',
-  name: 'Shadow Hawk SHD-2H',
-  designation: 'SHD',
-  position: { q: 0, r: 0 },
-  facing: Facing.Northeast,
-  isSelected: true,
-};
-
-const isometricMountainTerrain: IHexTerrain[] = [
-  ...isometricAdjacentCliffTerrain,
-  {
-    coordinate: { q: -1, r: 0 },
-    elevation: 2,
-    features: [{ type: TerrainType.LightWoods, level: 1 }],
-  },
-  {
-    coordinate: { q: 2, r: -1 },
-    elevation: 6,
-    features: [{ type: TerrainType.Building, level: 2 }],
-  },
-  {
-    coordinate: { q: -2, r: 2 },
-    elevation: 3,
-    features: [{ type: TerrainType.HeavyIndustrial, level: 1 }],
-  },
-  {
-    coordinate: { q: 2, r: 0 },
-    elevation: 0,
-    features: [{ type: TerrainType.Road, level: 0 }],
-  },
-];
-
 export const IsometricAdjacentCliffs: Story = {
   args: {
     radius: 3,
@@ -474,144 +180,13 @@ export const IsometricUnitInPitBehindWall: Story = {
 export const IsometricMountainRotationFixture: Story = {
   args: {
     radius: 4,
-    tokens: [
-      {
-        ...badgeDenseToken,
-        unitId: 'mountain-griffin',
-        name: 'Griffin GRF-1N',
-        designation: 'GRF',
-        position: { q: 1, r: -1 },
-        facing: Facing.Southeast,
-      },
-    ],
+    tokens: [mountainRotationToken],
     selectedHex: { q: 1, r: -1 },
     hexTerrain: isometricMountainTerrain,
     showCoordinates: true,
     projectionMode: 'isometric2d',
   },
 };
-
-const movementOverlayToken: IUnitToken = {
-  ...overlayToken,
-  unitId: 'griffin-move',
-  name: 'Griffin GRF-1N',
-  designation: 'G1',
-  position: { q: -1, r: 0 },
-  facing: Facing.Northeast,
-};
-
-const movementEncodingTerrain: IHexTerrain[] = [
-  {
-    coordinate: { q: -1, r: 0 },
-    elevation: 0,
-    features: [{ type: TerrainType.Clear, level: 0 }],
-  },
-  {
-    coordinate: { q: 0, r: 0 },
-    elevation: 0,
-    features: [{ type: TerrainType.Clear, level: 0 }],
-  },
-  {
-    coordinate: { q: 1, r: 0 },
-    elevation: 1,
-    features: [{ type: TerrainType.Rough, level: 1 }],
-  },
-  {
-    coordinate: { q: 2, r: 0 },
-    elevation: 2,
-    features: [{ type: TerrainType.Building, level: 1 }],
-  },
-  {
-    coordinate: { q: 0, r: 1 },
-    elevation: -1,
-    features: [{ type: TerrainType.Water, level: 2 }],
-  },
-];
-
-const movementEncodingRange: readonly IMovementRangeHex[] = [
-  {
-    hex: { q: 0, r: 0 },
-    mpCost: 1,
-    terrainCost: 0,
-    elevationDelta: 0,
-    elevationCost: 0,
-    heatGenerated: 0,
-    movementMode: 'biped',
-    reachable: true,
-    movementType: MovementType.Walk,
-  },
-  {
-    hex: { q: 1, r: 0 },
-    mpCost: 4,
-    terrainCost: 1,
-    elevationDelta: 1,
-    elevationCost: 1,
-    heatGenerated: 2,
-    movementMode: 'biped',
-    reachable: true,
-    movementType: MovementType.Run,
-  },
-  {
-    hex: { q: 2, r: 0 },
-    mpCost: 7,
-    terrainCost: 2,
-    elevationDelta: 2,
-    elevationCost: 2,
-    heatGenerated: 0,
-    movementMode: 'biped',
-    reachable: false,
-    movementType: MovementType.Run,
-    blockedReason: 'Destination exceeds remaining MP',
-    movementInvalidReason: 'InsufficientMP',
-    movementInvalidDetails: 'Destination exceeds remaining MP',
-  },
-  {
-    hex: { q: 0, r: 1 },
-    mpCost: 3,
-    terrainCost: 0,
-    elevationDelta: -1,
-    elevationCost: 0,
-    heatGenerated: 3,
-    movementMode: 'jump',
-    reachable: true,
-    movementType: MovementType.Jump,
-  },
-];
-
-const attackOverlayTokens: IUnitToken[] = [
-  {
-    ...overlayToken,
-    unitId: 'warhammer-attacker',
-    name: 'Warhammer WHM-6R',
-    designation: 'W6',
-    position: { q: 0, r: 0 },
-    facing: Facing.Northeast,
-    isSelected: true,
-  },
-  {
-    ...overlayToken,
-    unitId: 'hunchback-target',
-    name: 'Hunchback HBK-4G',
-    designation: 'H4',
-    position: { q: 3, r: -1 },
-    facing: Facing.Southwest,
-    side: GameSide.Opponent,
-    isSelected: false,
-    isValidTarget: true,
-    isActiveTarget: true,
-  },
-  {
-    ...overlayToken,
-    unitId: 'locust-target',
-    name: 'Locust LCT-1V',
-    designation: 'L1',
-    position: { q: 2, r: 1 },
-    facing: Facing.Northwest,
-    side: GameSide.Opponent,
-    isSelected: false,
-    isValidTarget: true,
-  },
-];
 
 export const MovementAndPathOverlay: Story = {
   args: {
@@ -620,44 +195,8 @@ export const MovementAndPathOverlay: Story = {
     selectedHex: { q: -1, r: 0 },
     hexTerrain: overlayTerrain,
     showCoordinates: true,
-    movementRange: [
-      {
-        hex: { q: 0, r: 0 },
-        mpCost: 1,
-        reachable: true,
-        movementType: MovementType.Walk,
-      },
-      {
-        hex: { q: 1, r: 0 },
-        mpCost: 2,
-        reachable: true,
-        movementType: MovementType.Walk,
-      },
-      {
-        hex: { q: 2, r: 0 },
-        mpCost: 4,
-        reachable: true,
-        movementType: MovementType.Run,
-      },
-      {
-        hex: { q: 2, r: -1 },
-        mpCost: 5,
-        reachable: false,
-        movementType: MovementType.Run,
-      },
-      {
-        hex: { q: 0, r: 2 },
-        mpCost: 3,
-        reachable: true,
-        movementType: MovementType.Jump,
-      },
-    ],
-    highlightPath: [
-      { q: -1, r: 0 },
-      { q: 0, r: 0 },
-      { q: 1, r: 0 },
-      { q: 2, r: 0 },
-    ],
+    movementRange: movementAndPathMovementRange,
+    highlightPath: movementAndPathHighlightPath,
     hoverMpCost: 4,
     mpLegend: {
       active: 'run',
@@ -692,14 +231,6 @@ export const AttackTargetOverlay: Story = {
     selectedHex: { q: 0, r: 0 },
     hexTerrain: overlayTerrain,
     showCoordinates: true,
-    attackRange: [
-      { q: 1, r: 0 },
-      { q: 2, r: 0 },
-      { q: 3, r: -1 },
-      { q: 2, r: 1 },
-      { q: 1, r: -1 },
-      { q: 0, r: 1 },
-      { q: -1, r: 1 },
-    ],
+    attackRange: attackOverlayRange,
   },
 };

--- a/src/components/gameplay/HexMapDisplay/HexCell.layers.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexCell.layers.tsx
@@ -1,0 +1,248 @@
+import React from 'react';
+
+import type { IHexCoordinate, IHexTerrain } from '@/types/gameplay';
+
+import { TerrainArtLayer } from '@/components/gameplay/terrain/TerrainArtLayer';
+
+import type { SvgDataAttributes } from './HexCell.overlayAttributes';
+import type { IsometricTerrainOccluderInfo } from './projection';
+
+const JUMP_PATTERN_URL = 'url(#pattern-jump-range)';
+const BLOCKED_MOVEMENT_PATTERN_URL = 'url(#pattern-blocked-movement)';
+
+export function HexCellTerrainArtLayer({
+  hex,
+  terrain,
+  terrainLookup,
+}: {
+  readonly hex: IHexCoordinate;
+  readonly terrain?: IHexTerrain;
+  readonly terrainLookup?: ReadonlyMap<string, IHexTerrain>;
+}): React.ReactElement | null {
+  if (!terrainLookup) return null;
+  return (
+    <TerrainArtLayer
+      hex={hex}
+      terrain={terrain}
+      terrainLookup={terrainLookup}
+    />
+  );
+}
+
+export function HexCellOverlayLayer({
+  hex,
+  pathD,
+  hasOverlay,
+  overlayFill,
+  overlayOpacity,
+  overlayAttributes,
+  isLegacyAttackRangeFallback,
+}: {
+  readonly hex: IHexCoordinate;
+  readonly pathD: string;
+  readonly hasOverlay: boolean;
+  readonly overlayFill: string | null;
+  readonly overlayOpacity: number;
+  readonly overlayAttributes: SvgDataAttributes;
+  readonly isLegacyAttackRangeFallback: boolean;
+}): React.ReactElement {
+  return (
+    <>
+      {hasOverlay && overlayFill && (
+        <path
+          d={pathD}
+          fill={overlayFill}
+          opacity={overlayOpacity}
+          pointerEvents="none"
+          data-testid={`hex-overlay-${hex.q}-${hex.r}`}
+          {...overlayAttributes}
+        />
+      )}
+      {isLegacyAttackRangeFallback && (
+        <path
+          d={pathD}
+          fill="none"
+          stroke="#334155"
+          strokeWidth={1.5}
+          strokeDasharray="4 3"
+          opacity={0.9}
+          pointerEvents="none"
+          data-testid={`hex-legacy-range-outline-${hex.q}-${hex.r}`}
+          aria-label={`Legacy range envelope for hex ${hex.q},${hex.r}; not weapon-backed`}
+        />
+      )}
+    </>
+  );
+}
+
+export function HexCellMovementEncodingLayers({
+  hex,
+  x,
+  y,
+  pathD,
+  isJumpTile,
+  isRunTile,
+  isBlockedTile,
+  isInPath,
+}: {
+  readonly hex: IHexCoordinate;
+  readonly x: number;
+  readonly y: number;
+  readonly pathD: string;
+  readonly isJumpTile: boolean;
+  readonly isRunTile: boolean;
+  readonly isBlockedTile: boolean;
+  readonly isInPath: boolean;
+}): React.ReactElement | null {
+  if (isInPath) return null;
+  return (
+    <>
+      {isJumpTile && (
+        <path
+          d={pathD}
+          fill={JUMP_PATTERN_URL}
+          opacity={0.6}
+          pointerEvents="none"
+          data-testid={`jump-pattern-${hex.q}-${hex.r}`}
+        />
+      )}
+      {isBlockedTile && (
+        <>
+          <path
+            d={pathD}
+            fill={BLOCKED_MOVEMENT_PATTERN_URL}
+            opacity={0.72}
+            pointerEvents="none"
+            data-testid={`blocked-movement-pattern-${hex.q}-${hex.r}`}
+          />
+          <g
+            pointerEvents="none"
+            data-testid={`blocked-movement-glyph-${hex.q}-${hex.r}`}
+            aria-label={`Blocked movement marker for hex ${hex.q},${hex.r}`}
+          >
+            <rect
+              x={x - 28}
+              y={y + 11}
+              width={16}
+              height={14}
+              rx={3}
+              fill="#0f172a"
+              fillOpacity={0.88}
+              stroke="#f8fafc"
+              strokeWidth={0.75}
+            />
+            <text
+              x={x - 20}
+              y={y + 21}
+              textAnchor="middle"
+              fontSize={10}
+              fontWeight="bold"
+              fill="#f8fafc"
+            >
+              !
+            </text>
+          </g>
+        </>
+      )}
+      {isRunTile && (
+        <path
+          d={pathD}
+          fill="none"
+          stroke="#854d0e"
+          strokeWidth={2}
+          strokeDasharray="5 3"
+          opacity={0.92}
+          pointerEvents="none"
+          data-testid={`run-range-outline-${hex.q}-${hex.r}`}
+          aria-label={`Run-only movement marker for hex ${hex.q},${hex.r}`}
+        />
+      )}
+    </>
+  );
+}
+
+export function HexCellIsometricOccluderHighlight({
+  hex,
+  x,
+  y,
+  pathD,
+  isIsometricOccluder,
+  isometricOccluderInfo,
+  occludedUnitIds,
+  occlusionReasons,
+  occluderElevationLabel,
+}: {
+  readonly hex: IHexCoordinate;
+  readonly x: number;
+  readonly y: number;
+  readonly pathD: string;
+  readonly isIsometricOccluder: boolean;
+  readonly isometricOccluderInfo?: IsometricTerrainOccluderInfo;
+  readonly occludedUnitIds?: string;
+  readonly occlusionReasons?: string;
+  readonly occluderElevationLabel: string;
+}): React.ReactElement | null {
+  if (!isIsometricOccluder || !isometricOccluderInfo) return null;
+  return (
+    <g
+      pointerEvents="none"
+      data-testid={`hex-isometric-occluder-highlight-${hex.q}-${hex.r}`}
+      data-isometric-occludes-units={occludedUnitIds}
+      data-isometric-occlusion-reasons={occlusionReasons}
+      data-isometric-occluder-rotation-step={isometricOccluderInfo.rotationStep}
+      aria-label={`Tall elevation ${occluderElevationLabel} may hide units ${occludedUnitIds}`}
+    >
+      <title>
+        {`Tall elevation ${occluderElevationLabel} may hide units ${occludedUnitIds}`}
+      </title>
+      <path
+        d={pathD}
+        fill="none"
+        stroke="#38bdf8"
+        strokeWidth={2.25}
+        strokeDasharray="5 3"
+        opacity={0.92}
+      />
+      <rect
+        x={x - 18}
+        y={y - 25}
+        width={36}
+        height={12}
+        rx={2}
+        fill="#0f172a"
+        fillOpacity={0.88}
+        stroke="#38bdf8"
+        strokeWidth={0.75}
+      />
+      <text
+        x={x}
+        y={y - 16}
+        textAnchor="middle"
+        fontSize={8}
+        fontWeight="bold"
+        fill="#e0f2fe"
+      >
+        OCC
+      </text>
+    </g>
+  );
+}
+
+export function HexCellCoordinateLabel({
+  hex,
+  x,
+  y,
+  showCoordinate,
+}: {
+  readonly hex: IHexCoordinate;
+  readonly x: number;
+  readonly y: number;
+  readonly showCoordinate: boolean;
+}): React.ReactElement | null {
+  if (!showCoordinate) return null;
+  return (
+    <text x={x} y={y + 4} textAnchor="middle" fontSize={10} fill="#64748b">
+      {hex.q},{hex.r}
+    </text>
+  );
+}

--- a/src/components/gameplay/HexMapDisplay/HexCell.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexCell.tsx
@@ -18,7 +18,6 @@ import type {
   TacticalMapMovementProjectionStatus,
 } from '@/utils/gameplay/tacticalMapProjection';
 
-import { TerrainArtLayer } from '@/components/gameplay/terrain/TerrainArtLayer';
 import { HEX_COLORS } from '@/constants/hexMap';
 import { MovementType } from '@/types/gameplay';
 
@@ -28,6 +27,13 @@ import {
   getIsometricElevationStackMetrics,
 } from './HexCell.isometricStack';
 import { formatElevationLabel } from './HexCell.labels';
+import {
+  HexCellCoordinateLabel,
+  HexCellIsometricOccluderHighlight,
+  HexCellMovementEncodingLayers,
+  HexCellOverlayLayer,
+  HexCellTerrainArtLayer,
+} from './HexCell.layers';
 import { deriveHexOverlayState } from './HexCell.overlayModel';
 import { buildHexCellRenderModel } from './HexCell.renderModel';
 import {
@@ -35,17 +41,6 @@ import {
   type IsometricTerrainOccluderInfo,
 } from './projection';
 import { hexToPixel, hexPath, getTerrainFill } from './renderHelpers';
-
-/**
- * Per `add-movement-phase-ui` task 3.4: when jump-range tiles render
- * they need a distinct diagonal-hatch pattern on top of the blue
- * tint so the player can visually distinguish "land here by
- * jumping" from "walk/run here." The pattern id is defined in
- * `Overlays.tsx` under <TerrainPatternDefs> so every HexCell can
- * reference it by URL.
- */
-const JUMP_PATTERN_URL = 'url(#pattern-jump-range)';
-const BLOCKED_MOVEMENT_PATTERN_URL = 'url(#pattern-blocked-movement)';
 
 function isJumpRangeTile(movementInfo?: IMovementRangeHex): boolean {
   return (
@@ -300,13 +295,11 @@ export const HexCell = React.memo(function HexCell({
           isIsometricOccluder ? isometricOccluderInfo : undefined
         }
       />
-      {hasTerrainArt && terrainLookup && (
-        <TerrainArtLayer
-          hex={hex}
-          terrain={terrain}
-          terrainLookup={terrainLookup}
-        />
-      )}
+      <HexCellTerrainArtLayer
+        hex={hex}
+        terrain={terrain}
+        terrainLookup={terrainLookup}
+      />
       <path
         d={pathD}
         fill={polygonFill}
@@ -315,139 +308,42 @@ export const HexCell = React.memo(function HexCell({
         pointerEvents="all"
         data-terrain={terrainType}
       />
-      {hasOverlay && overlayFill && (
-        <path
-          d={pathD}
-          fill={overlayFill}
-          opacity={overlayOpacity}
-          pointerEvents="none"
-          data-testid={`hex-overlay-${hex.q}-${hex.r}`}
-          {...overlayAttributes}
-        />
-      )}
-      {isLegacyAttackRangeFallback && (
-        <path
-          d={pathD}
-          fill="none"
-          stroke="#334155"
-          strokeWidth={1.5}
-          strokeDasharray="4 3"
-          opacity={0.9}
-          pointerEvents="none"
-          data-testid={`hex-legacy-range-outline-${hex.q}-${hex.r}`}
-          aria-label={`Legacy range envelope for hex ${hex.q},${hex.r}; not weapon-backed`}
-        />
-      )}
-      {isJumpTile && !isInPath && (
-        <path
-          d={pathD}
-          fill={JUMP_PATTERN_URL}
-          opacity={0.6}
-          pointerEvents="none"
-          data-testid={`jump-pattern-${hex.q}-${hex.r}`}
-        />
-      )}
-      {isBlockedTile && !isInPath && (
-        <>
-          <path
-            d={pathD}
-            fill={BLOCKED_MOVEMENT_PATTERN_URL}
-            opacity={0.72}
-            pointerEvents="none"
-            data-testid={`blocked-movement-pattern-${hex.q}-${hex.r}`}
-          />
-          <g
-            pointerEvents="none"
-            data-testid={`blocked-movement-glyph-${hex.q}-${hex.r}`}
-            aria-label={`Blocked movement marker for hex ${hex.q},${hex.r}`}
-          >
-            <rect
-              x={x - 28}
-              y={y + 11}
-              width={16}
-              height={14}
-              rx={3}
-              fill="#0f172a"
-              fillOpacity={0.88}
-              stroke="#f8fafc"
-              strokeWidth={0.75}
-            />
-            <text
-              x={x - 20}
-              y={y + 21}
-              textAnchor="middle"
-              fontSize={10}
-              fontWeight="bold"
-              fill="#f8fafc"
-            >
-              !
-            </text>
-          </g>
-        </>
-      )}
-      {isRunTile && !isInPath && (
-        <path
-          d={pathD}
-          fill="none"
-          stroke="#854d0e"
-          strokeWidth={2}
-          strokeDasharray="5 3"
-          opacity={0.92}
-          pointerEvents="none"
-          data-testid={`run-range-outline-${hex.q}-${hex.r}`}
-          aria-label={`Run-only movement marker for hex ${hex.q},${hex.r}`}
-        />
-      )}
-      {isIsometricOccluder && (
-        <g
-          pointerEvents="none"
-          data-testid={`hex-isometric-occluder-highlight-${hex.q}-${hex.r}`}
-          data-isometric-occludes-units={occludedUnitIds}
-          data-isometric-occlusion-reasons={occlusionReasons}
-          data-isometric-occluder-rotation-step={
-            isometricOccluderInfo.rotationStep
-          }
-          aria-label={`Tall elevation ${occluderElevationLabel} may hide units ${occludedUnitIds}`}
-        >
-          <title>
-            {`Tall elevation ${occluderElevationLabel} may hide units ${occludedUnitIds}`}
-          </title>
-          <path
-            d={pathD}
-            fill="none"
-            stroke="#38bdf8"
-            strokeWidth={2.25}
-            strokeDasharray="5 3"
-            opacity={0.92}
-          />
-          <rect
-            x={x - 18}
-            y={y - 25}
-            width={36}
-            height={12}
-            rx={2}
-            fill="#0f172a"
-            fillOpacity={0.88}
-            stroke="#38bdf8"
-            strokeWidth={0.75}
-          />
-          <text
-            x={x}
-            y={y - 16}
-            textAnchor="middle"
-            fontSize={8}
-            fontWeight="bold"
-            fill="#e0f2fe"
-          >
-            OCC
-          </text>
-        </g>
-      )}
-      {showCoordinate && (
-        <text x={x} y={y + 4} textAnchor="middle" fontSize={10} fill="#64748b">
-          {hex.q},{hex.r}
-        </text>
-      )}
+      <HexCellOverlayLayer
+        hex={hex}
+        pathD={pathD}
+        hasOverlay={hasOverlay}
+        overlayFill={overlayFill}
+        overlayOpacity={overlayOpacity}
+        overlayAttributes={overlayAttributes}
+        isLegacyAttackRangeFallback={isLegacyAttackRangeFallback}
+      />
+      <HexCellMovementEncodingLayers
+        hex={hex}
+        x={x}
+        y={y}
+        pathD={pathD}
+        isJumpTile={isJumpTile}
+        isRunTile={isRunTile}
+        isBlockedTile={isBlockedTile}
+        isInPath={isInPath}
+      />
+      <HexCellIsometricOccluderHighlight
+        hex={hex}
+        x={x}
+        y={y}
+        pathD={pathD}
+        isIsometricOccluder={isIsometricOccluder}
+        isometricOccluderInfo={isometricOccluderInfo}
+        occludedUnitIds={occludedUnitIds}
+        occlusionReasons={occlusionReasons}
+        occluderElevationLabel={occluderElevationLabel}
+      />
+      <HexCellCoordinateLabel
+        hex={hex}
+        x={x}
+        y={y}
+        showCoordinate={showCoordinate}
+      />
       <HexCellBadgeStack
         x={x}
         y={y}

--- a/src/components/gameplay/TacticalActionDock/commands/movementCommands.ts
+++ b/src/components/gameplay/TacticalActionDock/commands/movementCommands.ts
@@ -33,9 +33,9 @@ import { buildRuntimeMovementStateCommands } from './runtimeMovementStateCommand
 /**
  * Build the movement-family command list for the current active unit.
  *
- * TODO(wave-8): gate by `viewerPlayerId === activeUnit.ownerId` once
- * multi-viewer command authorization lands. Today every movement
- * command is visible to the local viewer when an active unit exists.
+ * Wave 8 authorization note: gate by `viewerPlayerId === activeUnit.ownerId`
+ * once multi-viewer command authorization lands. Today every movement command
+ * is visible to the local viewer when an active unit exists.
  */
 export function buildMovementCommands(
   ctx?: ITacticalCommandContext,

--- a/src/hooks/gameplay/useActivationFocusRequest.ts
+++ b/src/hooks/gameplay/useActivationFocusRequest.ts
@@ -53,7 +53,8 @@ export interface IFocusRequest {
  * the active unit actually changes, so consumers can use it as a dependency
  * in their own effects without over-firing.
  *
- * TODO(wave-8): filter rail by viewerPlayerId for opponent fog
+ * Wave 8 visibility note: opponent-fog filtering will gate rail focus by
+ * viewerPlayerId once multi-viewer visibility lands.
  */
 export function useActivationFocusRequest(): IFocusRequest | null {
   const session = useGameplayStore((s) => s.session);

--- a/src/hooks/gameplay/usePhaseQueueProjection.ts
+++ b/src/hooks/gameplay/usePhaseQueueProjection.ts
@@ -113,7 +113,8 @@ const EMPTY_PROJECTION: IPhaseQueueProjection = {
  * Selector memoised inside `useMemo` so component re-renders only on
  * structural changes to session state (phase, turn, unit lock states).
  *
- * TODO(wave-8): filter rail by viewerPlayerId for opponent fog
+ * Wave 8 visibility note: opponent-fog filtering will gate rail projection by
+ * viewerPlayerId once multi-viewer visibility lands.
  */
 export function usePhaseQueueProjection(): IPhaseQueueProjection {
   const session = useGameplayStore((s) => s.session);

--- a/src/lib/interventions/InterventionLedger.ts
+++ b/src/lib/interventions/InterventionLedger.ts
@@ -5,6 +5,7 @@ import type {
   IInterventionLedgerRecord,
   InterventionApplyResult,
   InterventionDomain,
+  InterventionProjectionVisibility,
 } from '@/types/interventions';
 
 export interface IInterventionLedgerOptions {
@@ -38,10 +39,6 @@ export class InterventionLedger<TState = unknown> {
 
     this.implementers.set(implementer.domain, implementer);
     return this;
-  }
-
-  hasImplementer(domain: InterventionDomain): boolean {
-    return this.implementers.has(domain);
   }
 
   preview(
@@ -102,24 +99,20 @@ export class InterventionLedger<TState = unknown> {
     };
   }
 
-  projectPublic<TPublic = unknown>(record: IInterventionLedgerRecord): TPublic {
-    const implementer = this.implementers.get(record.domain);
-    if (!implementer) {
-      return record.publicEffect as TPublic;
-    }
-
-    return implementer.projectPublic(record) as TPublic;
-  }
-
-  projectPrivate<TPrivate = unknown>(
+  project<TProjection = unknown>(
     record: IInterventionLedgerRecord,
-  ): TPrivate {
+    visibility: InterventionProjectionVisibility,
+  ): TProjection {
     const implementer = this.implementers.get(record.domain);
-    if (!implementer) {
-      return record.privateMetadata as TPrivate;
+    if (visibility === 'public') {
+      return (
+        implementer ? implementer.projectPublic(record) : record.publicEffect
+      ) as TProjection;
     }
 
-    return implementer.projectPrivate(record) as TPrivate;
+    return (
+      implementer ? implementer.projectPrivate(record) : record.privateMetadata
+    ) as TProjection;
   }
 
   getRecords(): readonly IInterventionLedgerRecord[] {

--- a/src/lib/interventions/__tests__/GmCombatInterventionImplementer.test.ts
+++ b/src/lib/interventions/__tests__/GmCombatInterventionImplementer.test.ts
@@ -221,7 +221,6 @@ describe('GM combat intervention implementer', () => {
       state,
     );
 
-    expect(ledger.hasImplementer('combat')).toBe(true);
     expect(preview.status).toBe('ready');
     expect(unsupported.status).toBe('unsupported');
   });

--- a/src/lib/interventions/__tests__/InterventionLedger.test.ts
+++ b/src/lib/interventions/__tests__/InterventionLedger.test.ts
@@ -212,11 +212,11 @@ describe('InterventionLedger', () => {
     );
     const record = makeRecord();
 
-    expect(ledger.projectPublic<TestPublicEffect>(record)).toEqual({
+    expect(ledger.project<TestPublicEffect>(record, 'public')).toEqual({
       summary: 'Unit armor corrected.',
       changedStateRefs: ['unit-1'],
     });
-    expect(ledger.projectPrivate<TestPrivateMetadata>(record)).toEqual({
+    expect(ledger.project<TestPrivateMetadata>(record, 'private')).toEqual({
       reason: 'Correct missed armor damage.',
       hiddenNotes: 'NPC ambush remains hidden.',
     });

--- a/src/simulation/runner/phases/weaponAttackHitResolution.ts
+++ b/src/simulation/runner/phases/weaponAttackHitResolution.ts
@@ -1,7 +1,12 @@
 import type { CriticalSlotManifest } from '@/utils/gameplay/criticalHitResolution/types';
 import type { ILOSDamageableCoverProvider } from '@/utils/gameplay/lineOfSight';
 
-import { IGameEvent, IGameState, IHexGrid } from '@/types/gameplay';
+import {
+  IGameEvent,
+  IGameState,
+  IHexGrid,
+  type IAttackResolvedPayload,
+} from '@/types/gameplay';
 import {
   checkTACTrigger,
   processTAC,
@@ -295,42 +300,21 @@ export function resolveWeaponHit(options: {
   // Per `combat-resolution` delta: emit `AttackResolved` AFTER the
   // roll resolves. Hit-location is included only on hits per the
   // discriminated-union contract.
-  appendAttackResolvedEvent({
+  appendWeaponHitResolvedEvent({
     events,
     gameId,
     turn: currentState.turn,
-    payload: {
-      attackerId: unitId,
-      targetId,
-      weaponId,
-      roll: attackRoll,
-      toHitNumber,
-      hit: true,
-      location,
-      damage,
-      heat: weapon.heat,
-      ...(projectileCount !== undefined ? { projectileCount } : {}),
-      attackerArc: firingArc,
-      ...(hitLocationResult.edgeReroll !== undefined
-        ? { edgeReroll: hitLocationResult.edgeReroll }
-        : {}),
-      ...(hitLocationResult.edgeSuperseded !== undefined
-        ? { edgeSuperseded: hitLocationResult.edgeSuperseded }
-        : {}),
-      ...(hitLocationResult.edgeTrigger !== undefined
-        ? { edgeTrigger: hitLocationResult.edgeTrigger }
-        : {}),
-      ...(hitLocationResult.edgePointsRemaining !== undefined
-        ? { edgePointsRemaining: hitLocationResult.edgePointsRemaining }
-        : {}),
-      ...(hitLocationResult.supersededLocation !== undefined
-        ? { edgeSupersededLocation: hitLocationResult.supersededLocation }
-        : {}),
-      ...(hitLocationResult.supersededRoll !== undefined
-        ? { edgeSupersededRoll: hitLocationResult.supersededRoll.total }
-        : {}),
-    },
-    actorId: unitId,
+    unitId,
+    targetId,
+    weaponId,
+    attackRoll,
+    toHitNumber,
+    location,
+    damage,
+    heat: weapon.heat,
+    projectileCount,
+    firingArc,
+    hitLocationResult,
   });
 
   // Decrement the firing weapon's ammo bin and emit `AmmoConsumed`
@@ -455,4 +439,90 @@ export function resolveWeaponHit(options: {
   currentState = applyDamageThresholdPSR(currentState, targetId);
 
   return currentState;
+}
+
+type WeaponHitLocationResult = ReturnType<typeof determineHitLocation>;
+
+interface IAppendWeaponHitResolvedEventInput {
+  readonly events: IGameEvent[];
+  readonly gameId: string;
+  readonly turn: number;
+  readonly unitId: string;
+  readonly targetId: string;
+  readonly weaponId: string;
+  readonly attackRoll: number;
+  readonly toHitNumber: number;
+  readonly location: string;
+  readonly damage: number;
+  readonly heat: number;
+  readonly projectileCount: number | undefined;
+  readonly firingArc: 'front' | 'left' | 'right' | 'rear';
+  readonly hitLocationResult: WeaponHitLocationResult;
+}
+
+function appendWeaponHitResolvedEvent(
+  options: IAppendWeaponHitResolvedEventInput,
+): void {
+  appendAttackResolvedEvent({
+    events: options.events,
+    gameId: options.gameId,
+    turn: options.turn,
+    payload: buildWeaponHitResolvedPayload(options),
+    actorId: options.unitId,
+  });
+}
+
+function buildWeaponHitResolvedPayload(
+  options: IAppendWeaponHitResolvedEventInput,
+): IAttackResolvedPayload {
+  return {
+    attackerId: options.unitId,
+    targetId: options.targetId,
+    weaponId: options.weaponId,
+    roll: options.attackRoll,
+    toHitNumber: options.toHitNumber,
+    hit: true,
+    location: options.location,
+    damage: options.damage,
+    heat: options.heat,
+    attackerArc: options.firingArc,
+    ...optionalAttackResolvedField('projectileCount', options.projectileCount),
+    ...buildWeaponHitEdgePayload(options.hitLocationResult),
+  };
+}
+
+function buildWeaponHitEdgePayload(
+  hitLocationResult: WeaponHitLocationResult,
+): Partial<IAttackResolvedPayload> {
+  const edgeSupersededRoll = hitLocationResult.supersededRoll
+    ? hitLocationResult.supersededRoll.total
+    : undefined;
+  return {
+    ...optionalAttackResolvedField('edgeReroll', hitLocationResult.edgeReroll),
+    ...optionalAttackResolvedField(
+      'edgeSuperseded',
+      hitLocationResult.edgeSuperseded,
+    ),
+    ...optionalAttackResolvedField(
+      'edgeTrigger',
+      hitLocationResult.edgeTrigger,
+    ),
+    ...optionalAttackResolvedField(
+      'edgePointsRemaining',
+      hitLocationResult.edgePointsRemaining,
+    ),
+    ...optionalAttackResolvedField(
+      'edgeSupersededLocation',
+      hitLocationResult.supersededLocation,
+    ),
+    ...optionalAttackResolvedField('edgeSupersededRoll', edgeSupersededRoll),
+  };
+}
+
+function optionalAttackResolvedField<K extends keyof IAttackResolvedPayload>(
+  key: K,
+  value: IAttackResolvedPayload[K] | undefined,
+): Partial<IAttackResolvedPayload> {
+  if (value === undefined) return {};
+  return { [key]: value } as Pick<IAttackResolvedPayload, K>;
 }

--- a/src/types/interventions/InterventionLedgerTypes.ts
+++ b/src/types/interventions/InterventionLedgerTypes.ts
@@ -99,6 +99,8 @@ export type InterventionApplyResult<TState = unknown> =
   | IAppliedInterventionResult<TState>
   | IUnsupportedInterventionResult<TState>;
 
+export type InterventionProjectionVisibility = 'public' | 'private';
+
 export interface IInterventionLedgerImplementer<
   TCommand extends IInterventionLedgerCommand = IInterventionLedgerCommand,
   TState = unknown,

--- a/src/types/interventions/index.ts
+++ b/src/types/interventions/index.ts
@@ -67,6 +67,7 @@ export type {
   InterventionApplyResult,
   InterventionDomain,
   InterventionLedgerRecordStatus,
+  InterventionProjectionVisibility,
   InterventionPreviewStatus,
   IUnsupportedInterventionResult,
   KnownInterventionDomain,

--- a/src/utils/gameplay/tacticalMapProjection.status.ts
+++ b/src/utils/gameplay/tacticalMapProjection.status.ts
@@ -142,54 +142,95 @@ export function deriveMovementHazardProjectionReasons({
 function formatReachableMovementCostReasons(
   option: IMovementRangeModeOption,
 ): readonly string[] {
-  const reasons: string[] = [];
-  if (hasPositiveCost(option.terrainCost)) {
-    reasons.push(`terrain ${formatSignedCost(option.terrainCost)}`);
-  }
-  if (hasPositiveCost(option.turningCost)) {
-    reasons.push(`turning ${formatSignedCost(option.turningCost)}`);
-  }
-  if (hasElevationCostConsequence(option)) {
-    reasons.push(`elevation ${formatMovementOptionElevation(option)}`);
-  }
-  if (hasPositiveCost(option.heatGenerated)) {
-    reasons.push(`heat ${formatSignedCost(option.heatGenerated)}`);
-  }
-  if (
+  return [
+    formatPositiveMovementCostReason('terrain', option.terrainCost),
+    formatPositiveMovementCostReason('turning', option.turningCost),
+    formatElevationMovementCostReason(option),
+    formatPositiveMovementCostReason('heat', option.heatGenerated),
+    formatConversionMovementCostReason(option),
+    formatAltitudeControlMovementCostReason(option),
+    formatAutomaticLandingMovementCostReason(option),
+    formatHullDownExitMovementCostReason(option),
+  ].filter(isDefinedString);
+}
+
+function formatPositiveMovementCostReason(
+  label: string,
+  cost: number | undefined,
+): string | undefined {
+  return hasPositiveCost(cost)
+    ? `${label} ${formatSignedCost(cost)}`
+    : undefined;
+}
+
+function formatElevationMovementCostReason(
+  option: IMovementRangeModeOption,
+): string | undefined {
+  return hasElevationCostConsequence(option)
+    ? `elevation ${formatMovementOptionElevation(option)}`
+    : undefined;
+}
+
+function formatConversionMovementCostReason(
+  option: IMovementRangeModeOption,
+): string | undefined {
+  if (!hasMovementConversionCost(option)) return undefined;
+  return `conversion ${option.conversionStepCount ?? 0} steps ${
+    option.conversionMpCost ?? 0
+  } MP`;
+}
+
+function hasMovementConversionCost(option: IMovementRangeModeOption): boolean {
+  return (
     hasPositiveCost(option.conversionStepCount) ||
     hasPositiveCost(option.conversionMpCost)
-  ) {
-    reasons.push(
-      `conversion ${option.conversionStepCount ?? 0} steps ${
-        option.conversionMpCost ?? 0
-      } MP`,
-    );
-  }
-  if (
+  );
+}
+
+function formatAltitudeControlMovementCostReason(
+  option: IMovementRangeModeOption,
+): string | undefined {
+  if (!hasAltitudeControlCost(option)) return undefined;
+  return `altitude control ${option.altitudeControlStepCount ?? 0} steps ${
+    option.altitudeControlMpCost ?? 0
+  } MP`;
+}
+
+function hasAltitudeControlCost(option: IMovementRangeModeOption): boolean {
+  return (
     option.altitudeControlRequired ||
     hasPositiveCost(option.altitudeControlStepCount) ||
     hasPositiveCost(option.altitudeControlMpCost)
-  ) {
-    reasons.push(
-      `altitude control ${option.altitudeControlStepCount ?? 0} steps ${
-        option.altitudeControlMpCost ?? 0
-      } MP`,
-    );
-  }
-  if (option.automaticLandingRequired) {
-    const reason = option.automaticLandingReason
-      ? ` ${option.automaticLandingReason}`
-      : '';
-    reasons.push(
-      `automatic landing ${option.automaticLandingDistance ?? 0}/${
-        option.automaticLandingMinimumDistance ?? 0
-      } hexes${reason}`,
-    );
-  }
-  if (option.hullDownExitRequired || hasPositiveCost(option.hullDownExitCost)) {
-    reasons.push(`hull-down exit ${option.hullDownExitCost ?? 0} MP`);
-  }
-  return reasons;
+  );
+}
+
+function formatAutomaticLandingMovementCostReason(
+  option: IMovementRangeModeOption,
+): string | undefined {
+  if (!option.automaticLandingRequired) return undefined;
+  const reason = option.automaticLandingReason
+    ? ` ${option.automaticLandingReason}`
+    : '';
+  return `automatic landing ${option.automaticLandingDistance ?? 0}/${
+    option.automaticLandingMinimumDistance ?? 0
+  } hexes${reason}`;
+}
+
+function formatHullDownExitMovementCostReason(
+  option: IMovementRangeModeOption,
+): string | undefined {
+  if (!hasHullDownExitCost(option)) return undefined;
+  return `hull-down exit ${option.hullDownExitCost ?? 0} MP`;
+}
+
+function hasHullDownExitCost(option: IMovementRangeModeOption): boolean {
+  return (
+    option.hullDownExitRequired || hasPositiveCost(option.hullDownExitCost)
+  );
+}
+
+function isDefinedString(reason: string | undefined): reason is string {
+  return reason !== undefined;
 }
 
 function hasElevationCostConsequence(


### PR DESCRIPTION
﻿## Summary
- Clears the current maintenance source-gate findings: 3 high-complexity functions, 3 stale TODO markers, 1 InterventionLedger public-surface warning, and 1 Storybook bloat warning.
- Extracts HexMapDisplay story data into a fixture helper and HexCell SVG layers into focused components without changing test ids or labels.
- Narrows InterventionLedger projection to a visibility-aware API and moves weapon-hit/status formatter branch logic into helpers.

## Verification
- `npm run verify`
- `npm run build`
- `npm test -- --runInBand --runTestsByPath src/lib/interventions/__tests__/InterventionLedger.test.ts src/lib/interventions/__tests__/GmCombatInterventionImplementer.test.ts src/lib/interventions/__tests__/GmCascadePreviewPipeline.test.ts`
- `npm test -- --runInBand src/simulation/runner/__tests__/criticalHitEvents src/simulation/runner/phases/__tests__/weaponAttackPartialCover.test.ts`
- `npm test -- --runInBand src/components/gameplay/HexMapDisplay/__tests__`
- `npm run maintain:scan:gate`

## Notes
- `npm run lint` still exits 0 with the repository's existing warning backlog.
- Build/test output still includes the existing `baseline-browser-mapping` freshness warning.
