### PR TITLE
Enable GM time cascade ledger replay

### DIFF
--- a/openspec/changes/archive/2026-06-23-add-time-cascade-system/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-23-add-time-cascade-system/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-23

--- a/openspec/changes/archive/2026-06-23-add-time-cascade-system/design.md
+++ b/openspec/changes/archive/2026-06-23-add-time-cascade-system/design.md
@@ -1,0 +1,68 @@
+## Context
+
+Wave 8 added ledger-backed campaign corrections for salvage, repair, economy, inventory, and base unit state. The remaining campaign intervention gap is accumulated time: a GM may need to advance or repair one day, several travel days, a repair window, a contract deadline, a market cycle, or upkeep after players have already acted.
+
+The repo already has a deterministic day pipeline in `src/lib/campaign/dayPipeline.ts` plus built-in processors for repair progress, contracts, finances, markets, and other daily campaign effects. Store actions such as `advanceDay`, `advanceDays`, and `travelToSystem` currently mutate live Zustand state directly. Wave 9 keeps those processors as the source of time rules, but wraps them in a preview/apply/replay contract for GM approvals.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add a `time` campaign intervention domain that uses the shared intervention ledger.
+- Preview one-day and multi-day campaign time advancement before state mutation.
+- Capture changed state references, per-day summaries, generated day events, and conflict blockers.
+- Apply approved time records by replaying stored projected effects, not by re-running random or store-coupled processors.
+- Emit public net effects while keeping GM reason, hidden notes, default outcome, and manual-takeover notes private.
+- Treat ambiguous external-store effects, such as roster-owned pilot recovery without a projected roster patch, as manual-takeover conflicts.
+
+**Non-Goals:**
+
+- Rewrite campaign day processors or rebalance economics, market generation, repair hours, travel times, or contract generation.
+- Build the final browser UI. The UI will call the domain service added here.
+- Solve long-campaign stability or catalog combat parity. Those remain later waves.
+
+## Decisions
+
+### Decision 1: Reuse the intervention ledger instead of adding a time-specific override log
+
+Time cascades SHALL be implemented as an intervention domain with the same preview, approval, public projection, private projection, and replay hooks used by combat and campaign corrections.
+
+Alternative considered: add a separate time-jump history. Rejected because it would split player-visible history and make cross-domain causality harder to audit.
+
+### Decision 2: Store projected time effects in the approved record
+
+Preview SHALL build serializable projected effects containing the before/after campaign dates, affected state references, day summaries, generated events, and changed campaign root snapshots needed for replay. Apply SHALL consume those projected effects directly.
+
+Alternative considered: replay the day pipeline from the command payload during apply. Rejected because random streams, current processor registration, and store-coupled personnel processors could drift between preview and approval.
+
+### Decision 3: Separate campaign-owned auto-apply from external-store manual takeover
+
+Campaign-root effects such as `currentDate`, `currentSystemId`, `repairQueue`, `partsInventory`, `unitCombatStates`, `finances`, `missions`, and command-extension markets can be replayed automatically from projected effects. Effects owned outside `ICampaign`, such as roster/vault pilot recovery patches, require explicit projected patches; otherwise the preview SHALL require manual takeover.
+
+Alternative considered: let the time cascade mutate roster stores during preview. Rejected because preview must be side-effect-free and player-visible redaction depends on stable stored projections.
+
+### Decision 4: Keep travel as an optional time-cascade input
+
+The time payload MAY include a destination system and travel-day count. The preview SHALL show both the location change and the days advanced. Travel validation will reuse the current system ID and known destination identifier; detailed jump-route/pathfinding remains outside this slice.
+
+Alternative considered: require a full starmap route planner now. Rejected because the requested GM control surface can be useful with explicit GM-approved travel-day inputs.
+
+## Risks / Trade-offs
+
+- [Risk] Day processors with hidden store side effects make pure preview unsafe. -> Mitigation: preview treats unsupported external side effects as manual-takeover conflicts unless the command includes explicit projected patches.
+- [Risk] Multi-day previews can become large. -> Mitigation: store compact day summaries and final root snapshots, with detailed generated events capped or grouped when necessary.
+- [Risk] Applying stored snapshots can overwrite later campaign changes. -> Mitigation: projected effects carry `baseUpdatedAt` and changed state references so stale approvals can be blocked or escalated.
+- [Risk] Time reversal is more complex than advancement. -> Mitigation: Wave 9 supports forward time jumps first; reversal is represented as a manual correction requiring explicit replacement snapshots.
+
+## Migration Plan
+
+1. Add time-cascade types and a `time` domain implementer.
+2. Add pure preview/projection helpers that produce serializable time effects.
+3. Register the time implementer alongside campaign intervention domains.
+4. Add focused Jest coverage for ready preview, approval replay, player/GM redaction, stale/manual takeover conflict, and deferred-boundary removal.
+5. Archive the OpenSpec change after strict validation and green tests.
+
+## Open Questions
+
+- Should Wave 10 or Wave 11 add a compact artifact retention policy for very long time previews?
+- Should UI expose route-derived travel days before the starmap has a dedicated campaign route planner?

--- a/openspec/changes/archive/2026-06-23-add-time-cascade-system/proposal.md
+++ b/openspec/changes/archive/2026-06-23-add-time-cascade-system/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+GM-ledger corrections can now repair combat, post-combat, and base economy mistakes, but accumulated campaign time remains the hardest state transition to audit because travel, repairs, contract windows, markets, recovery, and upkeep can all cascade from one approval. Wave 9 adds a rules-backed time cascade surface so time jumps are previewed, approved, replayable, and manually recoverable instead of being an opaque day-advance mutation.
+
+## What Changes
+
+- Add a ledger-backed time cascade capability for one-day advances, multi-day jumps, travel windows, repair progression, contract deadline/window updates, market refreshes, pilot recovery, upkeep, and accumulated campaign effects.
+- Extend GM cascade previews so time effects show player-visible net changes separately from private GM rationale and conflict analysis.
+- Extend the intervention ledger implementer boundary so time-cascade records can be previewed, approved, replayed, redacted, and blocked for manual takeover when conflicts are ambiguous.
+- Add deterministic tests and fixtures that prove preview/apply/replay parity for simple and conflicting time jumps.
+
+## Non-goals
+
+- Rebalancing campaign economy values, repair durations, travel times, market tables, or contract generation.
+- Building the final browser UI for every time-cascade control; this slice provides the domain contract and testable orchestration surface the UI can call.
+- Catalog/rules parity expansion for weapons, ammo, physical attacks, or special combat behavior; that remains Wave 10.
+
+## Capabilities
+
+### New Capabilities
+
+- `time-cascade-system`: Ledger-backed campaign time advancement previews, approvals, replay, redaction, and manual conflict fallback.
+
+### Modified Capabilities
+
+- `gm-cascade-preview`: Time advancement joins the GM preview contract with net-effect summaries, blockers, and manual takeover escalation.
+- `gm-campaign-intervention-boundaries`: Time moves from deferred to supported campaign intervention scope while preserving hidden GM rationale boundaries.
+- `gm-authority-redaction`: Time-cascade approvals emit player-safe summaries and keep private conflict/rationale details GM-only.
+- `intervention-ledger-abstraction`: Approved time-cascade records must be replayable action-ledger entries with deterministic projected effects.
+
+## Impact
+
+- Types under `src/types/interventions/` and `src/types/campaign/`.
+- Intervention preview/projection/implementer modules under `src/lib/interventions/`.
+- Existing campaign date, travel, repair, contract, market, recovery, and finance models are consumed by the cascade engine without changing their source-of-truth ownership.
+- Focused Jest coverage for preview/apply/replay/redaction/manual-takeover behavior.

--- a/openspec/changes/archive/2026-06-23-add-time-cascade-system/specs/gm-authority-redaction/spec.md
+++ b/openspec/changes/archive/2026-06-23-add-time-cascade-system/specs/gm-authority-redaction/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Time Cascade Redaction
+
+The system SHALL separate GM-private metadata from player-public net effects for accumulated time cascades. Player-facing campaign logs SHALL expose only approved net time, travel, repair, market, contract, recovery, upkeep, and visible changed state references.
+
+#### Scenario: Player sees only net time cascade
+- **GIVEN** an approved time cascade with a GM-private reason, default outcome, hidden notes, conflict analysis, and public summary
+- **WHEN** a player views the action log or intervention projection
+- **THEN** the projection SHALL show the public summary and visible campaign state references
+- **AND** it SHALL NOT show the GM-private reason, default outcome, hidden notes, conflict analysis, or manual takeover notes
+
+#### Scenario: GM sees full time cascade context
+- **GIVEN** an approved time cascade with private metadata and public net effect
+- **WHEN** the owning GM views the GM ledger projection
+- **THEN** the projection SHALL include the GM-private metadata
+- **AND** it SHALL include the same public net effect players can see

--- a/openspec/changes/archive/2026-06-23-add-time-cascade-system/specs/gm-campaign-intervention-boundaries/spec.md
+++ b/openspec/changes/archive/2026-06-23-add-time-cascade-system/specs/gm-campaign-intervention-boundaries/spec.md
@@ -1,9 +1,5 @@
-# gm-campaign-intervention-boundaries Specification
+## MODIFIED Requirements
 
-## Purpose
-
-Defines the campaign boundary for GM interventions, including ledger-backed post-combat, economy, repair, salvage, and accumulated time-cascade domains once each implementer declares safe mutable roots and public projections.
-## Requirements
 ### Requirement: First Slice Defers Campaign Cascades
 
 The campaign intervention boundary SHALL support ledger-backed post-combat amendments, base/economy corrections, repair corrections, salvage corrections, and accumulated time cascades through registered domain implementers. Registered time-cascade implementers SHALL declare safe mutable roots, public projections, and manual-takeover conflict handling before applying any campaign time mutation.
@@ -42,38 +38,7 @@ The system SHALL document and preserve extension seams for intervention ledger i
 - **THEN** the preview SHALL identify the affected travel, repair progress, contract window, market refresh, pilot recovery, upkeep, and campaign date roots
 - **AND** the preview SHALL explicitly mark external-store effects as projected or manual-takeover conflicts
 
