### PR TITLE
Reject invalid journey parameters before evidence

### DIFF
--- a/docs/qc/mekstation-journey-qc.md
+++ b/docs/qc/mekstation-journey-qc.md
@@ -87,6 +87,14 @@ Journey-specific parameters include `--pilot-count`,
 `--start-funds`, `--repair-policy`, `--salvage-policy`,
 `--advance-days-between`, and `--campaign-difficulty`.
 
+The runner validates overrides against the selected journey catalog before it
+writes trusted evidence. Unknown journey parameters, malformed integers,
+ambiguous booleans, unsupported enum values, empty explicit string lists, and
+numeric min/max violations fail before `run-plan.json`, `result.json`, or
+diagnostic logs are claimed for the run. Failure messages name the journey ID,
+parameter name, received value, and expected constraint so a bad command can be
+fixed without digging through artifacts.
+
 ## Evidence Bundle
 
 Each run writes:

--- a/openspec/changes/archive/2026-06-23-wave-02-journey-parameter-validation/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-23-wave-02-journey-parameter-validation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-23

--- a/openspec/changes/archive/2026-06-23-wave-02-journey-parameter-validation/design.md
+++ b/openspec/changes/archive/2026-06-23-wave-02-journey-parameter-validation/design.md
@@ -1,0 +1,43 @@
+## Context
+
+`scripts/qc/journey-qc-core.mjs` materializes run plans for all seven required journeys and is also used by the long-campaign stability wrapper. It currently coerces override values into primitive types but does not reject malformed integers, unsupported enum values, out-of-range numbers, or ambiguous booleans before writing passing evidence.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Validate catalog-defined parameter overrides during run-plan materialization.
+- Fail fast with journey ID, parameter name, offending value, and expected constraint.
+- Preserve existing successful command behavior and evidence layout for valid inputs.
+- Cover failures with focused journey QC tests so bad inputs cannot become trusted evidence again.
+
+**Non-Goals:**
+
+- Replace synthetic journey execution backing with domain or browser adapters.
+- Change journey catalog structure beyond using existing `type`, `values`, `minimum`, and optional `maximum` constraints.
+- Change long-campaign stability digest behavior except through shared validation.
+
+## Decisions
+
+- Validate in `materializeRunPlan` through `resolveParameters`.
+  - Rationale: every journey command, dry run, and stability wrapper passes through the same run-plan materialization path.
+  - Alternative rejected: validate only in CLI wrappers; that would let future callers bypass the contract.
+
+- Keep validation catalog-driven.
+  - Rationale: parameter requirements already live beside each journey definition and remain the single source for defaults, enum values, and numeric bounds.
+  - Alternative rejected: hard-code journey-specific validation tables in the runner; that would duplicate the catalog and drift quickly.
+
+- Fail before evidence bundle execution.
+  - Rationale: malformed input should not produce `result.json`, `system.ndjson`, or `bugs.json` that look like a completed run.
+  - Alternative rejected: emit a failed evidence bundle for malformed CLI input; that is useful for execution failures, but malformed run-plan inputs are not a journey execution result.
+
+## Risks / Trade-offs
+
+- [Risk] Existing local scripts may rely on permissive coercion.
+  - Mitigation: defaults and valid overrides remain unchanged; failures name the exact parameter and allowed range/value set.
+
+- [Risk] String-list values cannot express an empty list after filtering.
+  - Mitigation: keep existing non-empty filtering behavior and only reject empty explicit string-list overrides where the catalog default is non-empty.
+
+- [Risk] Boolean parsing can surprise users who pass `yes` or `1`.
+  - Mitigation: accept only explicit `true` or `false` so run evidence is unambiguous.

