### PR TITLE
Trust shared tactical projection frames

### DIFF
--- a/openspec/changes/archive/2026-06-22-add-tactical-map-projection-parity/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-22-add-tactical-map-projection-parity/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-22

--- a/openspec/changes/archive/2026-06-22-add-tactical-map-projection-parity/design.md
+++ b/openspec/changes/archive/2026-06-22-add-tactical-map-projection-parity/design.md
@@ -1,0 +1,52 @@
+## Context
+
+`HexMapDisplay` currently derives a `tacticalMapProjectionLookup` internally from terrain, movement range, combat range, highlighted path, and legacy attack range inputs. Individual hexes already consume that lookup and expose projection status, movement cost, blocked reasons, LOS blocker references, source references, and explanation data attributes. The remaining architectural gap is that callers cannot pass the shared projection frame as the primary data contract, so drift between engine projection and UI-derived fallback can be hidden.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add a typed projection frame boundary that carries the lookup plus source metadata.
+- Prefer supplied shared projection frames over locally-derived fallback projections.
+- Expose frame source and coverage diagnostics for QC and automated tests.
+- Keep the existing public props working while identifying them as fallback-derived projection input.
+
+**Non-Goals:**
+- Rewrite movement or combat validation engines.
+- Remove legacy props in this wave.
+- Expand official rules catalog coverage beyond the projection contract.
+
+## Decisions
+
+1. **Use an explicit projection frame object instead of a bare lookup.**
+   - A bare lookup would let the UI render from shared data, but it would not prove where the data came from or whether it covers the rendered map.
+   - The frame records `source`, `lookup`, and optional metadata so tests and QC can distinguish `shared-engine-projection` from `hex-map-derived-fallback`.
+
+2. **Fallback remains local and backward-compatible.**
+   - Existing callers pass `movementRange`, `attackRange`, terrain, and combat options. Removing those in one wave would be noisy and risky.
+   - The fallback path keeps behavior stable while exposing provenance attributes that make future migration measurable.
+
+3. **Coverage warnings are diagnostics, not runtime exceptions.**
+   - Throwing on missing hexes would make partial test fixtures and future progressive rendering brittle.
+   - Diagnostics on the map container provide a testable and user-debuggable signal without interrupting gameplay.
+
+4. **Hex rendering continues to consume `ITacticalMapHexProjection`.**
+   - The existing per-hex projection shape already carries terrain, movement, combat, LOS blocker references, statuses, blocked reasons, and explanation text.
+   - This wave strengthens the boundary around that shape instead of introducing a parallel projection model.
+
+## Risks / Trade-offs
+
+- **Risk:** Callers may keep using fallback inputs indefinitely. -> **Mitigation:** expose `data-tactical-projection-frame-source` so QC and journey tests can require shared frames in specific flows later.
+- **Risk:** A supplied frame may omit hexes. -> **Mitigation:** compute missing rendered hex keys and expose them as diagnostics.
+- **Risk:** Duplicate data paths can confuse maintainers. -> **Mitigation:** document fallback as compatibility-only and add tests that prove shared frames take precedence.
+
+## Migration Plan
+
+1. Introduce projection frame types and optional `HexMapDisplay` prop.
+2. Wrap the existing local derivation in a fallback frame.
+3. Prefer supplied frames and add provenance/coverage attributes.
+4. Add focused tests for shared-frame precedence and missing-hex diagnostics.
+5. Later waves can update higher-level tactical game surfaces to provide shared-engine frames directly and make QC require that source.
+
+## Open Questions
+
+- Which top-level gameplay page should be the first mandatory shared-frame caller in a later browser-backed journey wave?

