### PR TITLE
Add shared action ledger core

### DIFF
--- a/openspec/changes/archive/2026-06-22-add-action-ledger-core/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-22-add-action-ledger-core/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-22

--- a/openspec/changes/archive/2026-06-22-add-action-ledger-core/design.md
+++ b/openspec/changes/archive/2026-06-22-add-action-ledger-core/design.md
@@ -1,0 +1,61 @@
+## Context
+
+`InterventionLedger` already provides domain registration, GM cascade preview, approved intervention append, replay application, and public/private projections for GM intervention records. The missing core is a shared action ledger stream that can preserve normal player actions beside GM-specific corrections without teaching every domain reducer about GM metadata.
+
+Later waves need one stable view of "what happened" across normal combat actions, GM overrides, economy reversals, and time cascades. That view must be append-only, causality-aware, and safe to project to players.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Provide a generic `ActionLedger` for normal, GM intervention, and system records.
+- Keep normal action records and GM-specific intervention records in one ordered append-only stream.
+- Allow GM cascade approval to append a generic action ledger record after the domain intervention record is accepted.
+- Provide player and GM projections with private GM metadata redacted from player output.
+- Keep the action ledger independent from domain state reducers so it can be adopted incrementally.
+
+**Non-Goals:**
+
+- Replacing combat/session event streams or campaign event stores.
+- Implementing post-combat, economy, repair, salvage, or time-cascade domain mutation.
+- Adding persistence or a UI timeline in this slice.
+
+## Decisions
+
+### Decision: Add a Generic Action Ledger Beside InterventionLedger
+
+`InterventionLedger` remains the domain-specific GM intervention engine. A new `ActionLedger` stores reviewable action records for normal actions and GM intervention actions. This avoids forcing normal player actions to carry GM-only preview/apply methods.
+
+Alternative considered: Rename and broaden `InterventionLedger`. Rejected because existing domain implementers and tests already use it specifically for GM interventions; widening it would blur responsibilities and increase migration risk.
+
+### Decision: GM Approval Appends to Action Ledger Only After Domain Approval
+
+`approveGmCascadePreview` accepts an optional action ledger. It appends to that ledger only after the preview is ready, an intervention record is appended, and domain application succeeds.
+
+Alternative considered: Append a pending action record during preview. Rejected because the player-visible history would then need cancellation/retraction semantics before any domain effect exists.
+
+### Decision: Player Projection Is Public-Effect Only
+
+Normal actions project their public summary and changed state. GM intervention records project only their public net effect. GM projections include private metadata, default outcome, hidden notes, and manual takeover notes when present.
+
+Alternative considered: Use one projection with caller-side filtering. Rejected because redaction must be a central contract, not a UI convention.
+
+## Risks / Trade-offs
+
+- [Risk] A second ledger-like surface may look redundant next to event stores. → Mitigation: keep this as a small projection/review ledger, not a domain event reducer.
+- [Risk] Later persistence needs may require schema changes. → Mitigation: keep record fields serializable and explicitly versionless for now.
+- [Risk] Appending to the action ledger after intervention append but before state application could expose failed effects. → Mitigation: append only after `ledger.apply` returns `applied`.
+
+## Migration Plan
+
+1. Add action ledger types and implementation.
+2. Wire optional action ledger append into GM cascade approval.
+3. Prove normal action and GM action ordering/redaction in focused tests.
+4. Leave existing callers unchanged until later waves pass an action ledger.
+
+Rollback is deleting the optional action-ledger integration and the new standalone ledger files; existing intervention behavior remains intact.
+
+## Open Questions
+
+- Which persistent store should own the action ledger once campaign/session persistence is wired?
+- Should later UI timelines merge this action ledger with existing game event visibility streams or read from the action ledger directly?