-### Requirement: Deferred Domain Logging
-
-The system SHALL log deferred domain intervention attempts so missing campaign support is visible during testing without applying unsupported state changes.
-
-#### Scenario: Deferred request is logged safely
-- **GIVEN** a GM requests a deferred time cascade intervention
-- **WHEN** the intervention pipeline returns a deferred result
-- **THEN** the system SHALL log the domain, actor, target refs, and deferred reason
-- **AND** the log SHALL NOT include hidden scenario notes in any player-visible output
-
-### Requirement: Ledger-Backed Campaign Correction Domains
-
-The system SHALL provide campaign intervention implementers for `post-combat`, `economy`, `repair`, and `salvage`. These implementers SHALL support targeted corrections for salvage allocations, repair tickets, funds transactions, parts inventory lots, and base unit state or configuration roots.
-
-#### Scenario: GM previews targeted campaign correction
-- **GIVEN** the owning GM requests a targeted campaign correction
-- **WHEN** the correction references an existing supported campaign root or provides a complete replacement for that root
-- **THEN** the preview SHALL be ready
-- **AND** the preview SHALL include changed state references for only the affected campaign roots
-- **AND** no campaign state SHALL be mutated before approval
-
-#### Scenario: Ambiguous campaign cascade requires manual takeover
-- **GIVEN** a campaign correction declares unresolved cascading conflicts
-- **WHEN** the GM requests a preview
-- **THEN** the preview SHALL require manual takeover
-- **AND** the approval pipeline SHALL NOT append the intervention automatically
-
-#### Scenario: Approved campaign correction replays from ledger record
-- **GIVEN** a ready campaign correction preview
-- **WHEN** the GM approves it
-- **THEN** the intervention ledger SHALL append an approved campaign intervention record
-- **AND** replaying the record's projected effects SHALL derive the same corrected campaign state
+## ADDED Requirements
 
 ### Requirement: Ledger-Backed Time Cascade Domain
 

--- a/openspec/changes/archive/2026-06-23-add-time-cascade-system/specs/gm-cascade-preview/spec.md
+++ b/openspec/changes/archive/2026-06-23-add-time-cascade-system/specs/gm-cascade-preview/spec.md
@@ -1,0 +1,41 @@
+## MODIFIED Requirements
+
+### Requirement: Deferred Domain Result
+
+The preview pipeline SHALL return explicit deferred or unsupported results for domains that are not implemented in the current slice. The accumulated `time` domain SHALL be supported when a time-cascade implementer is registered, while unregistered domains SHALL remain explicit unsupported or deferred results.
+
+#### Scenario: Registered time domain previews without mutation
+- **GIVEN** the accumulated time domain implementer is registered
+- **WHEN** the GM previews a travel or accumulated time correction
+- **THEN** the preview pipeline SHALL return a ready, blocked, or manual-takeover result from the implementer
+- **AND** campaign time, travel state, repair progress, contract windows, markets, pilot recovery, and upkeep SHALL remain unchanged until approval
+
+#### Scenario: Registered economy domain is not deferred
+- **GIVEN** the economy domain implementer is registered
+- **WHEN** the GM previews a merchant transaction reversal
+- **THEN** the preview pipeline SHALL return a ready, blocked, or manual-takeover result from the implementer
+- **AND** the preview SHALL NOT be normalized to deferred merely because it targets campaign economy state
+
+#### Scenario: Unknown domain remains unsupported
+- **GIVEN** no implementer is registered for a campaign domain
+- **WHEN** the GM previews a correction for that domain
+- **THEN** the preview pipeline SHALL return a deferred or unsupported result
+- **AND** the system SHALL NOT mutate campaign state
+
+## ADDED Requirements
+
+### Requirement: Time Cascade Preview Shape
+
+The preview pipeline SHALL represent accumulated time cascades with public net effect, GM-private context, affected campaign state references, projected time effects, generated day summaries, and conflicts before commit.
+
+#### Scenario: Time preview exposes public and private projections separately
+- **GIVEN** a GM requests a time advancement, travel window, repair progression, market refresh, pilot recovery, upkeep, or accumulated campaign effect correction
+- **WHEN** the preview is produced
+- **THEN** the preview SHALL include player-visible net effect in the public projection
+- **AND** the preview SHALL preserve GM reason, default outcome, hidden notes, conflict analysis, and manual takeover notes in the private projection only
+
+#### Scenario: Manual time preview cannot be approved automatically
+- **GIVEN** a time preview includes a conflict marked as requiring manual takeover
+- **WHEN** the GM attempts normal preview approval
+- **THEN** the approval pipeline SHALL return blocked
+- **AND** no intervention ledger record or action ledger record SHALL be appended

--- a/openspec/changes/archive/2026-06-23-add-time-cascade-system/specs/intervention-ledger-abstraction/spec.md
+++ b/openspec/changes/archive/2026-06-23-add-time-cascade-system/specs/intervention-ledger-abstraction/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Time Cascade Ledger Implementer
+
+The intervention ledger SHALL allow a `time` campaign-domain implementer to share the same preview, apply, public projection, and private projection contract used by tactical combat and campaign correction interventions.
+
+#### Scenario: Time implementer registers with ledger
+- **GIVEN** a time-cascade intervention implementer
+- **WHEN** the implementer is registered with the intervention ledger
+- **THEN** commands targeting the `time` domain SHALL route through that implementer
+- **AND** commands targeting unrelated domains SHALL NOT route through that implementer
+
+#### Scenario: Time approval appends through shared action ledger
+- **GIVEN** a ready time cascade preview and a shared action ledger
+- **WHEN** the GM approves the preview
+- **THEN** the intervention ledger SHALL append an approved time-cascade record
+- **AND** the action ledger SHALL append a GM intervention action after prior normal actions
+- **AND** prior normal actions SHALL remain present
+
+#### Scenario: Blocked time preview appends no action
+- **GIVEN** a time preview is blocked, rejected, unsupported, deferred, stale, or requires manual takeover
+- **WHEN** the preview is not approved
+- **THEN** the intervention ledger SHALL append no time-cascade record
+- **AND** the action ledger SHALL append no GM intervention action

--- a/openspec/changes/archive/2026-06-23-add-time-cascade-system/specs/time-cascade-system/spec.md
+++ b/openspec/changes/archive/2026-06-23-add-time-cascade-system/specs/time-cascade-system/spec.md
@@ -1,0 +1,70 @@
+## ADDED Requirements
+
+### Requirement: Time Cascade Preview
+
+The system SHALL provide a GM-only time cascade preview for campaign time advancement. The preview SHALL include the requested day count, optional travel destination, before and after campaign dates, affected campaign state references, generated day summaries, projected event effects, public net effect, GM-private context, and conflicts. The preview SHALL NOT mutate campaign state before approval.
+
+#### Scenario: Preview multi-day campaign advancement
+- **GIVEN** an owning GM requests a three-day time cascade for a campaign
+- **WHEN** the preview is produced
+- **THEN** the preview SHALL include the before campaign date
+- **AND** the preview SHALL include the projected after campaign date
+- **AND** the preview SHALL include one ordered summary per projected day
+- **AND** campaign state SHALL remain unchanged until approval
+
+#### Scenario: Preview travel with time advancement
+- **GIVEN** an owning GM requests travel to a destination system with a two-day travel window
+- **WHEN** the preview is produced
+- **THEN** the preview SHALL include the before and after system identifiers
+- **AND** the preview SHALL include the two projected day summaries
+- **AND** the player-public projection SHALL describe only the approved net travel and time effect
+
+### Requirement: Time Cascade Effect Coverage
+
+The time cascade preview SHALL project campaign-owned effects for date advancement, travel location, repair progress, contract expiration or closure, market refreshes, finances and upkeep, and campaign-owned unit state changes. Pilot recovery, roster progression, or vault-owned effects SHALL either be represented by explicit projected external patches or SHALL require manual takeover.
+
+#### Scenario: Campaign-owned effects are represented
+- **GIVEN** a time cascade changes campaign date, repair queue, finances, and command-extension markets
+- **WHEN** the preview is produced
+- **THEN** the preview SHALL include changed state references for each changed campaign root
+- **AND** the approved record SHALL contain enough projected effect data to replay those changes without re-running random generation
+
+#### Scenario: External roster effect requires manual takeover without projection
+- **GIVEN** a projected day would heal or alter a roster-owned pilot
+- **AND** the command does not include explicit projected roster patches
+- **WHEN** the preview is produced
+- **THEN** the preview SHALL require manual takeover
+- **AND** no intervention ledger record SHALL be appended by normal approval
+
+### Requirement: Time Cascade Approval Replay
+
+The system SHALL append a time-cascade intervention record only after GM approval. Applying an approved time-cascade record SHALL derive campaign state from the record's stored projected effects rather than re-running day processors.
+
+#### Scenario: Approved time cascade replays deterministically
+- **GIVEN** a ready time cascade preview
+- **WHEN** the GM approves it
+- **THEN** the intervention ledger SHALL append an approved `time` record
+- **AND** replaying the stored projected effects SHALL derive the same campaign date, location, repair, finance, mission, and market state shown in the preview
+
+#### Scenario: Stale approval is blocked
+- **GIVEN** a time cascade preview was produced from campaign state version `V1`
+- **AND** the campaign changed to version `V2` before approval
+- **WHEN** normal approval is attempted
+- **THEN** the system SHALL block approval or require manual takeover
+- **AND** no stale time-cascade record SHALL be appended automatically
+
+### Requirement: Time Cascade Redaction
+
+The system SHALL separate player-public net time effects from GM-private reason, hidden notes, default outcome, conflict analysis, and manual takeover notes.
+
+#### Scenario: Player sees public time summary only
+- **GIVEN** an approved time cascade contains GM-private rationale and hidden notes
+- **WHEN** a player views the action ledger or public projection
+- **THEN** the projection SHALL show the public net effect and visible changed state references
+- **AND** it SHALL omit GM-private rationale, hidden notes, default outcome, conflict analysis, and manual takeover notes
+
+#### Scenario: GM sees private time context
+- **GIVEN** an approved time cascade contains public and private metadata
+- **WHEN** the owning GM views the GM ledger projection
+- **THEN** the projection SHALL include the GM-private metadata
+- **AND** it SHALL include the same public net effect players can see

--- a/openspec/changes/archive/2026-06-23-add-time-cascade-system/tasks.md
+++ b/openspec/changes/archive/2026-06-23-add-time-cascade-system/tasks.md
@@ -1,0 +1,32 @@
+## 1. Time Cascade Contracts
+
+- [x] 1.1 Add typed time-cascade command, conflict, projected-effect, day-summary, public-effect, and domain-payload types under `src/types/interventions/`.
+- [x] 1.2 Extend campaign intervention domain exports so `time` can register without weakening existing post-combat/economy/repair/salvage typing.
+- [x] 1.3 Define changed-state reference helpers for campaign date, travel, repair queue, finances, missions/contracts, markets, unit state, and external roster/vault effects.
+
+## 2. Preview and Projection Engine
+
+- [x] 2.1 Implement a pure time-cascade preview helper that advances one or more days from an input campaign snapshot and returns serializable projected effects without mutating live store state.
+- [x] 2.2 Capture per-day summaries, generated day events, before/after campaign dates, optional travel destination, and affected campaign roots in the projected effect.
+- [x] 2.3 Detect stale base state, invalid day counts, unknown destinations, and unprojected external roster/vault effects as blocked or manual-takeover conflicts.
+- [x] 2.4 Implement replay/apply helpers that derive campaign state from stored projected effects without re-running day processors.
+
+## 3. Ledger Integration
+
+- [x] 3.1 Add a `time` intervention implementer that follows the existing preview/apply/public/private projection contract.
+- [x] 3.2 Register time-cascade implementers through an explicit helper without disrupting existing campaign implementer registration.
+- [x] 3.3 Ensure ready approvals append intervention and action ledger records, while blocked, stale, unsupported, or manual-takeover previews append nothing.
+- [x] 3.4 Ensure player-public projections redact GM-private rationale, hidden notes, default outcome, conflict analysis, and manual takeover notes.
+
+## 4. Tests and Validation
+
+- [x] 4.1 Add focused unit tests for ready one-day and multi-day previews, approval replay parity, optional travel, public/private redaction, and action-ledger append behavior.
+- [x] 4.2 Add tests for invalid payloads, stale approvals, unknown destinations, and manual-takeover conflicts for unprojected external roster/vault effects.
+- [x] 4.3 Update boundary tests proving `time` is no longer deferred when registered and remains unsupported when no implementer is registered.
+- [x] 4.4 Run `openspec.cmd validate add-time-cascade-system --strict`, focused intervention tests, `npm.cmd run typecheck`, `npm.cmd run format:check`, and `git diff --check`.
+
+## 5. Archive and PR Gate
+
+- [x] 5.1 Archive the OpenSpec change only after implementation tests pass.
+- [x] 5.2 Re-run `openspec.cmd validate --all --strict` after archive.
+- [ ] 5.3 Commit with the repo Lore protocol, open a PR, wait for CI, merge, and prune local branch state.

