### PR TITLE
Add GM post-combat and economy corrections

### DIFF
--- a/openspec/changes/archive/2026-06-23-add-post-combat-base-economy-fixes/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-23-add-post-combat-base-economy-fixes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-22

--- a/openspec/changes/archive/2026-06-23-add-post-combat-base-economy-fixes/design.md
+++ b/openspec/changes/archive/2026-06-23-add-post-combat-base-economy-fixes/design.md
@@ -1,0 +1,43 @@
+## Context
+
+Wave 4 established an append-only `InterventionLedger`, authority/redaction helpers, and a cascade preview/approval pipeline. Wave 5 registered combat and unit-reload implementers, while `gm-campaign-intervention-boundaries` deliberately kept post-combat, economy, repair, salvage, and time domains deferred.
+
+The campaign economic loop now has durable state roots for the next intervention layer: `ICampaign.finances`, `repairQueue`, `salvageAllocations`, `partsInventory`, `unitCombatStates`, and `unitConfigurations`. Wave 8 should correct those roots through the existing ledger instead of adding a parallel campaign override store.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Register campaign intervention implementers for `post-combat`, `economy`, `repair`, and `salvage`.
+- Reuse the existing preview-before-approval pipeline, action ledger append, authority guard, and redaction envelope.
+- Support targeted corrections for salvage allocation, repair ticket, funds transaction, inventory lot, and base unit state/configuration roots.
+- Return `requires-manual-takeover` when a command explicitly declares unresolved cascading conflicts.
+- Keep `time` deferred for the later accumulated time-cascade wave.
+
+**Non-Goals:**
+
+- No new economy processor, repair processor, salvage processor, or market behavior.
+- No UI implementation beyond exportable service contracts/tests.
+- No automatic long-range time cascade resolution.
+- No hidden mutation of campaign state outside approved intervention records.
+
+## Decisions
+
+1. **Use one shared campaign implementer factory registered per domain.**
+   The supported campaign domains mutate the same `ICampaign` roots and use the same preview/apply/projection behavior. A factory keeps validation and replay consistent while still preserving domain-specific command keys (`post-combat`, `economy`, `repair`, `salvage`). Rejected alternative: four separate implementers, which would duplicate redaction, conflict, and replay code with little domain benefit in this slice.
+
+2. **Persist projected effects in the intervention record.**
+   The preview stores a typed `projectedEffects` array in `domainPayload`, and apply replays those effects. This mirrors combat interventions and keeps approval deterministic even if the source command shape evolves. Rejected alternative: re-evaluate the raw command at approval time, which can drift if campaign state changed between preview and approval.
+
+3. **Treat broad or conflicting cascades as manual takeover.**
+   Commands can include conflict metadata when the GM or future UI detects that a correction spans ambiguous side effects. The implementer returns a ready preview with conflicts flagged for manual takeover; the cascade pipeline normalizes it to `requires-manual-takeover` and refuses approval. Rejected alternative: allow auto-approval with warnings, which would hide exactly the class of high-risk campaign cascade the user wants surfaced.
+
+4. **Player visibility remains net-effect only.**
+   Campaign corrections use `buildGmInterventionRedactionEnvelope`; public projection includes summary, family, changed refs, and optional visible player IDs. Private metadata retains the GM reason, default outcome, hidden notes, and manual takeover notes. Rejected alternative: put all context in event payloads, which would leak hidden GM rationale into player-facing logs.
+
+## Risks / Trade-offs
+
+- **Risk: Patch-based roots can accept an invalid domain object.** -> Mitigation: validate identity fields for targeted roots and keep tests focused on known `ICampaign` shapes. Rich domain validation remains owned by the existing processors/UI.
+- **Risk: Manual takeover command support could become a bypass.** -> Mitigation: manual takeover previews are not approvable through `approveGmCascadePreview`; tests lock that blocked behavior.
+- **Risk: Existing deferred-boundary tests become misleading.** -> Mitigation: update them to assert only `time` remains deferred and campaign domains no longer defer when registered.
+- **Risk: No UI yet means discoverability is service-level only.** -> Mitigation: expose the implementer and projection helpers through the intervention barrel so future UI can consume the same tested API.

--- a/openspec/changes/archive/2026-06-23-add-post-combat-base-economy-fixes/proposal.md
+++ b/openspec/changes/archive/2026-06-23-add-post-combat-base-economy-fixes/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The GM intervention ledger can already correct tactical combat safely, but the next campaign checkpoints still fall back to deferred results. Post-combat and base-economy mistakes need the same preview, approval, replay, and redaction contract so a GM can repair salvage, repair, inventory, funds, or base-state errors without resetting a campaign.
+
+## What Changes
+
+- Add ledger-backed campaign correction implementers for `post-combat`, `economy`, `repair`, and `salvage`.
+- Support ready cascade previews for salvage allocations, repair tickets, funds/merchant reversals, parts inventory lots, and base unit state/configuration corrections.
+- Preserve separate GM-private rationale and player-visible net effect projections for approved campaign corrections.
+- Replay approved records into campaign state and action ledger history using the existing intervention/cascade pipeline.
+- Keep accumulated `time` cascades deferred for the later time-cascade wave.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `gm-campaign-intervention-boundaries`: post-combat, economy, repair, and salvage domains move from deferred-only seams to supported first-class campaign implementers; `time` remains deferred.
+- `gm-cascade-preview`: ready campaign previews SHALL show net effects for post-combat/base economy corrections while conflicts still require manual takeover.
+- `intervention-ledger-abstraction`: campaign implementers SHALL satisfy the shared append-only preview/apply/public/private projection interface.
+- `gm-authority-redaction`: player projections for campaign corrections SHALL omit hidden GM rationale while GM projections retain it.
+
+## Impact
+
+- New intervention types and implementer/projection helpers under `src/types/interventions` and `src/lib/interventions`.
+- Focused intervention tests covering preview, rejection, manual takeover, approval replay, action-ledger append, redaction, and remaining `time` deferral.
+- No new economic processor behavior: existing campaign fields such as `finances`, `repairQueue`, `salvageAllocations`, `partsInventory`, `unitCombatStates`, and `unitConfigurations` are corrected by additive GM records.
+- No UI implementation in this wave; UI surfaces can consume the same cascade preview and public/private projection contracts.

--- a/openspec/changes/archive/2026-06-23-add-post-combat-base-economy-fixes/specs/gm-authority-redaction/spec.md
+++ b/openspec/changes/archive/2026-06-23-add-post-combat-base-economy-fixes/specs/gm-authority-redaction/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Campaign Correction Redaction
+
+The system SHALL separate GM-private metadata from player-public net effects for post-combat, economy, repair, and salvage corrections. Player-facing campaign logs SHALL expose only the approved net effect and visible changed state references.
+
+#### Scenario: Player sees only net campaign correction
+- **GIVEN** an approved campaign correction with a GM-private reason, default outcome, hidden notes, and a public summary
+- **WHEN** a player views the action log or intervention projection
+- **THEN** the projection SHALL show the public summary and visible campaign state references
+- **AND** it SHALL NOT show the GM-private reason, default outcome, hidden notes, or manual takeover notes
+
+#### Scenario: GM sees full campaign correction context
+- **GIVEN** an approved campaign correction with private metadata and public net effect
+- **WHEN** the owning GM views the GM ledger projection
+- **THEN** the projection SHALL include the GM-private metadata
+- **AND** it SHALL include the same public net effect players can see

--- a/openspec/changes/archive/2026-06-23-add-post-combat-base-economy-fixes/specs/gm-campaign-intervention-boundaries/spec.md
+++ b/openspec/changes/archive/2026-06-23-add-post-combat-base-economy-fixes/specs/gm-campaign-intervention-boundaries/spec.md
@@ -1,9 +1,5 @@
-# gm-campaign-intervention-boundaries Specification
+## MODIFIED Requirements
 
-## Purpose
-
-Defines the first-slice campaign boundary for GM interventions, explicitly deferring post-combat, economy, repair, salvage, and time cascades until domain implementers declare safe mutable roots and public projections.
-## Requirements
 ### Requirement: First Slice Defers Campaign Cascades
 
 The campaign intervention boundary SHALL now support ledger-backed post-combat amendments, base/economy corrections, repair corrections, and salvage corrections through registered domain implementers. Accumulated time cascades SHALL remain explicitly deferred until the time-cascade phase declares safe mutable roots and conflict handling.
@@ -42,15 +38,7 @@ The system SHALL document and preserve extension seams for intervention ledger i
 - **THEN** the preview SHALL identify the domain as unsupported or deferred
 - **AND** the preview SHALL NOT imply that travel, repair progress, contract windows, market refreshes, pilot recovery, upkeep, or campaign dates were mutated
 
-### Requirement: Deferred Domain Logging
-
-The system SHALL log deferred domain intervention attempts so missing campaign support is visible during testing without applying unsupported state changes.
-
-#### Scenario: Deferred request is logged safely
-- **GIVEN** a GM requests a deferred time cascade intervention
-- **WHEN** the intervention pipeline returns a deferred result
-- **THEN** the system SHALL log the domain, actor, target refs, and deferred reason
-- **AND** the log SHALL NOT include hidden scenario notes in any player-visible output
+## ADDED Requirements
 
 ### Requirement: Ledger-Backed Campaign Correction Domains
 

--- a/openspec/changes/archive/2026-06-23-add-post-combat-base-economy-fixes/specs/gm-cascade-preview/spec.md
+++ b/openspec/changes/archive/2026-06-23-add-post-combat-base-economy-fixes/specs/gm-cascade-preview/spec.md
@@ -1,0 +1,35 @@
+## MODIFIED Requirements
+
+### Requirement: Deferred Domain Result
+
+The preview pipeline SHALL return explicit deferred or unsupported results for domains that are not implemented in the current slice. The accumulated `time` domain SHALL remain deferred in this slice, while registered post-combat, economy, repair, and salvage implementers SHALL return normal ready, blocked, or manual-takeover previews.
+
+#### Scenario: Time domain does not mutate state
+- **GIVEN** the accumulated time domain is not implemented
+- **WHEN** the GM previews a travel or accumulated time correction
+- **THEN** the preview pipeline SHALL return a deferred or unsupported result
+- **AND** campaign time, travel state, repair progress, contract windows, markets, pilot recovery, and upkeep SHALL remain unchanged
+
+#### Scenario: Registered economy domain is not deferred
+- **GIVEN** the economy domain implementer is registered
+- **WHEN** the GM previews a merchant transaction reversal
+- **THEN** the preview pipeline SHALL return a ready, blocked, or manual-takeover result from the implementer
+- **AND** the preview SHALL NOT be normalized to deferred merely because it targets campaign economy state
+
+## ADDED Requirements
+
+### Requirement: Campaign Correction Preview Shape
+
+The preview pipeline SHALL represent post-combat and base-economy corrections with public net effect, GM-private context, affected campaign state references, projected campaign effects, and conflicts before commit.
+
+#### Scenario: Campaign preview exposes public and private projections separately
+- **GIVEN** a GM requests a salvage, repair, funds, inventory, or base-state correction
+- **WHEN** the preview is produced
+- **THEN** the preview SHALL include player-visible net effect in the public projection
+- **AND** the preview SHALL preserve GM reason, default outcome, hidden notes, and manual takeover notes in the private projection only
+
+#### Scenario: Manual campaign preview cannot be approved automatically
+- **GIVEN** a campaign preview includes a conflict marked as requiring manual takeover
+- **WHEN** the GM attempts normal preview approval
+- **THEN** the approval pipeline SHALL return blocked
+- **AND** no intervention ledger record or action ledger record SHALL be appended

