### PR TITLE
Harden journey evidence backing contract

### DIFF
--- a/docs/qc/mekstation-journey-qc.md
+++ b/docs/qc/mekstation-journey-qc.md
@@ -55,6 +55,7 @@ npm.cmd run verify:qc:journeys
 - `--dry-run`
 - `--continue-on-error`
 - `--fail-on-bug-severity=info|medium|high|critical`
+- `--require-domain-backed`
 
 Journey-specific parameters include `--pilot-count`,
 `--pilot-skill-band`, `--pilot-abilities`, `--unit-type`, `--chassis`,
@@ -83,6 +84,17 @@ Each run writes:
 
 `latest.json` points bug and log commands at the most recent run.
 
+Step results, diagnostic entries, and step artifacts include execution backing
+metadata:
+
+- `executionBacking`: backing type such as `synthetic-projection`
+- `syntheticBacking`: whether the step is still catalog/synthetic backed
+- `executionEvidenceSource`: where the backing evidence came from
+
+Use `--require-domain-backed` when you need the run to fail if selected
+required steps are still synthetic/catalog-backed. That strict mode is expected
+to fail until a journey step has a real domain, browser, or hybrid adapter.
+
 ## Bug And Log Workflow
 
 1. Run the narrow journey first, with explicit seed and parameters.
@@ -94,7 +106,9 @@ Each run writes:
    `api.payload_rejected` warning is an expected negative-control probe; it
    remains warning-level evidence but is classified as `expected-probe` and
    `blocking=false`.
-6. Rerun the same journey with the same run-plan inputs after a fix.
+6. Use `--require-domain-backed` to distinguish real adapter coverage from
+   synthetic projection coverage.
+7. Rerun the same journey with the same run-plan inputs after a fix.
 
 Known gaps are recorded in journey output and the validation graph. They do not
 silently hide unrelated failures.

