### PR TITLE
Guard combat catalog parity gap baseline

### DIFF
--- a/openspec/changes/archive/2026-06-23-expand-catalog-rules-parity/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-23-expand-catalog-rules-parity/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-23

--- a/openspec/changes/archive/2026-06-23-expand-catalog-rules-parity/design.md
+++ b/openspec/changes/archive/2026-06-23-expand-catalog-rules-parity/design.md
@@ -1,0 +1,67 @@
+## Context
+
+MekStation already has a catalog-backed BattleMech combat validation substrate in `src/simulation/runner/CombatValidationCatalog.ts`, `CombatValidationRequirementSupport.*`, `CombatValidationGapInventory.ts`, and the `battlemechCombatCatalog.*` Jest fragments. The runnable command surface is also present: `npm.cmd run validate:combat:gaps`, `npm.cmd run validate:combat`, and `npm.cmd run verify:rules`.
+
+Wave 10 does not need a second validation framework. It needs to tighten the existing one around official combat catalog rows so official ranged weapons, ammunition, physical weapons, and special-mode behavior are either proven by catalog-backed tests or listed as explicit gaps. The main architectural constraint is honesty: synthetic/static fallback data and broad `knownLimitations` suppression must not make unsupported mechanics look supported.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define a single BattleMech combat catalog parity matrix for official ranged weapon, ammunition, physical weapon, and special-mode rows.
+- Extend the existing gap exporter so newly closed or newly discovered rows are visible and expectation-gated.
+- Add focused tests that prove newly represented rows are loaded from official/catalog-backed data and consumed by runtime behavior.
+- Keep unsupported, helper-only, modifier-only, and non-BattleMech rows explicit.
+
+**Non-Goals:**
+
+- Do not rewrite combat resolution or tactical map projection.
+- Do not add UI controls in this wave.
+- Do not claim full non-BattleMech rules parity.
+- Do not remove `knownLimitations` buckets except where focused tests prove the bucket is no longer required.
+
+## Decisions
+
+### Decision 1: Extend the existing combat validation catalog
+
+Wave 10 SHALL add rows, support references, and fragment tests under the existing combat validation catalog surface instead of introducing a separate catalog-parity runner.
+
+Alternative considered: create a new standalone catalog audit command. Rejected because `validate:combat:gaps` and `validate:combat` already provide the on-demand evidence and gap accounting surface.
+
+### Decision 2: Classify every official row before claiming support
+
+Each catalog row SHALL land in one explicit classification: integrated runtime behavior, represented helper/modifier behavior, partial/unsupported gap, or out-of-scope split. Physical weapons need a separate standalone-attack vs modifier-only split so claws/talons-style equipment does not inflate selectable attack support.
+
+Alternative considered: only add tests for newly supported rows. Rejected because unclassified official rows are the failure mode this wave is meant to expose.
+
+### Decision 3: Treat fallback data as a failure unless explicitly marked as fixture-only
+
+Runtime parity SHALL not use static/synthetic fallback data to satisfy official catalog coverage. Tests should pin that official catalog assets loaded and that missing catalog rows fail with named gap refs.
+
+Alternative considered: keep fallback rows to keep tests stable. Rejected because fallback data hides the exact class of regression the user wants surfaced.
+
+### Decision 4: Audit known limitations instead of deleting them broadly
+
+`knownLimitations` SHALL remain a legacy-detector suppression layer, not a feature-status ledger. Wave 10 should add tests that bypass or trap suppressions for the targeted catalog rows, and only narrow suppressions when the targeted detector proof exists.
+
+Alternative considered: remove broad known-limitation buckets now. Rejected because unrelated legacy detectors could start producing noisy false positives without proving catalog parity.
+
+## Risks / Trade-offs
+
+- [Risk] Catalog parity work becomes too broad for one PR. -> Mitigation: focus on BattleMech ranged weapons/ammunition/physical weapons and special-mode rows named in the proposal; split non-BattleMech rows.
+- [Risk] Existing support maps already contain many rows and a broad edit could regress unrelated validation. -> Mitigation: use focused fragment tests plus `validate:combat:gaps`, `validate:combat`, and `verify:rules` before archive.
+- [Risk] Official catalog names differ across equipment JSON, runner weapon IDs, and MegaMek references. -> Mitigation: add alias/mapping tests that fail loudly when a row has no source-backed mapping.
+- [Risk] MML-style damage hazards have mixed runtime/display semantics. -> Mitigation: classify MML rows explicitly as integrated, helper-only, partial, or unsupported rather than leaving string-damage hazards implicit.
+
+## Migration Plan
+
+1. Capture the current gap inventory summary with `npm.cmd run validate:combat:gaps -- --format=summary`.
+2. Add/adjust catalog support rows and focused fragment tests for official ranged weapons, ammunition, physical weapons, and special modes.
+3. Add expectation-gated gap checks for rows that should disappear or remain explicit.
+4. Run focused Jest fragments, `npm.cmd run validate:combat:gaps`, `npm.cmd run validate:combat`, `npm.cmd run verify:rules`, `npm.cmd run typecheck`, and OpenSpec strict validation.
+5. Sync specs, archive the change, open PR, wait for CI, merge, reset/prune local state.
+
+## Open Questions
+
+- Which remaining unresolved refs should Wave 10 close first if the current gap summary is larger than expected?
+- Should the MML hazard classification live under ammunition compatibility, weapon resolution, or a dedicated missile-family support map?

