### PR TITLE
Connect gameplay UI flows to journey QC

### DIFF
--- a/docs/qc/mekstation-journey-qc.md
+++ b/docs/qc/mekstation-journey-qc.md
@@ -11,6 +11,7 @@ scenario catalog.
 - Journey catalog: `docs/qc/mekstation-journey-scenarios.json`
 - QC validation graph: `docs/qc/mekstation-qc-validation-graph.json`
 - Logging map: `docs/qc/mekstation-logging-map.json`
+- UI flow shell registry: `src/qc/gameplayUiFlowShell.json`
 - Evidence root: `.sisyphus/evidence/qc-journeys`
 
 ## Commands
@@ -31,6 +32,11 @@ npm.cmd run qc:logs -- --run-id=latest --level=warn,error --exclude-probes
 npm.cmd run verify:qc:journeys
 ```
 
+`qc:journeys:validate` also checks the gameplay UI flow shell. Each required
+journey must have a UI flow entry, every UI flow journey must exist in the
+catalog and validation graph, and every route checkpoint must map to a Next.js
+page template such as `/gameplay/campaigns/[id]/salvage`.
+
 ## Supported Journeys
 
 | Journey             | Default mode | Primary module | Default proof                                      |
@@ -42,6 +48,20 @@ npm.cmd run verify:qc:journeys
 | `contract-campaign` | headless     | campaign       | contract selection, outcome, economy update        |
 | `campaign-short`    | headless     | campaign       | 3 to 5 contract sequence                           |
 | `campaign-long`     | headless     | campaign       | 6 to 10 contract sequence                          |
+
+## UI Flow Shell
+
+The gameplay hub mounts the UI flow shell from `src/qc/gameplayUiFlowShell.json`.
+It maps each supported journey to:
+
+- player-visible launch and inspection routes
+- GM review or intervention checkpoints
+- the QC command that proves the journey
+- placeholder routes such as `:campaignId`, `:missionId`, and `:gameId`
+
+Route placeholders are validation targets, not generated runtime IDs. The
+validator normalizes them against the concrete Next.js page templates before
+accepting the registry.
 
 ## Common Parameters
 

--- a/docs/qc/mekstation-qc-map.md
+++ b/docs/qc/mekstation-qc-map.md
@@ -10,7 +10,8 @@ The machine-readable source is `docs/qc/mekstation-qc-registry.json`. The
 repeatable pass/fail scenario layer for the 12 top-level QC surfaces is
 `docs/qc/mekstation-major-capability-scenarios.json`.
 The journey-level validation layer is `docs/qc/mekstation-journey-scenarios.json`,
-with graph lookup in `docs/qc/mekstation-qc-validation-graph.json` and logging
+with graph lookup in `docs/qc/mekstation-qc-validation-graph.json`, gameplay UI
+flow shell mapping in `src/qc/gameplayUiFlowShell.json`, and logging
 coverage in `docs/qc/mekstation-logging-map.json`.
 
 ## Commands

--- a/docs/qc/mekstation-qc-validation-graph.json
+++ b/docs/qc/mekstation-qc-validation-graph.json
@@ -9,6 +9,11 @@
       "label": "Journey QC"
     },
     {
+      "id": "capability:ui-flow-shell",
+      "kind": "capability",
+      "label": "UI Flow Shell"
+    },
+    {
       "id": "capability:logging-system",
       "kind": "capability",
       "label": "Logging System"
@@ -123,6 +128,11 @@
       "label": ".sisyphus/evidence/qc-journeys"
     },
     {
+      "id": "evidence:gameplay-ui-flow-shell",
+      "kind": "evidence",
+      "label": "src/qc/gameplayUiFlowShell.json"
+    },
+    {
       "id": "log-event:character.created",
       "kind": "log-event",
       "label": "character.created"
@@ -198,6 +208,21 @@
       "from": "capability:journey-qc",
       "to": "journey:campaign-long",
       "relation": "contains"
+    },
+    {
+      "from": "capability:journey-qc",
+      "to": "capability:ui-flow-shell",
+      "relation": "contains"
+    },
+    {
+      "from": "capability:ui-flow-shell",
+      "to": "command:qc-journeys-validate",
+      "relation": "validated-by"
+    },
+    {
+      "from": "capability:ui-flow-shell",
+      "to": "evidence:gameplay-ui-flow-shell",
+      "relation": "validated-by"
     },
     {
       "from": "module:roster",

--- a/openspec/changes/archive/2026-06-22-add-ui-flow-shell/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-22-add-ui-flow-shell/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-22

--- a/openspec/changes/archive/2026-06-22-add-ui-flow-shell/design.md
+++ b/openspec/changes/archive/2026-06-22-add-ui-flow-shell/design.md
@@ -1,0 +1,67 @@
+## Context
+
+Journey QC already defines the required end-to-end scenarios and writes evidence for character build, BattleMech build, 1v1 combat, 4v4 combat, contract campaign, short campaign, and long campaign flows. The gameplay UI has route surfaces for pilots, forces, campaigns, encounters, active games, victory/review/replay, repair, salvage, starmap, finances, and campaign logs, but there is no single UI map that shows how those surfaces compose into the validated player and GM flows.
+
+The UI flow shell is a thin coordination layer: it does not own campaign state, combat resolution, or GM ledger mutation. It exposes route and QC alignment so users can start, continue, or inspect the same flows the journey runner validates.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Provide a typed gameplay flow registry for the seven required journey IDs.
+- Render a gameplay hub section that shows each flow's ordered route checkpoints, primary action, GM review intent, and QC command.
+- Validate the UI flow registry against the journey catalog and validation graph.
+- Keep the shell usable without requiring an existing campaign or encounter ID by using template placeholders where runtime IDs are needed.
+
+**Non-Goals:**
+
+- Add new campaign, combat, economy, salvage, repair, or time cascade mechanics.
+- Replace existing gameplay route implementations.
+- Require browser-backed journey execution for every journey.
+- Add new external dependencies or persistence schemas.
+
+## Decisions
+
+1. **Use a static registry with a typed TypeScript wrapper instead of deriving UI routes from docs JSON at runtime.**
+
+   The UI needs typed labels, phases, route placeholders, roles, and action affordances. Keeping that in TypeScript gives compile-time safety and avoids importing docs-only JSON into the Next.js client bundle as a source of truth. The validator reads both sides and fails on drift.
+
+   Alternative considered: render directly from `docs/qc/mekstation-journey-scenarios.json`. Rejected because the catalog describes QC execution, not operator UX labels or route placeholders.
+
+2. **Render the shell on `/gameplay` instead of creating another top-level route first.**
+
+   The gameplay hub is already the launch point for quick games, pilots, forces, campaigns, encounters, and games. Adding the flow shell there makes the path discoverable without changing existing route ownership.
+
+   Alternative considered: add `/gameplay/flows`. Rejected for this wave because it adds route sprawl before the hub proves useful.
+
+3. **Validate route placeholders by matching page templates, not by requiring concrete IDs.**
+
+   Campaign, encounter, mission, and game routes naturally contain IDs. The registry records placeholder routes such as `/gameplay/campaigns/:campaignId/salvage`; the validator normalizes them against Next.js page templates such as `/gameplay/campaigns/[id]/salvage`.
+
+   Alternative considered: point all shell links only to list pages. Rejected because the user needs to understand the full flow, including ID-bound inspection surfaces.
+
+4. **Keep GM controls as inspection intent in this wave.**
+
+   GM ledger and combat intervention behavior already has separate specs. This shell identifies where GM review/override surfaces belong in the flow, but the detailed cascade controls remain owned by GM ledger and later campaign intervention waves.
+
+## Risks / Trade-offs
+
+- **Registry can drift from journey catalog** -> Add a validator and include it in `qc:journeys:validate`.
+- **Placeholder links could confuse users if treated as clickable runtime links** -> Render placeholders as route checkpoints and only make concrete entry routes clickable.
+- **Gameplay hub could become too dense** -> Use compact flow rows grouped by module and keep existing hub cards intact.
+- **Long campaign remains headless-first** -> Keep this visible as a QC note and do not imply full browser parity until later waves add it.
+
+## Migration Plan
+
+1. Add the UI flow registry and shell component.
+2. Mount the shell on the gameplay hub.
+3. Extend QC validation to check required journey coverage, graph nodes, and route templates.
+4. Add focused unit/script tests.
+5. Archive the OpenSpec change after verification passes.
+
+Rollback is removing the shell mount, registry, validator checks, and spec delta; no stored data changes are involved.
+
+## Open Questions
+
+- Should `/gameplay/flows` become a dedicated expanded route once the shell grows beyond hub-sized inspection?
+- Which later GM intervention wave should replace route placeholder checkpoints with concrete campaign/session-aware deep links?

--- a/openspec/changes/archive/2026-06-22-add-ui-flow-shell/proposal.md
+++ b/openspec/changes/archive/2026-06-22-add-ui-flow-shell/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+Journey QC can now prove the core MekStation flows from the command line, but the gameplay UI does not yet expose a single operator view that connects those same validated journeys across campaign, contract, encounter, tactical combat, post-combat, repair, salvage, economy, and time surfaces. Wave 6 needs a thin UI shell so players and GMs can launch or inspect the same top-level scenarios that automated QC already validates.
+
+## What Changes
+
+- Add a gameplay flow shell that renders the major player and GM routes in the same order as the end-to-end journey model.
+- Add a typed UI flow registry that maps each required journey QC ID to gameplay routes, modules, default QC commands, and GM/player inspection intent.
+- Add drift validation so journey catalog, validation graph, and UI flow registry cannot disagree silently.
+- Surface the flow shell from the gameplay hub without replacing existing quick game, campaign, encounter, force, pilot, game, or multiplayer pages.
+- Document the UI flow shell in the journey QC docs.
+
+## Non-goals
+
+- Do not implement new campaign, combat, repair, salvage, economy, or time mechanics.
+- Do not replace the existing journey runner or evidence bundle format.
+- Do not make browser-backed journey execution mandatory for every journey in this wave.
+- Do not add GM ledger behaviors beyond linking to the already available review/intervention routes.
+
+## Capabilities
+
+### New Capabilities
+
+- `ui-flow-shell`: Gameplay UI flow mapping and inspection surface for journey-backed player and GM scenarios.
+
+### Modified Capabilities
+
+- `journey-qc`: Adds a requirement that required journey IDs remain mapped to UI flow shell entries.
+
+## Impact
+
+- Gameplay hub UI and any new flow-shell components under `src/components/gameplay`.
+- Journey QC docs and validation scripts under `docs/qc` and `scripts/qc`.
+- Unit/script tests that prove required journey IDs, graph nodes, and UI flow mappings stay aligned.
+- No new runtime dependency or database migration.

--- a/openspec/changes/archive/2026-06-22-add-ui-flow-shell/specs/journey-qc/spec.md
+++ b/openspec/changes/archive/2026-06-22-add-ui-flow-shell/specs/journey-qc/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: Journey UI flow mapping validation
+The journey QC validator SHALL verify that every required journey ID is represented by the gameplay UI flow registry and that every UI flow journey ID exists in the journey catalog and validation graph.
+
+#### Scenario: Required journey lacks UI flow
+- **WHEN** `npm.cmd run qc:journeys:validate` runs and a required journey ID is missing from the UI flow registry
+- **THEN** validation fails and names the missing journey ID
+
+#### Scenario: UI flow references unknown journey
+- **WHEN** the UI flow registry references a journey ID that is not present in the journey scenario catalog
+- **THEN** validation fails and names the unknown journey ID

--- a/openspec/changes/archive/2026-06-22-add-ui-flow-shell/specs/ui-flow-shell/spec.md
+++ b/openspec/changes/archive/2026-06-22-add-ui-flow-shell/specs/ui-flow-shell/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Journey-backed gameplay flow registry
+The system SHALL define a typed gameplay UI flow registry that maps every required journey QC ID to an ordered player and GM flow through gameplay UI routes. Each flow entry MUST include journey ID, display name, module, role intent, ordered route checkpoints, primary action route, QC command, and inspection notes.
+
+#### Scenario: Registry covers required journeys
+- **WHEN** the UI flow registry is validated
+- **THEN** it contains exactly one flow entry for each required journey QC ID
+
+#### Scenario: Flow checkpoints preserve route order
+- **WHEN** the `contract-campaign` flow is rendered or validated
+- **THEN** its checkpoints preserve campaign/base, contract selection, encounter launch, tactical combat, post-combat, salvage, repair, economy, and log review order
+
+### Requirement: Gameplay hub flow shell
+The gameplay hub SHALL render a flow shell that exposes the required journey-backed flows without replacing existing gameplay navigation. The shell MUST show the journey ID, module, primary action, route checkpoints, QC command, and GM/player inspection intent for each flow.
+
+#### Scenario: Hub shows validated journeys
+- **WHEN** a user opens `/gameplay`
+- **THEN** the hub shows flow-shell entries for character build, BattleMech build, 1v1 combat, 4v4 combat, contract campaign, short campaign, and long campaign
+
+#### Scenario: Existing gameplay cards remain available
+- **WHEN** the flow shell renders on the gameplay hub
+- **THEN** the existing Quick Game, Pilots, Forces, Campaigns, Encounters, Games, and Multiplayer navigation cards remain available
+
+### Requirement: Route checkpoint validation
+The system SHALL validate that every UI flow checkpoint maps to an existing gameplay page template or an explicitly non-clickable placeholder route. Placeholder routes MUST use stable parameter names and MUST include a concrete entry route when the flow needs runtime IDs.
+
+#### Scenario: Placeholder route maps to page template
+- **WHEN** the validator reads `/gameplay/campaigns/:campaignId/salvage`
+- **THEN** it matches the existing `/gameplay/campaigns/[id]/salvage` page template
+
+#### Scenario: Missing page template fails validation
+- **WHEN** a UI flow checkpoint references a route without a matching gameplay page template or documented placeholder handling
+- **THEN** UI flow validation fails and names the flow ID and route
+
+### Requirement: GM and player visibility separation
+The UI flow shell SHALL distinguish player action checkpoints from GM review or override checkpoints. GM-only notes MUST be labeled as GM inspection or intervention intent and MUST NOT imply that hidden GM rationale is player-visible.
+
+#### Scenario: Combat flow exposes GM review intent
+- **WHEN** the `combat-1v1` or `combat-4v4` flow is rendered
+- **THEN** the shell identifies tactical combat and post-battle review as player-visible checkpoints and GM intervention/review as GM inspection intent
+
+#### Scenario: Campaign flow preserves player-safe framing
+- **WHEN** a campaign flow includes salvage, repair, economy, or time checkpoints
+- **THEN** the shell describes player-visible net-effect inspection separately from GM correction authority

--- a/openspec/changes/archive/2026-06-22-add-ui-flow-shell/tasks.md
+++ b/openspec/changes/archive/2026-06-22-add-ui-flow-shell/tasks.md
@@ -1,0 +1,21 @@
+## 1. UI Flow Registry
+
+- [x] 1.1 Add a typed gameplay UI flow registry covering all required journey QC IDs.
+- [x] 1.2 Add route checkpoint metadata for player-visible and GM inspection phases.
+
+## 2. Gameplay Hub Shell
+
+- [x] 2.1 Add a compact gameplay flow shell component that renders journey ID, module, action route, checkpoints, QC command, and role intent.
+- [x] 2.2 Mount the flow shell on `/gameplay` without removing existing gameplay navigation cards.
+- [x] 2.3 Add React tests for required journey rendering and route/checkpoint visibility.
+
+## 3. QC Drift Validation
+
+- [x] 3.1 Extend journey QC validation to load and validate UI flow mappings.
+- [x] 3.2 Validate required journey coverage, unknown UI journey IDs, graph node coverage, and route template coverage.
+- [x] 3.3 Add script tests for UI flow validation failure modes.
+
+## 4. Documentation And Verification
+
+- [x] 4.1 Document the UI flow shell in journey QC docs.
+- [x] 4.2 Run focused tests, OpenSpec validation, typecheck, and QC validation.

--- a/openspec/specs/journey-qc/spec.md
+++ b/openspec/specs/journey-qc/spec.md
@@ -118,3 +118,14 @@ The system SHALL include a triage packet on each journey bug candidate. The pack
 #### Scenario: Bug reporter remains compatible with older evidence
 - **WHEN** the bug reporter reads a bug candidate that does not contain a triage packet
 - **THEN** it still lists the bug using the existing summary, fingerprint, and evidence references
+
+### Requirement: Journey UI flow mapping validation
+The journey QC validator SHALL verify that every required journey ID is represented by the gameplay UI flow registry and that every UI flow journey ID exists in the journey catalog and validation graph.
+
+#### Scenario: Required journey lacks UI flow
+- **WHEN** `npm.cmd run qc:journeys:validate` runs and a required journey ID is missing from the UI flow registry
+- **THEN** validation fails and names the missing journey ID
+
+#### Scenario: UI flow references unknown journey
+- **WHEN** the UI flow registry references a journey ID that is not present in the journey scenario catalog
+- **THEN** validation fails and names the unknown journey ID

--- a/openspec/specs/ui-flow-shell/spec.md
+++ b/openspec/specs/ui-flow-shell/spec.md
@@ -1,0 +1,48 @@
+# ui-flow-shell Specification
+
+## Purpose
+TBD - created by archiving change add-ui-flow-shell. Update Purpose after archive.
+## Requirements
+### Requirement: Journey-backed gameplay flow registry
+The system SHALL define a typed gameplay UI flow registry that maps every required journey QC ID to an ordered player and GM flow through gameplay UI routes. Each flow entry MUST include journey ID, display name, module, role intent, ordered route checkpoints, primary action route, QC command, and inspection notes.
+
+#### Scenario: Registry covers required journeys
+- **WHEN** the UI flow registry is validated
+- **THEN** it contains exactly one flow entry for each required journey QC ID
+
+#### Scenario: Flow checkpoints preserve route order
+- **WHEN** the `contract-campaign` flow is rendered or validated
+- **THEN** its checkpoints preserve campaign/base, contract selection, encounter launch, tactical combat, post-combat, salvage, repair, economy, and log review order
+
+### Requirement: Gameplay hub flow shell
+The gameplay hub SHALL render a flow shell that exposes the required journey-backed flows without replacing existing gameplay navigation. The shell MUST show the journey ID, module, primary action, route checkpoints, QC command, and GM/player inspection intent for each flow.
+
+#### Scenario: Hub shows validated journeys
+- **WHEN** a user opens `/gameplay`
+- **THEN** the hub shows flow-shell entries for character build, BattleMech build, 1v1 combat, 4v4 combat, contract campaign, short campaign, and long campaign
+
+#### Scenario: Existing gameplay cards remain available
+- **WHEN** the flow shell renders on the gameplay hub
+- **THEN** the existing Quick Game, Pilots, Forces, Campaigns, Encounters, Games, and Multiplayer navigation cards remain available
+
+### Requirement: Route checkpoint validation
+The system SHALL validate that every UI flow checkpoint maps to an existing gameplay page template or an explicitly non-clickable placeholder route. Placeholder routes MUST use stable parameter names and MUST include a concrete entry route when the flow needs runtime IDs.
+
+#### Scenario: Placeholder route maps to page template
+- **WHEN** the validator reads `/gameplay/campaigns/:campaignId/salvage`
+- **THEN** it matches the existing `/gameplay/campaigns/[id]/salvage` page template
+
+#### Scenario: Missing page template fails validation
+- **WHEN** a UI flow checkpoint references a route without a matching gameplay page template or documented placeholder handling
+- **THEN** UI flow validation fails and names the flow ID and route
+
+### Requirement: GM and player visibility separation
+The UI flow shell SHALL distinguish player action checkpoints from GM review or override checkpoints. GM-only notes MUST be labeled as GM inspection or intervention intent and MUST NOT imply that hidden GM rationale is player-visible.
+
+#### Scenario: Combat flow exposes GM review intent
+- **WHEN** the `combat-1v1` or `combat-4v4` flow is rendered
+- **THEN** the shell identifies tactical combat and post-battle review as player-visible checkpoints and GM intervention/review as GM inspection intent
+
+#### Scenario: Campaign flow preserves player-safe framing
+- **WHEN** a campaign flow includes salvage, repair, economy, or time checkpoints
+- **THEN** the shell describes player-visible net-effect inspection separately from GM correction authority

--- a/scripts/__tests__/journey-qc.test.ts
+++ b/scripts/__tests__/journey-qc.test.ts
@@ -10,15 +10,24 @@ function makeTempDir(prefix: string): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
 }
 
-function runNodeScript(scriptPath: string, args: string[] = []) {
+function runNodeScript(
+  scriptPath: string,
+  args: string[] = [],
+  env: NodeJS.ProcessEnv = {},
+) {
   return spawnSync(NODE, [path.resolve(repoRoot, scriptPath), ...args], {
     cwd: repoRoot,
     encoding: 'utf-8',
+    env: { ...process.env, ...env },
   });
 }
 
 function readJson<T>(filePath: string): T {
   return JSON.parse(fs.readFileSync(filePath, 'utf-8')) as T;
+}
+
+function writeJson(filePath: string, value: unknown): void {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
 }
 
 describe('journey QC scripts', () => {
@@ -37,7 +46,70 @@ describe('journey QC scripts', () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('catalog=7 journeys');
+    expect(result.stdout).toContain('uiFlows=7');
     expect(result.stdout).toContain('errors=0');
+  });
+
+  it('fails validation when a required journey lacks UI flow coverage', () => {
+    const shell = readJson<{
+      flows: Array<{ journeyId: string }>;
+    }>(path.join(repoRoot, 'src/qc/gameplayUiFlowShell.json'));
+    shell.flows = shell.flows.filter(
+      (flow) => flow.journeyId !== 'campaign-long',
+    );
+    const shellPath = path.join(evidenceDir, 'missing-ui-flow.json');
+    writeJson(shellPath, shell);
+
+    const result = runNodeScript('scripts/qc/validate-journey-qc.mjs', [], {
+      MEKSTATION_UI_FLOW_SHELL_PATH: shellPath,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain(
+      'UI flow shell missing required journey campaign-long',
+    );
+  });
+
+  it('fails validation when a UI flow references an unknown journey', () => {
+    const shell = readJson<{
+      flows: Array<{ journeyId: string; qcCommand: string }>;
+    }>(path.join(repoRoot, 'src/qc/gameplayUiFlowShell.json'));
+    shell.flows[0] = {
+      ...shell.flows[0],
+      journeyId: 'unknown-journey',
+      qcCommand: 'npm.cmd run qc:journeys -- --journey=unknown-journey',
+    };
+    const shellPath = path.join(evidenceDir, 'unknown-ui-flow.json');
+    writeJson(shellPath, shell);
+
+    const result = runNodeScript('scripts/qc/validate-journey-qc.mjs', [], {
+      MEKSTATION_UI_FLOW_SHELL_PATH: shellPath,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain(
+      'UI flow shell references unknown journey unknown-journey',
+    );
+  });
+
+  it('fails validation when a UI checkpoint route has no page template', () => {
+    const shell = readJson<{
+      flows: Array<{
+        checkpoints: Array<{ href: string }>;
+      }>;
+    }>(path.join(repoRoot, 'src/qc/gameplayUiFlowShell.json'));
+    shell.flows[0]!.checkpoints[0]!.href = '/gameplay/not-a-real-route';
+    const shellPath = path.join(evidenceDir, 'bad-route-ui-flow.json');
+    writeJson(shellPath, shell);
+
+    const result = runNodeScript('scripts/qc/validate-journey-qc.mjs', [], {
+      MEKSTATION_UI_FLOW_SHELL_PATH: shellPath,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain(
+      'UI flow character-build: checkpoint pilot-create route /gameplay/not-a-real-route does not match a page template',
+    );
   });
 
   it('writes a dry-run plan without failing the command', () => {

--- a/scripts/qc/journey-qc-core.mjs
+++ b/scripts/qc/journey-qc-core.mjs
@@ -22,6 +22,9 @@ export const loggingMapPath = path.join(
   'qc',
   'mekstation-logging-map.json',
 );
+export const uiFlowShellPath = process.env.MEKSTATION_UI_FLOW_SHELL_PATH
+  ? path.resolve(repoRoot, process.env.MEKSTATION_UI_FLOW_SHELL_PATH)
+  : path.join(repoRoot, 'src', 'qc', 'gameplayUiFlowShell.json');
 
 export const requiredJourneyIds = [
   'character-build',
@@ -166,6 +169,7 @@ export function loadJourneyArtifacts() {
     catalog: loadJsonFile(journeyCatalogPath),
     graph: loadJsonFile(validationGraphPath),
     loggingMap: loadJsonFile(loggingMapPath),
+    uiFlowShell: loadJsonFile(uiFlowShellPath),
   };
 }
 
@@ -560,6 +564,304 @@ export function validateLoggingMap(loggingMap, catalog) {
   return issues;
 }
 
+function pageRouteSegments(filePath) {
+  const relative = toRepoRelative(filePath);
+  if (!relative.startsWith('src/pages/')) return null;
+  const withoutPrefix = relative
+    .replace(/^src\/pages\//, '')
+    .replace(/\.(tsx|ts|jsx|js)$/, '');
+  if (
+    withoutPrefix.startsWith('api/') ||
+    withoutPrefix === '_app' ||
+    withoutPrefix === '_document'
+  ) {
+    return null;
+  }
+  const segments = withoutPrefix.split('/').filter(Boolean);
+  if (segments.at(-1) === 'index') segments.pop();
+  return segments;
+}
+
+function collectPageRouteSegments(
+  directory = path.join(repoRoot, 'src', 'pages'),
+) {
+  const routes = [];
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      routes.push(...collectPageRouteSegments(entryPath));
+      continue;
+    }
+    if (!/\.(tsx|ts|jsx|js)$/.test(entry.name)) continue;
+    const segments = pageRouteSegments(entryPath);
+    if (segments) routes.push(segments);
+  }
+  return routes;
+}
+
+function routeSegments(route) {
+  return route.split(/[?#]/, 1)[0].split('/').filter(Boolean);
+}
+
+function segmentMatches(routeSegment, pageSegment) {
+  if (/^\[[^\]]+\]$/.test(pageSegment)) return true;
+  return routeSegment === pageSegment;
+}
+
+function routeMatchesPageSegments(route, pageSegments) {
+  const segments = routeSegments(route);
+  let routeIndex = 0;
+
+  for (let pageIndex = 0; pageIndex < pageSegments.length; pageIndex += 1) {
+    const pageSegment = pageSegments[pageIndex];
+    const isLastPageSegment = pageIndex === pageSegments.length - 1;
+
+    if (/^\[\[\.\.\.[^\]]+\]\]$/.test(pageSegment)) {
+      return isLastPageSegment;
+    }
+    if (/^\[\.\.\.[^\]]+\]$/.test(pageSegment)) {
+      return isLastPageSegment && routeIndex < segments.length;
+    }
+    if (routeIndex >= segments.length) return false;
+    if (!segmentMatches(segments[routeIndex], pageSegment)) return false;
+    routeIndex += 1;
+  }
+
+  return routeIndex === segments.length;
+}
+
+function routeMatchesAnyPage(route, pageRoutes) {
+  return pageRoutes.some((pageSegments) =>
+    routeMatchesPageSegments(route, pageSegments),
+  );
+}
+
+function validateFlowRoute(flowId, label, href, issues, pageRoutes) {
+  if (typeof href !== 'string' || href.trim() === '') {
+    issues.push(
+      issue('error', `UI flow ${flowId}: ${label} href is required.`),
+    );
+    return;
+  }
+  if (!href.startsWith('/')) {
+    issues.push(
+      issue(
+        'error',
+        `UI flow ${flowId}: ${label} route ${href} must start with /.`,
+      ),
+    );
+    return;
+  }
+  if (!routeMatchesAnyPage(href, pageRoutes)) {
+    issues.push(
+      issue(
+        'error',
+        `UI flow ${flowId}: ${label} route ${href} does not match a page template.`,
+      ),
+    );
+  }
+}
+
+export function validateUiFlowShell(uiFlowShell, catalog, graph) {
+  const issues = [];
+  const allowedVisibility = new Set(['player', 'gm', 'both']);
+  const allowedRoles = new Set(['player', 'gm']);
+  const pageRoutes = collectPageRouteSegments();
+
+  if (uiFlowShell.version !== 1) {
+    issues.push(issue('error', 'UI flow shell version must be 1.'));
+  }
+  if (!Array.isArray(uiFlowShell.requiredJourneyIds)) {
+    issues.push(
+      issue('error', 'UI flow shell must declare requiredJourneyIds array.'),
+    );
+  }
+  if (!Array.isArray(uiFlowShell.flows)) {
+    issues.push(issue('error', 'UI flow shell must declare flows array.'));
+    return issues;
+  }
+
+  const catalogJourneyIds = new Set(
+    catalog.journeys.map((journey) => journey.id),
+  );
+  const catalogById = new Map(
+    catalog.journeys.map((journey) => [journey.id, journey]),
+  );
+  const graphNodeIds = new Set(graph.nodes.map((node) => node.id));
+  const flowIds = new Set();
+
+  for (const [index, flow] of uiFlowShell.flows.entries()) {
+    const label = flow.journeyId || `flows[${index}]`;
+    if (typeof flow.journeyId !== 'string' || flow.journeyId.trim() === '') {
+      issues.push(
+        issue('error', `${label}: journeyId must be a non-empty string.`),
+      );
+      continue;
+    }
+    if (flowIds.has(flow.journeyId)) {
+      issues.push(
+        issue('error', `UI flow shell duplicates journey ${flow.journeyId}.`),
+      );
+    }
+    flowIds.add(flow.journeyId);
+
+    const catalogJourney = catalogById.get(flow.journeyId);
+    if (!catalogJourneyIds.has(flow.journeyId)) {
+      issues.push(
+        issue(
+          'error',
+          `UI flow shell references unknown journey ${flow.journeyId}.`,
+        ),
+      );
+    }
+    if (!graphNodeIds.has(`journey:${flow.journeyId}`)) {
+      issues.push(
+        issue(
+          'error',
+          `UI flow shell journey ${flow.journeyId} is missing from validation graph.`,
+        ),
+      );
+    }
+    if (catalogJourney && flow.module !== catalogJourney.module) {
+      issues.push(
+        issue(
+          'error',
+          `UI flow ${flow.journeyId}: module ${flow.module} does not match catalog module ${catalogJourney.module}.`,
+        ),
+      );
+    }
+    for (const field of ['displayName', 'module', 'qcCommand']) {
+      if (typeof flow[field] !== 'string' || flow[field].trim() === '') {
+        issues.push(
+          issue('error', `UI flow ${flow.journeyId}: ${field} is required.`),
+        );
+      }
+    }
+    if (
+      typeof flow.qcCommand === 'string' &&
+      !flow.qcCommand.includes(`--journey=${flow.journeyId}`)
+    ) {
+      issues.push(
+        issue(
+          'error',
+          `UI flow ${flow.journeyId}: qcCommand must include --journey=${flow.journeyId}.`,
+        ),
+      );
+    }
+    if (!Array.isArray(flow.roleIntent) || flow.roleIntent.length === 0) {
+      issues.push(
+        issue('error', `UI flow ${flow.journeyId}: roleIntent is required.`),
+      );
+    } else {
+      for (const role of flow.roleIntent) {
+        if (!allowedRoles.has(role)) {
+          issues.push(
+            issue('error', `UI flow ${flow.journeyId}: invalid role ${role}.`),
+          );
+        }
+      }
+    }
+    if (
+      !Array.isArray(flow.inspectionNotes) ||
+      flow.inspectionNotes.length === 0
+    ) {
+      issues.push(
+        issue(
+          'error',
+          `UI flow ${flow.journeyId}: inspectionNotes are required.`,
+        ),
+      );
+    }
+    if (!flow.primaryAction || typeof flow.primaryAction !== 'object') {
+      issues.push(
+        issue('error', `UI flow ${flow.journeyId}: primaryAction is required.`),
+      );
+    } else {
+      validateFlowRoute(
+        flow.journeyId,
+        'primary action',
+        flow.primaryAction.href,
+        issues,
+        pageRoutes,
+      );
+    }
+    if (!Array.isArray(flow.checkpoints) || flow.checkpoints.length === 0) {
+      issues.push(
+        issue('error', `UI flow ${flow.journeyId}: checkpoints are required.`),
+      );
+      continue;
+    }
+    const checkpointIds = new Set();
+    for (const checkpoint of flow.checkpoints) {
+      const checkpointLabel = checkpoint.id || 'checkpoint';
+      if (typeof checkpoint.id !== 'string' || checkpoint.id.trim() === '') {
+        issues.push(
+          issue(
+            'error',
+            `UI flow ${flow.journeyId}: checkpoint id is required.`,
+          ),
+        );
+      }
+      if (checkpointIds.has(checkpoint.id)) {
+        issues.push(
+          issue(
+            'error',
+            `UI flow ${flow.journeyId}: duplicate checkpoint ${checkpoint.id}.`,
+          ),
+        );
+      }
+      checkpointIds.add(checkpoint.id);
+      if (
+        typeof checkpoint.label !== 'string' ||
+        checkpoint.label.trim() === ''
+      ) {
+        issues.push(
+          issue(
+            'error',
+            `UI flow ${flow.journeyId}: checkpoint ${checkpointLabel} label is required.`,
+          ),
+        );
+      }
+      if (!allowedVisibility.has(checkpoint.visibility)) {
+        issues.push(
+          issue(
+            'error',
+            `UI flow ${flow.journeyId}: checkpoint ${checkpointLabel} has invalid visibility ${checkpoint.visibility}.`,
+          ),
+        );
+      }
+      validateFlowRoute(
+        flow.journeyId,
+        `checkpoint ${checkpointLabel}`,
+        checkpoint.href,
+        issues,
+        pageRoutes,
+      );
+    }
+  }
+
+  const requiredIds = catalog.requiredJourneyIds ?? requiredJourneyIds;
+  for (const requiredId of requiredIds) {
+    if (!flowIds.has(requiredId)) {
+      issues.push(
+        issue('error', `UI flow shell missing required journey ${requiredId}.`),
+      );
+    }
+  }
+  for (const requiredId of uiFlowShell.requiredJourneyIds ?? []) {
+    if (!flowIds.has(requiredId)) {
+      issues.push(
+        issue(
+          'error',
+          `UI flow shell requiredJourneyIds references unmapped journey ${requiredId}.`,
+        ),
+      );
+    }
+  }
+
+  return issues;
+}
+
 export function printIssues(issues) {
   for (const item of issues) {
     const prefix = item.severity === 'error' ? 'ERROR' : 'WARN';
@@ -568,16 +870,23 @@ export function printIssues(issues) {
 }
 
 export function validationSummary() {
-  const { catalog, graph, loggingMap } = loadJourneyArtifacts();
+  const { catalog, graph, loggingMap, uiFlowShell } = loadJourneyArtifacts();
   const catalogIssues = validateJourneyCatalog(catalog);
   const graphIssues = validateValidationGraph(graph, catalog);
   const loggingIssues = validateLoggingMap(loggingMap, catalog);
-  const issues = [...catalogIssues, ...graphIssues, ...loggingIssues];
+  const uiFlowIssues = validateUiFlowShell(uiFlowShell, catalog, graph);
+  const issues = [
+    ...catalogIssues,
+    ...graphIssues,
+    ...loggingIssues,
+    ...uiFlowIssues,
+  ];
   return {
     catalog,
     graph,
     issues,
     loggingMap,
+    uiFlowShell,
     errors: issues.filter((item) => item.severity === 'error'),
     warnings: issues.filter((item) => item.severity === 'warning'),
   };

--- a/scripts/qc/validate-journey-qc.mjs
+++ b/scripts/qc/validate-journey-qc.mjs
@@ -17,7 +17,7 @@ if (options.parameters['logging-only'] === 'true') {
 
 printIssues(issues);
 console.log(
-  `[qc:journeys:validate] catalog=${summary.catalog.journeys.length} journeys graph=${summary.graph.nodes.length} nodes errors=${summary.errors.length} warnings=${summary.warnings.length}`,
+  `[qc:journeys:validate] catalog=${summary.catalog.journeys.length} journeys graph=${summary.graph.nodes.length} nodes uiFlows=${summary.uiFlowShell.flows.length} errors=${summary.errors.length} warnings=${summary.warnings.length}`,
 );
 
 process.exit(summary.errors.length > 0 ? 1 : 0);

--- a/src/components/gameplay/GameplayFlowShell.tsx
+++ b/src/components/gameplay/GameplayFlowShell.tsx
@@ -1,0 +1,137 @@
+import Link from 'next/link';
+
+import { GAMEPLAY_UI_FLOWS } from '@/qc/gameplayUiFlowShell';
+
+import { Badge } from '../ui';
+
+const visibilityLabel = {
+  player: 'Player',
+  gm: 'GM',
+  both: 'Both',
+} as const;
+
+const visibilityClass = {
+  player: 'border-cyan-500/30 bg-cyan-500/10 text-cyan-300',
+  gm: 'border-amber-500/30 bg-amber-500/10 text-amber-300',
+  both: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300',
+} as const;
+
+export function GameplayFlowShell(): React.ReactElement {
+  return (
+    <section
+      aria-labelledby="gameplay-flow-shell-heading"
+      className="border-border-theme-subtle mb-8 border-y py-5"
+      data-testid="gameplay-flow-shell"
+    >
+      <div className="mb-4 flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+        <div>
+          <h2
+            id="gameplay-flow-shell-heading"
+            className="text-text-theme-primary text-xl font-semibold"
+          >
+            Validated Gameplay Flows
+          </h2>
+          <p className="text-text-theme-secondary mt-1 max-w-3xl text-sm">
+            Journey-backed launch and inspection paths for player and GM
+            operations.
+          </p>
+        </div>
+        <Badge variant="cyan" size="md" pill>
+          {GAMEPLAY_UI_FLOWS.length} journeys
+        </Badge>
+      </div>
+
+      <div className="border-border-theme-subtle overflow-x-auto border">
+        <table className="divide-border-theme-subtle min-w-full divide-y text-left text-sm">
+          <thead className="bg-surface-base/40 text-text-theme-secondary">
+            <tr>
+              <th className="px-4 py-3 font-medium">Flow</th>
+              <th className="px-4 py-3 font-medium">Route Sequence</th>
+              <th className="px-4 py-3 font-medium">QC Command</th>
+              <th className="px-4 py-3 font-medium">Inspection</th>
+            </tr>
+          </thead>
+          <tbody className="divide-border-theme-subtle divide-y">
+            {GAMEPLAY_UI_FLOWS.map((flow) => (
+              <tr
+                key={flow.journeyId}
+                className="align-top"
+                data-testid={`gameplay-flow-row-${flow.journeyId}`}
+              >
+                <td className="w-64 px-4 py-4">
+                  <div className="space-y-2">
+                    <div>
+                      <div className="text-text-theme-primary font-medium">
+                        {flow.displayName}
+                      </div>
+                      <div className="text-text-theme-muted font-mono text-xs">
+                        {flow.journeyId}
+                      </div>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <Badge variant="slate" size="sm">
+                        {flow.module}
+                      </Badge>
+                      {flow.roleIntent.map((role) => (
+                        <Badge
+                          key={role}
+                          variant={role === 'gm' ? 'amber' : 'cyan'}
+                          size="sm"
+                        >
+                          {role === 'gm' ? 'GM' : 'Player'}
+                        </Badge>
+                      ))}
+                    </div>
+                    <Link
+                      className="inline-flex text-sm font-medium !text-cyan-300 hover:!text-cyan-200 hover:underline"
+                      href={flow.primaryAction.href}
+                      data-testid={`gameplay-flow-action-${flow.journeyId}`}
+                    >
+                      {flow.primaryAction.label}
+                    </Link>
+                  </div>
+                </td>
+                <td className="min-w-[22rem] px-4 py-4">
+                  <ol
+                    className="flex flex-wrap gap-2"
+                    data-testid={`gameplay-flow-checkpoints-${flow.journeyId}`}
+                  >
+                    {flow.checkpoints.map((checkpoint, index) => (
+                      <li
+                        key={checkpoint.id}
+                        className={`rounded border px-2 py-1 ${visibilityClass[checkpoint.visibility]}`}
+                        data-testid={`gameplay-flow-checkpoint-${flow.journeyId}-${checkpoint.id}`}
+                      >
+                        <span className="font-medium">
+                          {index + 1}. {checkpoint.label}
+                        </span>
+                        <span className="ml-2 text-xs opacity-80">
+                          {visibilityLabel[checkpoint.visibility]}
+                        </span>
+                        <div className="font-mono text-[11px] opacity-75">
+                          {checkpoint.href}
+                        </div>
+                      </li>
+                    ))}
+                  </ol>
+                </td>
+                <td className="w-72 px-4 py-4">
+                  <code className="text-text-theme-secondary bg-surface-raised rounded px-2 py-1 text-xs break-all">
+                    {flow.qcCommand}
+                  </code>
+                </td>
+                <td className="w-80 px-4 py-4">
+                  <ul className="text-text-theme-secondary list-disc space-y-1 pl-4 text-sm">
+                    {flow.inspectionNotes.map((note) => (
+                      <li key={note}>{note}</li>
+                    ))}
+                  </ul>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/src/components/gameplay/__tests__/GameplayFlowShell.test.tsx
+++ b/src/components/gameplay/__tests__/GameplayFlowShell.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen, within } from '@testing-library/react';
+
+import GameplayHubPage from '@/pages/gameplay';
+import { GAMEPLAY_UI_FLOW_SHELL } from '@/qc/gameplayUiFlowShell';
+
+import { GameplayFlowShell } from '../GameplayFlowShell';
+
+describe('GameplayFlowShell', () => {
+  it('renders every required journey-backed flow', () => {
+    render(<GameplayFlowShell />);
+
+    for (const journeyId of GAMEPLAY_UI_FLOW_SHELL.requiredJourneyIds) {
+      expect(
+        screen.getByTestId(`gameplay-flow-row-${journeyId}`),
+      ).toBeInTheDocument();
+    }
+  });
+
+  it('preserves contract campaign route checkpoint order', () => {
+    render(<GameplayFlowShell />);
+
+    const checkpointList = screen.getByTestId(
+      'gameplay-flow-checkpoints-contract-campaign',
+    );
+    const checkpointText = within(checkpointList)
+      .getAllByRole('listitem')
+      .map((item) => item.textContent);
+
+    expect(checkpointText).toEqual([
+      expect.stringContaining('1. Campaign base'),
+      expect.stringContaining('2. Contract market'),
+      expect.stringContaining('3. Mission launch'),
+      expect.stringContaining('4. Tactical combat'),
+      expect.stringContaining('5. Post-combat report'),
+      expect.stringContaining('6. Salvage'),
+      expect.stringContaining('7. Repair bay'),
+      expect.stringContaining('8. Finances'),
+      expect.stringContaining('9. Campaign log'),
+    ]);
+  });
+
+  it('exposes QC command and GM inspection intent for combat flows', () => {
+    render(<GameplayFlowShell />);
+
+    const row = screen.getByTestId('gameplay-flow-row-combat-1v1');
+    expect(row).toHaveTextContent(
+      'npm.cmd run qc:journeys -- --journey=combat-1v1',
+    );
+    expect(row).toHaveTextContent('GM review');
+    expect(row).toHaveTextContent('GM inspection');
+  });
+});
+
+describe('GameplayHubPage flow shell integration', () => {
+  it('keeps existing gameplay navigation cards while showing the flow shell', () => {
+    render(<GameplayHubPage />);
+
+    expect(screen.getByTestId('gameplay-flow-shell')).toBeInTheDocument();
+    expect(screen.getByText('Quick Game')).toBeInTheDocument();
+    expect(screen.getByText('Pilots')).toBeInTheDocument();
+    expect(screen.getByText('Forces')).toBeInTheDocument();
+    expect(screen.getByText('Campaigns')).toBeInTheDocument();
+    expect(screen.getByText('Encounters')).toBeInTheDocument();
+    expect(screen.getByText('Games')).toBeInTheDocument();
+    expect(screen.getByText('Multiplayer')).toBeInTheDocument();
+  });
+});

--- a/src/pages/gameplay/index.tsx
+++ b/src/pages/gameplay/index.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 
 import { getGameplayNavItems } from '@/components/common/gameplayNavItems';
+import { GameplayFlowShell } from '@/components/gameplay/GameplayFlowShell';
 import { PageLayout, Card } from '@/components/ui';
 
 export default function GameplayHubPage(): React.ReactElement {
@@ -12,6 +13,8 @@ export default function GameplayHubPage(): React.ReactElement {
       subtitle="Start battles, manage forces, and continue campaign operations."
       maxWidth="wide"
     >
+      <GameplayFlowShell />
+
       <div className="grid grid-cols-1 gap-4 pb-20 md:grid-cols-2 lg:grid-cols-3">
         {gameplayItems.map((item) => (
           <Link key={item.href} href={item.href} className="block h-full">

--- a/src/qc/gameplayUiFlowShell.json
+++ b/src/qc/gameplayUiFlowShell.json
@@ -1,0 +1,394 @@
+{
+  "version": 1,
+  "title": "MekStation gameplay UI flow shell",
+  "sourceCatalog": "docs/qc/mekstation-journey-scenarios.json",
+  "sourceGraph": "docs/qc/mekstation-qc-validation-graph.json",
+  "requiredJourneyIds": [
+    "character-build",
+    "mek-build",
+    "combat-1v1",
+    "combat-4v4",
+    "contract-campaign",
+    "campaign-short",
+    "campaign-long"
+  ],
+  "flows": [
+    {
+      "journeyId": "character-build",
+      "displayName": "Character build",
+      "module": "roster",
+      "roleIntent": ["player"],
+      "primaryAction": {
+        "label": "Create pilot",
+        "href": "/gameplay/pilots/create"
+      },
+      "qcCommand": "npm.cmd run qc:journeys -- --journey=character-build --tier=smoke",
+      "inspectionNotes": [
+        "Player-visible roster creation and export evidence",
+        "GM review is limited to roster readiness and force assignment"
+      ],
+      "checkpoints": [
+        {
+          "id": "pilot-create",
+          "label": "Pilot creation",
+          "href": "/gameplay/pilots/create",
+          "visibility": "player"
+        },
+        {
+          "id": "pilot-roster",
+          "label": "Roster inspection",
+          "href": "/gameplay/pilots",
+          "visibility": "both"
+        },
+        {
+          "id": "force-assignment",
+          "label": "Force assignment",
+          "href": "/gameplay/forces/create",
+          "visibility": "both"
+        }
+      ]
+    },
+    {
+      "journeyId": "mek-build",
+      "displayName": "BattleMech build",
+      "module": "construction",
+      "roleIntent": ["player", "gm"],
+      "primaryAction": {
+        "label": "Open customizer",
+        "href": "/customizer"
+      },
+      "qcCommand": "npm.cmd run qc:journeys -- --journey=mek-build --tier=smoke",
+      "inspectionNotes": [
+        "Player-visible BattleMech construction and export evidence",
+        "GM can inspect campaign Mech Bay state before encounter launch"
+      ],
+      "checkpoints": [
+        {
+          "id": "customizer",
+          "label": "BattleMech customizer",
+          "href": "/customizer",
+          "visibility": "player"
+        },
+        {
+          "id": "unit-catalog",
+          "label": "Unit catalog",
+          "href": "/units",
+          "visibility": "both"
+        },
+        {
+          "id": "force-roster",
+          "label": "Force roster",
+          "href": "/gameplay/forces",
+          "visibility": "both"
+        },
+        {
+          "id": "campaign-mech-bay",
+          "label": "Campaign Mech Bay",
+          "href": "/gameplay/campaigns/:campaignId/mech-bay",
+          "visibility": "gm"
+        }
+      ]
+    },
+    {
+      "journeyId": "combat-1v1",
+      "displayName": "BattleMech 1v1 combat",
+      "module": "combat",
+      "roleIntent": ["player", "gm"],
+      "primaryAction": {
+        "label": "Start duel",
+        "href": "/gameplay/quick"
+      },
+      "qcCommand": "npm.cmd run qc:journeys -- --journey=combat-1v1 --seed=42 --player-units=1 --opponent-units=1",
+      "inspectionNotes": [
+        "Player-visible duel setup, tactical combat, and post-battle outcome",
+        "GM inspection covers invalid action reasons and intervention review"
+      ],
+      "checkpoints": [
+        {
+          "id": "quick-setup",
+          "label": "Quick setup",
+          "href": "/gameplay/quick",
+          "visibility": "player"
+        },
+        {
+          "id": "encounter-create",
+          "label": "Encounter draft",
+          "href": "/gameplay/encounters/create",
+          "visibility": "both"
+        },
+        {
+          "id": "pre-battle",
+          "label": "Pre-battle launch",
+          "href": "/gameplay/encounters/:encounterId/pre-battle",
+          "visibility": "both"
+        },
+        {
+          "id": "tactical-combat",
+          "label": "Tactical combat",
+          "href": "/gameplay/games/:gameId",
+          "visibility": "player"
+        },
+        {
+          "id": "gm-review",
+          "label": "GM review",
+          "href": "/gameplay/games/:gameId/review",
+          "visibility": "gm"
+        },
+        {
+          "id": "victory",
+          "label": "Post-battle report",
+          "href": "/gameplay/games/:gameId/victory",
+          "visibility": "both"
+        }
+      ]
+    },
+    {
+      "journeyId": "combat-4v4",
+      "displayName": "BattleMech 4v4 combat",
+      "module": "combat",
+      "roleIntent": ["player", "gm"],
+      "primaryAction": {
+        "label": "Build lance encounter",
+        "href": "/gameplay/encounters/create"
+      },
+      "qcCommand": "npm.cmd run qc:journeys -- --journey=combat-4v4 --seed=42 --player-units=4 --opponent-units=4",
+      "inspectionNotes": [
+        "Player-visible lance setup, tactical combat, terminal outcome, and replay",
+        "GM inspection covers intervention review and replay reference checks"
+      ],
+      "checkpoints": [
+        {
+          "id": "force-build",
+          "label": "Lance force setup",
+          "href": "/gameplay/forces/create",
+          "visibility": "both"
+        },
+        {
+          "id": "encounter-create",
+          "label": "Encounter draft",
+          "href": "/gameplay/encounters/create",
+          "visibility": "both"
+        },
+        {
+          "id": "pre-battle",
+          "label": "Pre-battle launch",
+          "href": "/gameplay/encounters/:encounterId/pre-battle",
+          "visibility": "both"
+        },
+        {
+          "id": "tactical-combat",
+          "label": "Tactical combat",
+          "href": "/gameplay/games/:gameId",
+          "visibility": "player"
+        },
+        {
+          "id": "gm-review",
+          "label": "GM review",
+          "href": "/gameplay/games/:gameId/review",
+          "visibility": "gm"
+        },
+        {
+          "id": "replay",
+          "label": "Replay reference",
+          "href": "/gameplay/games/:gameId/replay",
+          "visibility": "both"
+        }
+      ]
+    },
+    {
+      "journeyId": "contract-campaign",
+      "displayName": "Contract campaign scenario",
+      "module": "campaign",
+      "roleIntent": ["player", "gm"],
+      "primaryAction": {
+        "label": "Open contracts",
+        "href": "/gameplay/campaigns"
+      },
+      "qcCommand": "npm.cmd run qc:journeys -- --journey=contract-campaign --tier=smoke",
+      "inspectionNotes": [
+        "Player-visible contract selection, encounter, post-combat, salvage, repair, and finance state",
+        "GM authority applies to approved net effects, not hidden rationale in player logs"
+      ],
+      "checkpoints": [
+        {
+          "id": "campaign-base",
+          "label": "Campaign base",
+          "href": "/gameplay/campaigns/:campaignId",
+          "visibility": "both"
+        },
+        {
+          "id": "contract-market",
+          "label": "Contract market",
+          "href": "/gameplay/campaigns/:campaignId/contract-market",
+          "visibility": "player"
+        },
+        {
+          "id": "mission-launch",
+          "label": "Mission launch",
+          "href": "/gameplay/campaigns/:campaignId/missions/:missionId/launch",
+          "visibility": "both"
+        },
+        {
+          "id": "tactical-combat",
+          "label": "Tactical combat",
+          "href": "/gameplay/games/:gameId",
+          "visibility": "player"
+        },
+        {
+          "id": "post-combat",
+          "label": "Post-combat report",
+          "href": "/gameplay/games/:gameId/victory",
+          "visibility": "both"
+        },
+        {
+          "id": "salvage",
+          "label": "Salvage",
+          "href": "/gameplay/campaigns/:campaignId/salvage",
+          "visibility": "both"
+        },
+        {
+          "id": "repair",
+          "label": "Repair bay",
+          "href": "/gameplay/campaigns/:campaignId/repair-bay",
+          "visibility": "both"
+        },
+        {
+          "id": "economy",
+          "label": "Finances",
+          "href": "/gameplay/campaigns/:campaignId/finances",
+          "visibility": "both"
+        },
+        {
+          "id": "gm-log",
+          "label": "Campaign log",
+          "href": "/gameplay/campaigns/:campaignId/log",
+          "visibility": "gm"
+        }
+      ]
+    },
+    {
+      "journeyId": "campaign-short",
+      "displayName": "Short campaign",
+      "module": "campaign",
+      "roleIntent": ["player", "gm"],
+      "primaryAction": {
+        "label": "Continue campaign",
+        "href": "/gameplay/campaigns"
+      },
+      "qcCommand": "npm.cmd run qc:journeys -- --journey=campaign-short --contracts=5",
+      "inspectionNotes": [
+        "Player-visible 3-5 contract loop with repair, salvage, personnel, and funds",
+        "GM inspection focuses on accumulated state between contracts"
+      ],
+      "checkpoints": [
+        {
+          "id": "campaign-base",
+          "label": "Campaign base",
+          "href": "/gameplay/campaigns/:campaignId",
+          "visibility": "both"
+        },
+        {
+          "id": "starmap",
+          "label": "Starmap",
+          "href": "/gameplay/campaigns/:campaignId/starmap",
+          "visibility": "both"
+        },
+        {
+          "id": "contracts",
+          "label": "Contracts",
+          "href": "/gameplay/campaigns/:campaignId/contract-market",
+          "visibility": "player"
+        },
+        {
+          "id": "missions",
+          "label": "Missions",
+          "href": "/gameplay/campaigns/:campaignId/missions",
+          "visibility": "both"
+        },
+        {
+          "id": "repair",
+          "label": "Repair bay",
+          "href": "/gameplay/campaigns/:campaignId/repair-bay",
+          "visibility": "both"
+        },
+        {
+          "id": "personnel",
+          "label": "Personnel",
+          "href": "/gameplay/campaigns/:campaignId/personnel",
+          "visibility": "both"
+        },
+        {
+          "id": "finances",
+          "label": "Finances",
+          "href": "/gameplay/campaigns/:campaignId/finances",
+          "visibility": "both"
+        },
+        {
+          "id": "campaign-log",
+          "label": "Campaign log",
+          "href": "/gameplay/campaigns/:campaignId/log",
+          "visibility": "gm"
+        }
+      ]
+    },
+    {
+      "journeyId": "campaign-long",
+      "displayName": "Long campaign",
+      "module": "campaign",
+      "roleIntent": ["player", "gm"],
+      "primaryAction": {
+        "label": "Inspect campaign",
+        "href": "/gameplay/campaigns"
+      },
+      "qcCommand": "npm.cmd run qc:journeys -- --journey=campaign-long --tier=extended --contracts=10",
+      "inspectionNotes": [
+        "Player-visible 6-10 contract loop with long-running campaign state",
+        "GM inspection focuses on time, recovery, market, and accumulated-economy drift"
+      ],
+      "checkpoints": [
+        {
+          "id": "campaign-base",
+          "label": "Campaign base",
+          "href": "/gameplay/campaigns/:campaignId",
+          "visibility": "both"
+        },
+        {
+          "id": "starmap",
+          "label": "Starmap",
+          "href": "/gameplay/campaigns/:campaignId/starmap",
+          "visibility": "both"
+        },
+        {
+          "id": "medical",
+          "label": "Medical bay",
+          "href": "/gameplay/campaigns/:campaignId/medical-bay",
+          "visibility": "both"
+        },
+        {
+          "id": "salvage",
+          "label": "Salvage",
+          "href": "/gameplay/campaigns/:campaignId/salvage",
+          "visibility": "both"
+        },
+        {
+          "id": "repair",
+          "label": "Repair bay",
+          "href": "/gameplay/campaigns/:campaignId/repair-bay",
+          "visibility": "both"
+        },
+        {
+          "id": "finances",
+          "label": "Finances",
+          "href": "/gameplay/campaigns/:campaignId/finances",
+          "visibility": "both"
+        },
+        {
+          "id": "campaign-log",
+          "label": "Campaign log",
+          "href": "/gameplay/campaigns/:campaignId/log",
+          "visibility": "gm"
+        }
+      ]
+    }
+  ]
+}

--- a/src/qc/gameplayUiFlowShell.ts
+++ b/src/qc/gameplayUiFlowShell.ts
@@ -1,0 +1,41 @@
+import rawGameplayUiFlowShell from './gameplayUiFlowShell.json';
+
+export type GameplayUiFlowRole = 'player' | 'gm';
+export type GameplayUiFlowCheckpointVisibility = 'player' | 'gm' | 'both';
+
+export interface IGameplayUiFlowAction {
+  readonly label: string;
+  readonly href: string;
+}
+
+export interface IGameplayUiFlowCheckpoint {
+  readonly id: string;
+  readonly label: string;
+  readonly href: string;
+  readonly visibility: GameplayUiFlowCheckpointVisibility;
+}
+
+export interface IGameplayUiFlow {
+  readonly journeyId: string;
+  readonly displayName: string;
+  readonly module: string;
+  readonly roleIntent: readonly GameplayUiFlowRole[];
+  readonly primaryAction: IGameplayUiFlowAction;
+  readonly qcCommand: string;
+  readonly inspectionNotes: readonly string[];
+  readonly checkpoints: readonly IGameplayUiFlowCheckpoint[];
+}
+
+export interface IGameplayUiFlowShell {
+  readonly version: 1;
+  readonly title: string;
+  readonly sourceCatalog: string;
+  readonly sourceGraph: string;
+  readonly requiredJourneyIds: readonly string[];
+  readonly flows: readonly IGameplayUiFlow[];
+}
+
+export const GAMEPLAY_UI_FLOW_SHELL: IGameplayUiFlowShell =
+  rawGameplayUiFlowShell as IGameplayUiFlowShell;
+
+export const GAMEPLAY_UI_FLOWS = GAMEPLAY_UI_FLOW_SHELL.flows;


### PR DESCRIPTION
## Summary
- add a tracked gameplay UI flow registry covering all seven journey QC scenarios
- render the flow shell on /gameplay with primary actions, route checkpoints, QC commands, and GM/player inspection notes
- extend journey QC validation and tests so UI flow drift fails alongside catalog and graph drift
- archive the add-ui-flow-shell OpenSpec change into canonical specs

## Validation
- npm.cmd run verify
- openspec.cmd validate --all --strict
- git diff --check
- npx.cmd jest --selectProjects unit --ci --runTestsByPath src/components/gameplay/__tests__/GameplayFlowShell.test.tsx scripts/__tests__/journey-qc.test.ts --no-coverage

## Notes
- Full browser-backed execution of each journey remains later wave work.