--- a/openspec/changes/archive/2026-06-22-add-tactical-map-projection-parity/proposal.md
+++ b/openspec/changes/archive/2026-06-22-add-tactical-map-projection-parity/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The tactical map is already rich enough to explain movement, combat, LOS, terrain, elevation, overlays, and invalid reasons, but its public component boundary still accepts those channels as separate legacy inputs. Wave 7 makes the shared tactical projection data an explicit UI contract so previews can be proven to match the engine-facing projection surface before players commit actions.
+
+## What Changes
+
+- Add an explicit tactical projection frame input for `HexMapDisplay` so callers can provide the shared projection lookup directly.
+- Preserve the current locally-derived projection path as a compatibility fallback, but mark its source so QC and tests can distinguish it from supplied shared projection data.
+- Surface projection frame provenance, coverage, and missing-hex diagnostics on the map container/layer.
+- Lock the behavior with tests that prove rendered hexes, hover context, overlays, and invalid reasons are driven by the shared projection frame.
+
+## Capabilities
+
+### New Capabilities
+- None.
+
+### Modified Capabilities
+- `tactical-map-interface`: the tactical map projection layer becomes an explicit component contract with provenance and coverage diagnostics.
+
+## Impact
+
+- Affected UI: `src/components/gameplay/HexMapDisplay/*`.
+- Affected shared projection types: `src/utils/gameplay/tacticalMapProjection*`.
+- Affected tests: HexMapDisplay projection tests and tactical projection unit tests.
+- No external dependencies, persistence migrations, or BattleTech rules data changes.
+
+## Non-goals
+
+- This change does not complete every remaining BattleTech movement/combat rules gap.
+- This change does not replace the existing movement agreement suite or combat validation catalog.
+- This change does not remove legacy `movementRange` / `attackRange` props; it makes their fallback status explicit.

--- a/openspec/changes/archive/2026-06-22-add-tactical-map-projection-parity/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/archive/2026-06-22-add-tactical-map-projection-parity/specs/tactical-map-interface/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Shared Tactical Projection Frame Contract
+The tactical map interface SHALL accept an explicit shared tactical projection frame that contains the per-hex projection lookup and source metadata for movement, combat, terrain, elevation, LOS, overlays, and invalid reasons. When a shared frame is supplied, rendered hex state SHALL be driven by that frame instead of re-derived from legacy movement or attack range props.
+
+#### Scenario: Supplied shared frame drives rendered hex explanation
+- **GIVEN** `HexMapDisplay` receives a shared tactical projection frame with terrain, movement, combat, blocked reason, source reference, and explanation data for a hex
+- **WHEN** the hex renders
+- **THEN** the hex SHALL expose projection status, movement status, combat status, blocked reasons, source references, and explanation from the supplied frame
+- **AND** the map SHALL identify the projection source as shared projection data
+
+#### Scenario: Local fallback is marked explicitly
+- **GIVEN** `HexMapDisplay` receives legacy movement, terrain, or attack range props without a shared tactical projection frame
+- **WHEN** the map derives its projection lookup internally
+- **THEN** the map SHALL identify the projection source as a fallback-derived frame
+- **AND** rendered hexes SHALL continue to expose projection explanation data for backward compatibility
+
+#### Scenario: Missing shared projection coverage is diagnosable
+- **GIVEN** `HexMapDisplay` receives a shared tactical projection frame that does not cover every rendered hex
+- **WHEN** the map renders
+- **THEN** the map SHALL expose the missing rendered hex keys as projection coverage diagnostics
+- **AND** the missing coverage SHALL NOT be hidden by silently substituting legacy projection data for those hexes
+
+#### Scenario: Shared frame takes precedence over legacy props
+- **GIVEN** `HexMapDisplay` receives both a shared tactical projection frame and conflicting legacy movement or attack range props
+- **WHEN** the same hex appears in both inputs
+- **THEN** rendered projection status, invalid reasons, and explanations SHALL come from the shared frame
+- **AND** automated tests SHALL fail if the legacy props override the supplied frame

--- a/openspec/changes/archive/2026-06-22-add-tactical-map-projection-parity/tasks.md
+++ b/openspec/changes/archive/2026-06-22-add-tactical-map-projection-parity/tasks.md
@@ -1,0 +1,17 @@
+## 1. Specification
+
+- [x] 1.1 Create Wave 7 proposal, design, and tactical-map-interface delta spec.
+- [x] 1.2 Validate the active OpenSpec change before implementation.
+
+## 2. Implementation
+
+- [x] 2.1 Add a typed tactical projection frame contract and fallback frame source metadata.
+- [x] 2.2 Update `HexMapDisplay` state to prefer supplied shared frames over locally-derived fallback data.
+- [x] 2.3 Expose frame source, hex count, and missing-coverage diagnostics on the map surface.
+
+## 3. Validation
+
+- [x] 3.1 Add focused tests proving shared-frame precedence, explanation rendering, fallback provenance, and missing-hex diagnostics.
+- [x] 3.2 Run focused projection/map tests.
+- [x] 3.3 Run OpenSpec strict validation and full project verification.
+- [x] 3.4 Archive the OpenSpec change after validation passes.

--- a/openspec/specs/tactical-map-interface/spec.md
+++ b/openspec/specs/tactical-map-interface/spec.md
@@ -3847,6 +3847,33 @@ hover/selection props rather than baked into the shared projection objects.
 - **AND** every non-selected hex SHALL render the same projection intent, status,
   blocked reasons, and source references it rendered before the decoupling.
 