--- a/openspec/changes/archive/2026-06-22-add-action-ledger-core/proposal.md
+++ b/openspec/changes/archive/2026-06-22-add-action-ledger-core/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+The existing GM intervention ledger proves approved GM corrections can be previewed, approved, and redacted, but it does not provide a single append-only stream where normal player actions and GM-specific corrections can be reviewed together. The next combat, economy, and time-cascade waves need that shared action spine before they can safely layer richer interventions on top.
+
+## What Changes
+
+- Add a generic action ledger core for normal actions, approved GM interventions, and system actions.
+- Preserve append-only ordering and causality across normal actions and GM corrections.
+- Project the same ledger differently for players and owning GMs so GM-private rationale stays private.
+- Wire GM cascade approval into the action ledger as an optional sink, without changing existing intervention domain implementers.
+- Add tests proving normal action preservation, GM approval append behavior, redaction, and blocked-preview non-append behavior.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `intervention-ledger-abstraction`: Extends the intervention ledger contract with a shared action ledger stream for normal actions and GM-specific intervention actions.
+
+## Impact
+
+- Adds shared action ledger types and implementation under `src/types/interventions` and `src/lib/interventions`.
+- Extends GM cascade approval to optionally append a player-safe action ledger record alongside the domain intervention record.
+- Updates OpenSpec requirements and focused intervention tests.
+- No external dependencies or breaking API changes.
+
+## Non-goals
+
+- Does not implement post-combat, economy, repair, salvage, or time-cascade domain mutation.
+- Does not replace the existing campaign event store, combat event stream, or domain reducers.
+- Does not add GM UI controls beyond the already existing tactical intervention surfaces.

--- a/openspec/changes/archive/2026-06-22-add-action-ledger-core/specs/intervention-ledger-abstraction/spec.md
+++ b/openspec/changes/archive/2026-06-22-add-action-ledger-core/specs/intervention-ledger-abstraction/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Shared Action Ledger Stream
+The intervention ledger system SHALL provide a shared append-only action ledger stream that can record normal actions, approved GM intervention actions, and system actions in one ordered history without truncating canonical gameplay or campaign events.
+
+#### Scenario: Normal action and GM intervention share ordered history
+- **GIVEN** a normal player action has been committed to the action ledger
+- **WHEN** an approved GM intervention supersedes or fixes that normal action
+- **THEN** the action ledger SHALL append a new GM intervention action after the normal action
+- **AND** the original normal action SHALL remain present
+- **AND** the GM intervention action SHALL preserve causality references to the normal action
+
+#### Scenario: Blocked GM preview does not append action
+- **GIVEN** a GM cascade preview is blocked, rejected, deferred, unsupported, or requires manual takeover
+- **WHEN** the preview is not approved
+- **THEN** the action ledger SHALL append no GM intervention action
+
+### Requirement: Action Ledger Public And GM Projections
+The action ledger SHALL expose player-public and GM-private projections. Player-public projections SHALL include normal public summaries and approved GM public net effects only. GM-private projections MAY include GM rationale, default outcome, hidden notes, manual takeover notes, and domain payload references.
+
+#### Scenario: Player projection redacts GM-private data
+- **GIVEN** the action ledger contains an approved GM intervention action with private metadata and public net effect
+- **WHEN** a player views the action ledger projection
+- **THEN** the projection SHALL include the public net effect and visible changed state
+- **AND** it SHALL omit GM rationale, hidden notes, default outcome, and manual takeover notes
+
+#### Scenario: GM projection includes private action context
+- **GIVEN** the action ledger contains a normal action and an approved GM intervention action
+- **WHEN** the owning GM views the action ledger projection
+- **THEN** the projection SHALL include normal action public context
+- **AND** it SHALL include the GM intervention private metadata and public net effect

--- a/openspec/changes/archive/2026-06-22-add-action-ledger-core/tasks.md
+++ b/openspec/changes/archive/2026-06-22-add-action-ledger-core/tasks.md
@@ -1,0 +1,15 @@
+## 1. Action Ledger Core
+
+- [x] 1.1 Add shared action ledger types for normal, GM intervention, and system records.
+- [x] 1.2 Implement append-only action ledger ordering and read projections.
+- [x] 1.3 Add player-public and GM-private projection helpers with GM metadata redaction.
+
+## 2. GM Approval Integration
+
+- [x] 2.1 Extend GM cascade approval to optionally append approved GM intervention actions to the action ledger.
+- [x] 2.2 Ensure blocked, rejected, deferred, unsupported, or manual-takeover previews append no action ledger record.
+
+## 3. Validation
+
+- [x] 3.1 Add focused tests for normal action preservation, GM action append, causality, and projection redaction.
+- [x] 3.2 Run focused intervention tests, OpenSpec validation, typecheck, and QC validation.