--- a/openspec/changes/archive/2026-06-23-add-post-combat-base-economy-fixes/specs/intervention-ledger-abstraction/spec.md
+++ b/openspec/changes/archive/2026-06-23-add-post-combat-base-economy-fixes/specs/intervention-ledger-abstraction/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Campaign Domain Ledger Implementers
+
+The intervention ledger SHALL allow campaign-domain implementers for `post-combat`, `economy`, `repair`, and `salvage` to share the same preview, apply, public projection, and private projection contract used by tactical combat interventions.
+
+#### Scenario: Campaign implementer registers with ledger
+- **GIVEN** a campaign intervention implementer for `economy`
+- **WHEN** the implementer is registered with the intervention ledger
+- **THEN** commands targeting the `economy` domain SHALL route through that implementer
+- **AND** commands targeting unrelated domains SHALL NOT route through that implementer
+
+#### Scenario: Campaign approval appends through shared action ledger
+- **GIVEN** a ready campaign intervention preview and a shared action ledger
+- **WHEN** the GM approves the preview
+- **THEN** the intervention ledger SHALL append an approved campaign intervention record
+- **AND** the action ledger SHALL append a GM intervention action after prior normal actions
+- **AND** prior normal actions SHALL remain present
+
+#### Scenario: Blocked campaign preview appends no action
+- **GIVEN** a campaign preview is blocked, rejected, unsupported, deferred, or requires manual takeover
+- **WHEN** the preview is not approved
+- **THEN** the intervention ledger SHALL append no campaign intervention record
+- **AND** the action ledger SHALL append no GM intervention action

--- a/openspec/changes/archive/2026-06-23-add-post-combat-base-economy-fixes/tasks.md
+++ b/openspec/changes/archive/2026-06-23-add-post-combat-base-economy-fixes/tasks.md
@@ -1,0 +1,25 @@
+## 1. Intervention Types
+
+- [x] 1.1 Add typed campaign correction payloads, projected effects, public effects, and intervention state aliases for post-combat/base economy domains.
+- [x] 1.2 Export the campaign intervention types from the intervention type barrel.
+
+## 2. Campaign Implementer
+
+- [x] 2.1 Add a shared campaign intervention preview builder for salvage allocation, repair ticket, funds transaction, inventory lot, and base unit state/configuration corrections.
+- [x] 2.2 Add projection/apply helpers that replay projected campaign effects into `ICampaign` roots.
+- [x] 2.3 Add a factory/register helper for `post-combat`, `economy`, `repair`, and `salvage` implementers.
+- [x] 2.4 Export the new implementer and projection helpers from the intervention library barrel.
+
+## 3. Regression Coverage
+
+- [x] 3.1 Add focused tests for ready previews, approval replay, action-ledger append, and public/private redaction.
+- [x] 3.2 Add focused tests for rejection/manual takeover and malformed or missing target handling.
+- [x] 3.3 Update deferred-boundary tests so `time` remains deferred while registered campaign domains no longer defer.
+
+## 4. Validation And Closure
+
+- [x] 4.1 Run focused intervention tests.
+- [x] 4.2 Run `openspec.cmd validate add-post-combat-base-economy-fixes --strict`.
+- [x] 4.3 Run the broader verification surface required before PR.
+- [x] 4.4 Archive the OpenSpec change after verification passes.
+- [ ] 4.5 Commit, push, open PR, merge after green checks, and clean local state.

--- a/openspec/specs/gm-authority-redaction/spec.md
+++ b/openspec/specs/gm-authority-redaction/spec.md
@@ -46,3 +46,19 @@ The system SHALL log rejected GM intervention attempts with actor, target, domai
 - **WHEN** the authority guard rejects the request
 - **THEN** the system SHALL produce an internal rejection log entry
 - **AND** no player-visible log entry SHALL include private GM metadata
+
+### Requirement: Campaign Correction Redaction
+
+The system SHALL separate GM-private metadata from player-public net effects for post-combat, economy, repair, and salvage corrections. Player-facing campaign logs SHALL expose only the approved net effect and visible changed state references.
+
+#### Scenario: Player sees only net campaign correction
+- **GIVEN** an approved campaign correction with a GM-private reason, default outcome, hidden notes, and a public summary
+- **WHEN** a player views the action log or intervention projection
+- **THEN** the projection SHALL show the public summary and visible campaign state references
+- **AND** it SHALL NOT show the GM-private reason, default outcome, hidden notes, or manual takeover notes
+
+#### Scenario: GM sees full campaign correction context
+- **GIVEN** an approved campaign correction with private metadata and public net effect
+- **WHEN** the owning GM views the GM ledger projection
+- **THEN** the projection SHALL include the GM-private metadata
+- **AND** it SHALL include the same public net effect players can see

--- a/openspec/specs/gm-cascade-preview/spec.md
+++ b/openspec/specs/gm-cascade-preview/spec.md
@@ -43,10 +43,32 @@ The preview pipeline SHALL return a manual-takeover result when the system canno
 
 ### Requirement: Deferred Domain Result
 
-The preview pipeline SHALL return explicit deferred or unsupported results for domains that are not implemented in the current slice.
+The preview pipeline SHALL return explicit deferred or unsupported results for domains that are not implemented in the current slice. The accumulated `time` domain SHALL remain deferred in this slice, while registered post-combat, economy, repair, and salvage implementers SHALL return normal ready, blocked, or manual-takeover previews.
 
-#### Scenario: Deferred domain does not mutate state
-- **GIVEN** the economy domain is not implemented
-- **WHEN** the GM previews a merchant transaction reversal
+#### Scenario: Time domain does not mutate state
+- **GIVEN** the accumulated time domain is not implemented
+- **WHEN** the GM previews a travel or accumulated time correction
 - **THEN** the preview pipeline SHALL return a deferred or unsupported result
-- **AND** finances and inventory SHALL remain unchanged
+- **AND** campaign time, travel state, repair progress, contract windows, markets, pilot recovery, and upkeep SHALL remain unchanged
+
+#### Scenario: Registered economy domain is not deferred
+- **GIVEN** the economy domain implementer is registered
+- **WHEN** the GM previews a merchant transaction reversal
+- **THEN** the preview pipeline SHALL return a ready, blocked, or manual-takeover result from the implementer
+- **AND** the preview SHALL NOT be normalized to deferred merely because it targets campaign economy state
+
+### Requirement: Campaign Correction Preview Shape
+
+The preview pipeline SHALL represent post-combat and base-economy corrections with public net effect, GM-private context, affected campaign state references, projected campaign effects, and conflicts before commit.
+
+#### Scenario: Campaign preview exposes public and private projections separately
+- **GIVEN** a GM requests a salvage, repair, funds, inventory, or base-state correction
+- **WHEN** the preview is produced
+- **THEN** the preview SHALL include player-visible net effect in the public projection
+- **AND** the preview SHALL preserve GM reason, default outcome, hidden notes, and manual takeover notes in the private projection only
+
+#### Scenario: Manual campaign preview cannot be approved automatically
+- **GIVEN** a campaign preview includes a conflict marked as requiring manual takeover
+- **WHEN** the GM attempts normal preview approval
+- **THEN** the approval pipeline SHALL return blocked
+- **AND** no intervention ledger record or action ledger record SHALL be appended

--- a/openspec/specs/intervention-ledger-abstraction/spec.md
+++ b/openspec/specs/intervention-ledger-abstraction/spec.md
@@ -70,3 +70,26 @@ The action ledger SHALL expose player-public and GM-private projections. Player-
 - **WHEN** the owning GM views the action ledger projection
 - **THEN** the projection SHALL include normal action public context
 - **AND** it SHALL include the GM intervention private metadata and public net effect
+
+### Requirement: Campaign Domain Ledger Implementers
+
+The intervention ledger SHALL allow campaign-domain implementers for `post-combat`, `economy`, `repair`, and `salvage` to share the same preview, apply, public projection, and private projection contract used by tactical combat interventions.
+
+#### Scenario: Campaign implementer registers with ledger
+- **GIVEN** a campaign intervention implementer for `economy`
+- **WHEN** the implementer is registered with the intervention ledger
+- **THEN** commands targeting the `economy` domain SHALL route through that implementer
+- **AND** commands targeting unrelated domains SHALL NOT route through that implementer
+
+#### Scenario: Campaign approval appends through shared action ledger
+- **GIVEN** a ready campaign intervention preview and a shared action ledger
+- **WHEN** the GM approves the preview
+- **THEN** the intervention ledger SHALL append an approved campaign intervention record
+- **AND** the action ledger SHALL append a GM intervention action after prior normal actions
+- **AND** prior normal actions SHALL remain present
+
+#### Scenario: Blocked campaign preview appends no action
+- **GIVEN** a campaign preview is blocked, rejected, unsupported, deferred, or requires manual takeover
+- **WHEN** the preview is not approved
+- **THEN** the intervention ledger SHALL append no campaign intervention record
+- **AND** the action ledger SHALL append no GM intervention action