+### Requirement: Shared Tactical Projection Frame Contract
+The tactical map interface SHALL accept an explicit shared tactical projection frame that contains the per-hex projection lookup and source metadata for movement, combat, terrain, elevation, LOS, overlays, and invalid reasons. When a shared frame is supplied, rendered hex state SHALL be driven by that frame instead of re-derived from legacy movement or attack range props.
+
+#### Scenario: Supplied shared frame drives rendered hex explanation
+- **GIVEN** `HexMapDisplay` receives a shared tactical projection frame with terrain, movement, combat, blocked reason, source reference, and explanation data for a hex
+- **WHEN** the hex renders
+- **THEN** the hex SHALL expose projection status, movement status, combat status, blocked reasons, source references, and explanation from the supplied frame
+- **AND** the map SHALL identify the projection source as shared projection data
+
+#### Scenario: Local fallback is marked explicitly
+- **GIVEN** `HexMapDisplay` receives legacy movement, terrain, or attack range props without a shared tactical projection frame
+- **WHEN** the map derives its projection lookup internally
+- **THEN** the map SHALL identify the projection source as a fallback-derived frame
+- **AND** rendered hexes SHALL continue to expose projection explanation data for backward compatibility
+
+#### Scenario: Missing shared projection coverage is diagnosable
+- **GIVEN** `HexMapDisplay` receives a shared tactical projection frame that does not cover every rendered hex
+- **WHEN** the map renders
+- **THEN** the map SHALL expose the missing rendered hex keys as projection coverage diagnostics
+- **AND** the missing coverage SHALL NOT be hidden by silently substituting legacy projection data for those hexes
+
+#### Scenario: Shared frame takes precedence over legacy props
+- **GIVEN** `HexMapDisplay` receives both a shared tactical projection frame and conflicting legacy movement or attack range props
+- **WHEN** the same hex appears in both inputs
+- **THEN** rendered projection status, invalid reasons, and explanations SHALL come from the shared frame
+- **AND** automated tests SHALL fail if the legacy props override the supplied frame
+
 ## Data Model Requirements
 
 ### Required Interfaces

--- a/src/components/gameplay/HexMapDisplay/HexMapDisplay.state.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexMapDisplay.state.tsx
@@ -1,6 +1,11 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
-import type { IHexCoordinate } from '@/types/gameplay';
+import type {
+  ICombatRangeHex,
+  IHexCoordinate,
+  IHexTerrain,
+} from '@/types/gameplay';
+import type { ITacticalMapProjectionFrame } from '@/utils/gameplay/tacticalMapProjection';
 
 import { useScreenShake } from '@/hooks/useScreenShake';
 import { useAnimationQueue } from '@/stores/useAnimationQueue';