--- a/openspec/changes/archive/2026-06-23-expand-catalog-rules-parity/proposal.md
+++ b/openspec/changes/archive/2026-06-23-expand-catalog-rules-parity/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+MekStation already has a large BattleMech combat validation substrate, but the next leverage point is to make official catalog/rules parity harder to regress and easier to audit on demand. Catalog-backed weapons, ammunition, physical weapons, and special modes need one repeatable proof surface that distinguishes supported mechanics from explicit gaps without static fallback data hiding failures.
+
+## What Changes
+
+- Add a catalog/rules parity capability that defines the official combat catalog matrix, validation commands, evidence artifacts, and explicit gap accounting.
+- Expand equipment catalog requirements so official ranged weapons, ammunition, and physical weapons must load and map to runtime support or an explicit classified gap.
+- Expand weapon-resolution requirements for catalog-driven UAC, RAC, LB-X, Streak, Artemis, NARC, TAG, AMS, cluster, and MML-style behavior coverage.
+- Expand ammunition requirements for compatible ammo mapping, special ammo modes, and no-fallback failure handling.
+- Expand physical-weapon requirements so every official physical entry is classified as a standalone runtime attack, modifier-only equipment, construction-only/out-of-scope entry, or explicit unsupported gap.
+- Add validation tasks that run the existing combat validation suite and gap exporter, then add focused tests for newly covered catalog rows.
+
+## Non-goals
+
+- Do not rewrite the combat runner, tactical UI, or journey runner.
+- Do not claim support for non-BattleMech systems inside this matrix unless they are split into separate explicit specs.
+- Do not remove known limitations wholesale; audit and narrow them only when targeted tests prove the gap is actually closed.
+- Do not add synthetic fallback equipment to make catalog parity pass.
+
+## Capabilities
+
+### New Capabilities
+
+- `combat-catalog-rules-parity`: Defines the BattleMech official combat catalog parity matrix, validation evidence, gap taxonomy, and no-fallback proof rules.
+
+### Modified Capabilities
+
+- `equipment-database`: Requires official ranged weapon, ammunition, and physical weapon catalog entries to load and map to runtime support or explicit gap classifications.
+- `weapon-resolution-system`: Requires catalog-driven coverage for special ranged weapon behavior, cluster behavior, and unsupported-mode accounting.
+- `ammunition-system`: Requires official ammunition compatibility and special ammo behavior to map without static fallback masking failures.
+- `physical-weapons-system`: Requires every official physical weapon entry to be classified against runtime attack/modifier/out-of-scope support.
+
+## Impact
+
+- Affected code: `src/data/equipment/**`, `src/lib/equipment/**`, `src/simulation/runner/**`, `src/simulation/core/**`, and focused Jest tests under `src/simulation/**/__tests__/`.
+- Affected commands: `npm.cmd run validate:combat:gaps`, `npm.cmd run validate:combat`, `npm.cmd run verify:rules`, and any focused catalog parity Jest tests added in this wave.
+- Affected specs: new `combat-catalog-rules-parity` plus deltas for equipment, weapon resolution, ammunition, and physical weapons.
+- No new runtime dependency is expected.