--- a/openspec/changes/archive/2026-06-23-wave-02-journey-parameter-validation/proposal.md
+++ b/openspec/changes/archive/2026-06-23-wave-02-journey-parameter-validation/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Journey QC is now the proof surface for major gameplay flows, but the runner currently accepts malformed journey parameters and still writes passing evidence. A repeatable proof system needs to reject invalid configurable inputs before run plans, artifacts, logs, and bug reports can be trusted.
+
+## What Changes
+
+- Add strict runtime validation for journey parameter overrides before execution or dry-run evidence is claimed.
+- Reject invalid integer, boolean, enum, and string-list values with journey/parameter-specific messages.
+- Enforce numeric minimum and maximum bounds declared in the journey catalog.
+- Add regression coverage for invalid campaign contract counts, invalid BattleMech tech base values, and valid parameter coercion.
+- Document the runner contract so generated evidence can only be based on catalog-valid inputs.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `journey-qc`: Journey run-plan materialization must validate parameter overrides against catalog parameter definitions and fail before writing trusted execution evidence when overrides are malformed or out of bounds.
+
+## Impact
+
+- Affected scripts: `scripts/qc/journey-qc-core.mjs`, `scripts/qc/run-journey-scenarios.mjs`, and journey QC tests.
+- Affected docs/specs: `openspec/specs/journey-qc/spec.md` and journey QC usage documentation.
+- No dependency changes.
+
+## Non-goals
+
+- Do not replace synthetic/catalog-backed journey steps with domain, browser, or hybrid adapters in this slice.
+- Do not expand the journey catalog beyond the seven required journeys.
+- Do not change long-campaign stability behavior except through shared parameter validation.

--- a/openspec/changes/archive/2026-06-23-wave-02-journey-parameter-validation/specs/journey-qc/spec.md
+++ b/openspec/changes/archive/2026-06-23-wave-02-journey-parameter-validation/specs/journey-qc/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Catalog-valid journey parameter overrides
+The journey runner SHALL validate every provided parameter override against the selected journey catalog definition before writing execution evidence. Validation MUST reject malformed integer, boolean, enum, and string-list values; MUST enforce declared numeric minimum and maximum bounds; and MUST name the journey ID, parameter name, offending value, and expected constraint in the failure message.
+
+#### Scenario: Invalid integer override is rejected
+- **WHEN** the user runs `npm.cmd run qc:journeys -- --journey=campaign-short --contracts=abc`
+- **THEN** the command fails before claiming journey execution
+- **AND** the failure message names `campaign-short`, `contracts`, `abc`, and the integer requirement
+
+#### Scenario: Out-of-range integer override is rejected
+- **WHEN** the user runs `npm.cmd run qc:journeys -- --journey=campaign-short --contracts=1`
+- **THEN** the command fails before claiming journey execution
+- **AND** the failure message names `campaign-short`, `contracts`, `1`, and the minimum allowed value
+
+#### Scenario: Invalid enum override is rejected
+- **WHEN** the user runs `npm.cmd run qc:journeys -- --journey=mek-build --unitTechBase=NOT_REAL`
+- **THEN** the command fails before claiming journey execution
+- **AND** the failure message names `mek-build`, `unitTechBase`, `NOT_REAL`, and the allowed enum values
+
+#### Scenario: Unknown override is rejected
+- **WHEN** the user runs `npm.cmd run qc:journeys -- --journey=mek-build --unitTechBaseTypo=CLAN`
+- **THEN** the command fails before claiming journey execution
+- **AND** the failure message names `unitTechBaseTypo` as an unknown journey parameter for `mek-build`
+
+#### Scenario: Valid overrides remain evidence inputs
+- **WHEN** the user runs `npm.cmd run qc:journeys -- --journey=mek-build --era=3050 --unitTechBase=CLAN --weight-class=Heavy`
+- **THEN** the command succeeds
+- **AND** the resolved run plan and generated artifacts record `era` as integer `3050`, `unitTechBase` as `CLAN`, and `weight-class` as `Heavy`

--- a/openspec/changes/archive/2026-06-23-wave-02-journey-parameter-validation/tasks.md
+++ b/openspec/changes/archive/2026-06-23-wave-02-journey-parameter-validation/tasks.md
@@ -1,0 +1,18 @@
+## 1. Parameter Validation
+
+- [x] 1.1 Add catalog-driven journey parameter validation in `scripts/qc/journey-qc-core.mjs`.
+- [x] 1.2 Reject malformed integers, invalid booleans, unsupported enum values, empty explicit string lists, and numeric min/max violations before evidence execution.
+- [x] 1.3 Ensure validation errors name the journey ID, parameter name, offending value, and expected constraint.
+
+## 2. Regression Coverage
+
+- [x] 2.1 Add journey QC tests for invalid integer, below-minimum integer, and invalid enum overrides.
+- [x] 2.2 Add a journey QC test proving valid overrides are coerced and preserved in run-plan/artifact evidence.
+- [x] 2.3 Confirm existing dry-run, all-smoke, strict backing, log search, bug reporting, and long-campaign stability tests still pass.
+
+## 3. Documentation And Verification
+
+- [x] 3.1 Update journey QC docs to describe parameter validation behavior.
+- [x] 3.2 Run focused Jest coverage for `scripts/__tests__/journey-qc.test.ts`.
+- [x] 3.3 Run `openspec validate wave-02-journey-parameter-validation --strict`.
+- [x] 3.4 Run QC validation commands touched by this change.

