### PR TITLE
Make journey bug packets actionable

### DIFF
--- a/docs/qc/mekstation-journey-qc.md
+++ b/docs/qc/mekstation-journey-qc.md
@@ -95,20 +95,43 @@ Use `--require-domain-backed` when you need the run to fail if selected
 required steps are still synthetic/catalog-backed. That strict mode is expected
 to fail until a journey step has a real domain, browser, or hybrid adapter.
 
+Structured diagnostic entries also include a stable `fingerprint` and
+`metadata.triage` packet for journey steps. The triage packet is intentionally
+bounded and includes:
+
+- `actor`
+- `action`
+- `stateBefore`
+- `stateAfter`
+- `ruleDecision`
+- `validationResult`
+- `warnings`
+- `failureCause`
+- `evidenceRefs`
+- `nextDebuggingHint`
+
+Bug candidates copy that packet into `bugs.json` and add `logFingerprints` so a
+bug can be traced back to the exact diagnostic entry.
+
 ## Bug And Log Workflow
 
 1. Run the narrow journey first, with explicit seed and parameters.
 2. Inspect `report.md` for the human-readable result.
 3. Use `qc:journeys:bugs` to list grouped failures by severity and fingerprint.
+   Medium-or-higher bugs print action, validation result, failure cause,
+   debugging hint, and related log fingerprints when available.
 4. Use `qc:logs` to filter structured diagnostic entries by level, journey,
    service, event, or step.
 5. Add `--exclude-probes` when scanning for non-probe warnings. The
    `api.payload_rejected` warning is an expected negative-control probe; it
    remains warning-level evidence but is classified as `expected-probe` and
    `blocking=false`.
-6. Use `--require-domain-backed` to distinguish real adapter coverage from
+6. Copy a bug packet log fingerprint into
+   `npm.cmd run qc:logs -- --run-id=latest --fingerprint=<fingerprint>` when
+   you need the exact structured diagnostic that caused or explains the bug.
+7. Use `--require-domain-backed` to distinguish real adapter coverage from
    synthetic projection coverage.
-7. Rerun the same journey with the same run-plan inputs after a fix.
+8. Rerun the same journey with the same run-plan inputs after a fix.
 
 Known gaps are recorded in journey output and the validation graph. They do not
 silently hide unrelated failures.

--- a/docs/qc/mekstation-logging-map.json
+++ b/docs/qc/mekstation-logging-map.json
@@ -15,6 +15,18 @@
     "journey-runner-failure",
     "bug-extraction"
   ],