--- a/openspec/specs/intervention-ledger-abstraction/spec.md
+++ b/openspec/specs/intervention-ledger-abstraction/spec.md
@@ -40,3 +40,33 @@ The intervention ledger SHALL expose separate projection functions for GM-privat
 - **THEN** the projection SHALL omit private metadata
 - **WHEN** the same record is projected for the owning GM
 - **THEN** the projection MAY include private metadata
+
+### Requirement: Shared Action Ledger Stream
+The intervention ledger system SHALL provide a shared append-only action ledger stream that can record normal actions, approved GM intervention actions, and system actions in one ordered history without truncating canonical gameplay or campaign events.
+
+#### Scenario: Normal action and GM intervention share ordered history
+- **GIVEN** a normal player action has been committed to the action ledger
+- **WHEN** an approved GM intervention supersedes or fixes that normal action
+- **THEN** the action ledger SHALL append a new GM intervention action after the normal action
+- **AND** the original normal action SHALL remain present
+- **AND** the GM intervention action SHALL preserve causality references to the normal action
+
+#### Scenario: Blocked GM preview does not append action
+- **GIVEN** a GM cascade preview is blocked, rejected, deferred, unsupported, or requires manual takeover
+- **WHEN** the preview is not approved
+- **THEN** the action ledger SHALL append no GM intervention action
+
+### Requirement: Action Ledger Public And GM Projections
+The action ledger SHALL expose player-public and GM-private projections. Player-public projections SHALL include normal public summaries and approved GM public net effects only. GM-private projections MAY include GM rationale, default outcome, hidden notes, manual takeover notes, and domain payload references.
+
+#### Scenario: Player projection redacts GM-private data
+- **GIVEN** the action ledger contains an approved GM intervention action with private metadata and public net effect
+- **WHEN** a player views the action ledger projection
+- **THEN** the projection SHALL include the public net effect and visible changed state
+- **AND** it SHALL omit GM rationale, hidden notes, default outcome, and manual takeover notes
+
+#### Scenario: GM projection includes private action context
+- **GIVEN** the action ledger contains a normal action and an approved GM intervention action
+- **WHEN** the owning GM views the action ledger projection
+- **THEN** the projection SHALL include normal action public context
+- **AND** it SHALL include the GM intervention private metadata and public net effect