--- a/openspec/specs/gm-authority-redaction/spec.md
+++ b/openspec/specs/gm-authority-redaction/spec.md
@@ -62,3 +62,19 @@ The system SHALL separate GM-private metadata from player-public net effects for
 - **WHEN** the owning GM views the GM ledger projection
 - **THEN** the projection SHALL include the GM-private metadata
 - **AND** it SHALL include the same public net effect players can see
+
+### Requirement: Time Cascade Redaction
+
+The system SHALL separate GM-private metadata from player-public net effects for accumulated time cascades. Player-facing campaign logs SHALL expose only approved net time, travel, repair, market, contract, recovery, upkeep, and visible changed state references.
+
+#### Scenario: Player sees only net time cascade
+- **GIVEN** an approved time cascade with a GM-private reason, default outcome, hidden notes, conflict analysis, and public summary
+- **WHEN** a player views the action log or intervention projection
+- **THEN** the projection SHALL show the public summary and visible campaign state references
+- **AND** it SHALL NOT show the GM-private reason, default outcome, hidden notes, conflict analysis, or manual takeover notes
+
+#### Scenario: GM sees full time cascade context
+- **GIVEN** an approved time cascade with private metadata and public net effect
+- **WHEN** the owning GM views the GM ledger projection
+- **THEN** the projection SHALL include the GM-private metadata
+- **AND** it SHALL include the same public net effect players can see

--- a/openspec/specs/gm-cascade-preview/spec.md
+++ b/openspec/specs/gm-cascade-preview/spec.md
@@ -43,19 +43,25 @@ The preview pipeline SHALL return a manual-takeover result when the system canno
 
 ### Requirement: Deferred Domain Result
 
-The preview pipeline SHALL return explicit deferred or unsupported results for domains that are not implemented in the current slice. The accumulated `time` domain SHALL remain deferred in this slice, while registered post-combat, economy, repair, and salvage implementers SHALL return normal ready, blocked, or manual-takeover previews.
+The preview pipeline SHALL return explicit deferred or unsupported results for domains that are not implemented in the current slice. The accumulated `time` domain SHALL be supported when a time-cascade implementer is registered, while unregistered domains SHALL remain explicit unsupported or deferred results.
 
-#### Scenario: Time domain does not mutate state
-- **GIVEN** the accumulated time domain is not implemented
+#### Scenario: Registered time domain previews without mutation
+- **GIVEN** the accumulated time domain implementer is registered
 - **WHEN** the GM previews a travel or accumulated time correction
-- **THEN** the preview pipeline SHALL return a deferred or unsupported result
-- **AND** campaign time, travel state, repair progress, contract windows, markets, pilot recovery, and upkeep SHALL remain unchanged
+- **THEN** the preview pipeline SHALL return a ready, blocked, or manual-takeover result from the implementer
+- **AND** campaign time, travel state, repair progress, contract windows, markets, pilot recovery, and upkeep SHALL remain unchanged until approval
 
 #### Scenario: Registered economy domain is not deferred
 - **GIVEN** the economy domain implementer is registered
 - **WHEN** the GM previews a merchant transaction reversal
 - **THEN** the preview pipeline SHALL return a ready, blocked, or manual-takeover result from the implementer
 - **AND** the preview SHALL NOT be normalized to deferred merely because it targets campaign economy state
+
+#### Scenario: Unknown domain remains unsupported
+- **GIVEN** no implementer is registered for a campaign domain
+- **WHEN** the GM previews a correction for that domain
+- **THEN** the preview pipeline SHALL return a deferred or unsupported result
+- **AND** the system SHALL NOT mutate campaign state
 
 ### Requirement: Campaign Correction Preview Shape
 
@@ -69,6 +75,22 @@ The preview pipeline SHALL represent post-combat and base-economy corrections wi
 
 #### Scenario: Manual campaign preview cannot be approved automatically
 - **GIVEN** a campaign preview includes a conflict marked as requiring manual takeover
+- **WHEN** the GM attempts normal preview approval
+- **THEN** the approval pipeline SHALL return blocked
+- **AND** no intervention ledger record or action ledger record SHALL be appended
+
+### Requirement: Time Cascade Preview Shape
+
+The preview pipeline SHALL represent accumulated time cascades with public net effect, GM-private context, affected campaign state references, projected time effects, generated day summaries, and conflicts before commit.
+
+#### Scenario: Time preview exposes public and private projections separately
+- **GIVEN** a GM requests a time advancement, travel window, repair progression, market refresh, pilot recovery, upkeep, or accumulated campaign effect correction
+- **WHEN** the preview is produced
+- **THEN** the preview SHALL include player-visible net effect in the public projection
+- **AND** the preview SHALL preserve GM reason, default outcome, hidden notes, conflict analysis, and manual takeover notes in the private projection only
+
+#### Scenario: Manual time preview cannot be approved automatically
+- **GIVEN** a time preview includes a conflict marked as requiring manual takeover
 - **WHEN** the GM attempts normal preview approval
 - **THEN** the approval pipeline SHALL return blocked
 - **AND** no intervention ledger record or action ledger record SHALL be appended