+  "requiredTriageFields": [
+    "actor",
+    "action",
+    "stateBefore",
+    "stateAfter",
+    "ruleDecision",
+    "validationResult",
+    "warnings",
+    "failureCause",
+    "evidenceRefs",
+    "nextDebuggingHint"
+  ],
   "paths": [
     {
       "pathId": "character-pilot-creation",

--- a/openspec/changes/archive/2026-06-22-standardize-journey-triage-logs/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-22-standardize-journey-triage-logs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-22

--- a/openspec/changes/archive/2026-06-22-standardize-journey-triage-logs/design.md
+++ b/openspec/changes/archive/2026-06-22-standardize-journey-triage-logs/design.md
@@ -1,0 +1,37 @@
+## Context
+
+The journey runner writes `run-plan.json`, `result.json`, `system.ndjson`, `bugs.json`, and `report.md`. The previous evidence-contract slice made synthetic backing visible, but failed runs still require manual joins across step results, log entries, and artifacts to understand the actor, action, state effect, rule decision, validation result, warnings, and failure cause.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Define a compact triage context shape shared by journey diagnostics and bug candidates.
+- Preserve existing evidence file names, CLI commands, and JSON compatibility while adding fields.
+- Make text bug reports useful enough to identify the failing step, relevant log fingerprint, and likely next debugging surface.
+
+**Non-Goals:**
+- Replace synthetic journey steps with domain or browser adapters.
+- Build the GM ledger or durable domain event stream.
+- Redesign application-wide logger APIs outside journey QC.
+
+## Decisions
+
+- Use `metadata.triage` on structured log entries and `triage` on bug candidates.
+  - Rationale: existing log entries already preserve metadata, and bug candidates are already the reporter contract. Mirroring the same shape avoids inventing another artifact.
+  - Alternative rejected: infer triage context only inside the reporter. That would keep `system.ndjson` too weak for external tooling.
+- Use compact state summaries instead of full state snapshots.
+  - Rationale: journey evidence must stay bounded and safe to inspect. State before/after should point at entity IDs, counts, terminal states, or deltas, not full BattleMech or campaign payload dumps.
+  - Alternative rejected: embed complete artifacts in logs. That duplicates evidence files and violates diagnostic payload hygiene.
+- Add log fingerprints to bug candidates.
+  - Rationale: fingerprints let `qc:logs --fingerprint=<id>` jump from a bug to the causative diagnostic entry.
+  - Alternative rejected: evidence references only. `system.ndjson` is too broad without a stable lookup key.
+
+## Risks / Trade-offs
+
+- Triage fields could become vague if every step uses generic values -> tests will assert representative combat failure fields and reporter output.
+- Added fields increase evidence size -> use bounded summaries and artifact references rather than full payload copies.
+- Synthetic projections may appear more authoritative than they are -> retain execution backing fields and strict backing bug behavior.
+
+## Migration Plan
+
+Additive JSON fields are safe for existing consumers. Existing commands continue to read older evidence that lacks `triage`; reporter output should fall back gracefully when the field is absent.

--- a/openspec/changes/archive/2026-06-22-standardize-journey-triage-logs/proposal.md
+++ b/openspec/changes/archive/2026-06-22-standardize-journey-triage-logs/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Journey QC runs already produce evidence, logs, and bug candidates, but the failure packet is still too thin for the next waves. A failed run should explain who acted, what changed, which rule or validation decision was involved, and where to start debugging without manually correlating `result.json`, `system.ndjson`, artifacts, and runner output.
+
+## What Changes
+
+- Add a required journey triage context shape to structured diagnostics: actor, action, state before/after summaries, rule decision, validation result, warnings, failure cause, and evidence references.
+- Enrich bug candidates with the same context plus log fingerprints so `qc:journeys:bugs` can point directly at the diagnostic entries that caused or explain the bug.
+- Extend the bug reporter output to show concise triage context for medium-or-higher failures while preserving JSON output for tooling.
+- Tighten validation so journey logging paths continue to map to tested diagnostic coverage and bug extraction remains queryable.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `journey-qc`: bug candidate extraction and evidence bundles must carry enough triage context to locate failure causes without manual digging.
+- `logging-system`: structured journey diagnostics must include standardized journey triage fields for action, actor, state change, rule decision, validation result, warnings, and failure cause.
+
+## Impact
+
+- Affected code: `scripts/qc/journey-qc-core.mjs`, `scripts/qc/report-journey-bugs.mjs`, `scripts/qc/search-journey-logs.mjs`, and `scripts/__tests__/journey-qc.test.ts`.
+- Affected docs/specs: `docs/qc/mekstation-journey-qc.md`, `docs/qc/mekstation-logging-map.json`, `openspec/specs/journey-qc/spec.md`, and `openspec/specs/logging-system/spec.md`.
+- No new runtime dependency is planned.
+
+## Non-goals
+
+- This change does not replace synthetic journey execution with real domain or browser adapters.
+- This change does not introduce the GM ledger or durable domain event store.
+- This change does not redesign the application logger used by React, Next.js, or Electron surfaces outside journey QC.

--- a/openspec/changes/archive/2026-06-22-standardize-journey-triage-logs/specs/journey-qc/spec.md
+++ b/openspec/changes/archive/2026-06-22-standardize-journey-triage-logs/specs/journey-qc/spec.md
@@ -1,0 +1,13 @@
+## ADDED Requirements
+
+### Requirement: Bug Triage Packets
+The system SHALL include a triage packet on each journey bug candidate. The packet MUST include actor, action, stateBefore, stateAfter, ruleDecision, validationResult, warnings, failureCause, logFingerprints, and nextDebuggingHint fields when the source evidence provides them. The packet MUST use compact summaries and artifact references rather than unbounded domain object dumps.
+
+#### Scenario: Failed journey step produces actionable bug packet
+- **WHEN** a journey step fails during `qc:journeys`
+- **THEN** `bugs.json` records the failing actor, action, state before/after summary, validation result, failure cause, related log fingerprint, and next debugging hint for that bug
+- **AND** the text bug reporter displays the failure cause, action, validation result, and log fingerprint without requiring manual inspection of `system.ndjson`
+
+#### Scenario: Bug reporter remains compatible with older evidence
+- **WHEN** the bug reporter reads a bug candidate that does not contain a triage packet
+- **THEN** it still lists the bug using the existing summary, fingerprint, and evidence references

--- a/openspec/changes/archive/2026-06-22-standardize-journey-triage-logs/specs/logging-system/spec.md
+++ b/openspec/changes/archive/2026-06-22-standardize-journey-triage-logs/specs/logging-system/spec.md
@@ -1,0 +1,13 @@
+## ADDED Requirements
+
+### Requirement: Journey Diagnostic Triage Context
+Structured journey diagnostics SHALL include standardized triage context when emitted by journey QC. The context MUST identify actor, action, stateBefore, stateAfter, ruleDecision, validationResult, warnings, failureCause, evidenceRefs, and nextDebuggingHint when those fields are applicable to the step. Failure diagnostics MUST include a stable fingerprint that can be used by log search and bug reports.
+
+#### Scenario: Tactical rejection diagnostic explains action context
+- **WHEN** a tactical action rejection is logged by a journey step
+- **THEN** the structured diagnostic includes actor, rejected action, state before/after summary, rule decision, validation result, warning reasons, evidence references, and a stable fingerprint
+
+#### Scenario: Failure diagnostic links to bug packet
+- **WHEN** a required journey step fails
+- **THEN** the failure diagnostic includes failureCause and fingerprint
+- **AND** the generated bug packet references that fingerprint in its triage logFingerprints

--- a/openspec/changes/archive/2026-06-22-standardize-journey-triage-logs/tasks.md
+++ b/openspec/changes/archive/2026-06-22-standardize-journey-triage-logs/tasks.md
@@ -1,0 +1,17 @@
+## 1. Triage Context Contract
+
+- [x] 1.1 Add shared triage context creation for journey step diagnostics.
+- [x] 1.2 Add stable diagnostic fingerprints to structured journey logs.
+- [x] 1.3 Preserve bounded state summaries and evidence references in log metadata.
+
+## 2. Bug Packet Enrichment
+
+- [x] 2.1 Copy triage context and log fingerprints from failing step diagnostics into bug candidates.
+- [x] 2.2 Keep bug extraction compatible with older evidence that lacks triage packets.
+- [x] 2.3 Extend text bug reports with action, validation result, failure cause, debugging hint, and log fingerprint.
+
+## 3. Documentation And Validation
+
+- [x] 3.1 Document the richer bug packet and log query workflow.
+- [x] 3.2 Add focused tests for triage fields, reporter output, and fingerprint log lookup.
+- [x] 3.3 Run focused journey tests, QC validation, OpenSpec strict validation, formatting, and diff checks.

--- a/openspec/specs/journey-qc/spec.md
+++ b/openspec/specs/journey-qc/spec.md
@@ -106,3 +106,15 @@ The system SHALL report unsupported mechanics, non-BattleMech exclusions, or imp
 #### Scenario: Unsupported mechanic remains visible
 - **WHEN** a journey touches an unsupported combat mechanic
 - **THEN** the run result records the unsupported mechanic as a gap and preserves any unrelated failed assertions as failures
+
+### Requirement: Bug Triage Packets
+The system SHALL include a triage packet on each journey bug candidate. The packet MUST include actor, action, stateBefore, stateAfter, ruleDecision, validationResult, warnings, failureCause, logFingerprints, and nextDebuggingHint fields when the source evidence provides them. The packet MUST use compact summaries and artifact references rather than unbounded domain object dumps.
+
+#### Scenario: Failed journey step produces actionable bug packet
+- **WHEN** a journey step fails during `qc:journeys`
+- **THEN** `bugs.json` records the failing actor, action, state before/after summary, validation result, failure cause, related log fingerprint, and next debugging hint for that bug
+- **AND** the text bug reporter displays the failure cause, action, validation result, and log fingerprint without requiring manual inspection of `system.ndjson`
+
+#### Scenario: Bug reporter remains compatible with older evidence
+- **WHEN** the bug reporter reads a bug candidate that does not contain a triage packet
+- **THEN** it still lists the bug using the existing summary, fingerprint, and evidence references

--- a/openspec/specs/logging-system/spec.md
+++ b/openspec/specs/logging-system/spec.md
@@ -219,6 +219,18 @@ Structured diagnostics MUST avoid secrets, raw database dumps, and unbounded uni
 - **WHEN** Mek construction validation emits a diagnostic
 - **THEN** the entry includes identifiers, unitTechBase, weight class, validation summary, and bounded issue counts rather than a full serialized BattleMech object
 
+### Requirement: Journey Diagnostic Triage Context
+Structured journey diagnostics SHALL include standardized triage context when emitted by journey QC. The context MUST identify actor, action, stateBefore, stateAfter, ruleDecision, validationResult, warnings, failureCause, evidenceRefs, and nextDebuggingHint when those fields are applicable to the step. Failure diagnostics MUST include a stable fingerprint that can be used by log search and bug reports.
+
+#### Scenario: Tactical rejection diagnostic explains action context
+- **WHEN** a tactical action rejection is logged by a journey step
+- **THEN** the structured diagnostic includes actor, rejected action, state before/after summary, rule decision, validation result, warning reasons, evidence references, and a stable fingerprint
+
+#### Scenario: Failure diagnostic links to bug packet
+- **WHEN** a required journey step fails
+- **THEN** the failure diagnostic includes failureCause and fingerprint
+- **AND** the generated bug packet references that fingerprint in its triage logFingerprints
+
 ## Data Model Requirements
 
 ### LogLevel Type

--- a/scripts/__tests__/journey-qc.test.ts
+++ b/scripts/__tests__/journey-qc.test.ts
@@ -129,6 +129,72 @@ describe('journey QC scripts', () => {
     });
     expect(probeEntries[0]?.metadata.nonBlockingProbe).toBe(true);
 
+    const tacticalLogs = runNodeScript('scripts/qc/search-journey-logs.mjs', [
+      '--run-id=latest',
+      '--event=tactical.action_rejected',
+      '--json',
+      `--evidence-dir=${evidenceDir}`,
+    ]);
+    expect(tacticalLogs.status).toBe(0);
+    const tacticalEntries = JSON.parse(tacticalLogs.stdout) as Array<{
+      fingerprint: string;
+      metadata: {
+        triage: {
+          actor: string;
+          action: string;
+          stateBefore: { journeyId: string; stepId: string };
+          stateAfter: { status: string; syntheticBacking: boolean };
+          ruleDecision: { outcome: string; reason: string };
+          validationResult: { status: string; event: string };
+          warnings: string[];
+          evidenceRefs: string[];
+          nextDebuggingHint: string;
+        };
+      };
+    }>;
+    expect(tacticalEntries[0]).toMatchObject({
+      metadata: {
+        triage: {
+          actor: 'player-side-a',
+          action: 'move-through-blocked-hex',
+          stateBefore: {
+            journeyId: 'combat-1v1',
+            stepId: 'preview-invalid-action',
+          },
+          stateAfter: {
+            status: 'pass',
+            syntheticBacking: true,
+          },
+          ruleDecision: {
+            outcome: 'rejected',
+          },
+          validationResult: {
+            status: 'pass',
+            event: 'tactical.action_rejected',
+          },
+        },
+      },
+    });
+    expect(tacticalEntries[0]?.fingerprint).toMatch(/^[a-f0-9]{8}$/);
+    expect(tacticalEntries[0]?.metadata.triage.warnings[0]).toContain(
+      'Destination is blocked',
+    );
+    expect(tacticalEntries[0]?.metadata.triage.evidenceRefs[0]).toContain(
+      'tactical-rejection.json',
+    );
+
+    const fingerprintLogs = runNodeScript(
+      'scripts/qc/search-journey-logs.mjs',
+      [
+        '--run-id=latest',
+        `--fingerprint=${tacticalEntries[0]?.fingerprint}`,
+        '--json',
+        `--evidence-dir=${evidenceDir}`,
+      ],
+    );
+    expect(fingerprintLogs.status).toBe(0);
+    expect(JSON.parse(fingerprintLogs.stdout)).toHaveLength(1);
+
     const nonProbeWarnings = runNodeScript(
       'scripts/qc/search-journey-logs.mjs',
       [
@@ -210,6 +276,12 @@ describe('journey QC scripts', () => {
     expect(bugs.stdout).toContain(
       'Journey step failed: combat-1v1/resolve-combat',
     );
+    expect(bugs.stdout).toContain('action: movement-preview,attack-resolution');
+    expect(bugs.stdout).toContain('validation: fail');
+    expect(bugs.stdout).toContain(
+      'failure cause: Injected failure for combat-1v1/resolve-combat',
+    );
+    expect(bugs.stdout).toContain('logs: ');
   });
 
   it('fails strict backing-required runs while preserving bug evidence', () => {
@@ -254,6 +326,44 @@ describe('journey QC scripts', () => {
     expect(bugs.status).toBe(0);
     expect(bugs.stdout).toContain(
       'Missing non-synthetic execution backing: combat-1v1/launch-duel',
+    );
+    expect(bugs.stdout).toContain(
+      'failure cause: Required non-synthetic execution backing missing for combat-1v1/launch-duel (synthetic-projection).',
+    );
+
+    const bugsJson = runNodeScript('scripts/qc/report-journey-bugs.mjs', [
+      '--since=latest',
+      '--min-severity=medium',
+      '--json',
+      `--evidence-dir=${evidenceDir}`,
+    ]);
+    expect(bugsJson.status).toBe(0);
+    const bugPackets = JSON.parse(bugsJson.stdout) as Array<{
+      stepId: string;
+      triage?: {
+        action: string;
+        failureCause: string;
+        logFingerprints: string[];
+        nextDebuggingHint: string;
+        validationResult: { status: string; failureKind: string };
+      };
+    }>;
+    const launchDuelBug = bugPackets.find(
+      (bug) => bug.stepId === 'launch-duel',
+    );
+    expect(launchDuelBug?.triage).toMatchObject({
+      action: 'movement-preview,attack-resolution',
+      validationResult: {
+        status: 'fail',
+        failureKind: 'missing-required-execution-backing',
+      },
+    });
+    expect(launchDuelBug?.triage?.failureCause).toContain(
+      'Required non-synthetic execution backing missing',
+    );
+    expect(launchDuelBug?.triage?.logFingerprints[0]).toMatch(/^[a-f0-9]{8}$/);
+    expect(launchDuelBug?.triage?.nextDebuggingHint).toContain(
+      '--require-domain-backed',
     );
   });
 

--- a/scripts/qc/journey-qc-core.mjs
+++ b/scripts/qc/journey-qc-core.mjs
@@ -422,10 +422,38 @@ export function validateLoggingMap(loggingMap, catalog) {
   const issues = [];
   if (loggingMap.version !== 1)
     issues.push(issue('error', 'Logging map version must be 1.'));
+  const requiredTriageFields = [
+    'actor',
+    'action',
+    'stateBefore',
+    'stateAfter',
+    'ruleDecision',
+    'validationResult',
+    'warnings',
+    'failureCause',
+    'evidenceRefs',
+    'nextDebuggingHint',
+  ];
   if (!Array.isArray(loggingMap.requiredPathIds)) {
     issues.push(
       issue('error', 'Logging map requiredPathIds must be an array.'),
     );
+  }
+  if (!Array.isArray(loggingMap.requiredTriageFields)) {
+    issues.push(
+      issue('error', 'Logging map requiredTriageFields must be an array.'),
+    );
+  } else {
+    for (const requiredField of requiredTriageFields) {
+      if (!loggingMap.requiredTriageFields.includes(requiredField)) {
+        issues.push(
+          issue(
+            'error',
+            `Logging map missing required triage field ${requiredField}.`,
+          ),
+        );
+      }
+    }
   }
   if (!Array.isArray(loggingMap.paths)) {
     issues.push(issue('error', 'Logging map paths must be an array.'));
@@ -564,6 +592,10 @@ function hashString(value) {
   return (hash >>> 0).toString(16).padStart(8, '0');
 }
 
+function diagnosticFingerprint(entry) {
+  return hashString(`${entry.service}:${entry.event}:${entry.message ?? ''}`);
+}
+
 function coerceParameter(definition, rawValue) {
   if (rawValue === undefined) return definition.default;
   if (definition.type === 'integer') return Number.parseInt(rawValue, 10);
@@ -695,7 +727,7 @@ function logEntry({
   blocking,
   metadata,
 }) {
-  return {
+  const entry = {
     timestamp: new Date().toISOString(),
     level,
     service,
@@ -711,6 +743,10 @@ function logEntry({
       ...(journey ? { module: journey.module } : {}),
     },
     metadata: metadata ?? {},
+  };
+  return {
+    ...entry,
+    fingerprint: diagnosticFingerprint(entry),
   };
 }
 
@@ -827,6 +863,126 @@ function artifactPayload({ runPlan, journey, step, attempt }) {
   return common;
 }
 
+function actorForStep(journey, step) {
+  if (step.kind === 'tactical-rejection') return 'player-side-a';
+  if (step.kind === 'combat-resolution') return 'combat-engine';
+  if (step.kind === 'combat-encounter') return 'encounter-generator';
+  if (step.kind.startsWith('campaign')) return 'campaign-runner';
+  if (step.kind.startsWith('mek')) return 'construction-runner';
+  if (step.kind.startsWith('character')) return 'roster-runner';
+  return `${journey.module}-journey-runner`;
+}
+
+function actionForStep(step, payload) {
+  if (payload.rejectedAction) return payload.rejectedAction;
+  if (Array.isArray(payload.actions) && payload.actions.length > 0) {
+    return payload.actions.join(',');
+  }
+  return step.kind;
+}
+
+function compactStateBefore(journey, step, payload, attempt) {
+  return {
+    journeyId: journey.id,
+    stepId: step.id,
+    attempt,
+    module: journey.module,
+    expectedTerminalState: journey.expectedTerminalState,
+    parameterHash: hashString(JSON.stringify(payload.parameters ?? {})),
+  };
+}
+
+function compactStateAfter(step, payload, artifacts, status) {
+  return {
+    status,
+    terminalState: payload.terminalState ?? null,
+    artifactCount: artifacts.length,
+    executionBacking: step.executionBacking,
+    syntheticBacking: step.syntheticBacking,
+    executionEvidenceSource: step.executionEvidenceSource,
+  };
+}
+
+function ruleDecisionForStep(step, payload, shouldFail, failureMessage) {
+  if (shouldFail) {
+    return {
+      outcome: 'blocked',
+      source: 'journey-qc',
+      reason: failureMessage,
+    };
+  }
+  if (step.kind === 'tactical-rejection') {
+    return {
+      outcome: 'rejected',
+      source: step.executionEvidenceSource,
+      reason: payload.reason,
+    };
+  }
+  return {
+    outcome: 'accepted',
+    source: step.executionEvidenceSource,
+    reason: 'Journey step satisfied its synthetic evidence assertion.',
+  };
+}
+
+function warningsForStep(step, payload, failureKind) {
+  if (failureKind === 'missing-required-execution-backing') {
+    return ['Synthetic backing does not satisfy --require-domain-backed.'];
+  }
+  if (step.kind === 'tactical-rejection' && payload.reason) {
+    return [payload.reason];
+  }
+  return [];
+}
+
+function nextDebuggingHintForStep(journey, step, failureKind) {
+  if (failureKind === 'missing-required-execution-backing') {
+    return `Replace ${journey.id}/${step.id} with a domain, browser, or hybrid adapter before using --require-domain-backed as a release gate.`;
+  }
+  if (failureKind) {
+    return `Inspect ${journey.id}/${step.id} artifacts and system.ndjson for the failing diagnostic.`;
+  }
+  if (step.kind === 'tactical-rejection') {
+    return `Inspect the tactical rejection artifact for ${journey.id}/${step.id} and compare it to the engine projection reason.`;
+  }
+  return `Inspect ${journey.id}/${step.id} artifacts for the generated evidence summary.`;
+}
+
+function triageContext({
+  journey,
+  step,
+  attempt,
+  payload,
+  artifacts,
+  status,
+  event,
+  failureKind,
+  failureMessage,
+}) {
+  return {
+    actor: actorForStep(journey, step),
+    action: actionForStep(step, payload),
+    stateBefore: compactStateBefore(journey, step, payload, attempt),
+    stateAfter: compactStateAfter(step, payload, artifacts, status),
+    ruleDecision: ruleDecisionForStep(
+      step,
+      payload,
+      status === 'fail',
+      failureMessage,
+    ),
+    validationResult: {
+      status,
+      event,
+      required: step.required !== false,
+      ...(failureKind ? { failureKind } : {}),
+    },
+    warnings: warningsForStep(step, payload, failureKind),
+    ...(failureMessage ? { failureCause: failureMessage } : {}),
+    evidenceRefs: artifacts,
+    nextDebuggingHint: nextDebuggingHintForStep(journey, step, failureKind),
+  };
+}
+
 function writeArtifact(runDir, relativePath, payload) {
   const filePath = path.join(runDir, relativePath);
   writeJsonFile(filePath, payload);
@@ -867,10 +1023,31 @@ function severityMeets(candidateSeverity, minimumSeverity) {
 
 export function extractBugCandidates(result, logs) {
   const bugs = [];
+  const logsByStep = new Map();
+  for (const entry of logs) {
+    if (!entry.journeyId || !entry.stepId) continue;
+    const key = `${entry.journeyId}/${entry.stepId}`;
+    const existing = logsByStep.get(key) ?? [];
+    existing.push(entry);
+    logsByStep.set(key, existing);
+  }
+  const bugTriageFromLogs = (journeyId, stepId) => {
+    const matchingLogs = logsByStep.get(`${journeyId}/${stepId}`) ?? [];
+    const triage = matchingLogs.find((entry) => entry.metadata?.triage)
+      ?.metadata?.triage;
+    if (!triage) return undefined;
+    return {
+      ...triage,
+      logFingerprints: matchingLogs.map(
+        (entry) => entry.fingerprint ?? diagnosticFingerprint(entry),
+      ),
+    };
+  };
   for (const journey of result.journeys ?? []) {
     for (const attempt of journey.attempts ?? []) {
       for (const step of attempt.steps ?? []) {
         if (step.status !== 'pass') {
+          const triage = bugTriageFromLogs(journey.id, step.id);
           const summary =
             step.failureKind === 'missing-required-execution-backing'
               ? `Missing non-synthetic execution backing: ${journey.id}/${step.id}`
@@ -885,7 +1062,13 @@ export function extractBugCandidates(result, logs) {
               `${journey.id}:${step.id}:${step.status}:${step.failureKind ?? ''}:${step.error ?? ''}`,
             ),
             summary,
-            evidenceRefs: step.artifacts ?? [],
+            evidenceRefs: [
+              ...(step.artifacts ?? []),
+              ...(triage?.logFingerprints ?? []).map(
+                (fingerprint) => `system.ndjson#${fingerprint}`,
+              ),
+            ],
+            ...(triage ? { triage } : {}),
           });
         }
       }
@@ -905,17 +1088,23 @@ export function extractBugCandidates(result, logs) {
   }
   for (const entry of logs) {
     if (entry.level === 'error') {
+      const fingerprint = entry.fingerprint ?? diagnosticFingerprint(entry);
+      const triage = entry.metadata?.triage
+        ? {
+            ...entry.metadata.triage,
+            logFingerprints: [fingerprint],
+          }
+        : undefined;
       bugs.push({
         severity: 'medium',
         journeyId: entry.journeyId,
         runId: entry.runId,
         stepId: entry.stepId,
         module: entry.entityIds?.module,
-        fingerprint: hashString(
-          `${entry.service}:${entry.event}:${entry.message}`,
-        ),
+        fingerprint,
         summary: entry.message ?? `${entry.service}.${entry.event}`,
-        evidenceRefs: ['system.ndjson'],
+        evidenceRefs: [`system.ndjson#${fingerprint}`],
+        ...(triage ? { triage } : {}),
       });
     }
   }
@@ -997,15 +1186,28 @@ export function executeRunPlan(runPlan, options = {}) {
             );
           }
         }
+        const event = missingRequiredBacking
+          ? 'journey.execution_backing_missing'
+          : shouldFail
+            ? 'journey.step_failed'
+            : step.diagnosticEvent;
+        const status = shouldFail ? 'fail' : 'pass';
+        const triage = triageContext({
+          journey,
+          step,
+          attempt,
+          payload,
+          artifacts,
+          status,
+          event,
+          failureKind,
+          failureMessage: shouldFail ? failureMessage : undefined,
+        });
 
         const stepLog = logEntry({
           level: shouldFail ? 'error' : level,
           service: serviceForStep(journey, step),
-          event: missingRequiredBacking
-            ? 'journey.execution_backing_missing'
-            : shouldFail
-              ? 'journey.step_failed'
-              : step.diagnosticEvent,
+          event,
           message: shouldFail ? failureMessage : step.title,
           classification: shouldFail
             ? 'failure'
@@ -1024,6 +1226,7 @@ export function executeRunPlan(runPlan, options = {}) {
             executionBacking: step.executionBacking,
             syntheticBacking: step.syntheticBacking,
             executionEvidenceSource: step.executionEvidenceSource,
+            triage,
             ...(failureKind ? { failureKind } : {}),
           },
         });
@@ -1031,7 +1234,7 @@ export function executeRunPlan(runPlan, options = {}) {
 
         const stepResult = {
           id: step.id,
-          status: shouldFail ? 'fail' : 'pass',
+          status,
           artifacts,
           diagnosticEvent: stepLog.event,
           loggingPathId: step.loggingPathId,
@@ -1277,7 +1480,7 @@ export function filterLogs(logs, options = {}) {
     if (options.event && entry.event !== options.event) return false;
     if (
       options.fingerprint &&
-      hashString(`${entry.service}:${entry.event}:${entry.message}`) !==
+      (entry.fingerprint ?? diagnosticFingerprint(entry)) !==
         options.fingerprint
     )
       return false;

--- a/scripts/qc/report-journey-bugs.mjs
+++ b/scripts/qc/report-journey-bugs.mjs
@@ -16,6 +16,22 @@ if (options.json) {
     console.log(`- [${bug.severity}] ${bug.journeyId}: ${bug.summary}`);
     console.log(`  fingerprint: ${bug.fingerprint}`);
     console.log(`  evidence: ${(bug.evidenceRefs ?? []).join(', ') || 'none'}`);
+    if (bug.triage) {
+      console.log(`  action: ${bug.triage.action ?? '-'}`);
+      console.log(
+        `  validation: ${bug.triage.validationResult?.status ?? '-'}`,
+      );
+      if (bug.triage.failureCause) {
+        console.log(`  failure cause: ${bug.triage.failureCause}`);
+      }
+      if (bug.triage.nextDebuggingHint) {
+        console.log(`  next: ${bug.triage.nextDebuggingHint}`);
+      }
+      const logFingerprints = bug.triage.logFingerprints ?? [];
+      if (logFingerprints.length > 0) {
+        console.log(`  logs: ${logFingerprints.join(', ')}`);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds stable fingerprints and bounded `metadata.triage` packets to journey QC structured logs.
- Copies triage context and related log fingerprints into journey bug candidates.
- Extends `qc:journeys:bugs` output so failed runs show action, validation result, failure cause, debugging hint, and log lookup fingerprints without manual digging.
- Archives the `standardize-journey-triage-logs` OpenSpec change and updates canonical `journey-qc` / `logging-system` specs.

## Validation
- `npm.cmd run verify`
- `npm.cmd run qc:journeys -- --journey=all --tier=smoke --seed=77 --run-id=triage-all-smoke`
- `npm.cmd run qc:journeys -- --journey=combat-1v1 --run-id=triage-live-failure --inject-failure=resolve-combat --continue-on-error` expected fail
- `npm.cmd run qc:journeys -- --journey=combat-1v1 --run-id=triage-live-strict-backing --require-domain-backed --continue-on-error` expected fail
- `npm.cmd run qc:journeys:bugs -- --run-id=triage-live-failure --min-severity=medium`
- `npm.cmd run qc:logs -- --run-id=triage-live-failure --fingerprint=e68c6c33 --json`
- `npx.cmd jest --selectProjects unit --ci --runTestsByPath scripts/__tests__/journey-qc.test.ts --no-coverage`
- `npm.cmd run verify:qc`
- `npx.cmd openspec validate --all --strict`
- `npm.cmd run format:check`
- `git diff --check`

## Notes
This does not replace synthetic journey steps with domain/browser adapters. It makes the failure packets actionable enough for the next adapter and GM-ledger waves.