--- a/openspec/changes/archive/2026-06-23-expand-catalog-rules-parity/specs/ammunition-system/spec.md
+++ b/openspec/changes/archive/2026-06-23-expand-catalog-rules-parity/specs/ammunition-system/spec.md
@@ -1,40 +1,4 @@
-# ammunition-system Specification
-
-## Purpose
-
-Defines Ammunition System requirements for Ammunition Tracking, Ammunition Explosion, and Ammo Compatibility, preserving the source-of-truth scope introduced by archived change implement-phase3-equipment.
-
-## Requirements
-
-### Requirement: Ammunition Tracking
-
-The system SHALL track ammunition for ballistic and missile weapons.
-
-#### Scenario: Shots per ton
-
-- **WHEN** ammunition is defined
-- **THEN** shots per ton MUST be specified
-- **AND** ammunition MUST specify compatible weapon types
-
-### Requirement: Ammunition Explosion
-
-Ammunition SHALL be subject to explosion rules when critically hit.
-
-#### Scenario: Ammo explosion
-
-- **WHEN** ammunition location is critically hit
-- **THEN** remaining shots MAY cause explosion damage
-- **AND** CASE/CASE II protection MAY mitigate damage
-
-### Requirement: Ammo Compatibility
-
-Ammunition MUST be compatible with weapon type.
-
-#### Scenario: Compatibility check
-
-- **WHEN** loading ammunition
-- **THEN** ammo type MUST match weapon type
-- **AND** tech base SHOULD match unless mixed tech
+## ADDED Requirements
 
 ### Requirement: Official Ammunition Compatibility Mapping
 

--- a/openspec/changes/archive/2026-06-23-expand-catalog-rules-parity/specs/combat-catalog-rules-parity/spec.md
+++ b/openspec/changes/archive/2026-06-23-expand-catalog-rules-parity/specs/combat-catalog-rules-parity/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: Official Combat Catalog Parity Matrix
+
+The system SHALL maintain a BattleMech combat catalog parity matrix for official ranged weapons, ammunition entries, physical weapons, and special combat families. Each official row SHALL include a source-backed identifier, runtime mapping status, support level, evidence reference, and explicit gap text when not fully integrated.
+
+#### Scenario: Every official row is classified
+- **WHEN** the combat catalog parity validator runs
+- **THEN** every official BattleMech ranged weapon, ammunition entry, and physical weapon row is classified exactly once
+- **AND** each classification is integrated, partial, helper-only, modifier-only, unsupported, or out-of-scope
+
+#### Scenario: Missing official row is visible
+- **WHEN** an official catalog row has no runtime mapping
+- **THEN** the gap inventory includes a named unresolved row for that catalog entry
+- **AND** the row includes evidence and source references sufficient to decide whether to implement or defer it
+
+### Requirement: Catalog Fallback Guard
+
+Static, synthetic, or fixture-only fallback data SHALL NOT satisfy official combat catalog parity unless the row is explicitly classified as fixture-only and non-gating.
+
+#### Scenario: Synthetic fallback cannot hide catalog failure
+- **WHEN** a runtime behavior uses fallback equipment data for an official row
+- **THEN** the catalog parity validator fails or emits an unresolved gap for that row
+- **AND** the row is not counted as integrated support
+
+#### Scenario: Fixture-only data is marked non-gating
+- **WHEN** a test fixture uses synthetic equipment data
+- **THEN** the fixture declares that it is not official catalog evidence
+- **AND** catalog parity remains based on official loaded catalog rows
+
+### Requirement: Catalog Parity Validation Commands
+
+The system SHALL expose repeatable validation commands that report catalog parity coverage, unresolved gaps, out-of-scope rows, and expectation failures.
+
+#### Scenario: Gap command reports catalog parity state
+- **WHEN** `npm.cmd run validate:combat:gaps -- --format=summary` runs
+- **THEN** the output includes total unresolved rows and counts by level, scope, and section
+- **AND** expectation flags can require specific rows to be present or absent
+
+#### Scenario: Combat validation suite proves supported rows
+- **WHEN** `npm.cmd run validate:combat` runs
+- **THEN** focused catalog parity tests prove that integrated rows are loaded and consumed by runtime behavior
+- **AND** unsupported rows remain visible in the gap inventory
+
+### Requirement: Known Limitation Suppression Audit
+
+Known limitation suppression SHALL remain a legacy-detector filter, not a catalog support signal. Catalog parity tests SHALL bypass or trap broad suppressions for targeted official rows.
+
+#### Scenario: Known limitation cannot suppress targeted catalog failure
+- **WHEN** a targeted official catalog row fails parity validation
+- **THEN** broad `knownLimitations` suppression does not remove the failure from the catalog gap inventory
+- **AND** the failure remains visible until a source-backed support row or explicit out-of-scope split replaces it
+
+### Requirement: Non-BattleMech Boundary
+
+Catalog parity for this wave SHALL cover BattleMech combat rows. Non-BattleMech, aerospace, vehicle, battle armor, infantry, ProtoMech, or construction-only entries SHALL be split into explicit out-of-scope rows or separate future matrices.
+
+#### Scenario: Non-BattleMech entry is not counted as BattleMech support
+- **WHEN** an official row belongs to a non-BattleMech runtime family
+- **THEN** the BattleMech catalog parity matrix classifies it as out-of-scope or routes it to a separate matrix
+- **AND** the BattleMech support count does not include it as integrated behavior