--- a/src/lib/interventions/ActionLedger.ts
+++ b/src/lib/interventions/ActionLedger.ts
@@ -1,0 +1,150 @@
+import type {
+  ActionLedgerInterventionRecordInput,
+  ActionLedgerProjectionVisibility,
+  GmActionLedgerRecordFromIntervention,
+  IActionLedgerAppendInput,
+  IActionLedgerNormalActionInput,
+  IActionLedgerRecord,
+  IGmVisibleActionLedgerRecord,
+  IPlayerVisibleActionLedgerRecord,
+  NormalActionLedgerRecord,
+} from '@/types/interventions';
+
+export class ActionLedger {
+  private readonly records: IActionLedgerRecord[] = [];
+
+  private nextSequence = 1;
+
+  appendNormalAction<TPublic>(
+    input: IActionLedgerNormalActionInput<TPublic>,
+  ): NormalActionLedgerRecord<TPublic> {
+    const record = this.append({
+      ...input,
+      recordKind: 'normal',
+      actorRole: input.actorRole ?? 'player',
+      status: 'committed',
+    }) as NormalActionLedgerRecord<TPublic>;
+
+    return record;
+  }
+
+  appendSystemAction<TPublic>(
+    input: Omit<
+      IActionLedgerAppendInput<TPublic, undefined, undefined>,
+      'recordKind' | 'actorRole' | 'status'
+    >,
+  ): IActionLedgerRecord<TPublic, undefined, undefined> {
+    return this.append({
+      ...input,
+      recordKind: 'system',
+      actorRole: 'system',
+      status: 'committed',
+    });
+  }
+
+  appendGmInterventionRecord<TPrivate, TPublic, TDomainPayload>(
+    record: ActionLedgerInterventionRecordInput<
+      TPrivate,
+      TPublic,
+      TDomainPayload
+    >,
+  ): GmActionLedgerRecordFromIntervention<TPrivate, TPublic, TDomainPayload> {
+    const actionRecord = this.append({
+      id: `action:${record.id}`,
+      recordKind: 'gm-intervention',
+      actorId: record.actorId,
+      actorRole: 'gm',
+      domain: record.domain,
+      action: record.kind,
+      status: record.status === 'manual' ? 'manual' : 'approved',
+      targetRefs: record.targetRefs,
+      publicEffect: record.publicEffect,
+      privateMetadata: record.privateMetadata,
+      domainPayload: record.domainPayload,
+      causedBy: record.causedBy,
+      supersedes: record.supersedes,
+      interventionRecordId: record.id,
+      createdAt: record.createdAt,
+      approvedAt: record.approvedAt,
+    }) as GmActionLedgerRecordFromIntervention<
+      TPrivate,
+      TPublic,
+      TDomainPayload
+    >;
+
+    return actionRecord;
+  }
+
+  projectForPlayer<
+    TPublic = unknown,
+  >(): IPlayerVisibleActionLedgerRecord<TPublic>[] {
+    return this.records.map((record) => this.toPlayerProjection(record));
+  }
+
+  projectForGm<
+    TPublic = unknown,
+    TPrivate = unknown,
+    TDomainPayload = unknown,
+  >(): IGmVisibleActionLedgerRecord<TPublic, TPrivate, TDomainPayload>[] {
+    return this.records.map((record) => this.toGmProjection(record));
+  }
+
+  project<TPublic = unknown, TPrivate = unknown, TDomainPayload = unknown>(
+    visibility: ActionLedgerProjectionVisibility,
+  ):
+    | IPlayerVisibleActionLedgerRecord<TPublic>[]
+    | IGmVisibleActionLedgerRecord<TPublic, TPrivate, TDomainPayload>[] {
+    return visibility === 'public'
+      ? this.projectForPlayer<TPublic>()
+      : this.projectForGm<TPublic, TPrivate, TDomainPayload>();
+  }
+
+  getRecords(): readonly IActionLedgerRecord[] {
+    return [...this.records];
+  }
+
+  private append<TPublic, TPrivate, TDomainPayload>(
+    input: IActionLedgerAppendInput<TPublic, TPrivate, TDomainPayload>,
+  ): IActionLedgerRecord<TPublic, TPrivate, TDomainPayload> {
+    const record: IActionLedgerRecord<TPublic, TPrivate, TDomainPayload> = {
+      ...input,
+      sequence: this.nextSequence,
+    };
+
+    this.nextSequence += 1;
+    this.records.push(record);
+    return record;
+  }
+
+  private toPlayerProjection<TPublic>(
+    record: IActionLedgerRecord,
+  ): IPlayerVisibleActionLedgerRecord<TPublic> {
+    return {
+      id: record.id,
+      sequence: record.sequence,
+      recordKind: record.recordKind,
+      actorId: record.actorId,
+      actorRole: record.actorRole,
+      domain: record.domain,
+      action: record.action,
+      status: record.status,
+      targetRefs: record.targetRefs,
+      publicEffect: record.publicEffect as TPublic,
+      causedBy: record.causedBy,
+      supersedes: record.supersedes,
+      interventionRecordId: record.interventionRecordId,
+      createdAt: record.createdAt,
+      approvedAt: record.approvedAt,
+    };
+  }
+
+  private toGmProjection<TPublic, TPrivate, TDomainPayload>(
+    record: IActionLedgerRecord,
+  ): IGmVisibleActionLedgerRecord<TPublic, TPrivate, TDomainPayload> {
+    return {
+      ...this.toPlayerProjection<TPublic>(record),
+      privateMetadata: record.privateMetadata as TPrivate | undefined,
+      domainPayload: record.domainPayload as TDomainPayload | undefined,
+    };
+  }
+}

--- a/src/lib/interventions/GmCascadePreviewPipeline.ts
+++ b/src/lib/interventions/GmCascadePreviewPipeline.ts
@@ -11,6 +11,7 @@ import type {
 
 import { logger } from '@/utils/logger';
 
+import type { ActionLedger } from './ActionLedger';
 import type { InterventionLedger } from './InterventionLedger';
 
 import { previewGmInterventionWithAuthority } from './GmInterventionAuthority';
@@ -36,6 +37,7 @@ export interface IApproveGmCascadePreviewInput<
   TDomainPayload = unknown,
 > {
   readonly ledger: InterventionLedger<TState>;
+  readonly actionLedger?: ActionLedger;
   readonly preview: IGmCascadePreview<TPrivate, TPublic, TDomainPayload>;
   readonly state: TState;
   readonly approvedAt?: string;
@@ -201,11 +203,15 @@ export function approveGmCascadePreview<
     };
   }
 