--- a/src/lib/interventions/GmCampaignInterventionImplementer.ts
+++ b/src/lib/interventions/GmCampaignInterventionImplementer.ts
@@ -1,0 +1,214 @@
+import type {
+  GmCampaignInterventionDomain,
+  IGmCampaignInterventionCommandPayload,
+  IGmCampaignInterventionDomainPayload,
+  IGmCampaignInterventionState,
+  IGmCampaignPublicEffect,
+  IGmPrivateMetadata,
+  IInterventionConflict,
+  IInterventionLedgerCommand,
+  IInterventionLedgerImplementer,
+  IInterventionLedgerPreview,
+  IInterventionLedgerRecord,
+} from '@/types/interventions';
+
+import type { InterventionLedger } from './InterventionLedger';
+
+import { buildGmCampaignProjectedEffect } from './GmCampaignInterventionPreview';
+import {
+  applyGmCampaignProjectedEffects,
+  projectCampaignEffectsForRecord,
+} from './GmCampaignInterventionProjection';
+import { buildGmInterventionRedactionEnvelope } from './GmInterventionAuthority';
+
+type CampaignPreview = IInterventionLedgerPreview<
+  IGmPrivateMetadata,
+  IGmCampaignPublicEffect,
+  IGmCampaignInterventionDomainPayload
+>;
+
+type CampaignCommand =
+  IInterventionLedgerCommand<IGmCampaignInterventionCommandPayload>;
+
+type CampaignRecord = IInterventionLedgerRecord<
+  IGmPrivateMetadata,
+  IGmCampaignPublicEffect,
+  IGmCampaignInterventionDomainPayload
+>;
+
+const CAMPAIGN_INTERVENTION_DOMAINS = [
+  'post-combat',
+  'economy',
+  'repair',
+  'salvage',
+] as const satisfies readonly GmCampaignInterventionDomain[];
+
+export function createGmCampaignInterventionImplementer(
+  domain: GmCampaignInterventionDomain,
+): IInterventionLedgerImplementer<
+  CampaignCommand,
+  IGmCampaignInterventionState,
+  IGmPrivateMetadata,
+  IGmCampaignPublicEffect,
+  IGmCampaignInterventionDomainPayload
+> {
+  return {
+    domain,
+    preview(command, state): CampaignPreview {
+      if (!isCampaignCommandPayload(command.payload)) {
+        return blockedCampaignPreview(
+          domain,
+          command,
+          'campaign-payload-invalid',
+          'Campaign intervention command requires a correction and GM-private reason.',
+        );
+      }
+
+      const projected = buildGmCampaignProjectedEffect(
+        domain,
+        command.payload,
+        state,
+      );
+      if (!projected.effect) {
+        return blockedCampaignPreview(
+          domain,
+          command,
+          projected.code,
+          projected.reason,
+          projected.affectedRefs,
+        );
+      }
+
+      const envelope = buildGmInterventionRedactionEnvelope(
+        command.payload.privateMetadata,
+        {
+          summary: command.payload.publicSummary ?? projected.summary,
+          family: command.payload.correction.family,
+          changedStateRefs: projected.changedStateRefs,
+          visibleToPlayerIds: command.payload.visibleToPlayerIds,
+        },
+      );
+
+      return {
+        domain,
+        kind: command.kind,
+        status: 'ready',
+        actorId: command.actorId,
+        targetRefs: command.targetRefs,
+        causedBy: command.causedBy,
+        supersedes: command.supersedes,
+        privateMetadata: envelope.privateMetadata,
+        publicEffect: envelope.publicEffect,
+        domainPayload: {
+          correction: command.payload.correction,
+          projectedEffects: [projected.effect],
+        },
+        projectedEvents: [projected.effect],
+        conflicts: normalizeConflicts(command.payload.conflicts),
+      };
+    },
+    apply(record, state): IGmCampaignInterventionState {
+      return applyGmCampaignProjectedEffects(
+        state,
+        projectCampaignEffectsForRecord(record as CampaignRecord),
+      );
+    },
+    projectPublic(record): IGmCampaignPublicEffect {
+      return record.publicEffect;
+    },
+    projectPrivate(record): IGmPrivateMetadata {
+      return record.privateMetadata;
+    },
+  };
+}
+
+export function registerGmCampaignInterventionImplementer(
+  ledger: InterventionLedger<IGmCampaignInterventionState>,
+  domain: GmCampaignInterventionDomain,
+): InterventionLedger<IGmCampaignInterventionState> {
+  return ledger.register(
+    createGmCampaignInterventionImplementer(
+      domain,
+    ) as IInterventionLedgerImplementer<
+      IInterventionLedgerCommand,
+      IGmCampaignInterventionState
+    >,
+  );
+}
+
+export function registerGmCampaignInterventionImplementers(
+  ledger: InterventionLedger<IGmCampaignInterventionState>,
+  domains: readonly GmCampaignInterventionDomain[] = CAMPAIGN_INTERVENTION_DOMAINS,
+): InterventionLedger<IGmCampaignInterventionState> {
+  domains.forEach((domain) =>
+    registerGmCampaignInterventionImplementer(ledger, domain),
+  );
+  return ledger;
+}
+
+function blockedCampaignPreview(
+  domain: GmCampaignInterventionDomain,
+  command: IInterventionLedgerCommand,
+  code: string,
+  reason: string,
+  affectedRefs: readonly string[] = command.targetRefs,
+): CampaignPreview {
+  const conflict: IInterventionConflict = {
+    code,
+    message: reason,
+    affectedRefs,
+  };
+
+  return {
+    domain,
+    kind: command.kind,
+    status: 'blocked',
+    actorId: command.actorId,
+    targetRefs: command.targetRefs,
+    causedBy: command.causedBy,
+    supersedes: command.supersedes,
+    conflicts: [conflict],
+    reason,
+  };
+}
+
+function normalizeConflicts(
+  conflicts: IGmCampaignInterventionCommandPayload['conflicts'] | undefined,
+): readonly IInterventionConflict[] {
+  return (conflicts ?? [])
+    .filter(
+      (conflict) =>
+        isNonEmptyString(conflict.code) && isNonEmptyString(conflict.message),
+    )
+    .map((conflict) => ({
+      code: conflict.code,
+      message: conflict.message,
+      affectedRefs: conflict.affectedRefs,
+      requiresManualTakeover: conflict.requiresManualTakeover,
+    }));
+}
+
+function isCampaignCommandPayload(
+  payload: unknown,
+): payload is IGmCampaignInterventionCommandPayload {
+  if (!isRecord(payload)) return false;
+  if (!isRecord(payload.privateMetadata)) return false;
+  if (typeof payload.privateMetadata.reason !== 'string') return false;
+  if (!isRecord(payload.correction)) return false;
+
+  return (
+    payload.correction.family === 'salvage-allocation' ||
+    payload.correction.family === 'repair-ticket' ||
+    payload.correction.family === 'funds-transaction' ||
+    payload.correction.family === 'inventory-lot' ||
+    payload.correction.family === 'base-unit-state'
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}

--- a/src/lib/interventions/GmCampaignInterventionPreview.ts
+++ b/src/lib/interventions/GmCampaignInterventionPreview.ts
@@ -1,0 +1,515 @@
+import type { IPartsInventoryItem } from '@/types/campaign/PartsInventory';
+import type {
+  GmCampaignInterventionDomain,
+  IGmCampaignBaseUnitStateCorrection,
+  IGmCampaignFundsTransactionCorrection,
+  IGmCampaignInterventionCommandPayload,
+  IGmCampaignInterventionState,
+  IGmCampaignInventoryLotCorrection,
+  IGmCampaignProjectedEffect,
+  IGmCampaignRepairTicketCorrection,
+  IGmCampaignSalvageAllocationCorrection,
+} from '@/types/interventions';
+
+import { TransactionType } from '@/types/campaign/Transaction';
+
+export interface IGmCampaignProjectedEffectResult {
+  readonly effect: IGmCampaignProjectedEffect;
+  readonly changedStateRefs: readonly string[];
+  readonly summary: string;
+}
+
+export interface IGmCampaignProjectedEffectFailure {
+  readonly effect?: undefined;
+  readonly code: string;
+  readonly reason: string;
+  readonly affectedRefs?: readonly string[];
+}
+
+export function buildGmCampaignProjectedEffect(
+  domain: GmCampaignInterventionDomain,
+  payload: IGmCampaignInterventionCommandPayload,
+  state: IGmCampaignInterventionState,
+): IGmCampaignProjectedEffectResult | IGmCampaignProjectedEffectFailure {
+  const { correction } = payload;
+
+  switch (correction.family) {
+    case 'salvage-allocation':
+      return buildSalvageAllocationEffect(
+        domain,
+        correction,
+        state,
+        payload.publicSummary,
+      );
+    case 'repair-ticket':
+      return buildRepairTicketEffect(
+        domain,
+        correction,
+        state,
+        payload.publicSummary,
+      );
+    case 'funds-transaction':
+      return buildFundsTransactionEffect(
+        domain,
+        correction,
+        state,
+        payload.publicSummary,
+      );
+    case 'inventory-lot':
+      return buildInventoryLotEffect(
+        domain,
+        correction,
+        state,
+        payload.publicSummary,
+      );
+    case 'base-unit-state':
+      return buildBaseUnitStateEffect(
+        domain,
+        correction,
+        state,
+        payload.publicSummary,
+      );
+  }
+}
+
+function buildSalvageAllocationEffect(
+  domain: GmCampaignInterventionDomain,
+  correction: IGmCampaignSalvageAllocationCorrection,
+  state: IGmCampaignInterventionState,
+  summaryOverride?: string,
+): IGmCampaignProjectedEffectResult | IGmCampaignProjectedEffectFailure {
+  if (!isNonEmptyString(correction.matchId)) {
+    return failure(
+      'campaign-salvage-match-invalid',
+      'Salvage correction requires a matchId.',
+      [campaignFieldRef(state.id, 'salvageAllocations')],
+    );
+  }
+
+  const before = state.salvageAllocations?.[correction.matchId];
+  const after = resolveObjectCorrection({
+    before,
+    replacement: correction.allocation,
+    patch: correction.patch,
+    remove: correction.remove,
+  });
+
+  if (!after.found) {
+    return failure(
+      'campaign-salvage-allocation-not-found',
+      `Salvage allocation "${correction.matchId}" was not found and no replacement was provided.`,
+      [salvageAllocationRef(state.id, correction.matchId)],
+    );
+  }
+
+  const changedStateRefs = [
+    campaignFieldRef(state.id, 'salvageAllocations'),
+    salvageAllocationRef(state.id, correction.matchId),
+  ];
+  const summary =
+    summaryOverride ??
+    `Salvage allocation ${correction.matchId} corrected by the GM.`;
+
+  return {
+    summary,
+    changedStateRefs,
+    effect: {
+      type: 'gm.campaign.salvage_allocation_corrected',
+      domain,
+      family: 'salvage-allocation',
+      matchId: correction.matchId,
+      before,
+      after: after.value,
+      changedStateRefs,
+      publicSummary: summary,
+    },
+  };
+}
+
+function buildRepairTicketEffect(
+  domain: GmCampaignInterventionDomain,
+  correction: IGmCampaignRepairTicketCorrection,
+  state: IGmCampaignInterventionState,
+  summaryOverride?: string,
+): IGmCampaignProjectedEffectResult | IGmCampaignProjectedEffectFailure {
+  if (!isNonEmptyString(correction.ticketId)) {
+    return failure(
+      'campaign-repair-ticket-id-invalid',
+      'Repair-ticket correction requires a ticketId.',
+      [campaignFieldRef(state.id, 'repairQueue')],
+    );
+  }
+
+  const before = (state.repairQueue ?? []).find(
+    (ticket) => ticket.ticketId === correction.ticketId,
+  );
+  const after = resolveObjectCorrection({
+    before,
+    replacement: correction.ticket,
+    patch: correction.patch,
+    remove: correction.remove,
+  });
+
+  if (!after.found) {
+    return failure(
+      'campaign-repair-ticket-not-found',
+      `Repair ticket "${correction.ticketId}" was not found and no replacement was provided.`,
+      [repairTicketRef(state.id, correction.ticketId)],
+    );
+  }
+
+  const changedStateRefs = [
+    campaignFieldRef(state.id, 'repairQueue'),
+    repairTicketRef(state.id, correction.ticketId),
+  ];
+  const summary =
+    summaryOverride ??
+    `Repair ticket ${correction.ticketId} corrected by the GM.`;
+
+  return {
+    summary,
+    changedStateRefs,
+    effect: {
+      type: 'gm.campaign.repair_ticket_corrected',
+      domain,
+      family: 'repair-ticket',
+      ticketId: correction.ticketId,
+      before,
+      after: after.value,
+      changedStateRefs,
+      publicSummary: summary,
+    },
+  };
+}
+
+function buildFundsTransactionEffect(
+  domain: GmCampaignInterventionDomain,
+  correction: IGmCampaignFundsTransactionCorrection,
+  state: IGmCampaignInterventionState,
+  summaryOverride?: string,
+): IGmCampaignProjectedEffectResult | IGmCampaignProjectedEffectFailure {
+  if (
+    !isNonEmptyString(correction.transactionId) ||
+    !isNonEmptyString(correction.description) ||
+    !Number.isFinite(correction.amountCents)
+  ) {
+    return failure(
+      'campaign-funds-transaction-invalid',
+      'Funds correction requires transactionId, description, and finite amountCents.',
+      [campaignFieldRef(state.id, 'finances')],
+    );
+  }
+
+  const beforeBalanceCents = state.finances.balance.centsValue;
+  const afterBalanceCents = beforeBalanceCents + correction.amountCents;
+  const transaction = {
+    id: correction.transactionId,
+    type: correction.transactionType ?? TransactionType.Miscellaneous,
+    amountCents: correction.amountCents,
+    date: correction.date ?? new Date().toISOString(),
+    description: correction.description,
+  };
+  const changedStateRefs = [
+    campaignFieldRef(state.id, 'finances'),
+    campaignFieldRef(state.id, 'finances:transactions'),
+    transactionRef(state.id, correction.transactionId),
+  ];
+  const summary =
+    summaryOverride ??
+    `Campaign funds adjusted by ${formatCents(correction.amountCents)}.`;
+
+  return {
+    summary,
+    changedStateRefs,
+    effect: {
+      type: 'gm.campaign.funds_transaction_corrected',
+      domain,
+      family: 'funds-transaction',
+      transactionId: correction.transactionId,
+      before: {
+        balanceCents: beforeBalanceCents,
+        transactionIds: state.finances.transactions.map(
+          (existing) => existing.id,
+        ),
+      },
+      after: {
+        balanceCents: afterBalanceCents,
+        transaction,
+      },
+      changedStateRefs,
+      publicSummary: summary,
+    },
+  };
+}
+
+function buildInventoryLotEffect(
+  domain: GmCampaignInterventionDomain,
+  correction: IGmCampaignInventoryLotCorrection,
+  state: IGmCampaignInterventionState,
+  summaryOverride?: string,
+): IGmCampaignProjectedEffectResult | IGmCampaignProjectedEffectFailure {
+  if (!isNonEmptyString(correction.inventoryId)) {
+    return failure(
+      'campaign-inventory-lot-id-invalid',
+      'Inventory correction requires an inventoryId.',
+      [campaignFieldRef(state.id, 'partsInventory')],
+    );
+  }
+
+  const before = (state.partsInventory ?? []).find(
+    (item) => item.inventoryId === correction.inventoryId,
+  );
+  const after = resolveInventoryLotAfter(correction, before);
+
+  if (!after.found) {
+    return failure(
+      'campaign-inventory-lot-not-found',
+      `Inventory lot "${correction.inventoryId}" was not found and no replacement was provided.`,
+      [inventoryLotRef(state.id, correction.inventoryId)],
+    );
+  }
+
+  const changedStateRefs = [
+    campaignFieldRef(state.id, 'partsInventory'),
+    inventoryLotRef(state.id, correction.inventoryId),
+  ];
+  const summary =
+    summaryOverride ??
+    `Inventory lot ${correction.inventoryId} corrected by the GM.`;
+
+  return {
+    summary,
+    changedStateRefs,
+    effect: {
+      type: 'gm.campaign.inventory_lot_corrected',
+      domain,
+      family: 'inventory-lot',
+      inventoryId: correction.inventoryId,
+      before,
+      after: after.value,
+      changedStateRefs,
+      publicSummary: summary,
+    },
+  };
+}
+
+function buildBaseUnitStateEffect(
+  domain: GmCampaignInterventionDomain,
+  correction: IGmCampaignBaseUnitStateCorrection,
+  state: IGmCampaignInterventionState,
+  summaryOverride?: string,
+): IGmCampaignProjectedEffectResult | IGmCampaignProjectedEffectFailure {
+  if (!isNonEmptyString(correction.unitId)) {
+    return failure(
+      'campaign-unit-id-invalid',
+      'Base unit state correction requires a unitId.',
+      [campaignRef(state.id)],
+    );
+  }
+
+  const beforeCombatState = state.unitCombatStates[correction.unitId];
+  const beforeConfiguration = state.unitConfigurations?.[correction.unitId];
+  const combatState = resolveObjectCorrection({
+    before: beforeCombatState,
+    replacement: correction.combatState,
+    patch: correction.combatStatePatch,
+    remove: correction.removeCombatState,
+  });
+  const configuration = resolveObjectCorrection({
+    before: beforeConfiguration,
+    replacement: correction.configuration,
+    patch: correction.configurationPatch,
+    remove: correction.removeConfiguration,
+  });
+
+  const touchesCombatState = correctionTouchesObject({
+    replacement: correction.combatState,
+    patch: correction.combatStatePatch,
+    remove: correction.removeCombatState,
+  });
+  const touchesConfiguration = correctionTouchesObject({
+    replacement: correction.configuration,
+    patch: correction.configurationPatch,
+    remove: correction.removeConfiguration,
+  });
+
+  if (!touchesCombatState && !touchesConfiguration) {
+    return failure(
+      'campaign-base-unit-state-empty',
+      'Base unit state correction requires a combat state or configuration change.',
+      [unitRef(state.id, correction.unitId)],
+    );
+  }
+
+  if (touchesCombatState && !combatState.found) {
+    return failure(
+      'campaign-unit-combat-state-not-found',
+      `Combat state for unit "${correction.unitId}" was not found and no replacement was provided.`,
+      [unitCombatStateRef(state.id, correction.unitId)],
+    );
+  }
+
+  if (touchesConfiguration && !configuration.found) {
+    return failure(
+      'campaign-unit-configuration-not-found',
+      `Configuration for unit "${correction.unitId}" was not found and no replacement was provided.`,
+      [unitConfigurationRef(state.id, correction.unitId)],
+    );
+  }
+
+  const changedStateRefs = [
+    unitRef(state.id, correction.unitId),
+    ...(touchesCombatState
+      ? [
+          campaignFieldRef(state.id, 'unitCombatStates'),
+          unitCombatStateRef(state.id, correction.unitId),
+        ]
+      : []),
+    ...(touchesConfiguration
+      ? [
+          campaignFieldRef(state.id, 'unitConfigurations'),
+          unitConfigurationRef(state.id, correction.unitId),
+        ]
+      : []),
+  ];
+  const summary =
+    summaryOverride ??
+    `Base unit state for ${correction.unitId} corrected by the GM.`;
+
+  return {
+    summary,
+    changedStateRefs,
+    effect: {
+      type: 'gm.campaign.base_unit_state_corrected',
+      domain,
+      family: 'base-unit-state',
+      unitId: correction.unitId,
+      before: {
+        combatState: beforeCombatState,
+        configuration: beforeConfiguration,
+      },
+      after: {
+        ...(touchesCombatState ? { combatState: combatState.value } : {}),
+        ...(touchesConfiguration ? { configuration: configuration.value } : {}),
+      },
+      changedStateRefs,
+      publicSummary: summary,
+    },
+  };
+}
+
+function resolveInventoryLotAfter(
+  correction: IGmCampaignInventoryLotCorrection,
+  before: IPartsInventoryItem | undefined,
+): { readonly found: boolean; readonly value?: IPartsInventoryItem } {
+  if (correction.remove)
+    return { found: before !== undefined, value: undefined };
+  const replacement = correction.item;
+  if (replacement) return { found: true, value: replacement };
+  if (!before) return { found: false };
+
+  const patched = {
+    ...before,
+    ...definedObjectPatch(correction.patch ?? {}),
+  };
+
+  if (correction.quantityDelta !== undefined) {
+    const quantity = patched.quantity + correction.quantityDelta;
+    if (quantity <= 0) return { found: true, value: undefined };
+    return { found: true, value: { ...patched, quantity } };
+  }
+
+  return { found: true, value: patched };
+}
+
+function resolveObjectCorrection<T>(input: {
+  readonly before: T | undefined;
+  readonly replacement?: T;
+  readonly patch?: Partial<T>;
+  readonly remove?: boolean;
+}): { readonly found: boolean; readonly value?: T } {
+  if (input.remove)
+    return { found: input.before !== undefined, value: undefined };
+  if (input.replacement) return { found: true, value: input.replacement };
+  if (!input.patch)
+    return { found: input.before !== undefined, value: input.before };
+  if (!input.before) return { found: false };
+  return {
+    found: true,
+    value: {
+      ...input.before,
+      ...definedObjectPatch(input.patch),
+    },
+  };
+}
+
+function correctionTouchesObject<T>(input: {
+  readonly replacement?: T;
+  readonly patch?: Partial<T>;
+  readonly remove?: boolean;
+}): boolean {
+  return Boolean(input.remove || input.replacement || input.patch);
+}
+
+function failure(
+  code: string,
+  reason: string,
+  affectedRefs: readonly string[],
+): IGmCampaignProjectedEffectFailure {
+  return { code, reason, affectedRefs };
+}
+
+function definedObjectPatch<T extends object>(value: Partial<T>): Partial<T> {
+  const entries = Object.entries(value).filter(
+    ([, entryValue]) => entryValue !== undefined,
+  );
+  return Object.fromEntries(entries) as Partial<T>;
+}
+
+function campaignRef(campaignId: string): string {
+  return `campaign:${campaignId}`;
+}
+
+function campaignFieldRef(campaignId: string, field: string): string {
+  return `campaign:${campaignId}:${field}`;
+}
+
+function salvageAllocationRef(campaignId: string, matchId: string): string {
+  return `campaign:${campaignId}:salvageAllocations:${matchId}`;
+}
+
+function repairTicketRef(campaignId: string, ticketId: string): string {
+  return `campaign:${campaignId}:repairQueue:${ticketId}`;
+}
+
+function transactionRef(campaignId: string, transactionId: string): string {
+  return `campaign:${campaignId}:finances:transactions:${transactionId}`;
+}
+
+function inventoryLotRef(campaignId: string, inventoryId: string): string {
+  return `campaign:${campaignId}:partsInventory:${inventoryId}`;
+}
+
+function unitRef(campaignId: string, unitId: string): string {
+  return `campaign:${campaignId}:unit:${unitId}`;
+}
+
+function unitCombatStateRef(campaignId: string, unitId: string): string {
+  return `campaign:${campaignId}:unitCombatStates:${unitId}`;
+}
+
+function unitConfigurationRef(campaignId: string, unitId: string): string {
+  return `campaign:${campaignId}:unitConfigurations:${unitId}`;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function formatCents(amountCents: number): string {
+  const amount = amountCents / 100;
+  return `${amount.toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })} C-bills`;
+}

--- a/src/lib/interventions/GmCampaignInterventionProjection.ts
+++ b/src/lib/interventions/GmCampaignInterventionProjection.ts
@@ -1,0 +1,251 @@
+import type { Transaction } from '@/types/campaign/Transaction';
+import type {
+  IGmCampaignInterventionDomainPayload,
+  IGmCampaignInterventionState,
+  IGmCampaignProjectedEffect,
+  IGmCampaignProjectedTransaction,
+  IGmCampaignPublicEffect,
+  IGmPrivateMetadata,
+  IInterventionLedgerRecord,
+} from '@/types/interventions';
+
+import { Money } from '@/types/campaign/Money';
+
+type CampaignRecord = IInterventionLedgerRecord<
+  IGmPrivateMetadata,
+  IGmCampaignPublicEffect,
+  IGmCampaignInterventionDomainPayload
+>;
+
+export function projectCampaignEffectsForRecord(
+  record: CampaignRecord,
+): readonly IGmCampaignProjectedEffect[] {
+  if (!record.domainPayload) return [];
+
+  return record.domainPayload.projectedEffects.map(
+    (effect) =>
+      ({
+        ...effect,
+        interventionId: record.id,
+      }) as IGmCampaignProjectedEffect,
+  );
+}
+
+export function applyGmCampaignProjectedEffects(
+  state: IGmCampaignInterventionState,
+  effects: readonly IGmCampaignProjectedEffect[],
+): IGmCampaignInterventionState {
+  return effects.reduce(applyGmCampaignProjectedEffect, state);
+}
+
+function applyGmCampaignProjectedEffect(
+  state: IGmCampaignInterventionState,
+  effect: IGmCampaignProjectedEffect,
+): IGmCampaignInterventionState {
+  switch (effect.family) {
+    case 'salvage-allocation':
+      return appendGmCampaignEvent(
+        applySalvageAllocationEffect(state, effect),
+        effect,
+      );
+    case 'repair-ticket':
+      return appendGmCampaignEvent(
+        applyRepairTicketEffect(state, effect),
+        effect,
+      );
+    case 'funds-transaction':
+      return appendGmCampaignEvent(
+        applyFundsTransactionEffect(state, effect),
+        effect,
+      );
+    case 'inventory-lot':
+      return appendGmCampaignEvent(
+        applyInventoryLotEffect(state, effect),
+        effect,
+      );
+    case 'base-unit-state':
+      return appendGmCampaignEvent(
+        applyBaseUnitStateEffect(state, effect),
+        effect,
+      );
+  }
+}
+
+function applySalvageAllocationEffect(
+  state: IGmCampaignInterventionState,
+  effect: Extract<
+    IGmCampaignProjectedEffect,
+    { readonly family: 'salvage-allocation' }
+  >,
+): IGmCampaignInterventionState {
+  const next = { ...(state.salvageAllocations ?? {}) };
+  if (effect.after) {
+    next[effect.matchId] = effect.after;
+  } else {
+    delete next[effect.matchId];
+  }
+
+  return {
+    ...state,
+    salvageAllocations: next,
+  };
+}
+
+function applyRepairTicketEffect(
+  state: IGmCampaignInterventionState,
+  effect: Extract<
+    IGmCampaignProjectedEffect,
+    { readonly family: 'repair-ticket' }
+  >,
+): IGmCampaignInterventionState {
+  const queue = state.repairQueue ?? [];
+  const existingIndex = queue.findIndex(
+    (ticket) => ticket.ticketId === effect.ticketId,
+  );
+
+  if (!effect.after) {
+    return {
+      ...state,
+      repairQueue: queue.filter(
+        (ticket) => ticket.ticketId !== effect.ticketId,
+      ),
+    };
+  }
+
+  if (existingIndex < 0) {
+    return {
+      ...state,
+      repairQueue: [...queue, effect.after],
+    };
+  }
+
+  const next = [...queue];
+  next[existingIndex] = effect.after;
+  return {
+    ...state,
+    repairQueue: next,
+  };
+}
+
+function applyFundsTransactionEffect(
+  state: IGmCampaignInterventionState,
+  effect: Extract<
+    IGmCampaignProjectedEffect,
+    { readonly family: 'funds-transaction' }
+  >,
+): IGmCampaignInterventionState {
+  const existing = state.finances.transactions.filter(
+    (transaction) => transaction.id !== effect.transactionId,
+  );
+
+  return {
+    ...state,
+    finances: {
+      ...state.finances,
+      balance: Money.fromCents(effect.after.balanceCents),
+      transactions: [
+        ...existing,
+        projectedTransactionToTransaction(effect.after.transaction),
+      ],
+    },
+  };
+}
+
+function applyInventoryLotEffect(
+  state: IGmCampaignInterventionState,
+  effect: Extract<
+    IGmCampaignProjectedEffect,
+    { readonly family: 'inventory-lot' }
+  >,
+): IGmCampaignInterventionState {
+  const inventory = state.partsInventory ?? [];
+  const existingIndex = inventory.findIndex(
+    (item) => item.inventoryId === effect.inventoryId,
+  );
+
+  if (!effect.after) {
+    return {
+      ...state,
+      partsInventory: inventory.filter(
+        (item) => item.inventoryId !== effect.inventoryId,
+      ),
+    };
+  }
+
+  if (existingIndex < 0) {
+    return {
+      ...state,
+      partsInventory: [...inventory, effect.after],
+    };
+  }
+
+  const next = [...inventory];
+  next[existingIndex] = effect.after;
+  return {
+    ...state,
+    partsInventory: next,
+  };
+}
+
+function applyBaseUnitStateEffect(
+  state: IGmCampaignInterventionState,
+  effect: Extract<
+    IGmCampaignProjectedEffect,
+    { readonly family: 'base-unit-state' }
+  >,
+): IGmCampaignInterventionState {
+  const touchesCombatState = Object.prototype.hasOwnProperty.call(
+    effect.after,
+    'combatState',
+  );
+  const touchesConfiguration = Object.prototype.hasOwnProperty.call(
+    effect.after,
+    'configuration',
+  );
+  const nextCombatStates = { ...state.unitCombatStates };
+  const nextConfigurations = { ...(state.unitConfigurations ?? {}) };
+
+  if (touchesCombatState) {
+    if (effect.after.combatState) {
+      nextCombatStates[effect.unitId] = effect.after.combatState;
+    } else {
+      delete nextCombatStates[effect.unitId];
+    }
+  }
+
+  if (touchesConfiguration) {
+    if (effect.after.configuration) {
+      nextConfigurations[effect.unitId] = effect.after.configuration;
+    } else {
+      delete nextConfigurations[effect.unitId];
+    }
+  }
+
+  return {
+    ...state,
+    ...(touchesCombatState ? { unitCombatStates: nextCombatStates } : {}),
+    ...(touchesConfiguration ? { unitConfigurations: nextConfigurations } : {}),
+  };
+}
+
+function appendGmCampaignEvent(
+  state: IGmCampaignInterventionState,
+  effect: IGmCampaignProjectedEffect,
+): IGmCampaignInterventionState {
+  return {
+    ...state,
+    gmInterventionEvents: [...(state.gmInterventionEvents ?? []), effect],
+  };
+}
+
+function projectedTransactionToTransaction(
+  projected: IGmCampaignProjectedTransaction,
+): Transaction {
+  return {
+    id: projected.id,
+    type: projected.type,
+    amount: Money.fromCents(projected.amountCents),
+    date: new Date(projected.date),
+    description: projected.description,
+  };
+}

--- a/src/lib/interventions/__tests__/GmCampaignInterventionBoundaries.test.ts
+++ b/src/lib/interventions/__tests__/GmCampaignInterventionBoundaries.test.ts
@@ -38,10 +38,6 @@ interface DeferredCommandPayload {
 }
 
 const deferredDomains = [
-  'post-combat',
-  'economy',
-  'repair',
-  'salvage',
   'time',
 ] as const satisfies readonly InterventionDomain[];
 
@@ -153,7 +149,7 @@ describe('GM campaign intervention boundaries', () => {
     },
   );
 
-  it('logs deferred attempts without exposing hidden scenario notes', () => {
+  it('logs deferred time attempts without exposing hidden scenario notes', () => {
     const state = makeState();
     const ledger = new InterventionLedger<CampaignBoundaryState>();
     const logs: Array<{
@@ -163,7 +159,7 @@ describe('GM campaign intervention boundaries', () => {
 
     const preview = createGmCascadePreview({
       ledger,
-      command: makeCommand('economy'),
+      command: makeCommand('time'),
       state,
       authority: gmAuthority,
       interventionId: 'gm-int-safe-log',
@@ -176,9 +172,9 @@ describe('GM campaign intervention boundaries', () => {
     expect(JSON.stringify(preview)).not.toContain('secret merchant');
     expect(JSON.stringify(logs)).not.toContain('secret merchant');
     expect(logs[0]?.entry).toMatchObject({
-      domain: 'economy',
+      domain: 'time',
       deferredReason:
-        'No intervention ledger implementer registered for domain "economy".',
+        'No intervention ledger implementer registered for domain "time".',
     });
   });
 });

--- a/src/lib/interventions/__tests__/GmCampaignInterventionImplementer.test.ts
+++ b/src/lib/interventions/__tests__/GmCampaignInterventionImplementer.test.ts
@@ -1,0 +1,648 @@
+import type { IPartsInventoryItem } from '@/types/campaign/PartsInventory';
+import type { IRepairTicket } from '@/types/campaign/RepairTicket';
+import type { IUnitCombatState } from '@/types/campaign/UnitCombatState';
+import type {
+  GmCampaignInterventionDomain,
+  IGmAuthorityContext,
+  IGmCampaignInterventionCommandPayload,
+  IGmCampaignInterventionDomainPayload,
+  IGmCampaignInterventionState,
+  IGmCampaignPublicEffect,
+  IGmPrivateMetadata,
+  IInterventionLedgerCommand,
+  IInterventionLedgerRecord,
+} from '@/types/interventions';
+import type { MechBuildConfig } from '@/utils/construction/constructionRules/types';
+
+import { createCampaign } from '@/types/campaign/Campaign';
+import { Money } from '@/types/campaign/Money';
+import { DamageLevel, type ISalvageAllocation } from '@/types/campaign/Salvage';
+import { TransactionType } from '@/types/campaign/Transaction';
+import { ArmorTypeEnum } from '@/types/construction/ArmorType';
+import { CockpitType } from '@/types/construction/CockpitType';
+import { EngineType } from '@/types/construction/EngineType';
+import { GyroType } from '@/types/construction/GyroType';
+import { HeatSinkType } from '@/types/construction/HeatSinkType';
+import { InternalStructureType } from '@/types/construction/InternalStructureType';
+
+import { ActionLedger } from '../ActionLedger';
+import {
+  applyGmCampaignProjectedEffects,
+  approveGmCascadePreview,
+  createGmCascadePreview,
+  projectCampaignEffectsForRecord,
+  projectInterventionRecordForPlayer,
+  registerGmCampaignInterventionImplementers,
+} from '../index';
+import { InterventionLedger } from '../InterventionLedger';
+
+type CampaignRecord = IInterventionLedgerRecord<
+  IGmPrivateMetadata,
+  IGmCampaignPublicEffect,
+  IGmCampaignInterventionDomainPayload
+>;
+
+const gmAuthority: IGmAuthorityContext = {
+  actorId: 'gm-1',
+  role: 'gm',
+  gameId: 'game-1',
+  campaignId: 'campaign-1',
+  ownedStateRefs: ['campaign:campaign-1'],
+};
+
+function makeState(): IGmCampaignInterventionState {
+  const campaign = createCampaign('Wave 8 Test Campaign', 'mercenary');
+  return {
+    ...campaign,
+    id: 'campaign-1',
+    currentDate: new Date('3025-02-01T00:00:00.000Z'),
+    finances: {
+      balance: new Money(1_000_000),
+      transactions: [],
+    },
+    repairQueue: [makeRepairTicket()],
+    salvageAllocations: {
+      'match-1': makeSalvageAllocation({ processed: false }),
+    },
+    partsInventory: [makeInventoryItem({ quantity: 3 })],
+    unitCombatStates: {
+      'unit-1': makeCombatState({ combatReady: false }),
+    },
+    unitConfigurations: {
+      'unit-1': makeConfig({ jumpMP: 0 }),
+    },
+    gmInterventionEvents: [],
+  };
+}
+
+function makeLedger(): InterventionLedger<IGmCampaignInterventionState> {
+  return registerGmCampaignInterventionImplementers(
+    new InterventionLedger<IGmCampaignInterventionState>(),
+  );
+}
+
+function makeCommand(
+  domain: GmCampaignInterventionDomain,
+  payload: IGmCampaignInterventionCommandPayload,
+  overrides: Partial<
+    IInterventionLedgerCommand<IGmCampaignInterventionCommandPayload>
+  > = {},
+): IInterventionLedgerCommand<IGmCampaignInterventionCommandPayload> {
+  return {
+    domain,
+    kind: 'fix',
+    actorId: 'gm-1',
+    targetRefs: [`campaign:campaign-1:${payload.correction.family}`],
+    payload,
+    causedBy: ['player-action-1'],
+    ...overrides,
+  };
+}
+
+function payload(
+  correction: IGmCampaignInterventionCommandPayload['correction'],
+  publicSummary?: string,
+  overrides: Partial<IGmCampaignInterventionCommandPayload> = {},
+): IGmCampaignInterventionCommandPayload {
+  return {
+    correction,
+    publicSummary,
+    privateMetadata: {
+      reason: 'Hidden campaign correction reason.',
+      defaultOutcome: 'The campaign state would remain as originally resolved.',
+      hiddenNotes: 'Secret employer clause stays private.',
+    },
+    ...overrides,
+  };
+}
+
+function approveCommand(
+  command: IInterventionLedgerCommand<IGmCampaignInterventionCommandPayload>,
+  state = makeState(),
+  actionLedger?: ActionLedger,
+): {
+  readonly state: IGmCampaignInterventionState;
+  readonly record: CampaignRecord;
+} {
+  const ledger = makeLedger();
+  const preview = createGmCascadePreview({
+    ledger,
+    command,
+    state,
+    authority: gmAuthority,
+    interventionId: `gm-int-${command.domain}-${command.payload?.correction.family}`,
+  });
+
+  const result = approveGmCascadePreview({
+    ledger,
+    actionLedger,
+    preview,
+    state,
+    createdAt: '2026-06-22T00:00:00.000Z',
+    approvedAt: '2026-06-22T00:01:00.000Z',
+  });
+
+  expect(result.status).toBe('approved');
+  if (result.status !== 'approved' || !result.record) {
+    throw new Error('Expected campaign GM intervention approval.');
+  }
+
+  return {
+    state: result.state as IGmCampaignInterventionState,
+    record: result.record as CampaignRecord,
+  };
+}
+
+describe('GM campaign intervention implementer', () => {
+  it('registers campaign domains and leaves time deferred', () => {
+    const ledger = makeLedger();
+    const state = makeState();
+
+    const economyPreview = createGmCascadePreview({
+      ledger,
+      command: makeCommand(
+        'economy',
+        payload({
+          family: 'funds-transaction',
+          transactionId: 'gm-economy-1',
+          amountCents: -250_000,
+          description: 'Reverse duplicated merchant charge.',
+          transactionType: TransactionType.PartPurchase,
+          date: '3025-02-02T00:00:00.000Z',
+        }),
+      ),
+      state,
+      authority: gmAuthority,
+      interventionId: 'gm-int-economy-ready',
+    });
+    const timePreview = createGmCascadePreview({
+      ledger,
+      command: {
+        domain: 'time',
+        kind: 'fix',
+        actorId: 'gm-1',
+        targetRefs: ['campaign:campaign-1:currentDate'],
+      },
+      state,
+      authority: gmAuthority,
+      interventionId: 'gm-int-time-deferred',
+    });
+
+    expect(economyPreview.status).toBe('ready');
+    expect(timePreview).toMatchObject({
+      status: 'deferred',
+      domain: 'time',
+      projectedEvents: [],
+    });
+  });
+
+  it('previews and applies salvage allocation corrections with player-safe output', () => {
+    const result = approveCommand(
+      makeCommand(
+        'salvage',
+        payload(
+          {
+            family: 'salvage-allocation',
+            matchId: 'match-1',
+            patch: {
+              processed: true,
+            },
+          },
+          'Salvage allocation for match-1 corrected.',
+        ),
+      ),
+    );
+    const playerRecord = projectInterventionRecordForPlayer(result.record);
+
+    expect(result.state.salvageAllocations?.['match-1'].processed).toBe(true);
+    expect(result.state.gmInterventionEvents).toHaveLength(1);
+    expect(playerRecord.publicEffect).toMatchObject({
+      summary: 'Salvage allocation for match-1 corrected.',
+      family: 'salvage-allocation',
+      changedStateRefs: [
+        'campaign:campaign-1:salvageAllocations',
+        'campaign:campaign-1:salvageAllocations:match-1',
+      ],
+    });
+    expect(JSON.stringify(playerRecord)).not.toContain('Hidden campaign');
+    expect(JSON.stringify(playerRecord)).not.toContain('Secret employer');
+  });
+
+  it('previews and applies repair ticket corrections', () => {
+    const result = approveCommand(
+      makeCommand(
+        'repair',
+        payload({
+          family: 'repair-ticket',
+          ticketId: 'ticket-1',
+          patch: {
+            status: 'completed',
+            remainingHours: 0,
+          },
+        }),
+      ),
+    );
+
+    expect(result.state.repairQueue?.[0]).toMatchObject({
+      ticketId: 'ticket-1',
+      status: 'completed',
+      remainingHours: 0,
+    });
+    expect(result.record.publicEffect.changedStateRefs).toContain(
+      'campaign:campaign-1:repairQueue:ticket-1',
+    );
+  });
+
+  it('applies funds corrections through the intervention and action ledgers', () => {
+    const actionLedger = new ActionLedger();
+    actionLedger.appendNormalAction({
+      id: 'player-action-1',
+      actorId: 'player-1',
+      domain: 'economy',
+      action: 'buy-part',
+      targetRefs: ['campaign:campaign-1:partsInventory:inventory-1'],
+      publicEffect: {
+        summary: 'Player bought a part.',
+        changedStateRefs: ['campaign:campaign-1:finances'],
+      },
+      createdAt: '2026-06-22T00:00:00.000Z',
+    });
+
+    const state = makeState();
+    const result = approveCommand(
+      makeCommand(
+        'economy',
+        payload(
+          {
+            family: 'funds-transaction',
+            transactionId: 'merchant-reversal-1',
+            amountCents: -250_000,
+            description: 'Reverse duplicated merchant charge.',
+            transactionType: TransactionType.PartPurchase,
+            date: '3025-02-02T00:00:00.000Z',
+          },
+          'Merchant charge corrected by -2,500.00 C-bills.',
+        ),
+      ),
+      state,
+      actionLedger,
+    );
+    const replayed = applyGmCampaignProjectedEffects(
+      state,
+      projectCampaignEffectsForRecord(result.record),
+    );
+    const playerProjection = actionLedger.projectForPlayer();
+    const gmProjection = actionLedger.projectForGm();
+
+    expect(result.state.finances.balance.centsValue).toBe(99_750_000);
+    expect(result.state.finances.transactions).toHaveLength(1);
+    expect(result.state.finances.transactions[0]).toMatchObject({
+      id: 'merchant-reversal-1',
+      type: TransactionType.PartPurchase,
+      description: 'Reverse duplicated merchant charge.',
+    });
+    expect(result.state.finances.transactions[0].amount.centsValue).toBe(
+      -250_000,
+    );
+    expect(replayed).toEqual(result.state);
+    expect(playerProjection.map((record) => record.id)).toEqual([
+      'player-action-1',
+      'action:gm-int-economy-funds-transaction',
+    ]);
+    expect(JSON.stringify(playerProjection)).not.toContain('Hidden campaign');
+    expect(JSON.stringify(gmProjection)).toContain('Hidden campaign');
+  });
+
+  it('previews and applies inventory and base unit state corrections', () => {
+    const state = makeState();
+    const inventoryResult = approveCommand(
+      makeCommand(
+        'economy',
+        payload({
+          family: 'inventory-lot',
+          inventoryId: 'inventory-1',
+          quantityDelta: -1,
+        }),
+      ),
+      state,
+    );
+    const baseStateResult = approveCommand(
+      makeCommand(
+        'post-combat',
+        payload({
+          family: 'base-unit-state',
+          unitId: 'unit-1',
+          combatStatePatch: {
+            combatReady: true,
+            lastUpdated: '3025-02-02T00:00:00.000Z',
+          },
+          configurationPatch: {
+            jumpMP: 3,
+          },
+        }),
+      ),
+      inventoryResult.state,
+    );
+
+    expect(inventoryResult.state.partsInventory?.[0]).toMatchObject({
+      inventoryId: 'inventory-1',
+      quantity: 2,
+    });
+    expect(baseStateResult.state.unitCombatStates['unit-1']).toMatchObject({
+      combatReady: true,
+      lastUpdated: '3025-02-02T00:00:00.000Z',
+    });
+    expect(baseStateResult.state.unitConfigurations?.['unit-1'].jumpMP).toBe(3);
+  });
+
+  it('requires manual takeover for unresolved campaign cascades and blocks approval', () => {
+    const ledger = makeLedger();
+    const actionLedger = new ActionLedger();
+    const state = makeState();
+    const preview = createGmCascadePreview({
+      ledger,
+      command: makeCommand(
+        'economy',
+        payload(
+          {
+            family: 'inventory-lot',
+            inventoryId: 'inventory-1',
+            quantityDelta: -2,
+          },
+          undefined,
+          {
+            conflicts: [
+              {
+                code: 'merchant-cascade-ambiguous',
+                message:
+                  'Merchant reversal also affects a hidden contract option.',
+                affectedRefs: ['campaign:campaign-1:finances'],
+                requiresManualTakeover: true,
+              },
+            ],
+          },
+        ),
+      ),
+      state,
+      authority: gmAuthority,
+      interventionId: 'gm-int-manual-economy',
+    });
+    const result = approveGmCascadePreview({
+      ledger,
+      actionLedger,
+      preview,
+      state,
+    });
+
+    expect(preview.status).toBe('requires-manual-takeover');
+    expect(preview.conflicts[0]).toMatchObject({
+      code: 'merchant-cascade-ambiguous',
+      requiresManualTakeover: true,
+    });
+    expect(result).toMatchObject({
+      status: 'blocked',
+      state,
+      appended: false,
+    });
+    expect(ledger.getRecords()).toEqual([]);
+    expect(actionLedger.getRecords()).toEqual([]);
+  });
+
+  it('blocks missing campaign targets before approval', () => {
+    const ledger = makeLedger();
+    const state = makeState();
+    const preview = createGmCascadePreview({
+      ledger,
+      command: makeCommand(
+        'repair',
+        payload({
+          family: 'repair-ticket',
+          ticketId: 'missing-ticket',
+          patch: {
+            status: 'completed',
+          },
+        }),
+      ),
+      state,
+      authority: gmAuthority,
+      interventionId: 'gm-int-missing-ticket',
+    });
+
+    expect(preview.status).toBe('blocked');
+    expect(preview.conflicts).toContainEqual(
+      expect.objectContaining({
+        code: 'campaign-repair-ticket-not-found',
+      }),
+    );
+  });
+
+  it('rejects non-GM campaign corrections without returning private metadata', () => {
+    const ledger = makeLedger();
+    const state = makeState();
+    const preview = createGmCascadePreview({
+      ledger,
+      command: makeCommand(
+        'salvage',
+        payload({
+          family: 'salvage-allocation',
+          matchId: 'match-1',
+          patch: {
+            processed: true,
+          },
+        }),
+      ),
+      state,
+      authority: {
+        ...gmAuthority,
+        actorId: 'player-1',
+        role: 'player',
+      },
+      interventionId: 'gm-int-rejected',
+    });
+
+    expect(preview).toMatchObject({
+      status: 'rejected',
+      reason: 'Intervention actor does not match the authority context actor.',
+    });
+    expect(JSON.stringify(preview)).not.toContain('Hidden campaign');
+    expect(JSON.stringify(preview)).not.toContain('Secret employer');
+  });
+
+  it.each([
+    [
+      'salvage',
+      payload({
+        family: 'salvage-allocation',
+        matchId: 'match-1',
+        patch: {
+          processed: true,
+        },
+      }),
+    ],
+    [
+      'repair',
+      payload({
+        family: 'repair-ticket',
+        ticketId: 'ticket-1',
+        patch: {
+          status: 'completed',
+          remainingHours: 0,
+        },
+      }),
+    ],
+    [
+      'economy',
+      payload({
+        family: 'inventory-lot',
+        inventoryId: 'inventory-1',
+        quantityDelta: -1,
+      }),
+    ],
+    [
+      'post-combat',
+      payload({
+        family: 'base-unit-state',
+        unitId: 'unit-1',
+        combatStatePatch: {
+          combatReady: true,
+        },
+      }),
+    ],
+  ] as const)(
+    'replays projected effects for %s corrections',
+    (domain, body) => {
+      const state = makeState();
+      const result = approveCommand(makeCommand(domain, body), state);
+      const replayed = applyGmCampaignProjectedEffects(
+        state,
+        projectCampaignEffectsForRecord(result.record),
+      );
+
+      expect(replayed).toEqual(result.state);
+      expect(replayed.gmInterventionEvents).toHaveLength(1);
+    },
+  );
+});
+
+function makeSalvageAllocation(
+  overrides: Partial<ISalvageAllocation> = {},
+): ISalvageAllocation {
+  const candidate = {
+    source: 'part' as const,
+    unitId: 'enemy-1',
+    designation: 'Medium Laser',
+    destroyedFromBattle: 'match-1',
+    finalStatus: 'destroyed' as const,
+    damageLevel: DamageLevel.Moderate,
+    originalValue: 40_000,
+    recoveredValue: 20_000,
+    recoveryPercentage: 0.5,
+    repairCostEstimate: 2_000,
+    partId: 'medium-laser',
+    location: 'RA',
+    disposition: 'mercenary' as const,
+    status: 'awarded' as const,
+  };
+
+  return {
+    pool: {
+      battleId: 'match-1',
+      contractId: 'contract-1',
+      candidates: [candidate],
+      totalEstimatedValue: 20_000,
+      hostileTerritory: false,
+    },
+    employerAward: {
+      side: 'employer',
+      candidates: [],
+      totalValue: 0,
+      estimatedRepairCost: 0,
+    },
+    mercenaryAward: {
+      side: 'mercenary',
+      candidates: [candidate],
+      totalValue: 20_000,
+      estimatedRepairCost: 2_000,
+    },
+    splitMethod: 'contract',
+    processed: false,
+    ...overrides,
+  };
+}
+
+function makeRepairTicket(
+  overrides: Partial<IRepairTicket> = {},
+): IRepairTicket {
+  return {
+    ticketId: 'ticket-1',
+    unitId: 'unit-1',
+    kind: 'armor',
+    location: 'CT',
+    pointsToRestore: 8,
+    expectedHours: 4,
+    remainingHours: 4,
+    partsRequired: [],
+    source: 'combat',
+    matchId: 'match-1',
+    createdAt: '3025-02-01T00:00:00.000Z',
+    status: 'queued',
+    ...overrides,
+  };
+}
+
+function makeInventoryItem(
+  overrides: Partial<IPartsInventoryItem> = {},
+): IPartsInventoryItem {
+  return {
+    inventoryId: 'inventory-1',
+    partId: 'medium-laser',
+    partName: 'Medium Laser',
+    quantity: 1,
+    source: 'salvage',
+    acquiredAt: '3025-02-01T00:00:00.000Z',
+    unitId: 'enemy-1',
+    location: 'RA',
+    ...overrides,
+  };
+}
+
+function makeCombatState(
+  overrides: Partial<IUnitCombatState> = {},
+): IUnitCombatState {
+  return {
+    unitId: 'unit-1',
+    currentArmorPerLocation: {
+      CT: 20,
+      RA: 8,
+    },
+    currentStructurePerLocation: {
+      CT: 10,
+      RA: 0,
+    },
+    destroyedLocations: ['RA'],
+    destroyedComponents: [],
+    heatEnd: 0,
+    ammoRemaining: {},
+    combatReady: true,
+    lastCombatOutcomeId: 'match-1',
+    lastUpdated: '3025-02-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeConfig(overrides: Partial<MechBuildConfig> = {}): MechBuildConfig {
+  return {
+    tonnage: 55,
+    engineRating: 275,
+    engineType: EngineType.STANDARD,
+    gyroType: GyroType.STANDARD,
+    internalStructureType: InternalStructureType.STANDARD,
+    armorType: ArmorTypeEnum.STANDARD,
+    totalArmorPoints: 168,
+    cockpitType: CockpitType.STANDARD,
+    heatSinkType: HeatSinkType.SINGLE,
+    totalHeatSinks: 10,
+    jumpMP: 0,
+    ...overrides,
+  };
+}

--- a/src/lib/interventions/index.ts
+++ b/src/lib/interventions/index.ts
@@ -31,9 +31,20 @@ export {
 } from './GmCombatInterventionImplementer';
 
 export {
+  createGmCampaignInterventionImplementer,
+  registerGmCampaignInterventionImplementer,
+  registerGmCampaignInterventionImplementers,
+} from './GmCampaignInterventionImplementer';
+
+export {
   applyGmCombatProjectedEffects,
   projectCombatEffectsForRecord,
 } from './GmCombatInterventionProjection';
+
+export {
+  applyGmCampaignProjectedEffects,
+  projectCampaignEffectsForRecord,
+} from './GmCampaignInterventionProjection';
 
 export {
   createGmUnitReloadInterventionImplementer,

--- a/src/types/interventions/GmCampaignInterventionTypes.ts
+++ b/src/types/interventions/GmCampaignInterventionTypes.ts
@@ -1,0 +1,184 @@
+import type { ICampaign } from '@/types/campaign/Campaign';
+import type { IPartsInventoryItem } from '@/types/campaign/PartsInventory';
+import type { IRepairTicket } from '@/types/campaign/RepairTicket';
+import type { ISalvageAllocation } from '@/types/campaign/Salvage';
+import type { TransactionType } from '@/types/campaign/Transaction';
+import type { IUnitCombatState } from '@/types/campaign/UnitCombatState';
+import type { MechBuildConfig } from '@/utils/construction/constructionRules/types';
+
+import type {
+  IGmPrivateMetadata,
+  IGmPublicEffect,
+} from './GmInterventionAuthorityTypes';
+import type { InterventionDomain } from './InterventionLedgerTypes';
+
+export type GmCampaignInterventionDomain =
+  | 'post-combat'
+  | 'economy'
+  | 'repair'
+  | 'salvage';
+
+export type GmCampaignCorrectionFamily =
+  | 'salvage-allocation'
+  | 'repair-ticket'
+  | 'funds-transaction'
+  | 'inventory-lot'
+  | 'base-unit-state';
+
+export interface IGmCampaignInterventionState extends ICampaign {
+  readonly gmInterventionEvents?: readonly IGmCampaignProjectedEffect[];
+}
+
+export interface IGmCampaignInterventionConflictInput {
+  readonly code: string;
+  readonly message: string;
+  readonly affectedRefs?: readonly string[];
+  readonly requiresManualTakeover?: boolean;
+}
+
+export interface IGmCampaignSalvageAllocationCorrection {
+  readonly family: 'salvage-allocation';
+  readonly matchId: string;
+  readonly allocation?: ISalvageAllocation;
+  readonly patch?: Partial<ISalvageAllocation>;
+  readonly remove?: boolean;
+}
+
+export interface IGmCampaignRepairTicketCorrection {
+  readonly family: 'repair-ticket';
+  readonly ticketId: string;
+  readonly ticket?: IRepairTicket;
+  readonly patch?: Partial<IRepairTicket>;
+  readonly remove?: boolean;
+}
+
+export interface IGmCampaignFundsTransactionCorrection {
+  readonly family: 'funds-transaction';
+  readonly transactionId: string;
+  readonly amountCents: number;
+  readonly description: string;
+  readonly transactionType?: TransactionType;
+  readonly date?: string;
+}
+
+export interface IGmCampaignInventoryLotCorrection {
+  readonly family: 'inventory-lot';
+  readonly inventoryId: string;
+  readonly item?: IPartsInventoryItem;
+  readonly patch?: Partial<IPartsInventoryItem>;
+  readonly quantityDelta?: number;
+  readonly remove?: boolean;
+}
+
+export interface IGmCampaignBaseUnitStateCorrection {
+  readonly family: 'base-unit-state';
+  readonly unitId: string;
+  readonly combatState?: IUnitCombatState;
+  readonly combatStatePatch?: Partial<IUnitCombatState>;
+  readonly configuration?: MechBuildConfig;
+  readonly configurationPatch?: Partial<MechBuildConfig>;
+  readonly removeCombatState?: boolean;
+  readonly removeConfiguration?: boolean;
+}
+
+export type GmCampaignInterventionCorrection =
+  | IGmCampaignSalvageAllocationCorrection
+  | IGmCampaignRepairTicketCorrection
+  | IGmCampaignFundsTransactionCorrection
+  | IGmCampaignInventoryLotCorrection
+  | IGmCampaignBaseUnitStateCorrection;
+
+export interface IGmCampaignInterventionCommandPayload {
+  readonly correction: GmCampaignInterventionCorrection;
+  readonly privateMetadata: IGmPrivateMetadata;
+  readonly publicSummary?: string;
+  readonly visibleToPlayerIds?: readonly string[];
+  readonly conflicts?: readonly IGmCampaignInterventionConflictInput[];
+}
+
+export interface IGmCampaignProjectedTransaction {
+  readonly id: string;
+  readonly type: TransactionType;
+  readonly amountCents: number;
+  readonly date: string;
+  readonly description: string;
+}
+
+export type GmCampaignProjectedEffectType =
+  | 'gm.campaign.salvage_allocation_corrected'
+  | 'gm.campaign.repair_ticket_corrected'
+  | 'gm.campaign.funds_transaction_corrected'
+  | 'gm.campaign.inventory_lot_corrected'
+  | 'gm.campaign.base_unit_state_corrected';
+
+export interface IGmCampaignProjectedEffectBase<TType extends string> {
+  readonly type: TType;
+  readonly domain: InterventionDomain;
+  readonly family: GmCampaignCorrectionFamily;
+  readonly interventionId?: string;
+  readonly changedStateRefs: readonly string[];
+  readonly publicSummary: string;
+}
+
+export interface IGmCampaignSalvageAllocationEffect extends IGmCampaignProjectedEffectBase<'gm.campaign.salvage_allocation_corrected'> {
+  readonly family: 'salvage-allocation';
+  readonly matchId: string;
+  readonly before?: ISalvageAllocation;
+  readonly after?: ISalvageAllocation;
+}
+
+export interface IGmCampaignRepairTicketEffect extends IGmCampaignProjectedEffectBase<'gm.campaign.repair_ticket_corrected'> {
+  readonly family: 'repair-ticket';
+  readonly ticketId: string;
+  readonly before?: IRepairTicket;
+  readonly after?: IRepairTicket;
+}
+
+export interface IGmCampaignFundsTransactionEffect extends IGmCampaignProjectedEffectBase<'gm.campaign.funds_transaction_corrected'> {
+  readonly family: 'funds-transaction';
+  readonly transactionId: string;
+  readonly before: {
+    readonly balanceCents: number;
+    readonly transactionIds: readonly string[];
+  };
+  readonly after: {
+    readonly balanceCents: number;
+    readonly transaction: IGmCampaignProjectedTransaction;
+  };
+}
+
+export interface IGmCampaignInventoryLotEffect extends IGmCampaignProjectedEffectBase<'gm.campaign.inventory_lot_corrected'> {
+  readonly family: 'inventory-lot';
+  readonly inventoryId: string;
+  readonly before?: IPartsInventoryItem;
+  readonly after?: IPartsInventoryItem;
+}
+
+export interface IGmCampaignBaseUnitStateEffect extends IGmCampaignProjectedEffectBase<'gm.campaign.base_unit_state_corrected'> {
+  readonly family: 'base-unit-state';
+  readonly unitId: string;
+  readonly before: {
+    readonly combatState?: IUnitCombatState;
+    readonly configuration?: MechBuildConfig;
+  };
+  readonly after: {
+    readonly combatState?: IUnitCombatState;
+    readonly configuration?: MechBuildConfig;
+  };
+}
+
+export type IGmCampaignProjectedEffect =
+  | IGmCampaignSalvageAllocationEffect
+  | IGmCampaignRepairTicketEffect
+  | IGmCampaignFundsTransactionEffect
+  | IGmCampaignInventoryLotEffect
+  | IGmCampaignBaseUnitStateEffect;
+
+export interface IGmCampaignInterventionDomainPayload {
+  readonly correction: GmCampaignInterventionCorrection;
+  readonly projectedEffects: readonly IGmCampaignProjectedEffect[];
+}
+
+export interface IGmCampaignPublicEffect extends IGmPublicEffect {
+  readonly family: GmCampaignCorrectionFamily;
+}

--- a/src/types/interventions/index.ts
+++ b/src/types/interventions/index.ts
@@ -34,6 +34,30 @@ export type {
 } from './GmCombatInterventionTypes';
 
 export type {
+  GmCampaignCorrectionFamily,
+  GmCampaignInterventionCorrection,
+  GmCampaignInterventionDomain,
+  GmCampaignProjectedEffectType,
+  IGmCampaignBaseUnitStateCorrection,
+  IGmCampaignBaseUnitStateEffect,
+  IGmCampaignFundsTransactionCorrection,
+  IGmCampaignFundsTransactionEffect,
+  IGmCampaignInterventionCommandPayload,
+  IGmCampaignInterventionConflictInput,
+  IGmCampaignInterventionDomainPayload,
+  IGmCampaignInterventionState,
+  IGmCampaignInventoryLotCorrection,
+  IGmCampaignInventoryLotEffect,
+  IGmCampaignProjectedEffect,
+  IGmCampaignProjectedTransaction,
+  IGmCampaignPublicEffect,
+  IGmCampaignRepairTicketCorrection,
+  IGmCampaignRepairTicketEffect,
+  IGmCampaignSalvageAllocationCorrection,
+  IGmCampaignSalvageAllocationEffect,
+} from './GmCampaignInterventionTypes';
+
+export type {
   IGmUnitReloadCommandProjection,
   IGmUnitReloadInterventionCommandPayload,
   IGmUnitReloadInterventionDomainPayload,


### PR DESCRIPTION
## Summary
- Add a typed GM campaign intervention payload surface for post-combat and base economy fixes.
- Register ledger-backed implementers for salvage, repair, economy, and base unit-state correction domains.
- Project, replay, redact, and apply campaign correction effects through shared intervention ledger contracts.
- Archive the OpenSpec change into the live specs after validation.

## Validation
- `git diff --check`
- `openspec.cmd validate --all --strict` (208 passed, 0 failed)
- `npm.cmd run format:check`
- `npm.cmd run typecheck`
- `npx.cmd jest --selectProjects unit --runTestsByPath src\lib\interventions\__tests__\GmCampaignInterventionImplementer.test.ts src\lib\interventions\__tests__\GmCampaignInterventionBoundaries.test.ts src\lib\interventions\__tests__\GmCascadePreviewPipeline.test.ts --runInBand` (21 passed)

## Notes
- Wave 9 time/accumulated cascade corrections remain intentionally deferred.
- Browser UI controls for these GM campaign corrections are not included in this slice.