--- a/openspec/changes/archive/2026-06-23-expand-catalog-rules-parity/specs/equipment-database/spec.md
+++ b/openspec/changes/archive/2026-06-23-expand-catalog-rules-parity/specs/equipment-database/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Official Combat Equipment Catalog Coverage
+
+The equipment database SHALL load official BattleMech ranged weapon, ammunition, and physical weapon entries needed by combat validation. Each loaded entry SHALL expose stable identifiers, display names, tech base, rules level, temporal availability, damage or effect fields, heat, ranges, ammunition compatibility, and source-backed category metadata where applicable.
+
+#### Scenario: Official ranged weapon row is loadable
+- **WHEN** a catalog-backed combat validation test requests an official ranged weapon
+- **THEN** the equipment database returns a source-backed row with damage, heat, range brackets, minimum range when applicable, ammunition behavior when applicable, tech base, rules level, and temporal availability
+
+#### Scenario: Official ammunition row is loadable
+- **WHEN** a catalog-backed combat validation test requests an official ammunition entry
+- **THEN** the equipment database returns a source-backed row with compatible weapon mapping or an explicit unsupported compatibility gap
+
+#### Scenario: Official physical weapon row is loadable
+- **WHEN** a catalog-backed combat validation test requests an official physical weapon
+- **THEN** the equipment database returns a source-backed row with construction fields and combat classification metadata
+
+### Requirement: Official Catalog No-Fallback Failure
+
+The equipment database SHALL fail loudly or report an explicit gap when official combat validation requires a missing official row. Synthetic fallback rows SHALL NOT be used to satisfy official coverage.
+
+#### Scenario: Missing official row becomes gap
+- **WHEN** official catalog validation requests a row absent from the loaded equipment database
+- **THEN** validation records a named catalog gap
+- **AND** no static fallback row is counted as official support

--- a/openspec/changes/archive/2026-06-23-expand-catalog-rules-parity/specs/physical-weapons-system/spec.md
+++ b/openspec/changes/archive/2026-06-23-expand-catalog-rules-parity/specs/physical-weapons-system/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Official Physical Weapon Catalog Classification
+
+The physical weapon catalog SHALL classify every official BattleMech physical weapon entry as a standalone runtime attack, modifier-only equipment, construction-only/out-of-scope entry, partial support, or unsupported gap.
+
+#### Scenario: Standalone physical attack is runtime-backed
+- **WHEN** an official physical weapon is classified as a standalone attack
+- **THEN** runtime legality, to-hit, damage, hit location, and miss consequence behavior are validated with source-backed evidence
+
+#### Scenario: Modifier-only physical equipment is not selectable attack
+- **WHEN** an official physical weapon entry is modifier-only equipment such as a kick or punch modifier
+- **THEN** it is not counted as a selectable standalone attack
+- **AND** the modifier behavior is validated or listed as a precise gap
+
+#### Scenario: Unsupported physical entry remains explicit
+- **WHEN** an official physical weapon entry has no runtime support
+- **THEN** the combat validation gap inventory includes the entry with evidence and source references
+- **AND** the row is not hidden by physical-combat known limitation suppression

--- a/openspec/changes/archive/2026-06-23-expand-catalog-rules-parity/specs/weapon-resolution-system/spec.md
+++ b/openspec/changes/archive/2026-06-23-expand-catalog-rules-parity/specs/weapon-resolution-system/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Catalog-Driven Special Weapon Behavior
+
+Weapon resolution SHALL map official BattleMech ranged weapon catalog rows into runtime behavior for damage, heat, range bands, minimum range, ammunition use, special modes, and cluster behavior. Unsupported or helper-only behavior SHALL remain explicit in the combat validation gap inventory.
+
+#### Scenario: Autocannon special modes are catalog-backed
+- **WHEN** UAC, RAC, and LB-X official catalog rows are validated
+- **THEN** UAC multi-shot, RAC rate-of-fire, LB-X slug, and LB-X cluster behavior are represented by source-backed catalog mappings or explicit unresolved gaps
+- **AND** no static fallback row is counted as integrated support
+
+#### Scenario: Missile special modes are catalog-backed
+- **WHEN** Streak, Artemis, NARC, TAG, and MML-family rows are validated
+- **THEN** all-or-nothing Streak behavior, Artemis/NARC/TAG modifiers or marker effects, and MML-style damage hazards are integrated, helper-only, partial, unsupported, or out-of-scope with explicit evidence
+
+#### Scenario: AMS behavior is classified
+- **WHEN** Anti-Missile System rows are validated
+- **THEN** AMS interception behavior and helper boundaries are classified with source-backed evidence
+- **AND** unsupported runtime effects remain visible as gaps
+
+#### Scenario: Cluster behavior matches catalog rows
+- **WHEN** a catalog row declares cluster behavior
+- **THEN** runtime resolution uses the canonical cluster table, declared cluster size, and per-hit damage behavior
+- **AND** any unsupported cluster variant remains visible in the gap inventory