+  const actionLedgerRecord =
+    input.actionLedger?.appendGmInterventionRecord(record);
+
   return {
     status: 'approved',
     state: applyResult.state,
     appended: true,
     record,
+    actionLedgerRecord,
   };
 }
 

--- a/src/lib/interventions/__tests__/ActionLedger.test.ts
+++ b/src/lib/interventions/__tests__/ActionLedger.test.ts
@@ -1,0 +1,159 @@
+import type {
+  IActionLedgerRecord,
+  IInterventionLedgerRecord,
+  IGmPrivateMetadata,
+  IGmPublicEffect,
+} from '@/types/interventions';
+
+import { ActionLedger } from '../ActionLedger';
+
+interface TestDomainPayload {
+  readonly delta: number;
+}
+
+const makeGmInterventionRecord = (): IInterventionLedgerRecord<
+  IGmPrivateMetadata,
+  IGmPublicEffect,
+  TestDomainPayload
+> => ({
+  id: 'gm-int-1',
+  domain: 'combat',
+  kind: 'fix',
+  status: 'approved',
+  actorId: 'gm-1',
+  targetRefs: ['unit:atlas-1'],
+  causedBy: ['normal-action-1'],
+  supersedes: ['normal-action-1'],
+  privateMetadata: {
+    reason: 'GM-only damage correction.',
+    defaultOutcome: 'The target would remain destroyed.',
+    hiddenNotes: 'Hidden objective state stays private.',
+    manualTakeoverNotes: 'GM chose the least disruptive repair.',
+  },
+  publicEffect: {
+    summary: 'Atlas damage corrected.',
+    changedStateRefs: ['unit:atlas-1', 'armor:center-torso'],
+  },
+  domainPayload: {
+    delta: 4,
+  },
+  createdAt: '2026-06-22T00:00:00.000Z',
+  approvedAt: '2026-06-22T00:01:00.000Z',
+});
+
+describe('ActionLedger', () => {
+  it('keeps normal actions and approved GM interventions in one append-only order', () => {
+    const ledger = new ActionLedger();
+
+    const normal = ledger.appendNormalAction({
+      id: 'normal-action-1',
+      actorId: 'player-1',
+      domain: 'combat',
+      action: 'declare-attack',
+      targetRefs: ['unit:atlas-1'],
+      publicEffect: {
+        summary: 'Player declared an attack.',
+        changedStateRefs: ['attack:declared'],
+      },
+      createdAt: '2026-06-22T00:00:00.000Z',
+    });
+    const gmAction = ledger.appendGmInterventionRecord(
+      makeGmInterventionRecord(),
+    );
+
+    expect(normal).toMatchObject({
+      sequence: 1,
+      recordKind: 'normal',
+      actorRole: 'player',
+      status: 'committed',
+    });
+    expect(gmAction).toMatchObject({
+      sequence: 2,
+      recordKind: 'gm-intervention',
+      actorRole: 'gm',
+      action: 'fix',
+      interventionRecordId: 'gm-int-1',
+      causedBy: ['normal-action-1'],
+      supersedes: ['normal-action-1'],
+    });
+    expect(ledger.getRecords().map((record) => record.id)).toEqual([
+      'normal-action-1',
+      'action:gm-int-1',
+    ]);
+  });
+
+  it('projects player-safe output without GM-private metadata', () => {
+    const ledger = new ActionLedger();
+
+    ledger.appendNormalAction({
+      id: 'normal-action-1',
+      actorId: 'player-1',
+      domain: 'combat',
+      action: 'move',
+      targetRefs: ['unit:atlas-1'],
+      publicEffect: {
+        summary: 'Atlas moved.',
+        changedStateRefs: ['unit:atlas-1'],
+      },
+      createdAt: '2026-06-22T00:00:00.000Z',
+    });
+    ledger.appendGmInterventionRecord(makeGmInterventionRecord());
+
+    const playerProjection = ledger.projectForPlayer<IGmPublicEffect>();
+    const gmProjection = ledger.projectForGm<
+      IGmPublicEffect,
+      IGmPrivateMetadata,
+      TestDomainPayload
+    >();
+
+    expect(playerProjection).toHaveLength(2);
+    expect(playerProjection[1]).toMatchObject({
+      id: 'action:gm-int-1',
+      publicEffect: {
+        summary: 'Atlas damage corrected.',
+        changedStateRefs: ['unit:atlas-1', 'armor:center-torso'],
+      },
+    });
+    expect(JSON.stringify(playerProjection)).not.toContain(
+      'GM-only damage correction',
+    );
+    expect(JSON.stringify(playerProjection)).not.toContain(
+      'Hidden objective state',
+    );
+    expect(JSON.stringify(playerProjection)).not.toContain(
+      'least disruptive repair',
+    );
+
+    expect(gmProjection[1].privateMetadata).toMatchObject({
+      reason: 'GM-only damage correction.',
+      defaultOutcome: 'The target would remain destroyed.',
+      hiddenNotes: 'Hidden objective state stays private.',
+      manualTakeoverNotes: 'GM chose the least disruptive repair.',
+    });
+    expect(gmProjection[1].domainPayload).toEqual({
+      delta: 4,
+    });
+  });
+
+  it('returns copies so callers cannot mutate the ledger through record reads', () => {
+    const ledger = new ActionLedger();
+
+    ledger.appendSystemAction({
+      id: 'system-action-1',
+      actorId: 'system',
+      domain: 'combat',
+      action: 'phase-started',
+      targetRefs: ['phase:movement'],
+      publicEffect: {
+        summary: 'Movement phase started.',
+        changedStateRefs: ['phase:movement'],
+      },
+      createdAt: '2026-06-22T00:00:00.000Z',
+    });
+
+    const records = ledger.getRecords() as IActionLedgerRecord[];
+    records.pop();
+
+    expect(ledger.getRecords()).toHaveLength(1);
+  });
+});