--- a/openspec/specs/intervention-ledger-abstraction/spec.md
+++ b/openspec/specs/intervention-ledger-abstraction/spec.md
@@ -93,3 +93,26 @@ The intervention ledger SHALL allow campaign-domain implementers for `post-comba
 - **WHEN** the preview is not approved
 - **THEN** the intervention ledger SHALL append no campaign intervention record
 - **AND** the action ledger SHALL append no GM intervention action
+
+### Requirement: Time Cascade Ledger Implementer
+
+The intervention ledger SHALL allow a `time` campaign-domain implementer to share the same preview, apply, public projection, and private projection contract used by tactical combat and campaign correction interventions.
+
+#### Scenario: Time implementer registers with ledger
+- **GIVEN** a time-cascade intervention implementer
+- **WHEN** the implementer is registered with the intervention ledger
+- **THEN** commands targeting the `time` domain SHALL route through that implementer
+- **AND** commands targeting unrelated domains SHALL NOT route through that implementer
+
+#### Scenario: Time approval appends through shared action ledger
+- **GIVEN** a ready time cascade preview and a shared action ledger
+- **WHEN** the GM approves the preview
+- **THEN** the intervention ledger SHALL append an approved time-cascade record
+- **AND** the action ledger SHALL append a GM intervention action after prior normal actions
+- **AND** prior normal actions SHALL remain present
+
+#### Scenario: Blocked time preview appends no action
+- **GIVEN** a time preview is blocked, rejected, unsupported, deferred, stale, or requires manual takeover
+- **WHEN** the preview is not approved
+- **THEN** the intervention ledger SHALL append no time-cascade record
+- **AND** the action ledger SHALL append no GM intervention action

--- a/openspec/specs/time-cascade-system/spec.md
+++ b/openspec/specs/time-cascade-system/spec.md
@@ -1,0 +1,76 @@
+# time-cascade-system Specification
+
+## Purpose
+
+Defines the GM-only campaign time-cascade preview, approval, replay, and redaction contract for accumulated time advancement.
+
+## Requirements
+
+### Requirement: Time Cascade Preview
+
+The system SHALL provide a GM-only time cascade preview for campaign time advancement. The preview SHALL include the requested day count, optional travel destination, before and after campaign dates, affected campaign state references, generated day summaries, projected event effects, public net effect, GM-private context, and conflicts. The preview SHALL NOT mutate campaign state before approval.
+
+#### Scenario: Preview multi-day campaign advancement
+- **GIVEN** an owning GM requests a three-day time cascade for a campaign
+- **WHEN** the preview is produced
+- **THEN** the preview SHALL include the before campaign date
+- **AND** the preview SHALL include the projected after campaign date
+- **AND** the preview SHALL include one ordered summary per projected day
+- **AND** campaign state SHALL remain unchanged until approval
+
+#### Scenario: Preview travel with time advancement
+- **GIVEN** an owning GM requests travel to a destination system with a two-day travel window
+- **WHEN** the preview is produced
+- **THEN** the preview SHALL include the before and after system identifiers
+- **AND** the preview SHALL include the two projected day summaries
+- **AND** the player-public projection SHALL describe only the approved net travel and time effect
+
+### Requirement: Time Cascade Effect Coverage
+
+The time cascade preview SHALL project campaign-owned effects for date advancement, travel location, repair progress, contract expiration or closure, market refreshes, finances and upkeep, and campaign-owned unit state changes. Pilot recovery, roster progression, or vault-owned effects SHALL either be represented by explicit projected external patches or SHALL require manual takeover.
+
+#### Scenario: Campaign-owned effects are represented
+- **GIVEN** a time cascade changes campaign date, repair queue, finances, and command-extension markets
+- **WHEN** the preview is produced
+- **THEN** the preview SHALL include changed state references for each changed campaign root
+- **AND** the approved record SHALL contain enough projected effect data to replay those changes without re-running random generation
+
+#### Scenario: External roster effect requires manual takeover without projection
+- **GIVEN** a projected day would heal or alter a roster-owned pilot
+- **AND** the command does not include explicit projected roster patches
+- **WHEN** the preview is produced
+- **THEN** the preview SHALL require manual takeover
+- **AND** no intervention ledger record SHALL be appended by normal approval
+
+### Requirement: Time Cascade Approval Replay
+
+The system SHALL append a time-cascade intervention record only after GM approval. Applying an approved time-cascade record SHALL derive campaign state from the record's stored projected effects rather than re-running day processors.
+
+#### Scenario: Approved time cascade replays deterministically
+- **GIVEN** a ready time cascade preview
+- **WHEN** the GM approves it
+- **THEN** the intervention ledger SHALL append an approved `time` record
+- **AND** replaying the stored projected effects SHALL derive the same campaign date, location, repair, finance, mission, and market state shown in the preview
+
+#### Scenario: Stale approval is blocked
+- **GIVEN** a time cascade preview was produced from campaign state version `V1`
+- **AND** the campaign changed to version `V2` before approval
+- **WHEN** normal approval is attempted
+- **THEN** the system SHALL block approval or require manual takeover
+- **AND** no stale time-cascade record SHALL be appended automatically
+
+### Requirement: Time Cascade Redaction
+
+The system SHALL separate player-public net time effects from GM-private reason, hidden notes, default outcome, conflict analysis, and manual takeover notes.
+
+#### Scenario: Player sees public time summary only
+- **GIVEN** an approved time cascade contains GM-private rationale and hidden notes
+- **WHEN** a player views the action ledger or public projection
+- **THEN** the projection SHALL show the public net effect and visible changed state references
+- **AND** it SHALL omit GM-private rationale, hidden notes, default outcome, conflict analysis, and manual takeover notes
+
+#### Scenario: GM sees private time context
+- **GIVEN** an approved time cascade contains public and private metadata
+- **WHEN** the owning GM views the GM ledger projection
+- **THEN** the projection SHALL include the GM-private metadata
+- **AND** it SHALL include the same public net effect players can see

--- a/src/lib/campaign/processors/index.ts
+++ b/src/lib/campaign/processors/index.ts
@@ -11,6 +11,7 @@ export type {
   ICampaignWithBattleState,
 } from './postBattleProcessor';
 export { dailyCostsProcessor } from './dailyCostsProcessor';
+export { repairProgressProcessor } from './repairProgressProcessor';
 export { registerAcquisitionProcessor } from './acquisitionProcessor';
 export { autoAwardsProcessor } from './autoAwardsProcessor';
 export { randomEventsProcessor } from './randomEventsProcessor';

--- a/src/lib/interventions/GmCascadePreviewPipeline.ts
+++ b/src/lib/interventions/GmCascadePreviewPipeline.ts
@@ -189,6 +189,16 @@ export function approveGmCascadePreview<
     };
   }
 
+  const freshnessFailure = validatePreviewFreshness(preview, state);
+  if (freshnessFailure) {
+    return {
+      status: 'blocked',
+      state,
+      appended: false,
+      reason: freshnessFailure,
+    };
+  }
+
   const record = buildApprovedRecord(input);
   ledger.appendApprovedRecord(record);
   const applyResult = ledger.apply(record, state);
@@ -265,6 +275,57 @@ function normalizePreviewStatus(
   }
 
   return preview.status;
+}
+
+function validatePreviewFreshness(
+  preview: IGmCascadePreview,
+  state: unknown,
+): string | undefined {
+  const correction = readCorrection(preview.domainPayload);
+  if (!correction) return undefined;
+
+  const baseUpdatedAt = readString(correction, 'baseUpdatedAt');
+  if (baseUpdatedAt) {
+    const currentUpdatedAt = readString(state, 'updatedAt');
+    if (currentUpdatedAt && currentUpdatedAt !== baseUpdatedAt) {
+      return 'Cannot approve GM cascade preview from a stale campaign version.';
+    }
+  }
+
+  const baseCurrentDate = readString(correction, 'baseCurrentDate');
+  if (baseCurrentDate) {
+    const currentDate = readDateIso(state, 'currentDate');
+    if (currentDate && currentDate !== baseCurrentDate) {
+      return 'Cannot approve GM cascade preview from a stale campaign date.';
+    }
+  }
+
+  return undefined;
+}
+
+function readCorrection(value: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(value)) return undefined;
+  const correction = value.correction;
+  return isRecord(correction) ? correction : undefined;
+}
+
+function readString(value: unknown, key: string): string | undefined {
+  if (!isRecord(value)) return undefined;
+  const entry = value[key];
+  return typeof entry === 'string' ? entry : undefined;
+}
+
+function readDateIso(value: unknown, key: string): string | undefined {
+  if (!isRecord(value)) return undefined;
+  const entry = value[key];
+  if (entry instanceof Date) return entry.toISOString();
+  if (typeof entry !== 'string') return undefined;
+  const date = new Date(entry);
+  return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
 }
 
 function affectedStateRefs(

--- a/src/lib/interventions/GmTimeCascadeInterventionImplementer.ts
+++ b/src/lib/interventions/GmTimeCascadeInterventionImplementer.ts
@@ -1,0 +1,165 @@
+import type {
+  IGmPrivateMetadata,
+  IGmTimeCascadeInterventionCommandPayload,
+  IGmTimeCascadeInterventionDomainPayload,
+  IGmTimeCascadeInterventionState,
+  IGmTimeCascadePublicEffect,
+  IInterventionConflict,
+  IInterventionLedgerCommand,
+  IInterventionLedgerImplementer,
+  IInterventionLedgerPreview,
+  IInterventionLedgerRecord,
+} from '@/types/interventions';
+
+import type { InterventionLedger } from './InterventionLedger';
+
+import { buildGmInterventionRedactionEnvelope } from './GmInterventionAuthority';
+import { buildGmTimeCascadeProjectedEffect } from './GmTimeCascadePreview';
+import {
+  applyGmTimeCascadeProjectedEffects,
+  projectTimeCascadeEffectsForRecord,
+} from './GmTimeCascadeProjection';
+
+type TimeCascadePreview = IInterventionLedgerPreview<
+  IGmPrivateMetadata,
+  IGmTimeCascadePublicEffect,
+  IGmTimeCascadeInterventionDomainPayload
+>;
+
+type TimeCascadeCommand =
+  IInterventionLedgerCommand<IGmTimeCascadeInterventionCommandPayload>;
+
+type TimeCascadeRecord = IInterventionLedgerRecord<
+  IGmPrivateMetadata,
+  IGmTimeCascadePublicEffect,
+  IGmTimeCascadeInterventionDomainPayload
+>;
+
+export function createGmTimeCascadeInterventionImplementer(): IInterventionLedgerImplementer<
+  TimeCascadeCommand,
+  IGmTimeCascadeInterventionState,
+  IGmPrivateMetadata,
+  IGmTimeCascadePublicEffect,
+  IGmTimeCascadeInterventionDomainPayload
+> {
+  return {
+    domain: 'time',
+    preview(command, state): TimeCascadePreview {
+      if (!isTimeCascadeCommandPayload(command.payload)) {
+        return blockedTimeCascadePreview(
+          command,
+          'time-cascade-payload-invalid',
+          'Time cascade command requires a time advancement correction and GM-private reason.',
+        );
+      }
+
+      const projected = buildGmTimeCascadeProjectedEffect(
+        command.payload,
+        state,
+      );
+      if (!projected.effect) {
+        return blockedTimeCascadePreview(
+          command,
+          projected.code,
+          projected.reason,
+          projected.affectedRefs,
+        );
+      }
+
+      const envelope = buildGmInterventionRedactionEnvelope(
+        command.payload.privateMetadata,
+        {
+          summary: command.payload.publicSummary ?? projected.summary,
+          family: command.payload.correction.family,
+          days: command.payload.correction.days,
+          fromDate: projected.effect.before.currentDate,
+          toDate: projected.effect.after.currentDate,
+          fromSystemId: projected.effect.before.currentSystemId,
+          toSystemId: projected.effect.after.currentSystemId,
+          changedStateRefs: projected.changedStateRefs,
+          visibleToPlayerIds: command.payload.visibleToPlayerIds,
+        },
+      );
+
+      return {
+        domain: 'time',
+        kind: command.kind,
+        status: 'ready',
+        actorId: command.actorId,
+        targetRefs: command.targetRefs,
+        causedBy: command.causedBy,
+        supersedes: command.supersedes,
+        privateMetadata: envelope.privateMetadata,
+        publicEffect: envelope.publicEffect,
+        domainPayload: {
+          correction: command.payload.correction,
+          projectedEffects: [projected.effect],
+        },
+        projectedEvents: [projected.effect],
+        conflicts: projected.conflicts,
+      };
+    },
+    apply(record, state): IGmTimeCascadeInterventionState {
+      return applyGmTimeCascadeProjectedEffects(
+        state,
+        projectTimeCascadeEffectsForRecord(record as TimeCascadeRecord),
+      );
+    },
+    projectPublic(record): IGmTimeCascadePublicEffect {
+      return record.publicEffect;
+    },
+    projectPrivate(record): IGmPrivateMetadata {
+      return record.privateMetadata;
+    },
+  };
+}
+
+export function registerGmTimeCascadeInterventionImplementer(
+  ledger: InterventionLedger<IGmTimeCascadeInterventionState>,
+): InterventionLedger<IGmTimeCascadeInterventionState> {
+  return ledger.register(
+    createGmTimeCascadeInterventionImplementer() as IInterventionLedgerImplementer<
+      IInterventionLedgerCommand,
+      IGmTimeCascadeInterventionState
+    >,
+  );
+}
+
+function blockedTimeCascadePreview(
+  command: IInterventionLedgerCommand,
+  code: string,
+  reason: string,
+  affectedRefs: readonly string[] = command.targetRefs,
+): TimeCascadePreview {
+  const conflict: IInterventionConflict = {
+    code,
+    message: reason,
+    affectedRefs,
+  };
+
+  return {
+    domain: 'time',
+    kind: command.kind,
+    status: 'blocked',
+    actorId: command.actorId,
+    targetRefs: command.targetRefs,
+    causedBy: command.causedBy,
+    supersedes: command.supersedes,
+    conflicts: [conflict],
+    reason,
+  };
+}
+
+function isTimeCascadeCommandPayload(
+  payload: unknown,
+): payload is IGmTimeCascadeInterventionCommandPayload {
+  if (!isRecord(payload)) return false;
+  if (!isRecord(payload.privateMetadata)) return false;
+  if (typeof payload.privateMetadata.reason !== 'string') return false;
+  if (!isRecord(payload.correction)) return false;
+  return payload.correction.family === 'time-advance';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/src/lib/interventions/GmTimeCascadePreview.ts
+++ b/src/lib/interventions/GmTimeCascadePreview.ts
@@ -1,0 +1,331 @@
+import type { IDayEvent, IDayProcessor } from '@/lib/campaign/dayPipeline';
+import type { ICampaign } from '@/types/campaign/Campaign';
+import type { ICampaignWithCommand } from '@/types/campaign/CampaignCommandExtensions';
+import type {
+  IGmTimeCascadeInterventionCommandPayload,
+  IGmTimeCascadeInterventionConflictInput,
+  IGmTimeCascadeInterventionState,
+  IGmTimeCascadeProjectedEffect,
+} from '@/types/interventions';
+
+import {
+  contractProcessor,
+  dailyCostsProcessor,
+  repairProgressProcessor,
+  unitMarketProcessor,
+  personnelMarketProcessor,
+  contractMarketProcessor,
+} from '@/lib/campaign/processors';
+import { findSystemById } from '@/lib/starmap/loadInnerSphereSeed';
+
+export interface IGmTimeCascadeProjectedEffectResult {
+  readonly effect: IGmTimeCascadeProjectedEffect;
+  readonly changedStateRefs: readonly string[];
+  readonly summary: string;
+  readonly conflicts: readonly IGmTimeCascadeInterventionConflictInput[];
+}
+
+export interface IGmTimeCascadeProjectedEffectFailure {
+  readonly effect?: undefined;
+  readonly code: string;
+  readonly reason: string;
+  readonly affectedRefs?: readonly string[];
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const TIME_CASCADE_PROCESSORS = [
+  repairProgressProcessor,
+  contractProcessor,
+  dailyCostsProcessor,
+  unitMarketProcessor,
+  personnelMarketProcessor,
+  contractMarketProcessor,
+] as const satisfies readonly IDayProcessor[];
+
+const CAMPAIGN_ROOT_FIELDS = [
+  'currentDate',
+  'currentSystemId',
+  'repairQueue',
+  'partsInventory',
+  'unitCombatStates',
+  'finances',
+  'missions',
+  'loans',
+  'unitMarket',
+  'personnelMarket',
+  'contractMarket',
+] as const;
+
+export function buildGmTimeCascadeProjectedEffect(
+  payload: IGmTimeCascadeInterventionCommandPayload,
+  state: IGmTimeCascadeInterventionState,
+): IGmTimeCascadeProjectedEffectResult | IGmTimeCascadeProjectedEffectFailure {
+  const { correction } = payload;
+  if (correction.family !== 'time-advance') {
+    return failure(
+      'time-cascade-family-invalid',
+      'Unsupported time cascade correction family.',
+      [campaignRef(state.id)],
+    );
+  }
+
+  if (!Number.isInteger(correction.days) || correction.days <= 0) {
+    return failure(
+      'time-cascade-days-invalid',
+      'Time cascade requires a positive integer day count.',
+      [campaignFieldRef(state.id, 'currentDate')],
+    );
+  }
+
+  if (
+    correction.baseUpdatedAt !== undefined &&
+    correction.baseUpdatedAt !== state.updatedAt
+  ) {
+    return failure(
+      'time-cascade-base-stale',
+      'Time cascade preview was based on a stale campaign version.',
+      [campaignRef(state.id), campaignFieldRef(state.id, 'updatedAt')],
+    );
+  }
+
+  const currentDateIso = state.currentDate.toISOString();
+  if (
+    correction.baseCurrentDate !== undefined &&
+    correction.baseCurrentDate !== currentDateIso
+  ) {
+    return failure(
+      'time-cascade-date-stale',
+      'Time cascade preview was based on a stale campaign date.',
+      [campaignFieldRef(state.id, 'currentDate')],
+    );
+  }
+
+  if (
+    correction.destinationSystemId &&
+    !findSystemById(correction.destinationSystemId)
+  ) {
+    return failure(
+      'time-cascade-destination-unknown',
+      `Destination system "${correction.destinationSystemId}" was not found.`,
+      [campaignFieldRef(state.id, 'currentSystemId')],
+    );
+  }
+
+  const generatedAt = correction.generatedAt ?? new Date().toISOString();
+  const initialCampaign = applyTravelDestination(
+    state,
+    correction.destinationSystemId,
+  );
+  const projection = projectDays(initialCampaign, correction.days, generatedAt);
+  const externalEffects = correction.projectedExternalEffects ?? [];
+  const externalConflicts = buildExternalConflicts(
+    correction.externalEffectRefs,
+    externalEffects,
+  );
+  const explicitConflicts = normalizeConflicts(payload.conflicts);
+  const changedStateRefs = uniqueRefs([
+    ...computeChangedStateRefs(state, projection.campaign),
+    ...externalEffects.map((effect) => effect.ref),
+    ...externalConflicts.flatMap((conflict) => conflict.affectedRefs ?? []),
+    ...explicitConflicts.flatMap((conflict) => conflict.affectedRefs ?? []),
+  ]);
+  const summary =
+    payload.publicSummary ??
+    buildPublicSummary({
+      days: correction.days,
+      fromDate: state.currentDate.toISOString(),
+      toDate: projection.campaign.currentDate.toISOString(),
+      fromSystemId: state.currentSystemId,
+      toSystemId: projection.campaign.currentSystemId,
+    });
+
+  return {
+    summary,
+    changedStateRefs,
+    conflicts: [...externalConflicts, ...explicitConflicts],
+    effect: {
+      type: 'gm.campaign.time_cascade_applied',
+      domain: 'time',
+      family: 'time-advance',
+      days: correction.days,
+      destinationSystemId: correction.destinationSystemId,
+      before: snapshotState(state),
+      after: snapshotState(projection.campaign),
+      afterCampaign: projection.campaign,
+      daySummaries: projection.daySummaries,
+      generatedEvents: projection.events,
+      changedStateRefs,
+      externalEffects,
+      publicSummary: summary,
+    },
+  };
+}
+
+export function campaignRef(campaignId: string): string {
+  return `campaign:${campaignId}`;
+}
+
+export function campaignFieldRef(campaignId: string, field: string): string {
+  return `campaign:${campaignId}:${field}`;
+}
+
+export function externalRef(campaignId: string, ref: string): string {
+  return ref.startsWith('campaign:') ? ref : `campaign:${campaignId}:${ref}`;
+}
+
+function projectDays(
+  campaign: ICampaign,
+  days: number,
+  generatedAt: string,
+): {
+  readonly campaign: ICampaignWithCommand;
+  readonly daySummaries: IGmTimeCascadeProjectedEffect['daySummaries'];
+  readonly events: readonly IDayEvent[];
+} {
+  let current = campaign as ICampaignWithCommand;
+  const allEvents: IDayEvent[] = [];
+  const daySummaries: IGmTimeCascadeProjectedEffect['daySummaries'][number][] =
+    [];
+
+  for (let dayIndex = 1; dayIndex <= days; dayIndex += 1) {
+    const processedDate = current.currentDate;
+    const processorsRun: string[] = [];
+    const dayEvents: IDayEvent[] = [];
+    let working = current;
+
+    for (const processor of [...TIME_CASCADE_PROCESSORS].sort(
+      (a, b) => a.phase - b.phase,
+    )) {
+      const result = processor.process(working, processedDate);
+      working = result.campaign as ICampaignWithCommand;
+      dayEvents.push(...result.events);
+      processorsRun.push(processor.id);
+    }
+
+    const resultingDate = new Date(processedDate.getTime() + DAY_MS);
+    current = {
+      ...working,
+      currentDate: resultingDate,
+      updatedAt: generatedAt,
+    };
+
+    allEvents.push(...dayEvents);
+    daySummaries.push({
+      dayIndex,
+      processedDate: processedDate.toISOString(),
+      resultingDate: resultingDate.toISOString(),
+      eventCount: dayEvents.length,
+      eventTypes: uniqueRefs(dayEvents.map((event) => event.type)),
+      processorsRun,
+    });
+  }
+
+  return { campaign: current, daySummaries, events: allEvents };
+}
+
+function applyTravelDestination(
+  state: IGmTimeCascadeInterventionState,
+  destinationSystemId: string | undefined,
+): ICampaignWithCommand {
+  if (!destinationSystemId) return state;
+  return {
+    ...state,
+    currentSystemId: destinationSystemId,
+  };
+}
+
+function buildExternalConflicts(
+  externalRefs: readonly string[] | undefined,
+  externalEffects: readonly { readonly ref: string }[],
+): readonly IGmTimeCascadeInterventionConflictInput[] {
+  const projectedRefs = new Set(externalEffects.map((effect) => effect.ref));
+  return (externalRefs ?? [])
+    .filter((ref) => !projectedRefs.has(ref))
+    .map((ref) => ({
+      code: 'time-cascade-external-effect-unprojected',
+      message: `External time effect "${ref}" requires manual projection before approval.`,
+      affectedRefs: [ref],
+      requiresManualTakeover: true,
+    }));
+}
+
+function normalizeConflicts(
+  conflicts: IGmTimeCascadeInterventionCommandPayload['conflicts'] | undefined,
+): readonly IGmTimeCascadeInterventionConflictInput[] {
+  return (conflicts ?? []).filter(
+    (conflict) =>
+      isNonEmptyString(conflict.code) && isNonEmptyString(conflict.message),
+  );
+}
+
+function computeChangedStateRefs(
+  before: IGmTimeCascadeInterventionState,
+  after: ICampaignWithCommand,
+): readonly string[] {
+  const refs = CAMPAIGN_ROOT_FIELDS.filter(
+    (field) =>
+      snapshotValue(readCampaignField(before, field)) !==
+      snapshotValue(readCampaignField(after, field)),
+  ).map((field) => campaignFieldRef(before.id, field));
+  return uniqueRefs(refs);
+}
+
+function readCampaignField(
+  campaign: ICampaignWithCommand,
+  field: (typeof CAMPAIGN_ROOT_FIELDS)[number],
+): unknown {
+  return campaign[field];
+}
+
+function snapshotState(campaign: ICampaign): {
+  readonly currentDate: string;
+  readonly updatedAt: string;
+  readonly currentSystemId?: string;
+} {
+  return {
+    currentDate: campaign.currentDate.toISOString(),
+    updatedAt: campaign.updatedAt,
+    currentSystemId: campaign.currentSystemId,
+  };
+}
+
+function snapshotValue(value: unknown): string {
+  return JSON.stringify(value, (_key, entry) => {
+    if (entry instanceof Map) return Array.from(entry.entries());
+    if (entry && typeof entry === 'object' && 'centsValue' in entry) {
+      return (entry as { readonly centsValue: number }).centsValue;
+    }
+    return entry;
+  });
+}
+
+function buildPublicSummary(input: {
+  readonly days: number;
+  readonly fromDate: string;
+  readonly toDate: string;
+  readonly fromSystemId?: string;
+  readonly toSystemId?: string;
+}): string {
+  const dateSummary = `Campaign time advanced ${input.days} day${input.days === 1 ? '' : 's'} from ${input.fromDate.slice(0, 10)} to ${input.toDate.slice(0, 10)}.`;
+  if (!input.toSystemId || input.fromSystemId === input.toSystemId) {
+    return dateSummary;
+  }
+  return `${dateSummary} Campaign location changed from ${input.fromSystemId ?? 'terra'} to ${input.toSystemId}.`;
+}
+
+function failure(
+  code: string,
+  reason: string,
+  affectedRefs: readonly string[],
+): IGmTimeCascadeProjectedEffectFailure {
+  return { code, reason, affectedRefs };
+}
+
+function uniqueRefs(refs: readonly string[]): readonly string[] {
+  return Array.from(new Set(refs));
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}

--- a/src/lib/interventions/GmTimeCascadeProjection.ts
+++ b/src/lib/interventions/GmTimeCascadeProjection.ts
@@ -1,0 +1,43 @@
+import type {
+  IGmPrivateMetadata,
+  IGmTimeCascadeInterventionDomainPayload,
+  IGmTimeCascadeInterventionState,
+  IGmTimeCascadeProjectedEffect,
+  IGmTimeCascadePublicEffect,
+  IInterventionLedgerRecord,
+} from '@/types/interventions';
+
+type TimeCascadeRecord = IInterventionLedgerRecord<
+  IGmPrivateMetadata,
+  IGmTimeCascadePublicEffect,
+  IGmTimeCascadeInterventionDomainPayload
+>;
+
+export function projectTimeCascadeEffectsForRecord(
+  record: TimeCascadeRecord,
+): readonly IGmTimeCascadeProjectedEffect[] {
+  if (!record.domainPayload) return [];
+
+  return record.domainPayload.projectedEffects.map((effect) => ({
+    ...effect,
+    interventionId: record.id,
+  }));
+}
+
+export function applyGmTimeCascadeProjectedEffects(
+  state: IGmTimeCascadeInterventionState,
+  effects: readonly IGmTimeCascadeProjectedEffect[],
+): IGmTimeCascadeInterventionState {
+  return effects.reduce(applyGmTimeCascadeProjectedEffect, state);
+}
+
+function applyGmTimeCascadeProjectedEffect(
+  state: IGmTimeCascadeInterventionState,
+  effect: IGmTimeCascadeProjectedEffect,
+): IGmTimeCascadeInterventionState {
+  return {
+    ...state,
+    ...effect.afterCampaign,
+    timeCascadeEvents: [...(state.timeCascadeEvents ?? []), effect],
+  };
+}

--- a/src/lib/interventions/__tests__/GmCampaignInterventionBoundaries.test.ts
+++ b/src/lib/interventions/__tests__/GmCampaignInterventionBoundaries.test.ts
@@ -1,9 +1,14 @@
 import type {
   IGmAuthorityContext,
+  IGmTimeCascadeInterventionCommandPayload,
+  IGmTimeCascadeInterventionState,
   IGmPrivateMetadata,
   IInterventionLedgerCommand,
   InterventionDomain,
 } from '@/types/interventions';
+
+import { createCampaign } from '@/types/campaign/Campaign';
+import { Money } from '@/types/campaign/Money';
 
 import type { IGmDeferredInterventionAttemptLog } from '../index';
 
@@ -11,6 +16,7 @@ import {
   approveGmCascadePreview,
   createGmCascadePreview,
   InterventionLedger,
+  registerGmTimeCascadeInterventionImplementer,
 } from '../index';
 
 interface CampaignBoundaryState {
@@ -84,6 +90,47 @@ function makeCommand(
         reason: 'GM wants to adjust a campaign cascade.',
         defaultOutcome: 'The campaign state would remain unchanged.',
         hiddenNotes: 'secret merchant inventory branch',
+      },
+    },
+  };
+}
+
+function makeRegisteredTimeState(): IGmTimeCascadeInterventionState {
+  const campaign = createCampaign('Boundary Time Campaign', 'mercenary', {
+    useRoleBasedSalaries: true,
+  });
+
+  return {
+    ...campaign,
+    id: 'campaign-1',
+    currentDate: new Date('3025-02-02T00:00:00.000Z'),
+    updatedAt: '2026-06-22T00:00:00.000Z',
+    currentSystemId: 'terra',
+    finances: {
+      balance: new Money(1_000_000),
+      transactions: [],
+    },
+    timeCascadeEvents: [],
+  };
+}
+
+function makeRegisteredTimeCommand(): IInterventionLedgerCommand<IGmTimeCascadeInterventionCommandPayload> {
+  return {
+    domain: 'time',
+    kind: 'fix',
+    actorId: 'gm-1',
+    targetRefs: ['campaign:campaign-1:currentDate'],
+    payload: {
+      correction: {
+        family: 'time-advance',
+        days: 1,
+        baseUpdatedAt: '2026-06-22T00:00:00.000Z',
+        baseCurrentDate: '3025-02-02T00:00:00.000Z',
+        generatedAt: '2026-06-22T00:05:00.000Z',
+      },
+      privateMetadata: {
+        reason: 'Hidden time correction reason.',
+        defaultOutcome: 'The campaign state would remain unchanged.',
       },
     },
   };
@@ -176,5 +223,36 @@ describe('GM campaign intervention boundaries', () => {
       deferredReason:
         'No intervention ledger implementer registered for domain "time".',
     });
+  });
+
+  it('executes time interventions when the time cascade implementer is registered', () => {
+    const state = makeRegisteredTimeState();
+    const ledger = registerGmTimeCascadeInterventionImplementer(
+      new InterventionLedger<IGmTimeCascadeInterventionState>(),
+    );
+
+    const preview = createGmCascadePreview({
+      ledger,
+      command: makeRegisteredTimeCommand(),
+      state,
+      authority: gmAuthority,
+      interventionId: 'gm-int-time-registered',
+    });
+    const result = approveGmCascadePreview({
+      ledger,
+      preview,
+      state,
+    });
+
+    expect(preview).toMatchObject({
+      status: 'ready',
+      domain: 'time',
+      affectedStateRefs: ['campaign:campaign-1:currentDate'],
+    });
+    expect(result.status).toBe('approved');
+    expect(result.state.currentDate.toISOString()).toBe(
+      '3025-02-03T00:00:00.000Z',
+    );
+    expect(result.state.timeCascadeEvents).toHaveLength(1);
   });
 });

--- a/src/lib/interventions/__tests__/GmTimeCascadeInterventionImplementer.test.ts
+++ b/src/lib/interventions/__tests__/GmTimeCascadeInterventionImplementer.test.ts
@@ -1,0 +1,577 @@
+import type { IRepairTicket } from '@/types/campaign/RepairTicket';
+import type {
+  IUnitCombatState,
+  IUnitMaxState,
+} from '@/types/campaign/UnitCombatState';
+import type {
+  IGmAuthorityContext,
+  IGmPrivateMetadata,
+  IGmTimeCascadeInterventionCommandPayload,
+  IGmTimeCascadeInterventionDomainPayload,
+  IGmTimeCascadeInterventionState,
+  IGmTimeCascadePublicEffect,
+  IInterventionLedgerCommand,
+  IInterventionLedgerRecord,
+} from '@/types/interventions';
+
+import { createCampaign } from '@/types/campaign/Campaign';
+import { Money } from '@/types/campaign/Money';
+
+import { ActionLedger } from '../ActionLedger';
+import {
+  applyGmTimeCascadeProjectedEffects,
+  approveGmCascadePreview,
+  createGmCascadePreview,
+  projectInterventionRecordForGm,
+  projectInterventionRecordForPlayer,
+  projectTimeCascadeEffectsForRecord,
+  registerGmTimeCascadeInterventionImplementer,
+} from '../index';
+import { InterventionLedger } from '../InterventionLedger';
+
+type TimeCascadeCommand =
+  IInterventionLedgerCommand<IGmTimeCascadeInterventionCommandPayload>;
+
+type TimeCascadeRecord = IInterventionLedgerRecord<
+  IGmPrivateMetadata,
+  IGmTimeCascadePublicEffect,
+  IGmTimeCascadeInterventionDomainPayload
+>;
+
+const BASE_UPDATED_AT = '2026-06-22T00:00:00.000Z';
+const BASE_CURRENT_DATE = '3025-02-02T00:00:00.000Z';
+const GENERATED_AT = '2026-06-22T00:05:00.000Z';
+
+const gmAuthority: IGmAuthorityContext = {
+  actorId: 'gm-1',
+  role: 'gm',
+  gameId: 'game-1',
+  campaignId: 'campaign-1',
+  ownedStateRefs: ['campaign:campaign-1'],
+};
+
+function makeState(
+  overrides: Partial<IGmTimeCascadeInterventionState> = {},
+): IGmTimeCascadeInterventionState {
+  const campaign = createCampaign('Wave 9 Test Campaign', 'mercenary', {
+    useRoleBasedSalaries: true,
+  });
+
+  return {
+    ...campaign,
+    id: 'campaign-1',
+    currentDate: new Date(BASE_CURRENT_DATE),
+    currentSystemId: 'terra',
+    updatedAt: BASE_UPDATED_AT,
+    finances: {
+      balance: new Money(1_000_000),
+      transactions: [],
+    },
+    repairQueue: [makeRepairTicket({ remainingHours: 16 })],
+    unitCombatStates: {
+      'unit-1': makeCombatState(),
+    },
+    unitMaxStates: {
+      'unit-1': makeUnitMaxState(),
+    },
+    partsInventory: [],
+    timeCascadeEvents: [],
+    ...overrides,
+  };
+}
+
+function makeLedger(): InterventionLedger<IGmTimeCascadeInterventionState> {
+  return registerGmTimeCascadeInterventionImplementer(
+    new InterventionLedger<IGmTimeCascadeInterventionState>(),
+  );
+}
+
+function makePayload(
+  correction: Partial<
+    IGmTimeCascadeInterventionCommandPayload['correction']
+  > = {},
+  overrides: Partial<IGmTimeCascadeInterventionCommandPayload> = {},
+): IGmTimeCascadeInterventionCommandPayload {
+  return {
+    correction: {
+      family: 'time-advance',
+      days: 1,
+      baseUpdatedAt: BASE_UPDATED_AT,
+      baseCurrentDate: BASE_CURRENT_DATE,
+      generatedAt: GENERATED_AT,
+      ...correction,
+    },
+    publicSummary: overrides.publicSummary,
+    privateMetadata: {
+      reason: 'Hidden time correction reason.',
+      defaultOutcome: 'The campaign would remain on the original date.',
+      hiddenNotes: 'Secret contract timing branch stays private.',
+    },
+    visibleToPlayerIds: overrides.visibleToPlayerIds,
+    conflicts: overrides.conflicts,
+  };
+}
+
+function makeCommand(
+  payload: IGmTimeCascadeInterventionCommandPayload,
+  overrides: Partial<TimeCascadeCommand> = {},
+): TimeCascadeCommand {
+  return {
+    domain: 'time',
+    kind: 'fix',
+    actorId: 'gm-1',
+    targetRefs: ['campaign:campaign-1:currentDate'],
+    payload,
+    causedBy: ['player-action-1'],
+    ...overrides,
+  };
+}
+
+function approveCommand(input: {
+  readonly command: TimeCascadeCommand;
+  readonly state?: IGmTimeCascadeInterventionState;
+  readonly actionLedger?: ActionLedger;
+  readonly interventionId?: string;
+}): {
+  readonly state: IGmTimeCascadeInterventionState;
+  readonly record: TimeCascadeRecord;
+} {
+  const state = input.state ?? makeState();
+  const ledger = makeLedger();
+  const preview = createGmCascadePreview({
+    ledger,
+    command: input.command,
+    state,
+    authority: gmAuthority,
+    interventionId: input.interventionId ?? 'gm-int-time-advance',
+  });
+
+  const result = approveGmCascadePreview({
+    ledger,
+    actionLedger: input.actionLedger,
+    preview,
+    state,
+    createdAt: GENERATED_AT,
+    approvedAt: '2026-06-22T00:06:00.000Z',
+  });
+
+  expect(result.status).toBe('approved');
+  if (result.status !== 'approved' || !result.record) {
+    throw new Error('Expected time cascade GM intervention approval.');
+  }
+
+  return {
+    state: result.state as IGmTimeCascadeInterventionState,
+    record: result.record as TimeCascadeRecord,
+  };
+}
+
+describe('GM time cascade intervention implementer', () => {
+  it('previews and applies one day without mutating the source campaign', () => {
+    const state = makeState();
+    const ledger = makeLedger();
+    const command = makeCommand(makePayload());
+
+    const preview = createGmCascadePreview({
+      ledger,
+      command,
+      state,
+      authority: gmAuthority,
+      interventionId: 'gm-int-time-preview',
+    });
+    const result = approveGmCascadePreview({
+      ledger,
+      preview,
+      state,
+      createdAt: GENERATED_AT,
+      approvedAt: '2026-06-22T00:06:00.000Z',
+    });
+
+    expect(preview).toMatchObject({
+      status: 'ready',
+      domain: 'time',
+      affectedStateRefs: [
+        'campaign:campaign-1:currentDate',
+        'campaign:campaign-1:repairQueue',
+      ],
+      publicEffect: {
+        family: 'time-advance',
+        days: 1,
+        fromDate: BASE_CURRENT_DATE,
+        toDate: '3025-02-03T00:00:00.000Z',
+      },
+    });
+    expect(preview.projectedEvents).toHaveLength(1);
+    expect(state.currentDate.toISOString()).toBe(BASE_CURRENT_DATE);
+    expect(state.repairQueue?.[0].remainingHours).toBe(16);
+
+    expect(result.status).toBe('approved');
+    expect(result.state.currentDate.toISOString()).toBe(
+      '3025-02-03T00:00:00.000Z',
+    );
+    expect(result.state.repairQueue?.[0]).toMatchObject({
+      ticketId: 'ticket-1',
+      status: 'in-progress',
+      remainingHours: 8,
+    });
+    expect(result.state.timeCascadeEvents).toHaveLength(1);
+  });
+
+  it('replays stored projected effects for multi-day repair completion', () => {
+    const state = makeState();
+    const command = makeCommand(makePayload({ days: 2 }));
+    const approved = approveCommand({
+      command,
+      state,
+      interventionId: 'gm-int-time-two-days',
+    });
+    const effects = projectTimeCascadeEffectsForRecord(approved.record);
+    const replayed = applyGmTimeCascadeProjectedEffects(state, effects);
+
+    expect(approved.state.currentDate.toISOString()).toBe(
+      '3025-02-04T00:00:00.000Z',
+    );
+    expect(approved.state.repairQueue?.[0]).toMatchObject({
+      ticketId: 'ticket-1',
+      status: 'completed',
+      remainingHours: 0,
+    });
+    expect(approved.state.unitCombatStates['unit-1']).toMatchObject({
+      currentArmorPerLocation: {
+        CT: 28,
+      },
+      lastUpdated: '3025-02-03T00:00:00.000Z',
+    });
+    expect(effects[0]).toMatchObject({
+      interventionId: 'gm-int-time-two-days',
+      daySummaries: [
+        {
+          dayIndex: 1,
+          eventTypes: ['repair_progress'],
+        },
+        {
+          dayIndex: 2,
+          eventTypes: ['repair_completed'],
+        },
+      ],
+    });
+    expect(replayed.currentDate.toISOString()).toBe(
+      approved.state.currentDate.toISOString(),
+    );
+    expect(replayed.repairQueue).toEqual(approved.state.repairQueue);
+    expect(replayed.timeCascadeEvents).toHaveLength(1);
+  });
+
+  it('records action-ledger projections while redacting GM-private context', () => {
+    const actionLedger = new ActionLedger();
+    actionLedger.appendNormalAction({
+      id: 'player-action-1',
+      actorId: 'player-1',
+      domain: 'campaign',
+      action: 'advance-time-request',
+      targetRefs: ['campaign:campaign-1:currentDate'],
+      publicEffect: { summary: 'Player requested campaign time advance.' },
+      createdAt: '2026-06-22T00:04:00.000Z',
+    });
+
+    const approved = approveCommand({
+      command: makeCommand(
+        makePayload(
+          { days: 1 },
+          { publicSummary: 'Campaign date corrected by one day.' },
+        ),
+      ),
+      actionLedger,
+    });
+    const playerRecord = projectInterventionRecordForPlayer(approved.record);
+    const gmRecord = projectInterventionRecordForGm(approved.record);
+    const playerActions = actionLedger.projectForPlayer();
+    const gmActions = actionLedger.projectForGm();
+
+    expect(playerRecord.publicEffect).toMatchObject({
+      summary: 'Campaign date corrected by one day.',
+      days: 1,
+      toDate: '3025-02-03T00:00:00.000Z',
+    });
+    expect(gmRecord.privateMetadata).toMatchObject({
+      reason: 'Hidden time correction reason.',
+    });
+    expect(playerActions).toHaveLength(2);
+    expect(playerActions[1]).toMatchObject({
+      recordKind: 'gm-intervention',
+      interventionRecordId: approved.record.id,
+      publicEffect: {
+        summary: 'Campaign date corrected by one day.',
+      },
+    });
+    expect(gmActions[1]).toMatchObject({
+      privateMetadata: {
+        hiddenNotes: 'Secret contract timing branch stays private.',
+      },
+    });
+    expect(JSON.stringify(playerRecord)).not.toContain('Hidden time');
+    expect(JSON.stringify(playerRecord)).not.toContain('Secret contract');
+    expect(JSON.stringify(playerActions)).not.toContain('Secret contract');
+  });
+
+  it('supports optional travel in the same projected cascade', () => {
+    const approved = approveCommand({
+      command: makeCommand(makePayload({ destinationSystemId: 'new-avalon' })),
+      interventionId: 'gm-int-time-travel',
+    });
+
+    expect(approved.state.currentSystemId).toBe('new-avalon');
+    expect(approved.state.currentDate.toISOString()).toBe(
+      '3025-02-03T00:00:00.000Z',
+    );
+    expect(approved.record.publicEffect).toMatchObject({
+      fromSystemId: 'terra',
+      toSystemId: 'new-avalon',
+    });
+    expect(approved.record.domainPayload?.projectedEffects[0]).toMatchObject({
+      before: {
+        currentSystemId: 'terra',
+      },
+      after: {
+        currentSystemId: 'new-avalon',
+      },
+    });
+  });
+
+  it('blocks invalid day counts before approval', () => {
+    const state = makeState();
+    const ledger = makeLedger();
+    const preview = createGmCascadePreview({
+      ledger,
+      command: makeCommand(makePayload({ days: 0 })),
+      state,
+      authority: gmAuthority,
+      interventionId: 'gm-int-time-invalid-days',
+    });
+    const result = approveGmCascadePreview({ ledger, preview, state });
+
+    expect(preview).toMatchObject({
+      status: 'blocked',
+      conflicts: [
+        {
+          code: 'time-cascade-days-invalid',
+          affectedRefs: ['campaign:campaign-1:currentDate'],
+        },
+      ],
+    });
+    expect(result).toMatchObject({
+      status: 'blocked',
+      appended: false,
+      state,
+    });
+    expect(ledger.getRecords()).toEqual([]);
+  });
+
+  it('blocks stale base campaign versions', () => {
+    const state = makeState();
+    const ledger = makeLedger();
+    const preview = createGmCascadePreview({
+      ledger,
+      command: makeCommand(
+        makePayload({ baseUpdatedAt: '2026-06-21T00:00:00.000Z' }),
+      ),
+      state,
+      authority: gmAuthority,
+      interventionId: 'gm-int-time-stale-version',
+    });
+
+    expect(preview).toMatchObject({
+      status: 'blocked',
+      conflicts: [
+        {
+          code: 'time-cascade-base-stale',
+          affectedRefs: [
+            'campaign:campaign-1',
+            'campaign:campaign-1:updatedAt',
+          ],
+        },
+      ],
+    });
+  });
+
+  it('blocks approval when campaign state changes after preview creation', () => {
+    const state = makeState();
+    const ledger = makeLedger();
+    const preview = createGmCascadePreview({
+      ledger,
+      command: makeCommand(makePayload()),
+      state,
+      authority: gmAuthority,
+      interventionId: 'gm-int-time-stale-approval',
+    });
+    const changedState = {
+      ...state,
+      updatedAt: '2026-06-22T00:30:00.000Z',
+    };
+    const result = approveGmCascadePreview({
+      ledger,
+      preview,
+      state: changedState,
+    });
+
+    expect(preview.status).toBe('ready');
+    expect(result).toMatchObject({
+      status: 'blocked',
+      appended: false,
+      state: changedState,
+      reason:
+        'Cannot approve GM cascade preview from a stale campaign version.',
+    });
+    expect(ledger.getRecords()).toEqual([]);
+  });
+
+  it('blocks unknown travel destinations', () => {
+    const state = makeState();
+    const ledger = makeLedger();
+    const preview = createGmCascadePreview({
+      ledger,
+      command: makeCommand(
+        makePayload({ destinationSystemId: 'does-not-exist' }),
+      ),
+      state,
+      authority: gmAuthority,
+      interventionId: 'gm-int-time-unknown-destination',
+    });
+
+    expect(preview).toMatchObject({
+      status: 'blocked',
+      conflicts: [
+        {
+          code: 'time-cascade-destination-unknown',
+          affectedRefs: ['campaign:campaign-1:currentSystemId'],
+        },
+      ],
+    });
+  });
+
+  it('requires manual takeover when external effects are named but not projected', () => {
+    const state = makeState();
+    const ledger = makeLedger();
+    const preview = createGmCascadePreview({
+      ledger,
+      command: makeCommand(
+        makePayload({
+          externalEffectRefs: ['roster:pilot-1:fatigue'],
+        }),
+      ),
+      state,
+      authority: gmAuthority,
+      interventionId: 'gm-int-time-external-manual',
+    });
+    const result = approveGmCascadePreview({ ledger, preview, state });
+
+    expect(preview).toMatchObject({
+      status: 'requires-manual-takeover',
+      conflicts: [
+        {
+          code: 'time-cascade-external-effect-unprojected',
+          affectedRefs: ['roster:pilot-1:fatigue'],
+          requiresManualTakeover: true,
+        },
+      ],
+    });
+    expect(result).toMatchObject({
+      status: 'blocked',
+      appended: false,
+      state,
+    });
+  });
+
+  it('approves external effects once the cascade includes their projection', () => {
+    const approved = approveCommand({
+      command: makeCommand(
+        makePayload({
+          externalEffectRefs: ['roster:pilot-1:fatigue'],
+          projectedExternalEffects: [
+            {
+              ref: 'roster:pilot-1:fatigue',
+              summary: 'Pilot fatigue advanced one day.',
+              before: { daysRested: 0 },
+              after: { daysRested: 1 },
+            },
+          ],
+        }),
+      ),
+      interventionId: 'gm-int-time-external-projected',
+    });
+
+    expect(approved.record.publicEffect.changedStateRefs).toContain(
+      'roster:pilot-1:fatigue',
+    );
+    expect(approved.record.domainPayload?.projectedEffects[0]).toMatchObject({
+      externalEffects: [
+        {
+          ref: 'roster:pilot-1:fatigue',
+          summary: 'Pilot fatigue advanced one day.',
+        },
+      ],
+    });
+    expect(approved.state.timeCascadeEvents?.[0]).toMatchObject({
+      externalEffects: [
+        {
+          ref: 'roster:pilot-1:fatigue',
+        },
+      ],
+    });
+  });
+});
+
+function makeRepairTicket(
+  overrides: Partial<IRepairTicket> = {},
+): IRepairTicket {
+  return {
+    ticketId: 'ticket-1',
+    unitId: 'unit-1',
+    kind: 'armor',
+    location: 'CT',
+    pointsToRestore: 8,
+    expectedHours: 16,
+    remainingHours: 16,
+    partsRequired: [],
+    source: 'combat',
+    matchId: 'match-1',
+    createdAt: BASE_CURRENT_DATE,
+    status: 'queued',
+    ...overrides,
+  };
+}
+
+function makeCombatState(
+  overrides: Partial<IUnitCombatState> = {},
+): IUnitCombatState {
+  return {
+    unitId: 'unit-1',
+    currentArmorPerLocation: {
+      CT: 20,
+    },
+    currentStructurePerLocation: {
+      CT: 10,
+    },
+    destroyedLocations: [],
+    destroyedComponents: [],
+    heatEnd: 0,
+    ammoRemaining: {},
+    combatReady: true,
+    lastCombatOutcomeId: 'match-1',
+    lastUpdated: BASE_CURRENT_DATE,
+    ...overrides,
+  };
+}
+
+function makeUnitMaxState(): IUnitMaxState {
+  return {
+    unitId: 'unit-1',
+    maxArmorPerLocation: {
+      CT: 28,
+    },
+    maxStructurePerLocation: {
+      CT: 10,
+    },
+    maxAmmoPerBin: {},
+  };
+}

--- a/src/lib/interventions/index.ts
+++ b/src/lib/interventions/index.ts
@@ -37,6 +37,11 @@ export {
 } from './GmCampaignInterventionImplementer';
 
 export {
+  createGmTimeCascadeInterventionImplementer,
+  registerGmTimeCascadeInterventionImplementer,
+} from './GmTimeCascadeInterventionImplementer';
+
+export {
   applyGmCombatProjectedEffects,
   projectCombatEffectsForRecord,
 } from './GmCombatInterventionProjection';
@@ -45,6 +50,11 @@ export {
   applyGmCampaignProjectedEffects,
   projectCampaignEffectsForRecord,
 } from './GmCampaignInterventionProjection';
+
+export {
+  applyGmTimeCascadeProjectedEffects,
+  projectTimeCascadeEffectsForRecord,
+} from './GmTimeCascadeProjection';
 
 export {
   createGmUnitReloadInterventionImplementer,

--- a/src/types/interventions/GmCampaignInterventionTypes.ts
+++ b/src/types/interventions/GmCampaignInterventionTypes.ts
@@ -18,6 +18,8 @@ export type GmCampaignInterventionDomain =
   | 'repair'
   | 'salvage';
 
+export type GmCampaignLedgerDomain = GmCampaignInterventionDomain | 'time';
+
 export type GmCampaignCorrectionFamily =
   | 'salvage-allocation'
   | 'repair-ticket'

--- a/src/types/interventions/GmTimeCascadeInterventionTypes.ts
+++ b/src/types/interventions/GmTimeCascadeInterventionTypes.ts
@@ -1,0 +1,102 @@
+import type { IDayEvent } from '@/lib/campaign/dayPipeline';
+import type { ICampaign } from '@/types/campaign/Campaign';
+import type { ICampaignWithCommand } from '@/types/campaign/CampaignCommandExtensions';
+
+import type {
+  IGmPrivateMetadata,
+  IGmPublicEffect,
+} from './GmInterventionAuthorityTypes';
+
+export type GmTimeCascadeInterventionDomain = 'time';
+
+export type GmTimeCascadeCorrectionFamily = 'time-advance';
+
+export interface IGmTimeCascadeInterventionState extends ICampaignWithCommand {
+  readonly timeCascadeEvents?: readonly IGmTimeCascadeProjectedEffect[];
+}
+
+export interface IGmTimeCascadeInterventionConflictInput {
+  readonly code: string;
+  readonly message: string;
+  readonly affectedRefs?: readonly string[];
+  readonly requiresManualTakeover?: boolean;
+}
+
+export interface IGmTimeCascadeExternalEffectProjection {
+  readonly ref: string;
+  readonly summary: string;
+  readonly before?: unknown;
+  readonly after?: unknown;
+  readonly visibleToPlayerIds?: readonly string[];
+}
+
+export interface IGmTimeCascadeAdvanceCorrection {
+  readonly family: 'time-advance';
+  readonly days: number;
+  readonly destinationSystemId?: string;
+  readonly baseUpdatedAt?: string;
+  readonly baseCurrentDate?: string;
+  readonly generatedAt?: string;
+  readonly externalEffectRefs?: readonly string[];
+  readonly projectedExternalEffects?: readonly IGmTimeCascadeExternalEffectProjection[];
+}
+
+export type GmTimeCascadeInterventionCorrection =
+  IGmTimeCascadeAdvanceCorrection;
+
+export interface IGmTimeCascadeInterventionCommandPayload {
+  readonly correction: GmTimeCascadeInterventionCorrection;
+  readonly privateMetadata: IGmPrivateMetadata;
+  readonly publicSummary?: string;
+  readonly visibleToPlayerIds?: readonly string[];
+  readonly conflicts?: readonly IGmTimeCascadeInterventionConflictInput[];
+}
+
+export interface IGmTimeCascadeDaySummary {
+  readonly dayIndex: number;
+  readonly processedDate: string;
+  readonly resultingDate: string;
+  readonly eventCount: number;
+  readonly eventTypes: readonly string[];
+  readonly processorsRun: readonly string[];
+}
+
+export interface IGmTimeCascadeStateSnapshot {
+  readonly currentDate: string;
+  readonly updatedAt: string;
+  readonly currentSystemId?: string;
+}
+
+export type GmTimeCascadeProjectedEffectType =
+  'gm.campaign.time_cascade_applied';
+
+export interface IGmTimeCascadeProjectedEffect {
+  readonly type: GmTimeCascadeProjectedEffectType;
+  readonly domain: GmTimeCascadeInterventionDomain;
+  readonly family: GmTimeCascadeCorrectionFamily;
+  readonly interventionId?: string;
+  readonly days: number;
+  readonly destinationSystemId?: string;
+  readonly before: IGmTimeCascadeStateSnapshot;
+  readonly after: IGmTimeCascadeStateSnapshot;
+  readonly afterCampaign: ICampaign;
+  readonly daySummaries: readonly IGmTimeCascadeDaySummary[];
+  readonly generatedEvents: readonly IDayEvent[];
+  readonly changedStateRefs: readonly string[];
+  readonly externalEffects: readonly IGmTimeCascadeExternalEffectProjection[];
+  readonly publicSummary: string;
+}
+
+export interface IGmTimeCascadeInterventionDomainPayload {
+  readonly correction: GmTimeCascadeInterventionCorrection;
+  readonly projectedEffects: readonly IGmTimeCascadeProjectedEffect[];
+}
+
+export interface IGmTimeCascadePublicEffect extends IGmPublicEffect {
+  readonly family: GmTimeCascadeCorrectionFamily;
+  readonly days: number;
+  readonly fromDate: string;
+  readonly toDate: string;
+  readonly fromSystemId?: string;
+  readonly toSystemId?: string;
+}

--- a/src/types/interventions/index.ts
+++ b/src/types/interventions/index.ts
@@ -37,6 +37,7 @@ export type {
   GmCampaignCorrectionFamily,
   GmCampaignInterventionCorrection,
   GmCampaignInterventionDomain,
+  GmCampaignLedgerDomain,
   GmCampaignProjectedEffectType,
   IGmCampaignBaseUnitStateCorrection,
   IGmCampaignBaseUnitStateEffect,
@@ -56,6 +57,23 @@ export type {
   IGmCampaignSalvageAllocationCorrection,
   IGmCampaignSalvageAllocationEffect,
 } from './GmCampaignInterventionTypes';
+
+export type {
+  GmTimeCascadeCorrectionFamily,
+  GmTimeCascadeInterventionCorrection,
+  GmTimeCascadeInterventionDomain,
+  GmTimeCascadeProjectedEffectType,
+  IGmTimeCascadeAdvanceCorrection,
+  IGmTimeCascadeDaySummary,
+  IGmTimeCascadeExternalEffectProjection,
+  IGmTimeCascadeInterventionCommandPayload,
+  IGmTimeCascadeInterventionConflictInput,
+  IGmTimeCascadeInterventionDomainPayload,
+  IGmTimeCascadeInterventionState,
+  IGmTimeCascadeProjectedEffect,
+  IGmTimeCascadePublicEffect,
+  IGmTimeCascadeStateSnapshot,
+} from './GmTimeCascadeInterventionTypes';
 
 export type {
   IGmUnitReloadCommandProjection,


### PR DESCRIPTION
## Summary
- Adds a ledger-backed `time` GM intervention domain for campaign time cascades.
- Previews one-day and multi-day campaign advancement, optional travel, repair progression, stale-base checks, manual-takeover external effects, and approval replay from stored projections.
- Syncs and archives the `add-time-cascade-system` OpenSpec change.

## Validation
- `npx.cmd jest --selectProjects unit --runTestsByPath src\lib\interventions\__tests__\ActionLedger.test.ts src\lib\interventions\__tests__\GmCampaignInterventionBoundaries.test.ts src\lib\interventions\__tests__\GmCampaignInterventionImplementer.test.ts src\lib\interventions\__tests__\GmCombatInterventionImplementer.test.ts src\lib\interventions\__tests__\GmInterventionAuthority.test.ts src\lib\interventions\__tests__\GmTimeCascadeInterventionImplementer.test.ts src\lib\interventions\__tests__\GmUnitReloadInterventionImplementer.test.ts src\lib\interventions\__tests__\InterventionLedger.test.ts --runInBand`
- `npm.cmd run typecheck`
- `npm.cmd run format:check`
- `openspec.cmd validate --all --strict`
- `git diff --check`
- Commit hook: lint-staged, `npx tsc --noEmit --skipLibCheck`, and `npm.cmd run build`

## Notes
- Browser UI wiring for GM time-cascade controls remains a later wave.
- External roster/vault effects are represented as explicit projected patches or manual-takeover conflicts in this slice.