--- a/openspec/changes/archive/2026-06-23-expand-catalog-rules-parity/tasks.md
+++ b/openspec/changes/archive/2026-06-23-expand-catalog-rules-parity/tasks.md
@@ -1,0 +1,43 @@
+## 1. Baseline and Inventory
+
+- [x] 1.1 Capture current `npm.cmd run validate:combat:gaps -- --format=summary` output and identify target refs for this wave.
+- [x] 1.2 Inspect `battlemechCombatCatalog.*` fragments and current support maps to avoid duplicating existing covered rows.
+- [x] 1.3 Identify official ranged weapon, ammunition, physical weapon, and special-family rows still relying on partial/helper/unsupported support.
+
+## 2. Catalog Classification Contract
+
+- [x] 2.1 Confirm the typed catalog parity classification helper covers integrated, partial, helper-only, modifier-only, unsupported, and out-of-scope rows.
+- [x] 2.2 Confirm tests prove every targeted official row is classified exactly once.
+- [x] 2.3 Confirm no-fallback assertions prevent synthetic/static equipment rows from counting as official support.
+
+## 3. Equipment and Ammunition Mapping
+
+- [x] 3.1 Confirm official equipment catalog load tests cover ranged weapons, ammunition, and physical weapons.
+- [x] 3.2 Confirm ammunition compatibility tests cover special ammo families including Artemis, NARC, Streak, LB-X, RAC, UAC, AMS, and MML-style rows.
+- [x] 3.3 Ensure unmapped official ammo rows remain explicit unresolved or out-of-scope gaps.
+
+## 4. Ranged Weapon Rules Parity
+
+- [x] 4.1 Confirm focused tests cover UAC, RAC, and LB-X catalog-driven modes and heat/damage/range behavior.
+- [x] 4.2 Confirm focused tests cover Streak, Artemis, NARC, TAG, AMS, cluster, and MML-style behavior classification.
+- [x] 4.3 Confirm combat validation support rows and source refs are current for proven special-family behavior.
+
+## 5. Physical Weapon Rules Parity
+
+- [x] 5.1 Confirm official physical weapon catalog tests cover standalone runtime attacks.
+- [x] 5.2 Confirm modifier-only classification tests prevent claws/talons-style equipment from becoming selectable attack support.
+- [x] 5.3 Keep unsupported or construction-only physical rows explicit in the gap inventory.
+
+## 6. Known-Limitations and Gap Gates
+
+- [x] 6.1 Confirm tests prove targeted catalog failures are not hidden by broad `knownLimitations` suppression.
+- [x] 6.2 Add `validate:combat:gaps` expectation flags for rows closed by this wave and rows that must remain explicit.
+- [x] 6.3 Confirm no gap evidence text or source refs required row changes because unresolved gap inventory is zero.
+
+## 7. Validation and Archive
+
+- [x] 7.1 Run focused catalog parity Jest fragments touched by this wave.
+- [x] 7.2 Run `npm.cmd run validate:combat:gaps`, `npm.cmd run validate:combat`, `npm.cmd run verify:rules`, `npm.cmd run typecheck`, `npm.cmd run format:check`, and `git diff --check`.
+- [x] 7.3 Run `openspec.cmd validate expand-catalog-rules-parity --strict`.
+- [x] 7.4 Sync specs, archive the change, and rerun `openspec.cmd validate --all --strict`.
+- [ ] 7.5 Commit with Lore trailers, open a PR, wait for CI, merge, reset to `origin/main`, and prune local branch state.