--- a/src/lib/interventions/__tests__/GmCascadePreviewPipeline.test.ts
+++ b/src/lib/interventions/__tests__/GmCascadePreviewPipeline.test.ts
@@ -7,6 +7,7 @@ import type {
   IInterventionLedgerPreview,
 } from '@/types/interventions';
 
+import { ActionLedger } from '../ActionLedger';
 import {
   approveGmCascadePreview,
   cancelGmCascadePreview,
@@ -227,6 +228,62 @@ describe('GM cascade preview pipeline', () => {
     });
   });
 
+  it('appends approved GM interventions to the shared action ledger after normal actions', () => {
+    const ledger = makeLedger();
+    const actionLedger = new ActionLedger();
+    const state = makeState();
+    actionLedger.appendNormalAction({
+      id: 'player-attack-1',
+      actorId: 'player-1',
+      domain: 'combat',
+      action: 'declare-attack',
+      targetRefs: ['unit:atlas-1'],
+      publicEffect: {
+        summary: 'Player attack resolved.',
+        changedStateRefs: ['unit:atlas-1'],
+      },
+      createdAt: '2026-06-20T00:00:00.000Z',
+    });
+    const preview = createGmCascadePreview({
+      ledger,
+      command: makeCommand({ supersedes: ['player-attack-1'] }),
+      state,
+      authority: gmAuthority,
+      interventionId: 'gm-int-action-ledger',
+    });
+
+    const result = approveGmCascadePreview({
+      ledger,
+      actionLedger,
+      preview,
+      state,
+      createdAt: '2026-06-20T00:02:00.000Z',
+      approvedAt: '2026-06-20T00:03:00.000Z',
+    });
+
+    expect(result.status).toBe('approved');
+    expect(result.actionLedgerRecord).toMatchObject({
+      id: 'action:gm-int-action-ledger',
+      sequence: 2,
+      recordKind: 'gm-intervention',
+      interventionRecordId: 'gm-int-action-ledger',
+      causedBy: ['player-attack-1'],
+      supersedes: ['player-attack-1'],
+    });
+
+    const playerProjection = actionLedger.projectForPlayer();
+    const gmProjection = actionLedger.projectForGm();
+
+    expect(playerProjection.map((record) => record.id)).toEqual([
+      'player-attack-1',
+      'action:gm-int-action-ledger',
+    ]);
+    expect(JSON.stringify(playerProjection)).not.toContain(
+      'GM-only cascade reason',
+    );
+    expect(JSON.stringify(gmProjection)).toContain('GM-only cascade reason');
+  });
+
   it('cancels a preview without appending or changing derived state', () => {
     const ledger = makeLedger();
     const state = makeState();
@@ -250,6 +307,7 @@ describe('GM cascade preview pipeline', () => {
 
   it('requires manual takeover for unresolved conflicts and blocks approval', () => {
     const ledger = makeLedger();
+    const actionLedger = new ActionLedger();
     const state = makeState();
     const preview = createGmCascadePreview({
       ledger,
@@ -261,6 +319,7 @@ describe('GM cascade preview pipeline', () => {
 
     const result = approveGmCascadePreview({
       ledger,
+      actionLedger,
       preview,
       state,
     });
@@ -276,6 +335,7 @@ describe('GM cascade preview pipeline', () => {
       appended: false,
     });
     expect(ledger.getRecords()).toEqual([]);
+    expect(actionLedger.getRecords()).toEqual([]);
   });
 
   it('returns deferred previews for unsupported first-slice campaign domains without mutation', () => {

--- a/src/lib/interventions/index.ts
+++ b/src/lib/interventions/index.ts
@@ -1,3 +1,4 @@
+export { ActionLedger } from './ActionLedger';
 export {
   approveGmCascadePreview,
   cancelGmCascadePreview,

--- a/src/types/interventions/ActionLedgerTypes.ts
+++ b/src/types/interventions/ActionLedgerTypes.ts
@@ -1,0 +1,113 @@
+import type {
+  GmInterventionKind,
+  IInterventionLedgerRecord,
+  InterventionDomain,
+} from './InterventionLedgerTypes';
+
+export type ActionLedgerRecordKind = 'normal' | 'gm-intervention' | 'system';
+
+export type ActionLedgerActorRole = 'player' | 'gm' | 'system';
+
+export type ActionLedgerRecordStatus = 'committed' | 'approved' | 'manual';
+
+export type ActionLedgerProjectionVisibility = 'public' | 'gm-private';
+
+export interface IActionLedgerAppendInput<
+  TPublic = unknown,
+  TPrivate = unknown,
+  TDomainPayload = unknown,
+> {
+  readonly id: string;
+  readonly recordKind: ActionLedgerRecordKind;
+  readonly actorId: string;
+  readonly actorRole: ActionLedgerActorRole;
+  readonly domain: InterventionDomain;
+  readonly action: string;
+  readonly status: ActionLedgerRecordStatus;
+  readonly targetRefs: readonly string[];
+  readonly publicEffect: TPublic;
+  readonly privateMetadata?: TPrivate;
+  readonly domainPayload?: TDomainPayload;
+  readonly causedBy?: readonly string[];
+  readonly supersedes?: readonly string[];
+  readonly interventionRecordId?: string;
+  readonly createdAt: string;
+  readonly approvedAt?: string;
+}
+
+export interface IActionLedgerNormalActionInput<TPublic = unknown> extends Omit<
+  IActionLedgerAppendInput<TPublic, never, never>,
+  'recordKind' | 'actorRole' | 'status' | 'privateMetadata' | 'domainPayload'
+> {
+  readonly actorRole?: Extract<ActionLedgerActorRole, 'player' | 'system'>;
+}
+
+export interface IActionLedgerRecord<
+  TPublic = unknown,
+  TPrivate = unknown,
+  TDomainPayload = unknown,
+> extends IActionLedgerAppendInput<TPublic, TPrivate, TDomainPayload> {
+  readonly sequence: number;
+}
+
+export interface IPlayerVisibleActionLedgerRecord<TPublic = unknown> {
+  readonly id: string;
+  readonly sequence: number;
+  readonly recordKind: ActionLedgerRecordKind;
+  readonly actorId: string;
+  readonly actorRole: ActionLedgerActorRole;
+  readonly domain: InterventionDomain;
+  readonly action: string;
+  readonly status: ActionLedgerRecordStatus;
+  readonly targetRefs: readonly string[];
+  readonly publicEffect: TPublic;
+  readonly causedBy?: readonly string[];
+  readonly supersedes?: readonly string[];
+  readonly interventionRecordId?: string;
+  readonly createdAt: string;
+  readonly approvedAt?: string;
+}
+
+export interface IGmVisibleActionLedgerRecord<
+  TPublic = unknown,
+  TPrivate = unknown,
+  TDomainPayload = unknown,
+> extends IPlayerVisibleActionLedgerRecord<TPublic> {
+  readonly privateMetadata?: TPrivate;
+  readonly domainPayload?: TDomainPayload;
+}
+
+export type ActionLedgerProjection<
+  TPublic = unknown,
+  TPrivate = unknown,
+  TDomainPayload = unknown,
+> =
+  | IPlayerVisibleActionLedgerRecord<TPublic>
+  | IGmVisibleActionLedgerRecord<TPublic, TPrivate, TDomainPayload>;
+
+export type GmActionLedgerRecordFromIntervention<
+  TPrivate = unknown,
+  TPublic = unknown,
+  TDomainPayload = unknown,
+> = IActionLedgerRecord<TPublic, TPrivate, TDomainPayload> & {
+  readonly recordKind: 'gm-intervention';
+  readonly actorRole: 'gm';
+  readonly action: GmInterventionKind;
+  readonly interventionRecordId: string;
+};
+
+export type NormalActionLedgerRecord<TPublic = unknown> = IActionLedgerRecord<
+  TPublic,
+  undefined,
+  undefined
+> & {
+  readonly recordKind: 'normal';
+  readonly actorRole: 'player' | 'system';
+  readonly status: 'committed';
+};
+
+export type ActionLedgerInterventionRecordInput<
+  TPrivate = unknown,
+  TPublic = unknown,
+  TDomainPayload = unknown,
+> = IInterventionLedgerRecord<TPrivate, TPublic, TDomainPayload>;

--- a/src/types/interventions/GmCascadePreviewTypes.ts
+++ b/src/types/interventions/GmCascadePreviewTypes.ts
@@ -1,3 +1,4 @@
+import type { GmActionLedgerRecordFromIntervention } from './ActionLedgerTypes';
 import type {
   GmInterventionKind,
   IInterventionConflict,
@@ -40,6 +41,7 @@ export interface IGmCascadeApprovalResult<TState = unknown> {
   readonly state: TState;
   readonly appended: boolean;
   readonly record?: IInterventionLedgerRecord;
+  readonly actionLedgerRecord?: GmActionLedgerRecordFromIntervention;
   readonly reason?: string;
 }
 

--- a/src/types/interventions/index.ts
+++ b/src/types/interventions/index.ts
@@ -57,6 +57,22 @@ export type {
 } from './GmInterventionAuthorityTypes';
 
 export type {
+  ActionLedgerActorRole,
+  ActionLedgerInterventionRecordInput,
+  ActionLedgerProjection,
+  ActionLedgerProjectionVisibility,
+  ActionLedgerRecordKind,
+  ActionLedgerRecordStatus,
+  GmActionLedgerRecordFromIntervention,
+  IActionLedgerAppendInput,
+  IActionLedgerNormalActionInput,
+  IActionLedgerRecord,
+  IGmVisibleActionLedgerRecord,
+  IPlayerVisibleActionLedgerRecord,
+  NormalActionLedgerRecord,
+} from './ActionLedgerTypes';
+
+export type {
   GmInterventionKind,
   IAppliedInterventionResult,
   IInterventionConflict,


### PR DESCRIPTION
## Summary
- add a shared append-only ActionLedger for normal, system, and approved GM intervention actions
- wire GM cascade approval to optionally append player-safe action ledger records after successful domain application
- archive OpenSpec change add-action-ledger-core and extend intervention-ledger-abstraction requirements

## Validation
- npm run verify
- npx openspec validate --all --strict
- npm run verify:qc
- npx jest --selectProjects unit --ci --runTestsByPath src/lib/interventions/__tests__/ActionLedger.test.ts src/lib/interventions/__tests__/InterventionLedger.test.ts src/lib/interventions/__tests__/GmCascadePreviewPipeline.test.ts src/lib/interventions/__tests__/GmInterventionAuthority.test.ts --no-coverage
- npm run qc:journeys -- --journey=all --tier=smoke --seed=88 --run-id=gm-ledger-core-smoke

## Notes
- Existing lint warnings still print in simulation source-ref files, but npm run verify exits green and this PR does not touch those files.
- Persistence and UI timeline consumption remain future waves.