--- a/openspec/specs/journey-qc/spec.md
+++ b/openspec/specs/journey-qc/spec.md
@@ -180,3 +180,31 @@ The long-campaign stability command SHALL write structured diagnostic logs for s
 #### Scenario: Successful stability writes completion log
 - **WHEN** the long-campaign stability command completes without drift or save round-trip failures
 - **THEN** `system.ndjson` includes a non-blocking `campaign.stability_checked` entry that records the compared artifact roles and run count
+
+### Requirement: Catalog-valid journey parameter overrides
+The journey runner SHALL validate every provided parameter override against the selected journey catalog definition before writing execution evidence. Validation MUST reject malformed integer, boolean, enum, and string-list values; MUST enforce declared numeric minimum and maximum bounds; and MUST name the journey ID, parameter name, offending value, and expected constraint in the failure message.
+
+#### Scenario: Invalid integer override is rejected
+- **WHEN** the user runs `npm.cmd run qc:journeys -- --journey=campaign-short --contracts=abc`
+- **THEN** the command fails before claiming journey execution
+- **AND** the failure message names `campaign-short`, `contracts`, `abc`, and the integer requirement
+
+#### Scenario: Out-of-range integer override is rejected
+- **WHEN** the user runs `npm.cmd run qc:journeys -- --journey=campaign-short --contracts=1`
+- **THEN** the command fails before claiming journey execution
+- **AND** the failure message names `campaign-short`, `contracts`, `1`, and the minimum allowed value
+
+#### Scenario: Invalid enum override is rejected
+- **WHEN** the user runs `npm.cmd run qc:journeys -- --journey=mek-build --unitTechBase=NOT_REAL`
+- **THEN** the command fails before claiming journey execution
+- **AND** the failure message names `mek-build`, `unitTechBase`, `NOT_REAL`, and the allowed enum values
+
+#### Scenario: Unknown override is rejected
+- **WHEN** the user runs `npm.cmd run qc:journeys -- --journey=mek-build --unitTechBaseTypo=CLAN`
+- **THEN** the command fails before claiming journey execution
+- **AND** the failure message names `unitTechBaseTypo` as an unknown journey parameter for `mek-build`
+
+#### Scenario: Valid overrides remain evidence inputs
+- **WHEN** the user runs `npm.cmd run qc:journeys -- --journey=mek-build --era=3050 --unitTechBase=CLAN --weight-class=Heavy`
+- **THEN** the command succeeds
+- **AND** the resolved run plan and generated artifacts record `era` as integer `3050`, `unitTechBase` as `CLAN`, and `weight-class` as `Heavy`

--- a/scripts/__tests__/journey-qc.test.ts
+++ b/scripts/__tests__/journey-qc.test.ts
@@ -112,6 +112,139 @@ describe('journey QC scripts', () => {
     );
   });
 