--- a/openspec/specs/combat-catalog-rules-parity/spec.md
+++ b/openspec/specs/combat-catalog-rules-parity/spec.md
@@ -1,0 +1,67 @@
+# combat-catalog-rules-parity Specification
+
+## Purpose
+
+Defines the BattleMech combat catalog parity matrix that keeps official ranged weapons, ammunition entries, physical weapons, and special combat families tied to source-backed runtime support, explicit gaps, and repeatable validation gates.
+
+## Requirements
+
+### Requirement: Official Combat Catalog Parity Matrix
+
+The system SHALL maintain a BattleMech combat catalog parity matrix for official ranged weapons, ammunition entries, physical weapons, and special combat families. Each official row SHALL include a source-backed identifier, runtime mapping status, support level, evidence reference, and explicit gap text when not fully integrated.
+
+#### Scenario: Every official row is classified
+- **WHEN** the combat catalog parity validator runs
+- **THEN** every official BattleMech ranged weapon, ammunition entry, and physical weapon row is classified exactly once
+- **AND** each classification is integrated, partial, helper-only, modifier-only, unsupported, or out-of-scope
+
+#### Scenario: Missing official row is visible
+- **WHEN** an official catalog row has no runtime mapping
+- **THEN** the gap inventory includes a named unresolved row for that catalog entry
+- **AND** the row includes evidence and source references sufficient to decide whether to implement or defer it
+
+### Requirement: Catalog Fallback Guard
+
+Static, synthetic, or fixture-only fallback data SHALL NOT satisfy official combat catalog parity unless the row is explicitly classified as fixture-only and non-gating.
+
+#### Scenario: Synthetic fallback cannot hide catalog failure
+- **WHEN** a runtime behavior uses fallback equipment data for an official row
+- **THEN** the catalog parity validator fails or emits an unresolved gap for that row
+- **AND** the row is not counted as integrated support
+
+#### Scenario: Fixture-only data is marked non-gating
+- **WHEN** a test fixture uses synthetic equipment data
+- **THEN** the fixture declares that it is not official catalog evidence
+- **AND** catalog parity remains based on official loaded catalog rows
+
+### Requirement: Catalog Parity Validation Commands
+
+The system SHALL expose repeatable validation commands that report catalog parity coverage, unresolved gaps, out-of-scope rows, and expectation failures.
+
+#### Scenario: Gap command reports catalog parity state
+- **WHEN** `npm.cmd run validate:combat:gaps -- --format=summary` runs
+- **THEN** the output includes total unresolved rows and counts by level, scope, and section
+- **AND** expectation flags can require specific rows to be present or absent
+
+#### Scenario: Combat validation suite proves supported rows
+- **WHEN** `npm.cmd run validate:combat` runs
+- **THEN** focused catalog parity tests prove that integrated rows are loaded and consumed by runtime behavior
+- **AND** unsupported rows remain visible in the gap inventory
+
+### Requirement: Known Limitation Suppression Audit
+
+Known limitation suppression SHALL remain a legacy-detector filter, not a catalog support signal. Catalog parity tests SHALL bypass or trap broad suppressions for targeted official rows.
+
+#### Scenario: Known limitation cannot suppress targeted catalog failure
+- **WHEN** a targeted official catalog row fails parity validation
+- **THEN** broad `knownLimitations` suppression does not remove the failure from the catalog gap inventory
+- **AND** the failure remains visible until a source-backed support row or explicit out-of-scope split replaces it
+
+### Requirement: Non-BattleMech Boundary
+
+Catalog parity for this wave SHALL cover BattleMech combat rows. Non-BattleMech, aerospace, vehicle, battle armor, infantry, ProtoMech, or construction-only entries SHALL be split into explicit out-of-scope rows or separate future matrices.
+
+#### Scenario: Non-BattleMech entry is not counted as BattleMech support
+- **WHEN** an official row belongs to a non-BattleMech runtime family
+- **THEN** the BattleMech catalog parity matrix classifies it as out-of-scope or routes it to a separate matrix
+- **AND** the BattleMech support count does not include it as integrated behavior

--- a/openspec/specs/equipment-database/spec.md
+++ b/openspec/specs/equipment-database/spec.md
@@ -233,6 +233,31 @@ Abbreviated names SHALL be used in compact UI contexts.
   - Record sheet exports
   - Database queries and filters
 