--- a/docs/qc/mekstation-logging-map.json
+++ b/docs/qc/mekstation-logging-map.json
@@ -103,7 +103,11 @@
     {
       "pathId": "journey-runner-failure",
       "service": "journey.runner",
-      "events": ["journey.step_failed", "journey.run_failed"],
+      "events": [
+        "journey.step_failed",
+        "journey.run_failed",
+        "journey.execution_backing_missing"
+      ],
       "severity": "error",
       "classification": "failure",
       "blocking": true,

--- a/openspec/changes/archive/2026-06-22-harden-journey-evidence-contract/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-22-harden-journey-evidence-contract/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-22

--- a/openspec/changes/archive/2026-06-22-harden-journey-evidence-contract/design.md
+++ b/openspec/changes/archive/2026-06-22-harden-journey-evidence-contract/design.md
@@ -1,0 +1,58 @@
+## Context
+
+The current `journey-qc` capability already defines the seven required end-to-end journeys, a single runner command, evidence bundles, log search, bug extraction, and QC graph lookup. Live smoke runs prove the command surface and evidence bundle work, but the runner currently writes catalog-shaped in-process artifacts for journey steps. That is useful as a deterministic scaffold, yet it does not clearly distinguish synthetic/catalog-backed proof from domain-backed or UI-backed execution.
+
+This change keeps the scaffold fast while making the evidence contract honest enough to drive the next waves: each step reports its execution backing, reports whether that backing is synthetic, and can be rejected by a stricter caller when non-synthetic execution is required.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add explicit backing metadata to run plans, step results, diagnostic logs, reports, and generated artifacts.
+- Add a CLI option that fails when selected steps are still synthetic/catalog-backed and the caller requires domain-backed execution.
+- Preserve existing smoke journey behavior for normal local QC.
+- Add tests for both the default pass path and strict backing-required failure path.
+
+**Non-Goals:**
+
+- Do not replace all journey steps with real domain or browser adapters in this slice.
+- Do not change player-facing UI or production gameplay APIs.
+- Do not hide synthetic backing behind known limitations or expected probes.
+- Do not make routine `verify:qc` slower by default.
+
+## Decisions
+
+- **Use per-step execution backing metadata.**
+  - Rationale: The gap exists at step granularity. A campaign journey may later mix synthetic setup with domain-backed economy processing, while a combat journey may mix domain-backed encounter launch with browser-backed tactical previews.
+  - Alternative rejected: One journey-level `synthetic` flag. That would be too coarse for incremental adapter migration.
+
+- **Default to `synthetic-projection` for existing in-process artifact generation.**
+  - Rationale: This names what the current runner actually does without breaking existing smoke gates.
+  - Alternative rejected: Rename existing evidence as domain evidence. That would make the current proof stronger-looking than it is.
+
+- **Add a caller opt-in strict gate.**
+  - Rationale: Routine smoke QC should stay fast, while roadmap and release checks need a way to prove that a journey is no longer synthetic.
+  - Alternative rejected: Fail all synthetic steps by default. That would immediately break useful journey smoke coverage before real adapters exist.
+
+- **Surface strict-gate failures through the existing bug/log path.**
+  - Rationale: Missing non-synthetic backing is a validation failure that should produce the same bug packet and searchable logs as other journey failures.
+  - Alternative rejected: Print a special CLI-only warning. That would not feed the bug/log workflow.
+
+## Risks / Trade-offs
+
+- **Risk: Synthetic runs may still look like complete journey passes.** → Reports and artifacts will show synthetic counts and backing names so the limitation remains visible.
+- **Risk: Strict gate adds another command mode to learn.** → Document the flag in journey QC docs and test it through the existing script test suite.
+- **Risk: Step metadata could drift from future adapters.** → Keep validation close to the runner and make adapter migration update the backing metadata with tests.
+
+## Migration Plan
+
+1. Add backing metadata to the runner output without changing default pass/fail behavior.
+2. Add a strict option for non-synthetic backing and verify it fails with bug/log evidence today.
+3. Replace synthetic steps with domain or browser adapters in later waves, using the strict option as the progress gate.
+
+Rollback is a normal code revert: no persisted production data or user save format changes are involved.
+
+## Open Questions
+
+- Which journey gets the first real domain adapter after this slice: `character-build`, `mek-build`, or `combat-1v1`?
+- Should the strict gate later become part of `verify:qc:journeys` after enough adapters exist?

--- a/openspec/changes/archive/2026-06-22-harden-journey-evidence-contract/proposal.md
+++ b/openspec/changes/archive/2026-06-22-harden-journey-evidence-contract/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Journey QC now provides the right command surface, catalog, logs, and evidence bundle, but current runs can still pass without making the execution backing explicit. That makes it too easy to confuse catalog-shaped synthetic evidence with domain-backed or UI-backed journey execution.
+
+## What Changes
+
+- Add explicit execution backing metadata to journey run plans, step results, diagnostics, reports, and artifacts.
+- Add a runner gate that can fail selected journeys when domain-backed or UI-backed execution is required but only synthetic/catalog-backed evidence exists.
+- Keep existing smoke journey runs fast and non-breaking while making the remaining adapter gap visible and queryable.
+- Update tests so the evidence contract proves both the default smoke behavior and the stricter backing-required failure path.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `journey-qc`: Journey runs must distinguish synthetic/catalog-backed evidence from domain-backed or UI-backed execution and expose a strict gate for callers that require non-synthetic backing.
+
+## Impact
+
+- Affects `scripts/qc/journey-qc-core.mjs`, `scripts/qc/run-journey-scenarios.mjs`, journey QC tests, journey QC docs, and the `journey-qc` OpenSpec capability.
+- Does not change player-facing UI, production APIs, or persisted campaign/combat data.
+- Establishes a clear migration path for replacing synthetic steps with real domain or browser adapters in later waves.

--- a/openspec/changes/archive/2026-06-22-harden-journey-evidence-contract/specs/journey-qc/spec.md
+++ b/openspec/changes/archive/2026-06-22-harden-journey-evidence-contract/specs/journey-qc/spec.md
@@ -1,18 +1,4 @@
-# journey-qc Specification
-
-## Purpose
-Defines repeatable journey-level QC for major MekStation user flows, including scenario catalogs, configurable run commands, evidence bundles, bug extraction, log search, validation graph lookup, and explicit known-gap accounting.
-## Requirements
-### Requirement: Required Journey Scenario Catalog
-The system SHALL define a versioned journey scenario catalog for the required player journeys: `character-build`, `mek-build`, `combat-1v1`, `combat-4v4`, `contract-campaign`, `campaign-short`, and `campaign-long`. Each scenario entry MUST declare its supported tiers, execution mode, configurable parameters, required steps, expected terminal state, evidence assertions, and explicit known limitation references when applicable.
-
-#### Scenario: Catalog contains all required journeys
-- **WHEN** the journey catalog validator runs
-- **THEN** it confirms that all seven required journey IDs are present exactly once
-
-#### Scenario: Catalog exposes BattleMech construction parameters
-- **WHEN** the `mek-build` journey is validated
-- **THEN** the scenario exposes era, unitTechBase, chassis, variant, weight class, and equipment-selection parameters needed to generate a repeatable BattleMech construction flow
+## MODIFIED Requirements
 
 ### Requirement: Configurable Journey Command Surface
 The system SHALL provide a single journey runner command that can execute one journey or all journeys with configurable major parameters. The command MUST support journey selection, tier, mode, seed, run count, run ID, evidence directory, dry-run, continue-on-error, failure severity gate options, and an opt-in gate that requires non-synthetic execution backing.
@@ -29,31 +15,6 @@ The system SHALL provide a single journey runner command that can execute one jo
 - **WHEN** the user runs `npm.cmd run qc:journeys -- --journey=combat-1v1 --require-domain-backed`
 - **THEN** the runner fails any required step that only has synthetic/catalog-backed execution evidence
 - **AND** the evidence bundle records the missing non-synthetic backing as bug and log evidence
-
-### Requirement: QC Validation Graph
-The system SHALL define a versioned QC validation graph that maps top-level capabilities, main modules, submodules, journey scenarios, validation commands, evidence artifacts, structured diagnostic events, and known gaps. The graph MUST support on-demand lookup of which commands validate a given capability, module, submodule, or journey.
-
-#### Scenario: Graph maps combat journey coverage
-- **WHEN** the validation graph is queried for the combat module
-- **THEN** it identifies the `combat-1v1` and `combat-4v4` journeys, their runnable commands, produced evidence artifacts, and related structured diagnostic events
-
-#### Scenario: Graph validator rejects orphaned journey
-- **WHEN** the validation graph references a journey ID that is not present in the journey scenario catalog
-- **THEN** the graph validator fails and names the orphaned journey ID
-
-### Requirement: QC Graph Query Command
-The system SHALL provide a local command that queries the QC validation graph by capability, module, submodule, journey, command, or known gap. Query output MUST include matched graph nodes, related validation commands, evidence artifacts, logging events, and gap references.
-
-#### Scenario: Query Mek build validation
-- **WHEN** the user queries the QC validation graph for `mek-build`
-- **THEN** the command returns the Mek build journey, related construction modules, runnable validation command, produced evidence, and logging events
-
-### Requirement: Deterministic Run Plan Materialization
-The system SHALL materialize a run plan before executing journey steps. The run plan MUST include run ID, timestamp, selected journeys, tier, mode, seed, run count, evidence directory, resolved parameters, step list, and expected terminal states. Re-running with the same catalog version, seed, and parameters MUST produce equivalent generated inputs.
-
-#### Scenario: Repeatable campaign input generation
-- **WHEN** the user runs the `campaign-short` journey twice with the same seed and parameter set
-- **THEN** generated contract order, selected opposing forces, and expected terminal state inputs are equivalent across both run plans
 
 ### Requirement: Journey Execution Proves Generated Sequences
 The system SHALL verify that generated journey sequences are carried out, not merely generated. Each journey MUST assert the required terminal state and at least one domain or UI evidence point that proves the sequence completed. Each executed step MUST also record its execution backing, whether that backing is synthetic, and the backing evidence source so callers can distinguish catalog-shaped projections from domain-backed or UI-backed execution.
@@ -92,17 +53,3 @@ The system SHALL extract bug candidates from journey failures, structured logs, 
 #### Scenario: Missing required backing becomes a bug
 - **WHEN** a strict backing-required run encounters a synthetic-only required step
 - **THEN** the bug reporter lists a missing non-synthetic backing candidate for that journey step
-
-### Requirement: Structured Log Search
-The system SHALL provide a local log-search command for journey evidence. The command MUST filter structured diagnostic logs by run ID, journey ID, step ID, level, service, event, fingerprint, and time window.
-
-#### Scenario: Search warnings for latest run
-- **WHEN** the user runs `npm.cmd run qc:logs -- --run-id=latest --level=warn,error`
-- **THEN** the command returns warning and error diagnostic entries from the latest journey evidence
-
-### Requirement: Known Gap Accounting
-The system SHALL report unsupported mechanics, non-BattleMech exclusions, or implementation limitations as explicit gaps in journey results. Known gaps MUST NOT suppress failures unless the catalog marks the exact assertion as non-gating and links the gap reference.
-
-#### Scenario: Unsupported mechanic remains visible
-- **WHEN** a journey touches an unsupported combat mechanic
-- **THEN** the run result records the unsupported mechanic as a gap and preserves any unrelated failed assertions as failures

--- a/openspec/changes/archive/2026-06-22-harden-journey-evidence-contract/tasks.md
+++ b/openspec/changes/archive/2026-06-22-harden-journey-evidence-contract/tasks.md
@@ -1,0 +1,17 @@
+## 1. Evidence Contract
+
+- [x] 1.1 Add per-step execution backing metadata to journey run plans, step results, diagnostics, reports, and generated artifacts.
+- [x] 1.2 Add a `--require-domain-backed` runner option that fails required synthetic-backed steps.
+- [x] 1.3 Ensure missing non-synthetic backing failures feed existing bug extraction and log search output.
+
+## 2. Tests And Docs
+
+- [x] 2.1 Extend journey QC script tests for backing metadata in normal smoke runs.
+- [x] 2.2 Add a strict backing-required test proving synthetic-only steps fail with bug evidence.
+- [x] 2.3 Update journey QC documentation with the backing metadata and strict gate workflow.
+
+## 3. Validation
+
+- [x] 3.1 Run `npm.cmd run qc:journeys:validate`.
+- [x] 3.2 Run the focused journey QC Jest test.
+- [x] 3.3 Run a representative smoke journey and strict backing-required failure command.

--- a/scripts/__tests__/journey-qc.test.ts
+++ b/scripts/__tests__/journey-qc.test.ts
@@ -72,12 +72,30 @@ describe('journey QC scripts', () => {
 
     const result = readJson<{
       status: string;
-      journeys: Array<{ attempts: Array<{ terminalState: string }> }>;
+      executionBackingSummary: {
+        syntheticSteps: number;
+        totalSteps: number;
+      };
+      journeys: Array<{
+        attempts: Array<{
+          terminalState: string;
+          steps: Array<{
+            executionBacking: string;
+            syntheticBacking: boolean;
+          }>;
+        }>;
+      }>;
     }>(path.join(evidenceDir, 'test-combat', 'result.json'));
     expect(result.status).toBe('pass');
     expect(result.journeys[0]?.attempts[0]?.terminalState).toBe(
       'combat-complete',
     );
+    expect(result.executionBackingSummary.syntheticSteps).toBe(3);
+    expect(result.executionBackingSummary.totalSteps).toBe(3);
+    expect(result.journeys[0]?.attempts[0]?.steps[0]).toMatchObject({
+      executionBacking: 'synthetic-projection',
+      syntheticBacking: true,
+    });
 
     const logs = runNodeScript('scripts/qc/search-journey-logs.mjs', [
       '--run-id=latest',
@@ -128,6 +146,7 @@ describe('journey QC scripts', () => {
       path.join(evidenceDir, 'test-combat', 'report.md'),
       'utf-8',
     );
+    expect(report).toContain('- Synthetic-backed steps: 3/3');
     expect(report).toContain('- Expected probes: 1');
 
     const bugs = runNodeScript('scripts/qc/report-journey-bugs.mjs', [
@@ -190,6 +209,51 @@ describe('journey QC scripts', () => {
     expect(bugs.status).toBe(0);
     expect(bugs.stdout).toContain(
       'Journey step failed: combat-1v1/resolve-combat',
+    );
+  });
+
+  it('fails strict backing-required runs while preserving bug evidence', () => {
+    const runResult = runNodeScript('scripts/qc/run-journey-scenarios.mjs', [
+      '--journey=combat-1v1',
+      '--run-id=test-domain-backed-required',
+      '--require-domain-backed',
+      '--continue-on-error',
+      `--evidence-dir=${evidenceDir}`,
+    ]);
+    expect(runResult.status).toBe(1);
+
+    const result = readJson<{
+      status: string;
+      executionBackingSummary: { missingRequiredBacking: number };
+      journeys: Array<{
+        attempts: Array<{
+          steps: Array<{ failureKind?: string; syntheticBacking: boolean }>;
+        }>;
+      }>;
+    }>(path.join(evidenceDir, 'test-domain-backed-required', 'result.json'));
+    expect(result.status).toBe('fail');
+    expect(result.executionBackingSummary.missingRequiredBacking).toBe(3);
+    expect(result.journeys[0]?.attempts[0]?.steps[0]).toMatchObject({
+      failureKind: 'missing-required-execution-backing',
+      syntheticBacking: true,
+    });
+
+    const logs = runNodeScript('scripts/qc/search-journey-logs.mjs', [
+      '--run-id=latest',
+      '--event=journey.execution_backing_missing',
+      `--evidence-dir=${evidenceDir}`,
+    ]);
+    expect(logs.status).toBe(0);
+    expect(logs.stdout).toContain('execution_backing_missing');
+
+    const bugs = runNodeScript('scripts/qc/report-journey-bugs.mjs', [
+      '--since=latest',
+      '--min-severity=medium',
+      `--evidence-dir=${evidenceDir}`,
+    ]);
+    expect(bugs.status).toBe(0);
+    expect(bugs.stdout).toContain(
+      'Missing non-synthetic execution backing: combat-1v1/launch-duel',
     );
   });
 

--- a/scripts/qc/journey-qc-core.mjs
+++ b/scripts/qc/journey-qc-core.mjs
@@ -91,6 +91,7 @@ export function parseArgs(argv) {
     failOnBugSeverity: 'medium',
     journey: 'all',
     mode: null,
+    requireDomainBacked: false,
     runs: 1,
     seed: 42,
     tier: 'standard',
@@ -116,6 +117,13 @@ export function parseArgs(argv) {
     }
     if (arg === '--actionable-only') {
       options.actionableOnly = true;
+      continue;
+    }
+    if (
+      arg === '--require-domain-backed' ||
+      arg === '--require-non-synthetic-backing'
+    ) {
+      options.requireDomainBacked = true;
       continue;
     }
 
@@ -595,6 +603,15 @@ function selectJourneys(catalog, journeyOption) {
   });
 }
 
+function stepExecutionBacking(step) {
+  return {
+    executionBacking: step.executionBacking ?? 'synthetic-projection',
+    syntheticBacking: step.syntheticBacking !== false,
+    executionEvidenceSource:
+      step.executionEvidenceSource ?? 'journey-catalog-projection',
+  };
+}
+
 export function materializeRunPlan(catalog, options) {
   if (!allowedTiers.has(options.tier))
     throw new Error(`Invalid tier: ${options.tier}`);
@@ -622,6 +639,7 @@ export function materializeRunPlan(catalog, options) {
     dryRun: options.dryRun,
     tier: options.tier,
     mode: options.mode ?? 'catalog-default',
+    requireDomainBacked: options.requireDomainBacked,
     seed: options.seed,
     runs: options.runs,
     evidenceDir: toRepoRelative(path.join(evidenceDir, runId)),
@@ -642,6 +660,7 @@ export function materializeRunPlan(catalog, options) {
         diagnosticEvent: step.diagnosticEvent,
         loggingPathId: step.loggingPathId,
         produces: step.produces,
+        ...stepExecutionBacking(step),
       })),
       knownLimitations: journey.knownLimitations ?? [],
     })),
@@ -706,6 +725,9 @@ function artifactPayload({ runPlan, journey, step, attempt }) {
     stepId: step.id,
     attempt,
     generatedId: idBase,
+    executionBacking: step.executionBacking,
+    syntheticBacking: step.syntheticBacking,
+    executionEvidenceSource: step.executionEvidenceSource,
     parameters,
   };
 
@@ -811,6 +833,31 @@ function writeArtifact(runDir, relativePath, payload) {
   return toRepoRelative(filePath);
 }
 
+function backingSummary(journeys) {
+  let totalSteps = 0;
+  let syntheticSteps = 0;
+  let nonSyntheticSteps = 0;
+  let missingRequiredBacking = 0;
+  for (const journey of journeys) {
+    for (const attempt of journey.attempts ?? []) {
+      for (const step of attempt.steps ?? []) {
+        totalSteps += 1;
+        if (step.syntheticBacking) syntheticSteps += 1;
+        else nonSyntheticSteps += 1;
+        if (step.failureKind === 'missing-required-execution-backing') {
+          missingRequiredBacking += 1;
+        }
+      }
+    }
+  }
+  return {
+    totalSteps,
+    syntheticSteps,
+    nonSyntheticSteps,
+    missingRequiredBacking,
+  };
+}
+
 function severityMeets(candidateSeverity, minimumSeverity) {
   return (
     (severityRank[candidateSeverity] ?? 0) >=
@@ -824,6 +871,10 @@ export function extractBugCandidates(result, logs) {
     for (const attempt of journey.attempts ?? []) {
       for (const step of attempt.steps ?? []) {
         if (step.status !== 'pass') {
+          const summary =
+            step.failureKind === 'missing-required-execution-backing'
+              ? `Missing non-synthetic execution backing: ${journey.id}/${step.id}`
+              : `Journey step failed: ${journey.id}/${step.id}`;
           bugs.push({
             severity: 'high',
             journeyId: journey.id,
@@ -831,9 +882,9 @@ export function extractBugCandidates(result, logs) {
             stepId: step.id,
             module: journey.module,
             fingerprint: hashString(
-              `${journey.id}:${step.id}:${step.status}:${step.error ?? ''}`,
+              `${journey.id}:${step.id}:${step.status}:${step.failureKind ?? ''}:${step.error ?? ''}`,
             ),
-            summary: `Journey step failed: ${journey.id}/${step.id}`,
+            summary,
             evidenceRefs: step.artifacts ?? [],
           });
         }
@@ -917,9 +968,20 @@ export function executeRunPlan(runPlan, options = {}) {
 
       for (const step of journey.steps) {
         const artifacts = [];
-        const shouldFail =
+        const injectedFailure =
           options.injectFailure === step.id ||
           options.injectFailure === journey.id;
+        const missingRequiredBacking =
+          options.requireDomainBacked && step.syntheticBacking === true;
+        const shouldFail = injectedFailure || missingRequiredBacking;
+        const failureKind = missingRequiredBacking
+          ? 'missing-required-execution-backing'
+          : injectedFailure
+            ? 'injected-failure'
+            : null;
+        const failureMessage = missingRequiredBacking
+          ? `Required non-synthetic execution backing missing for ${journey.id}/${step.id} (${step.executionBacking}).`
+          : `Injected failure for ${journey.id}/${step.id}`;
         const level =
           step.loggingPathId === 'tactical-action-rejection' ? 'warn' : 'info';
         const payload = artifactPayload({ runPlan, journey, step, attempt });
@@ -939,10 +1001,12 @@ export function executeRunPlan(runPlan, options = {}) {
         const stepLog = logEntry({
           level: shouldFail ? 'error' : level,
           service: serviceForStep(journey, step),
-          event: shouldFail ? 'journey.step_failed' : step.diagnosticEvent,
-          message: shouldFail
-            ? `Injected failure for ${journey.id}/${step.id}`
-            : step.title,
+          event: missingRequiredBacking
+            ? 'journey.execution_backing_missing'
+            : shouldFail
+              ? 'journey.step_failed'
+              : step.diagnosticEvent,
+          message: shouldFail ? failureMessage : step.title,
           classification: shouldFail
             ? 'failure'
             : level === 'warn'
@@ -957,6 +1021,10 @@ export function executeRunPlan(runPlan, options = {}) {
             loggingPathId: step.loggingPathId,
             artifacts,
             terminalState: payload.terminalState,
+            executionBacking: step.executionBacking,
+            syntheticBacking: step.syntheticBacking,
+            executionEvidenceSource: step.executionEvidenceSource,
+            ...(failureKind ? { failureKind } : {}),
           },
         });
         logs.push(stepLog);
@@ -967,6 +1035,10 @@ export function executeRunPlan(runPlan, options = {}) {
           artifacts,
           diagnosticEvent: stepLog.event,
           loggingPathId: step.loggingPathId,
+          executionBacking: step.executionBacking,
+          syntheticBacking: step.syntheticBacking,
+          executionEvidenceSource: step.executionEvidenceSource,
+          failureKind: failureKind ?? undefined,
           error: shouldFail ? stepLog.message : undefined,
         };
         attemptResult.steps.push(stepResult);
@@ -1024,10 +1096,12 @@ export function executeRunPlan(runPlan, options = {}) {
     runId: runPlan.runId,
     status: failed ? 'fail' : 'pass',
     dryRun: false,
+    requireDomainBacked: runPlan.requireDomainBacked,
     startedAt,
     completedAt: new Date().toISOString(),
     journeys,
   };
+  result.executionBackingSummary = backingSummary(journeys);
   return { logs, result };
 }
 
@@ -1090,7 +1164,10 @@ function renderReport(runPlan, result, logs, bugs) {
     `- Mode: ${runPlan.mode}`,
     `- Seed: ${runPlan.seed}`,
     `- Runs: ${runPlan.runs}`,
+    `- Require domain-backed: ${runPlan.requireDomainBacked ? 'yes' : 'no'}`,
     `- Bugs: ${bugs.length}`,
+    `- Synthetic-backed steps: ${result.executionBackingSummary?.syntheticSteps ?? 0}/${result.executionBackingSummary?.totalSteps ?? 0}`,
+    `- Missing required backing: ${result.executionBackingSummary?.missingRequiredBacking ?? 0}`,
     `- Expected probes: ${expectedProbeCount}`,
     `- Actionable/diagnostic warnings: ${actionableWarningCount}`,
     `- Blocking log entries: ${blockingLogCount}`,


### PR DESCRIPTION
## Summary
- Adds explicit execution-backing metadata to journey QC steps and run summaries.
- Adds opt-in `--require-domain-backed` / `--require-non-synthetic-backing` gating so synthetic projections cannot be mistaken for domain/UI validation.
- Wires missing backing into bug/log reporting and archives the OpenSpec change.

## Validation
- `npm.cmd run verify`
- `npx.cmd jest --selectProjects unit --ci --runTestsByPath scripts/__tests__/journey-qc.test.ts --no-coverage`
- `npm.cmd run qc:journeys -- --journey=all --tier=smoke --seed=77 --run-id=verify-all-smoke-backing`
- `npm.cmd run qc:journeys -- --journey=combat-1v1 --seed=42 --run-id=verify-strict-exit --require-domain-backed --continue-on-error` expected exit 1
- `npm.cmd run qc:journeys:bugs -- --since=latest --min-severity=medium`
- `npm.cmd run qc:logs -- --run-id=latest --event=journey.execution_backing_missing`
- `npx.cmd openspec validate --all --strict`
- `npm.cmd run spec:purpose:validate:strict`
- `npm.cmd run format:check`
- `git diff --check`

## Notes
The existing smoke journeys still run quickly, but strict mode now exposes the known gap: journey steps are synthetic/catalog-backed until real domain/browser adapters replace them.