+  it('rejects malformed integer journey parameter overrides before writing evidence', () => {
+    const result = runNodeScript('scripts/qc/run-journey-scenarios.mjs', [
+      '--journey=campaign-short',
+      '--contracts=abc',
+      '--run-id=test-bad-contracts',
+      `--evidence-dir=${evidenceDir}`,
+    ]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      '[qc:journeys] campaign-short: invalid parameter contracts=abc; expected an integer.',
+    );
+    expect(
+      fs.existsSync(
+        path.join(evidenceDir, 'test-bad-contracts', 'result.json'),
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects out-of-range integer journey parameter overrides before writing evidence', () => {
+    const result = runNodeScript('scripts/qc/run-journey-scenarios.mjs', [
+      '--journey=campaign-short',
+      '--contracts=1',
+      '--run-id=test-short-campaign-too-short',
+      `--evidence-dir=${evidenceDir}`,
+    ]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      '[qc:journeys] campaign-short: invalid parameter contracts=1; expected an integer >= 3.',
+    );
+    expect(
+      fs.existsSync(
+        path.join(evidenceDir, 'test-short-campaign-too-short', 'result.json'),
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects invalid enum journey parameter overrides before writing evidence', () => {
+    const result = runNodeScript('scripts/qc/run-journey-scenarios.mjs', [
+      '--journey=mek-build',
+      '--unitTechBase=NOT_REAL',
+      '--run-id=test-bad-tech-base',
+      `--evidence-dir=${evidenceDir}`,
+    ]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      '[qc:journeys] mek-build: invalid parameter unitTechBase=NOT_REAL; expected one of INNER_SPHERE, CLAN, MIXED.',
+    );
+    expect(
+      fs.existsSync(
+        path.join(evidenceDir, 'test-bad-tech-base', 'result.json'),
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects unknown journey parameter overrides before writing evidence', () => {
+    const result = runNodeScript('scripts/qc/run-journey-scenarios.mjs', [
+      '--journey=mek-build',
+      '--unitTechBaseTypo=CLAN',
+      '--run-id=test-unknown-parameter',
+      `--evidence-dir=${evidenceDir}`,
+    ]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      '[qc:journeys] Unknown journey parameter unitTechBaseTypo for selected journey(s): mek-build.',
+    );
+    expect(
+      fs.existsSync(
+        path.join(evidenceDir, 'test-unknown-parameter', 'result.json'),
+      ),
+    ).toBe(false);
+  });
+
+  it('preserves valid journey parameter overrides in run-plan and generated evidence', () => {
+    const result = runNodeScript('scripts/qc/run-journey-scenarios.mjs', [
+      '--journey=mek-build',
+      '--era=3050',
+      '--unitTechBase=CLAN',
+      '--weight-class=Heavy',
+      '--run-id=test-mek-valid-overrides',
+      `--evidence-dir=${evidenceDir}`,
+    ]);
+
+    expect(result.status).toBe(0);
+    const runPlan = readJson<{
+      journeys: Array<{
+        resolvedParameters: {
+          era: number;
+          unitTechBase: string;
+          'weight-class': string;
+        };
+      }>;
+    }>(path.join(evidenceDir, 'test-mek-valid-overrides', 'run-plan.json'));
+    const generatedInput = readJson<{
+      era: number;
+      unitTechBase: string;
+      weightClass: string;
+      parameters: {
+        era: number;
+        unitTechBase: string;
+        'weight-class': string;
+      };
+    }>(
+      path.join(
+        evidenceDir,
+        'test-mek-valid-overrides',
+        'mek-build',
+        '1',
+        'generated',
+        'battlemech-input.json',
+      ),
+    );
+
+    expect(runPlan.journeys[0]?.resolvedParameters).toMatchObject({
+      era: 3050,
+      unitTechBase: 'CLAN',
+      'weight-class': 'Heavy',
+    });
+    expect(generatedInput).toMatchObject({
+      era: 3050,
+      unitTechBase: 'CLAN',
+      weightClass: 'Heavy',
+      parameters: {
+        era: 3050,
+        unitTechBase: 'CLAN',
+        'weight-class': 'Heavy',
+      },
+    });
+  });
+
   it('writes a dry-run plan without failing the command', () => {
     const result = runNodeScript('scripts/qc/run-journey-scenarios.mjs', [
       '--journey=mek-build',

--- a/scripts/qc/journey-qc-core.mjs
+++ b/scripts/qc/journey-qc-core.mjs
@@ -157,7 +157,9 @@ export function parseArgs(argv) {
     else if (key === 'query') options.query = value;
     else if (key === 'kind') options.kind = value;
     else if (key === 'inject-failure') options.injectFailure = value;
-    else parameters[key] = value;
+    else if (key === 'inject-stability-drift' || key === 'inject-drift') {
+      options.injectStabilityDrift = value;
+    } else parameters[key] = value;
   }
 
   options.parameters = parameters;
@@ -918,10 +920,115 @@ function coerceParameter(definition, rawValue) {
   return rawValue;
 }
 
+function formatParameterValue(value) {
+  if (Array.isArray(value)) return value.join(',');
+  return String(value);
+}
+
+function parameterError(journey, name, rawValue, expected) {
+  return new Error(
+    `${journey.id}: invalid parameter ${name}=${formatParameterValue(rawValue)}; expected ${expected}.`,
+  );
+}
+
+function validateAndCoerceParameter(journey, name, definition, rawValue) {
+  const value = coerceParameter(definition, rawValue);
+  const rawLabel = rawValue === undefined ? definition.default : rawValue;
+
+  if (definition.type === 'integer') {
+    if (rawValue !== undefined && !/^-?\d+$/.test(String(rawValue).trim())) {
+      throw parameterError(journey, name, rawValue, 'an integer');
+    }
+    if (!Number.isInteger(value)) {
+      throw parameterError(journey, name, rawLabel, 'an integer');
+    }
+    if (definition.minimum !== undefined && value < definition.minimum) {
+      throw parameterError(
+        journey,
+        name,
+        rawLabel,
+        `an integer >= ${definition.minimum}`,
+      );
+    }
+    if (definition.maximum !== undefined && value > definition.maximum) {
+      throw parameterError(
+        journey,
+        name,
+        rawLabel,
+        `an integer <= ${definition.maximum}`,
+      );
+    }
+  }
+
+  if (definition.type === 'boolean') {
+    if (rawValue !== undefined && rawValue !== 'true' && rawValue !== 'false') {
+      throw parameterError(journey, name, rawValue, 'true or false');
+    }
+    if (typeof value !== 'boolean') {
+      throw parameterError(journey, name, rawLabel, 'true or false');
+    }
+  }
+
+  if (definition.type === 'enum') {
+    if (
+      !Array.isArray(definition.values) ||
+      !definition.values.includes(value)
+    ) {
+      throw parameterError(
+        journey,
+        name,
+        rawLabel,
+        `one of ${definition.values.join(', ')}`,
+      );
+    }
+  }
+
+  if (definition.type === 'string-list') {
+    if (!Array.isArray(value)) {
+      throw parameterError(journey, name, rawLabel, 'a comma-separated list');
+    }
+    if (rawValue !== undefined && value.length === 0) {
+      throw parameterError(
+        journey,
+        name,
+        rawValue,
+        'a non-empty comma-separated list',
+      );
+    }
+  }
+
+  if (definition.type === 'string' && typeof value !== 'string') {
+    throw parameterError(journey, name, rawLabel, 'a string');
+  }
+
+  return value;
+}
+
+function validateKnownParameterOverrides(selectedJourneys, overrides) {
+  const knownNames = new Set(
+    selectedJourneys.flatMap((journey) => Object.keys(journey.parameters)),
+  );
+  for (const name of Object.keys(overrides ?? {})) {
+    if (!knownNames.has(name)) {
+      const journeyIds = selectedJourneys
+        .map((journey) => journey.id)
+        .join(', ');
+      throw new Error(
+        `Unknown journey parameter ${name} for selected journey(s): ${journeyIds}.`,
+      );
+    }
+  }
+}
+
 function resolveParameters(journey, overrides) {
   const resolved = {};
   for (const [name, definition] of Object.entries(journey.parameters)) {
-    resolved[name] = coerceParameter(definition, overrides[name]);
+    resolved[name] = validateAndCoerceParameter(
+      journey,
+      name,
+      definition,
+      overrides[name],
+    );
   }
   return resolved;
 }
@@ -962,6 +1069,7 @@ export function materializeRunPlan(catalog, options) {
     throw new Error('--runs must be an integer >= 1.');
   }
   const selected = selectJourneys(catalog, options.journey);
+  validateKnownParameterOverrides(selected, options.parameters);
   const timestamp = new Date().toISOString();
   const runId =
     options.runId ??


### PR DESCRIPTION
## Summary
- Adds catalog-backed journey parameter validation before trusted evidence is written.
- Rejects malformed integers, invalid booleans/enums/string-lists, min/max violations, and unknown overrides for selected journeys.
- Archives OpenSpec change `wave-02-journey-parameter-validation` into the durable `journey-qc` spec.

## Verification
- `npx.cmd jest --selectProjects unit --ci --runTestsByPath scripts/__tests__/journey-qc.test.ts --no-coverage`
- `npm.cmd run verify:qc:journeys`
- `npm.cmd run verify:qc`
- `npm.cmd run typecheck -- --pretty false`
- `npm.cmd run format:check`
- `npm.cmd run lint` (0 errors; existing warnings remain)
- `openspec.cmd validate --all --strict`
- `git diff --check`
- Commit hook: staged-file formatting/lint, TypeScript, and full `next build --webpack`

## Notes
- `verify:qc` reports zero baseline regressions and zero medium maintenance findings. Legacy tracked critical/high/warn ledger items remain unchanged and are outside this Wave 2 slice.