+### Requirement: Official Combat Equipment Catalog Coverage
+
+The equipment database SHALL load official BattleMech ranged weapon, ammunition, and physical weapon entries needed by combat validation. Each loaded entry SHALL expose stable identifiers, display names, tech base, rules level, temporal availability, damage or effect fields, heat, ranges, ammunition compatibility, and source-backed category metadata where applicable.
+
+#### Scenario: Official ranged weapon row is loadable
+- **WHEN** a catalog-backed combat validation test requests an official ranged weapon
+- **THEN** the equipment database returns a source-backed row with damage, heat, range brackets, minimum range when applicable, ammunition behavior when applicable, tech base, rules level, and temporal availability
+
+#### Scenario: Official ammunition row is loadable
+- **WHEN** a catalog-backed combat validation test requests an official ammunition entry
+- **THEN** the equipment database returns a source-backed row with compatible weapon mapping or an explicit unsupported compatibility gap
+
+#### Scenario: Official physical weapon row is loadable
+- **WHEN** a catalog-backed combat validation test requests an official physical weapon
+- **THEN** the equipment database returns a source-backed row with construction fields and combat classification metadata
+
+### Requirement: Official Catalog No-Fallback Failure
+
+The equipment database SHALL fail loudly or report an explicit gap when official combat validation requires a missing official row. Synthetic fallback rows SHALL NOT be used to satisfy official coverage.
+
+#### Scenario: Missing official row becomes gap
+- **WHEN** official catalog validation requests a row absent from the loaded equipment database
+- **THEN** validation records a named catalog gap
+- **AND** no static fallback row is counted as official support
+
 ## Non-Goals
 
 - Abbreviation customization or user preferences

--- a/openspec/specs/physical-weapons-system/spec.md
+++ b/openspec/specs/physical-weapons-system/spec.md
@@ -206,3 +206,21 @@ The system SHALL enforce combat restrictions on physical weapon usage.
 
 - **WHEN** a unit makes a physical weapon attack with an arm
 - **THEN** that arm SHALL NOT also make a standard punch attack in the same turn
+
+### Requirement: Official Physical Weapon Catalog Classification
+
+The physical weapon catalog SHALL classify every official BattleMech physical weapon entry as a standalone runtime attack, modifier-only equipment, construction-only/out-of-scope entry, partial support, or unsupported gap.
+
+#### Scenario: Standalone physical attack is runtime-backed
+- **WHEN** an official physical weapon is classified as a standalone attack
+- **THEN** runtime legality, to-hit, damage, hit location, and miss consequence behavior are validated with source-backed evidence
+
+#### Scenario: Modifier-only physical equipment is not selectable attack
+- **WHEN** an official physical weapon entry is modifier-only equipment such as a kick or punch modifier
+- **THEN** it is not counted as a selectable standalone attack
+- **AND** the modifier behavior is validated or listed as a precise gap
+
+#### Scenario: Unsupported physical entry remains explicit
+- **WHEN** an official physical weapon entry has no runtime support
+- **THEN** the combat validation gap inventory includes the entry with evidence and source references
+- **AND** the row is not hidden by physical-combat known limitation suppression

--- a/openspec/specs/ui-flow-shell/spec.md
+++ b/openspec/specs/ui-flow-shell/spec.md
@@ -1,7 +1,7 @@
 # ui-flow-shell Specification
 
 ## Purpose
-TBD - created by archiving change add-ui-flow-shell. Update Purpose after archive.
+Defines the gameplay UI flow shell that maps required journey QC IDs to player and GM route checkpoints, validation commands, and inspection intent so top-level gameplay flows remain discoverable, auditable, and tied to repeatable evidence.
 ## Requirements
 ### Requirement: Journey-backed gameplay flow registry
 The system SHALL define a typed gameplay UI flow registry that maps every required journey QC ID to an ordered player and GM flow through gameplay UI routes. Each flow entry MUST include journey ID, display name, module, role intent, ordered route checkpoints, primary action route, QC command, and inspection notes.

--- a/openspec/specs/weapon-resolution-system/spec.md
+++ b/openspec/specs/weapon-resolution-system/spec.md
@@ -791,6 +791,29 @@ re-resolving the weapon.
   how many trails to stagger
 - **AND** `projectileCount` SHALL match the number of missiles launched
 