@@ -74,6 +79,7 @@ export function useHexMapDisplayState({
   selectedHex,
   hexTerrain = EMPTY_HEX_TERRAIN,
   movementRange = EMPTY_MOVEMENT_RANGE,
+  tacticalProjectionFrame: suppliedTacticalProjectionFrame,
   attackRange = EMPTY_ATTACK_RANGE,
   targetUnitId = null,
   unitWeapons = EMPTY_UNIT_WEAPONS,
@@ -105,10 +111,18 @@ export function useHexMapDisplayState({
     interaction.showElevationBadges &&
     interaction.zoom >= ELEVATION_BADGE_MIN_ZOOM;
   const hexes = useMemo(() => generateHexesInRadius(radius), [radius]);
-  const terrainLookup = useTerrainLookup(hexTerrain);
+  const effectiveHexTerrain = useMemo(
+    () =>
+      buildEffectiveHexTerrainFromProjectionFrame(
+        hexTerrain,
+        suppliedTacticalProjectionFrame,
+      ),
+    [hexTerrain, suppliedTacticalProjectionFrame],
+  );
+  const terrainLookup = useTerrainLookup(effectiveHexTerrain);
   const movementRangeLookup = useMovementRangeLookup(movementRange);
   const highlightPathIndexLookup = useHighlightPathLookup(highlightPath);
-  const hexGrid = useHexGrid(hexTerrain, hexes, radius);
+  const hexGrid = useHexGrid(effectiveHexTerrain, hexes, radius);
 
   const renderedHexes = useRenderedHexes({
     hexes,
@@ -145,7 +159,7 @@ export function useHexMapDisplayState({
     selectedWeaponIds,
     unitWeapons,
   });
-  const combatRangeLookup = useCombatRangeLookup({
+  const derivedCombatRangeLookup = useCombatRangeLookup({
     selectedToken,
     friendlySide,
     hasConfiguredWeaponList: isWeaponCombatProjectionEnabled,
@@ -156,33 +170,67 @@ export function useHexMapDisplayState({
     targetUnitId,
     combatState,
   });
-  const combatProjectionValidTargetUnitIds =
-    useCombatProjectionValidTargetUnitIds({
-      combatRangeLookup,
-      enabled: isWeaponCombatProjectionEnabled,
-    });
   const legacyAttackRangeLookup = useLegacyAttackRangeLookup({
     attackRange,
     enabled: !hasConfiguredWeaponList,
   });
-  const tacticalMapProjectionLookup = useMemo(
+  const derivedTacticalMapProjectionLookup = useMemo(
     () =>
       buildTacticalMapHexProjectionLookup({
         hexes,
         terrainLookup,
         movementRangeLookup,
-        combatRangeLookup,
+        combatRangeLookup: derivedCombatRangeLookup,
         highlightPathIndexLookup,
         legacyAttackRangeLookup,
       }),
     [
-      combatRangeLookup,
+      derivedCombatRangeLookup,
       hexes,
       highlightPathIndexLookup,
       legacyAttackRangeLookup,
       movementRangeLookup,
       terrainLookup,
     ],
+  );
+  const tacticalMapProjectionFrame = useMemo<ITacticalMapProjectionFrame>(
+    () =>
+      suppliedTacticalProjectionFrame ?? {
+        source: 'hex-map-derived-fallback',
+        lookup: derivedTacticalMapProjectionLookup,
+        label: 'HexMapDisplay locally derived projection fallback',
+      },
+    [derivedTacticalMapProjectionLookup, suppliedTacticalProjectionFrame],
+  );
+  const tacticalMapProjectionLookup = tacticalMapProjectionFrame.lookup;
+  const combatRangeLookup = useMemo<
+    ReadonlyMap<string, ICombatRangeHex>
+  >(() => {
+    if (!suppliedTacticalProjectionFrame) return derivedCombatRangeLookup;
+
+    const lookup = new Map<string, ICombatRangeHex>();
+    tacticalMapProjectionLookup.forEach((projection, key) => {
+      if (projection.combat) lookup.set(key, projection.combat);
+    });
+    return lookup;
+  }, [
+    derivedCombatRangeLookup,
+    suppliedTacticalProjectionFrame,
+    tacticalMapProjectionLookup,
+  ]);
+  const combatProjectionValidTargetUnitIds =
+    useCombatProjectionValidTargetUnitIds({
+      combatRangeLookup,
+      enabled:
+        isWeaponCombatProjectionEnabled ||
+        suppliedTacticalProjectionFrame !== undefined,
+    });
+  const tacticalProjectionMissingHexKeys = useMemo(
+    () =>
+      renderedHexes
+        .map(coordToKey)
+        .filter((key) => !tacticalMapProjectionLookup.has(key)),
+    [renderedHexes, tacticalMapProjectionLookup],
   );
   // Audit 2026-06-09 G (W5.1a): ONE occlusion sweep per render pass.
   // The list is derived first; the by-unit "first hit" map below is
@@ -372,9 +420,28 @@ export function useHexMapDisplayState({
     hoverTerrainInfo,
     hoverProjectionInfo,
     hoverIsometricOccluderInfo,
+    tacticalProjectionFrameSource: tacticalMapProjectionFrame.source,
+    tacticalProjectionFrameHexCount: tacticalMapProjectionLookup.size,
+    tacticalProjectionMissingHexKeys,
     tacticalMapProjectionLookup,
     renderHexCell,
     handleTokenClick,
     handleTokenDoubleClick,
   };
+}
+
+function buildEffectiveHexTerrainFromProjectionFrame(
+  hexTerrain: readonly IHexTerrain[],
+  tacticalProjectionFrame: ITacticalMapProjectionFrame | undefined,
+): readonly IHexTerrain[] {
+  if (!tacticalProjectionFrame) return hexTerrain;
+
+  const terrainByKey = new Map<string, IHexTerrain>();
+  for (const terrain of hexTerrain) {
+    terrainByKey.set(coordToKey(terrain.coordinate), terrain);
+  }
+  tacticalProjectionFrame.lookup.forEach((projection, key) => {
+    terrainByKey.set(key, projection.terrain);
+  });
+  return Array.from(terrainByKey.values());
 }

--- a/src/components/gameplay/HexMapDisplay/HexMapDisplay.stateTypes.ts
+++ b/src/components/gameplay/HexMapDisplay/HexMapDisplay.stateTypes.ts
@@ -9,7 +9,10 @@ import type {
   IMovementRangeHex,
   IUnitToken,
 } from '@/types/gameplay';
-import type { ITacticalMapHexProjection } from '@/utils/gameplay/tacticalMapProjection';
+import type {
+  ITacticalMapHexProjection,
+  ITacticalMapProjectionFrame,
+} from '@/utils/gameplay/tacticalMapProjection';
 import type { UiFiringArc } from '@/utils/overlays/arcClassifier';
 
 import type { buildIsometricSceneItems } from './HexMapDisplay.isometric';
@@ -68,6 +71,9 @@ export interface HexMapDisplayState {
   readonly hoverTerrainInfo: IHexTerrain | undefined;
   readonly hoverProjectionInfo: ITacticalMapHexProjection | undefined;
   readonly hoverIsometricOccluderInfo: IsometricTerrainOccluderInfo | undefined;
+  readonly tacticalProjectionFrameSource: ITacticalMapProjectionFrame['source'];
+  readonly tacticalProjectionFrameHexCount: number;
+  readonly tacticalProjectionMissingHexKeys: readonly string[];
   readonly tacticalMapProjectionLookup: ReadonlyMap<
     string,
     ITacticalMapHexProjection

--- a/src/components/gameplay/HexMapDisplay/HexMapDisplay.tsx
+++ b/src/components/gameplay/HexMapDisplay/HexMapDisplay.tsx
@@ -66,6 +66,9 @@ export function HexMapDisplay(props: HexMapDisplayProps): React.ReactElement {
     hoverTerrainInfo,
     hoverProjectionInfo,
     hoverIsometricOccluderInfo,
+    tacticalProjectionFrameSource,
+    tacticalProjectionFrameHexCount,
+    tacticalProjectionMissingHexKeys,
     tacticalMapProjectionLookup,
     renderHexCell,
     handleTokenClick,
@@ -78,6 +81,16 @@ export function HexMapDisplay(props: HexMapDisplayProps): React.ReactElement {
       data-testid="hex-map-container"
       data-screen-shake-active={screenShake.isShaking ? 'true' : undefined}
       data-screen-shake-transform={screenShake.transform}
+      data-tactical-projection-frame-source={tacticalProjectionFrameSource}
+      data-tactical-projection-frame-hex-count={tacticalProjectionFrameHexCount}
+      data-tactical-projection-missing-hexes={
+        tacticalProjectionMissingHexKeys.length > 0
+          ? tacticalProjectionMissingHexKeys.join('|')
+          : undefined
+      }
+      data-tactical-projection-coverage-status={
+        tacticalProjectionMissingHexKeys.length > 0 ? 'partial' : 'complete'
+      }
       style={screenShake.style}
     >
       <svg
@@ -109,6 +122,18 @@ export function HexMapDisplay(props: HexMapDisplayProps): React.ReactElement {
           data-testid="map-projection-layer"
           data-projection-mode={interaction.projectionMode}
           data-isometric-rotation-step={interaction.isometricRotationStep}
+          data-tactical-projection-frame-source={tacticalProjectionFrameSource}
+          data-tactical-projection-frame-hex-count={
+            tacticalProjectionFrameHexCount
+          }
+          data-tactical-projection-missing-hexes={
+            tacticalProjectionMissingHexKeys.length > 0
+              ? tacticalProjectionMissingHexKeys.join('|')
+              : undefined
+          }
+          data-tactical-projection-coverage-status={
+            tacticalProjectionMissingHexKeys.length > 0 ? 'partial' : 'complete'
+          }
           transform={projectionTransform}
         >
           {isIsometricView ? (

--- a/src/components/gameplay/HexMapDisplay/HexMapDisplay.types.ts
+++ b/src/components/gameplay/HexMapDisplay/HexMapDisplay.types.ts
@@ -12,6 +12,7 @@ import type {
 } from '@/types/gameplay';
 import type { GameSide } from '@/types/gameplay';
 import type { IObjectiveMarker } from '@/types/scenario/ScenarioInterfaces';
+import type { ITacticalMapProjectionFrame } from '@/utils/gameplay/tacticalMapProjection';
 
 import type { MapInteractionState } from './useMapInteraction';
 
@@ -34,6 +35,7 @@ export interface HexMapDisplayProps {
   selectedHex: IHexCoordinate | null;
   hexTerrain?: readonly IHexTerrain[];
   movementRange?: readonly IMovementRangeHex[];
+  tacticalProjectionFrame?: ITacticalMapProjectionFrame;
   attackRange?: readonly IHexCoordinate[];
   targetUnitId?: string | null;
   unitWeapons?: Record<string, readonly IWeaponStatus[]>;

--- a/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.combatProjection.26.test.tsx
+++ b/src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.combatProjection.26.test.tsx
@@ -1,0 +1,306 @@
+import type {
+  ICombatRangeHex,
+  IHexCoordinate,
+  IHexTerrain,
+  IMovementRangeHex,
+} from '@/types/gameplay';
+import type { ITacticalMapProjectionFrame } from '@/utils/gameplay/tacticalMapProjection';
+
+import { RangeBracket } from '@/types/gameplay';
+import { coordToKey } from '@/utils/gameplay/hexMath';
+import { buildTacticalMapHexProjectionLookup } from '@/utils/gameplay/tacticalMapProjection';
+
+import { generateHexesInRadius } from '../renderHelpers';
+import * as H from './HexMapDisplay.combatProjection.test-helpers';
+
+const {
+  GameSide,
+  HexMapDisplay,
+  MovementType,
+  TerrainType,
+  fireEvent,
+  makeToken,
+  render,
+  screen,
+} = H;
+
+function clearTerrain(hex: IHexCoordinate): IHexTerrain {
+  return {
+    coordinate: hex,
+    elevation: hex.q === 1 && hex.r === 0 ? 2 : 0,
+    features: [{ type: TerrainType.Clear, level: 0 }],
+  };
+}
+
+function blockedSharedMovement(hex: IHexCoordinate): IMovementRangeHex {
+  return {
+    hex,
+    mpCost: 99,
+    terrainCost: 1,
+    elevationDelta: 2,
+    elevationCost: 2,
+    reachable: false,
+    movementType: MovementType.Walk,
+    movementMode: 'walk',
+    blockedReason: 'Shared engine projection rejected the destination',
+    movementInvalidReason: 'TerrainBlocked',
+    movementInvalidDetails: 'Shared engine says cliff blocks path',
+  };
+}
+
+function attackableSharedCombat(hex: IHexCoordinate): ICombatRangeHex {
+  return {
+    hex,
+    distance: 1,
+    rangeBracket: RangeBracket.Short,
+    inRange: true,
+    inArc: true,
+    losState: 'clear',
+    targetCoverLevel: 'none',
+    targetPartialCover: false,
+    targetCoverModifier: 0,
+    firingArc: 'front',
+    hasTarget: true,
+    targetVisibilityState: 'visible',
+    visibleTargetUnitIds: ['enemy'],
+    obscuredTargetUnitIds: [],
+    attackable: true,
+    weaponIdsInRange: ['medium-laser'],
+    weaponIdsInArc: ['medium-laser'],
+    weaponIdsAvailable: ['medium-laser'],
+    weaponRangeOptions: [
+      {
+        weaponId: 'medium-laser',
+        weaponName: 'Medium Laser',
+        heat: 3,
+        damage: 5,
+        ammoConsumed: 0,
+        rangeBracket: RangeBracket.Short,
+        inRange: true,
+        inArc: true,
+        environmentLegal: true,
+        available: true,
+      },
+    ],
+    availableWeaponImpacts: [
+      {
+        weaponId: 'medium-laser',
+        weaponName: 'Medium Laser',
+        heat: 3,
+        damage: 5,
+        ammoConsumed: 0,
+      },
+    ],
+    availableWeaponHeat: 3,
+    availableWeaponDamage: 5,
+    expectedDamage: 2.1,
+    targetUnitIds: ['enemy'],
+    validTargetUnitIds: ['enemy'],
+  } as ICombatRangeHex;
+}
+
+function sharedFrame({
+  radius = 1,
+  includeAllHexes = true,
+}: {
+  readonly radius?: number;
+  readonly includeAllHexes?: boolean;
+} = {}): ITacticalMapProjectionFrame {
+  const hexes = generateHexesInRadius(radius);
+  const targetHex = { q: 1, r: 0 };
+  const projectedHexes = includeAllHexes ? hexes : [targetHex];
+
+  return {
+    source: 'shared-engine-projection',
+    sourceId: 'unit-test-shared-frame',
+    label: 'Unit test shared tactical projection frame',
+    lookup: buildTacticalMapHexProjectionLookup({
+      hexes: projectedHexes,
+      terrainLookup: new Map(
+        projectedHexes.map((hex) => [coordToKey(hex), clearTerrain(hex)]),
+      ),
+      movementRangeLookup: new Map([
+        [coordToKey(targetHex), blockedSharedMovement(targetHex)],
+      ]),
+      combatRangeLookup: new Map([
+        [coordToKey(targetHex), attackableSharedCombat(targetHex)],
+      ]),
+      highlightPathIndexLookup: new Map([[coordToKey(targetHex), 1]]),
+      legacyAttackRangeLookup: new Set(),
+    }),
+  };
+}
+
+describe('HexMapDisplay tactical projection frame contract', () => {
+  it('uses supplied shared projection frames before conflicting legacy movement props', () => {
+    render(
+      <HexMapDisplay
+        mapId="shared-frame-map"
+        radius={1}
+        tokens={[
+          makeToken({
+            unitId: 'selected',
+            isSelected: true,
+            position: { q: 0, r: 0 },
+          }),
+          makeToken({
+            unitId: 'enemy',
+            side: GameSide.Opponent,
+            position: { q: 1, r: 0 },
+          }),
+        ]}
+        selectedHex={null}
+        movementRange={[
+          {
+            hex: { q: 1, r: 0 },
+            mpCost: 1,
+            terrainCost: 1,
+            reachable: true,
+            movementType: MovementType.Walk,
+            movementMode: 'walk',
+          },
+        ]}
+        tacticalProjectionFrame={sharedFrame()}
+      />,
+    );
+
+    const container = screen.getByTestId('hex-map-container');
+    expect(container).toHaveAttribute(
+      'data-tactical-projection-frame-source',
+      'shared-engine-projection',
+    );
+    expect(container).toHaveAttribute(
+      'data-tactical-projection-coverage-status',
+      'complete',
+    );
+    expect(container).toHaveAttribute(
+      'data-tactical-projection-frame-hex-count',
+      '7',
+    );
+
+    const sharedHex = screen.getByTestId('hex-1-0');
+    expect(sharedHex).toHaveAttribute('data-elevation', '2');
+    expect(sharedHex).toHaveAttribute(
+      'data-terrain-primary',
+      TerrainType.Clear,
+    );
+    expect(sharedHex).toHaveAttribute('data-reachable', 'false');
+    expect(sharedHex).toHaveAttribute(
+      'data-movement-invalid-reason',
+      'TerrainBlocked',
+    );
+    expect(sharedHex).toHaveAttribute(
+      'data-movement-invalid-details',
+      'Shared engine says cliff blocks path',
+    );
+    expect(sharedHex).toHaveAttribute(
+      'data-tactical-projection-status',
+      'mixed',
+    );
+    expect(sharedHex).toHaveAttribute(
+      'data-tactical-projection-combat-status',
+      'attackable',
+    );
+    expect(
+      sharedHex.getAttribute('data-tactical-projection-blocked-reasons'),
+    ).toContain('Shared engine says cliff blocks path');
+
+    fireEvent.mouseEnter(sharedHex);
+
+    expect(screen.getByTestId('hex-tactical-tooltip')).toHaveAttribute(
+      'data-tactical-tooltip-explanation',
+      expect.stringContaining('Shared engine says cliff blocks path'),
+    );
+    expect(screen.getByTestId('unit-token-enemy')).toHaveAttribute(
+      'data-token-valid-target-source',
+      'combat-projection',
+    );
+  });
+
+  it('marks locally derived projections as fallback frames', () => {
+    render(
+      <HexMapDisplay
+        mapId="fallback-frame-map"
+        radius={1}
+        tokens={[]}
+        selectedHex={null}
+        movementRange={[
+          {
+            hex: { q: 1, r: 0 },
+            mpCost: 2,
+            terrainCost: 1,
+            elevationDelta: 1,
+            elevationCost: 1,
+            reachable: true,
+            movementType: MovementType.Walk,
+            movementMode: 'walk',
+          },
+        ]}
+      />,
+    );
+
+    const container = screen.getByTestId('hex-map-container');
+    expect(container).toHaveAttribute(
+      'data-tactical-projection-frame-source',
+      'hex-map-derived-fallback',
+    );
+    expect(container).toHaveAttribute(
+      'data-tactical-projection-coverage-status',
+      'complete',
+    );
+    expect(container).toHaveAttribute(
+      'data-tactical-projection-frame-hex-count',
+      '7',
+    );
+    expect(screen.getByTestId('hex-1-0')).toHaveAttribute(
+      'data-tactical-projection-movement-status',
+      'legal',
+    );
+  });
+
+  it('exposes missing shared-frame coverage without substituting fallback projection data', () => {
+    render(
+      <HexMapDisplay
+        mapId="partial-shared-frame-map"
+        radius={1}
+        tokens={[]}
+        selectedHex={null}
+        hexTerrain={generateHexesInRadius(1).map(clearTerrain)}
+        movementRange={[
+          {
+            hex: { q: 0, r: 0 },
+            mpCost: 1,
+            terrainCost: 1,
+            reachable: true,
+            movementType: MovementType.Walk,
+            movementMode: 'walk',
+          },
+        ]}
+        tacticalProjectionFrame={sharedFrame({ includeAllHexes: false })}
+      />,
+    );
+
+    const container = screen.getByTestId('hex-map-container');
+    expect(container).toHaveAttribute(
+      'data-tactical-projection-frame-source',
+      'shared-engine-projection',
+    );
+    expect(container).toHaveAttribute(
+      'data-tactical-projection-coverage-status',
+      'partial',
+    );
+    expect(container).toHaveAttribute(
+      'data-tactical-projection-frame-hex-count',
+      '1',
+    );
+    expect(
+      container.getAttribute('data-tactical-projection-missing-hexes'),
+    ).toContain('0,0');
+
+    const missingHex = screen.getByTestId('hex-0-0');
+    expect(missingHex).not.toHaveAttribute('data-reachable');
+    expect(missingHex).not.toHaveAttribute(
+      'data-tactical-projection-movement-status',
+    );
+  });
+});

--- a/src/utils/gameplay/tacticalMapProjection.ts
+++ b/src/utils/gameplay/tacticalMapProjection.ts
@@ -38,6 +38,7 @@ export type {
   BuildTacticalMapHexProjectionLookupInput,
   ITacticalMapCombatLosBlockerReference,
   ITacticalMapHexProjection,
+  ITacticalMapProjectionFrame,
   ITacticalMapProjectionSourceReference,
   TacticalMapCombatProjectionStatus,
   TacticalMapHexProjectionIntent,
@@ -45,6 +46,7 @@ export type {
   TacticalMapMovementCostProjectionStatus,
   TacticalMapMovementHazardProjectionStatus,
   TacticalMapMovementProjectionStatus,
+  TacticalMapProjectionFrameSource,
   TacticalMapProjectionSourceChannel,
   TacticalMapProjectionSourceKind,
 } from './tacticalMapProjection.types';

--- a/src/utils/gameplay/tacticalMapProjection.types.ts
+++ b/src/utils/gameplay/tacticalMapProjection.types.ts
@@ -93,6 +93,17 @@ export interface ITacticalMapHexProjection {
   readonly explanation: string;
 }
 
+export type TacticalMapProjectionFrameSource =
+  | 'shared-engine-projection'
+  | 'hex-map-derived-fallback';
+
+export interface ITacticalMapProjectionFrame {
+  readonly source: TacticalMapProjectionFrameSource;
+  readonly lookup: ReadonlyMap<string, ITacticalMapHexProjection>;
+  readonly sourceId?: string;
+  readonly label?: string;
+}
+
 export interface BuildTacticalMapHexProjectionLookupInput {
   readonly hexes: readonly IHexCoordinate[];
   readonly terrainLookup: ReadonlyMap<string, IHexTerrain>;


### PR DESCRIPTION
## Summary
- add a typed tactical projection frame contract with shared-vs-fallback source metadata
- make HexMapDisplay prefer supplied shared frames for movement, combat, terrain/elevation, LOS grid data, and diagnostics
- expose frame source, coverage count, and missing-hex diagnostics on the map surface
- archive the OpenSpec change into tactical-map-interface

## Verification
- npx.cmd jest --selectProjects unit --ci --runTestsByPath src/utils/gameplay/__tests__/tacticalMapProjection.test.ts src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.renderStability.test.tsx src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.combatProjection.26.test.tsx --no-coverage
- npm.cmd run typecheck
- npm.cmd run lint
- npm.cmd run format:check
- npm.cmd run verify
- openspec.cmd validate --all --strict
- git diff --check

## Notes
- lint exits successfully but continues to report existing warning debt outside this change.
- manual browser tactical-map sweep was not run; covered by component contract tests and the stable Jest lane.