+### Requirement: Catalog-Driven Special Weapon Behavior
+
+Weapon resolution SHALL map official BattleMech ranged weapon catalog rows into runtime behavior for damage, heat, range bands, minimum range, ammunition use, special modes, and cluster behavior. Unsupported or helper-only behavior SHALL remain explicit in the combat validation gap inventory.
+
+#### Scenario: Autocannon special modes are catalog-backed
+- **WHEN** UAC, RAC, and LB-X official catalog rows are validated
+- **THEN** UAC multi-shot, RAC rate-of-fire, LB-X slug, and LB-X cluster behavior are represented by source-backed catalog mappings or explicit unresolved gaps
+- **AND** no static fallback row is counted as integrated support
+
+#### Scenario: Missile special modes are catalog-backed
+- **WHEN** Streak, Artemis, NARC, TAG, and MML-family rows are validated
+- **THEN** all-or-nothing Streak behavior, Artemis/NARC/TAG modifiers or marker effects, and MML-style damage hazards are integrated, helper-only, partial, unsupported, or out-of-scope with explicit evidence
+
+#### Scenario: AMS behavior is classified
+- **WHEN** Anti-Missile System rows are validated
+- **THEN** AMS interception behavior and helper boundaries are classified with source-backed evidence
+- **AND** unsupported runtime effects remain visible as gaps
+
+#### Scenario: Cluster behavior matches catalog rows
+- **WHEN** a catalog row declares cluster behavior
+- **THEN** runtime resolution uses the canonical cluster table, declared cluster size, and per-hit damage behavior
+- **AND** any unsupported cluster variant remains visible in the gap inventory
+
 ## Cross-References
 
 ### Dependencies

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "verify": "npm run typecheck && npm run lint && npm run format:check && npm run verify:qc && npm run test:stable",
     "verify:full": "npm run verify && npm run test:perf-sensitive && npm run verify:rules && npm run build",
     "verify:qc": "npm run qc:validate && npm run qc:journeys:validate && npm run qc:logging:validate && npm run maintain:scan:gate",
-    "verify:rules": "npm run validate:combat:gaps -- --format=summary && npm run validate:combat && npm run spec:purpose:validate:strict && npx openspec validate --all --strict",
+    "verify:rules": "npm run validate:combat:gaps -- --format=summary --expect-total=0 && npm run validate:combat && npm run spec:purpose:validate:strict && npx openspec validate --all --strict",
     "test": "jest",
     "test:stable": "node scripts/jest/run-jest-lane.mjs stable",
     "test:perf-sensitive": "node scripts/jest/run-jest-lane.mjs perf-sensitive",

--- a/scripts/__tests__/combat-validation-gaps.test.ts
+++ b/scripts/__tests__/combat-validation-gaps.test.ts
@@ -1,0 +1,56 @@
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const REPO_ROOT = process.cwd();
+const SCRIPT_PATH = path.resolve(
+  REPO_ROOT,
+  'scripts/print-combat-validation-gaps.ts',
+);
+const PACKAGE_PATH = path.resolve(REPO_ROOT, 'package.json');
+const NPX = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+
+function runCombatGapInventory(args: string[]) {
+  return spawnSync(NPX, ['tsx', SCRIPT_PATH, ...args], {
+    cwd: REPO_ROOT,
+    encoding: 'utf-8',
+    shell: process.platform === 'win32',
+  });
+}
+
+describe('combat validation gap inventory gate', () => {
+  jest.setTimeout(60_000);
+
+  it('passes when unresolved combat gaps match the committed zero baseline', () => {
+    const result = runCombatGapInventory([
+      '--format=summary',
+      '--expect-total=0',
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({ total: 0 });
+  });
+
+  it('fails loudly when unresolved combat gaps drift from the expected total', () => {
+    const result = runCombatGapInventory([
+      '--format=summary',
+      '--expect-total=1',
+    ]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      'Unresolved gap inventory baseline mismatch',
+    );
+    expect(result.stderr).toContain('total expected 1, received 0');
+  });
+
+  it('wires the zero-gap invariant into the rules verification command', () => {
+    const packageJson = JSON.parse(fs.readFileSync(PACKAGE_PATH, 'utf-8')) as {
+      scripts: Record<string, string>;
+    };
+
+    expect(packageJson.scripts['verify:rules']).toContain(
+      'validate:combat:gaps -- --format=summary --expect-total=0',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Enforces the zero unresolved BattleMech combat gap baseline in \erify:rules\ via \--expect-total=0\.
- Adds a script-level regression test for the combat gap CLI success/failure contract and rules verifier wiring.
- Syncs and archives the \expand-catalog-rules-parity\ OpenSpec change, including the new combat catalog parity spec and related equipment/ammo/weapon/physical spec additions.
- Repairs the archived \ui-flow-shell\ spec purpose placeholder so purpose lint stays clean.

## Verification
- \
pm.cmd run validate:combat:gaps -- --format=summary --expect-total=0\
- \
px.cmd jest --selectProjects unit --runTestsByPath scripts\\__tests__\\combat-validation-gaps.test.ts --runInBand\
- \
pm.cmd run verify:rules\
- \
pm.cmd run typecheck\
- \
pm.cmd run format:check\
- \openspec.cmd validate --all --strict\
- \git diff --check\
- Commit hook: lint-staged, \
px tsc --noEmit --skipLibCheck\, and full \
pm.cmd run build\ passed