### PR TITLE
Make journey failures collapse into usable bug packets

### DIFF
--- a/docs/qc/mekstation-journey-qc.md
+++ b/docs/qc/mekstation-journey-qc.md
@@ -150,15 +150,18 @@ bounded and includes:
 - `nextDebuggingHint`
 
 Bug candidates copy that packet into `bugs.json` and add `logFingerprints` so a
-bug can be traced back to the exact diagnostic entry.
+bug can be traced back to the exact diagnostic entry. Result-derived failures
+and matching error diagnostics are deduplicated into one canonical bug packet,
+so the report count should reflect issues rather than logging sources.
 
 ## Bug And Log Workflow
 
 1. Run the narrow journey first, with explicit seed and parameters.
 2. Inspect `report.md` for the human-readable result.
 3. Use `qc:journeys:bugs` to list grouped failures by severity and fingerprint.
-   Medium-or-higher bugs print action, validation result, failure cause,
-   debugging hint, and related log fingerprints when available.
+   Medium-or-higher bugs print actor, action, compact state before/after,
+   rule decision, validation result, failure cause, debugging hint, and related
+   log fingerprints when available.
 4. Use `qc:logs` to filter structured diagnostic entries by level, journey,
    service, event, or step.
 5. Add `--exclude-probes` when scanning for non-probe warnings. The
@@ -168,9 +171,12 @@ bug can be traced back to the exact diagnostic entry.
 6. Copy a bug packet log fingerprint into
    `npm.cmd run qc:logs -- --run-id=latest --fingerprint=<fingerprint>` when
    you need the exact structured diagnostic that caused or explains the bug.
-7. Use `--require-domain-backed` to distinguish real adapter coverage from
+7. Search `--event=bug.candidate_extracted` when you need the extraction
+   diagnostic that records bug count, gated count, severity gate, `bugs.json`,
+   and `report.md`.
+8. Use `--require-domain-backed` to distinguish real adapter coverage from
    synthetic projection coverage.
-8. Rerun the same journey with the same run-plan inputs after a fix.
+9. Rerun the same journey with the same run-plan inputs after a fix.
 
 Known gaps are recorded in journey output and the validation graph. They do not
 silently hide unrelated failures.

--- a/openspec/changes/archive/2026-06-23-wave-03-journey-bug-triage-logging/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-23-wave-03-journey-bug-triage-logging/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-23

--- a/openspec/changes/archive/2026-06-23-wave-03-journey-bug-triage-logging/design.md
+++ b/openspec/changes/archive/2026-06-23-wave-03-journey-bug-triage-logging/design.md
@@ -1,0 +1,44 @@
+## Context
+
+Journey QC currently writes structured per-step diagnostics and extracts bug candidates, but the failure evidence still has two usability problems:
+
+- A single failed step can become both a high-severity step bug and a medium-severity log bug with the same log fingerprint.
+- The text bug reporter shows only a subset of the triage packet, so the user must inspect JSON or `system.ndjson` to see actor, state, and rule-decision context.
+
+Wave 3 is the proof layer before GM ledger and UI-flow work. It should make failed journey runs produce a compact, repeatable bug packet that can be read directly from the command line.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Use a deterministic dedupe key so matching result-derived and log-derived bug candidates collapse into one canonical packet.
+- Preserve the richer severity/summary from the result-derived bug while retaining log fingerprint evidence.
+- Add a structured `bug.candidate_extracted` diagnostic with triage context for extraction count, gated count, severity gate, bug packet path, and report path.
+- Make the text reporter display actor, state before/after summary, rule decision, warnings, failure cause, next hint, and log fingerprints when available.
+- Cover the behavior with focused journey QC tests and the existing QC validation commands.
+
+**Non-Goals:**
+
+- No browser/domain journey adapter implementation.
+- No GM ledger implementation.
+- No changes to durable domain events, replay logs, or match-log persistence.
+
+## Decisions
+
+1. **Dedupe after candidate construction.**
+   Build candidates from result steps and error logs as today, then pass the final list through a deterministic dedupe function keyed by run ID, journey ID, step ID, and failure cause or matching log fingerprint. This keeps extraction sources simple while guaranteeing reporter output is canonical.
+
+2. **Prefer canonical step bugs over log-only duplicates.**
+   When duplicate candidates describe the same failed step, keep the higher-severity result-derived bug and merge evidence/log fingerprints from the log-derived bug. A log-only bug remains when there is no corresponding failed step.
+
+3. **Keep triage summaries compact.**
+   Reporter output should show stable summaries rather than dumping objects. State fields use concise one-line formatting for status, terminal state, artifact count, execution backing, and expected terminal state.
+
+4. **Treat extraction itself as a structured journey diagnostic.**
+   The `bug.candidate_extracted` log entry should include a triage packet with actor `journey-bug-extractor`, action `extract-bug-candidates`, before/after counts, rule decision based on severity gate, validation result, warning summaries, evidence references, and a next debugging hint.
+
+## Risks / Trade-offs
+
+- Duplicate bugs from unrelated sources could collapse if the key is too broad. Mitigation: include run ID, journey ID, step ID, and the failure/log cause in the dedupe key.
+- Reporter output could become noisy. Mitigation: show compact triage lines only when triage exists, and keep JSON output unchanged for machines.
+- Older evidence may lack triage. Mitigation: keep reporter compatibility with existing summary/fingerprint/evidence fields.

--- a/openspec/changes/archive/2026-06-23-wave-03-journey-bug-triage-logging/proposal.md
+++ b/openspec/changes/archive/2026-06-23-wave-03-journey-bug-triage-logging/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Wave 2 made journey inputs trustworthy, but failed journey runs can still be noisy to triage: a single step failure can appear as duplicate bug candidates, and the text reporter omits state and rule-decision context that already exists in structured logs. Wave 3 should make failure evidence useful without manual digging through `system.ndjson`.
+
+## What Changes
+
+- Deduplicate bug extraction so one failed step produces one canonical actionable bug packet, enriched by matching structured diagnostics.
+- Add structured triage context to the journey bug-extraction diagnostic so log search can explain what was extracted, what was gated, and where the bug packet lives.
+- Expand the text bug reporter to show actor, state before/after, rule decision, warnings, failure cause, and log fingerprints when triage data exists.
+- Add regression coverage proving failed journey evidence is deduped, searchable, and readable from the reporter.
+
+Non-goals:
+- This change does not add browser-backed journey adapters.
+- This change does not replace domain event, replay, or match-log persistence.
+- This change does not implement the GM ledger or tactical-map parity waves.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `journey-qc`: Bug extraction and reporting requirements for failed journey runs become stricter about deduplication and readable triage output.
+- `logging-system`: Journey bug-extraction diagnostics must carry standardized triage context and references to generated bug packets.
+
+## Impact
+
+- Affected scripts: `scripts/qc/journey-qc-core.mjs`, `scripts/qc/report-journey-bugs.mjs`, `scripts/qc/search-journey-logs.mjs`.
+- Affected tests: `scripts/__tests__/journey-qc.test.ts`.
+- Affected docs/specs: `docs/qc/mekstation-journey-qc.md`, `openspec/specs/journey-qc`, and `openspec/specs/logging-system` after archive.
+- No new runtime dependency is required.

--- a/openspec/changes/archive/2026-06-23-wave-03-journey-bug-triage-logging/specs/journey-qc/spec.md
+++ b/openspec/changes/archive/2026-06-23-wave-03-journey-bug-triage-logging/specs/journey-qc/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Deduplicated journey bug packets
+The journey QC runner SHALL collapse duplicate bug candidates that describe the same failed journey step and failure cause before writing `bugs.json`, `report.md`, or the bug-extraction diagnostic. Deduplication MUST preserve the highest severity candidate, all unique evidence references, all unique log fingerprints, and the most complete triage packet.
+
+#### Scenario: Failed step produces one canonical bug
+- **WHEN** a required `combat-1v1` step fails and the matching error diagnostic also contains triage metadata
+- **THEN** `bugs.json` contains one bug candidate for that journey step and failure cause
+- **AND** the bug candidate keeps the step failure summary, high severity, related `system.ndjson` fingerprint, and triage packet
+
+#### Scenario: Log-only bug remains reportable
+- **WHEN** an error diagnostic has no matching failed step result
+- **THEN** the runner keeps a log-derived bug candidate with its log fingerprint and triage metadata when present
+
+### Requirement: Readable journey bug reporter triage
+The journey bug reporter SHALL display compact triage context for every bug candidate that includes a triage packet. The reporter output MUST include actor, action, state before summary, state after summary, rule decision, validation result, warning list when present, failure cause when present, next debugging hint when present, and log fingerprints when present.
+
+#### Scenario: Reporter shows failure context without raw log inspection
+- **WHEN** the user runs `npm.cmd run qc:journeys:bugs -- --since=latest --min-severity=medium` after an injected combat journey failure
+- **THEN** the reporter shows the actor, action, state before summary, state after summary, rule decision, validation status, failure cause, next debugging hint, and log fingerprint for the canonical bug
+- **AND** the user does not need to open `system.ndjson` to identify the failed step context

--- a/openspec/changes/archive/2026-06-23-wave-03-journey-bug-triage-logging/specs/logging-system/spec.md
+++ b/openspec/changes/archive/2026-06-23-wave-03-journey-bug-triage-logging/specs/logging-system/spec.md
@@ -1,0 +1,13 @@
+## ADDED Requirements
+
+### Requirement: Journey bug extraction diagnostic context
+The logging system SHALL require journey QC bug extraction diagnostics to carry standardized triage context. A `bug.candidate_extracted` diagnostic MUST include actor, action, stateBefore, stateAfter, ruleDecision, validationResult, warnings, evidenceRefs, and nextDebuggingHint metadata describing the extraction run, severity gate, generated bug packet, and generated report.
+
+#### Scenario: Bug extraction log describes the bug packet
+- **WHEN** `qc:journeys` extracts one or more bug candidates
+- **THEN** `system.ndjson` includes a `journey.bugs` `bug.candidate_extracted` entry with a triage packet
+- **AND** the triage packet identifies the bug count, gated bug count, severity gate, `bugs.json`, `report.md`, and the next command to inspect the bugs
+
+#### Scenario: Search returns extraction triage by fingerprint
+- **WHEN** the user searches journey logs by the extraction diagnostic fingerprint
+- **THEN** the log search command returns the extraction diagnostic and its triage metadata

--- a/openspec/changes/archive/2026-06-23-wave-03-journey-bug-triage-logging/tasks.md
+++ b/openspec/changes/archive/2026-06-23-wave-03-journey-bug-triage-logging/tasks.md
@@ -1,0 +1,24 @@
+## 1. Bug Extraction Contract
+
+- [x] 1.1 Add deterministic journey bug candidate deduplication in `scripts/qc/journey-qc-core.mjs`.
+- [x] 1.2 Preserve highest severity, unique evidence references, unique log fingerprints, and richest triage packet when duplicates collapse.
+- [x] 1.3 Add extraction diagnostic triage metadata for bug count, gated bug count, severity gate, bug packet path, and report path.
+
+## 2. Reporter And Search Usability
+
+- [x] 2.1 Expand `scripts/qc/report-journey-bugs.mjs` text output with actor, compact state before/after, rule decision, warnings, and existing triage fields.
+- [x] 2.2 Preserve reporter compatibility for older bug evidence without triage packets.
+- [x] 2.3 Ensure `qc:logs` can return the bug-extraction diagnostic by event and fingerprint.
+
+## 3. Regression Coverage
+
+- [x] 3.1 Add focused journey QC tests proving injected failed steps produce one canonical bug.
+- [x] 3.2 Add tests for bug-extraction diagnostic triage and log-search fingerprint lookup.
+- [x] 3.3 Add tests proving reporter text exposes the required triage context without raw log inspection.
+
+## 4. Verification
+
+- [x] 4.1 Run focused Jest coverage for `scripts/__tests__/journey-qc.test.ts`.
+- [x] 4.2 Run `npm.cmd run verify:qc:journeys`.
+- [x] 4.3 Run `npm.cmd run verify:qc`.
+- [x] 4.4 Run `openspec.cmd validate wave-03-journey-bug-triage-logging --strict`.

--- a/openspec/specs/journey-qc/spec.md
+++ b/openspec/specs/journey-qc/spec.md
@@ -208,3 +208,23 @@ The journey runner SHALL validate every provided parameter override against the 
 - **WHEN** the user runs `npm.cmd run qc:journeys -- --journey=mek-build --era=3050 --unitTechBase=CLAN --weight-class=Heavy`
 - **THEN** the command succeeds
 - **AND** the resolved run plan and generated artifacts record `era` as integer `3050`, `unitTechBase` as `CLAN`, and `weight-class` as `Heavy`
+
+### Requirement: Deduplicated journey bug packets
+The journey QC runner SHALL collapse duplicate bug candidates that describe the same failed journey step and failure cause before writing `bugs.json`, `report.md`, or the bug-extraction diagnostic. Deduplication MUST preserve the highest severity candidate, all unique evidence references, all unique log fingerprints, and the most complete triage packet.
+
+#### Scenario: Failed step produces one canonical bug
+- **WHEN** a required `combat-1v1` step fails and the matching error diagnostic also contains triage metadata
+- **THEN** `bugs.json` contains one bug candidate for that journey step and failure cause
+- **AND** the bug candidate keeps the step failure summary, high severity, related `system.ndjson` fingerprint, and triage packet
+
+#### Scenario: Log-only bug remains reportable
+- **WHEN** an error diagnostic has no matching failed step result
+- **THEN** the runner keeps a log-derived bug candidate with its log fingerprint and triage metadata when present
+
+### Requirement: Readable journey bug reporter triage
+The journey bug reporter SHALL display compact triage context for every bug candidate that includes a triage packet. The reporter output MUST include actor, action, state before summary, state after summary, rule decision, validation result, warning list when present, failure cause when present, next debugging hint when present, and log fingerprints when present.
+
+#### Scenario: Reporter shows failure context without raw log inspection
+- **WHEN** the user runs `npm.cmd run qc:journeys:bugs -- --since=latest --min-severity=medium` after an injected combat journey failure
+- **THEN** the reporter shows the actor, action, state before summary, state after summary, rule decision, validation status, failure cause, next debugging hint, and log fingerprint for the canonical bug
+- **AND** the user does not need to open `system.ndjson` to identify the failed step context

--- a/openspec/specs/logging-system/spec.md
+++ b/openspec/specs/logging-system/spec.md
@@ -231,6 +231,18 @@ Structured journey diagnostics SHALL include standardized triage context when em
 - **THEN** the failure diagnostic includes failureCause and fingerprint
 - **AND** the generated bug packet references that fingerprint in its triage logFingerprints
 
+### Requirement: Journey bug extraction diagnostic context
+The logging system SHALL require journey QC bug extraction diagnostics to carry standardized triage context. A `bug.candidate_extracted` diagnostic MUST include actor, action, stateBefore, stateAfter, ruleDecision, validationResult, warnings, evidenceRefs, and nextDebuggingHint metadata describing the extraction run, severity gate, generated bug packet, and generated report.
+
+#### Scenario: Bug extraction log describes the bug packet
+- **WHEN** `qc:journeys` extracts one or more bug candidates
+- **THEN** `system.ndjson` includes a `journey.bugs` `bug.candidate_extracted` entry with a triage packet
+- **AND** the triage packet identifies the bug count, gated bug count, severity gate, `bugs.json`, `report.md`, and the next command to inspect the bugs
+
+#### Scenario: Search returns extraction triage by fingerprint
+- **WHEN** the user searches journey logs by the extraction diagnostic fingerprint
+- **THEN** the log search command returns the extraction diagnostic and its triage metadata
+
 ## Data Model Requirements
 
 ### LogLevel Type

--- a/scripts/__tests__/journey-qc.test.ts
+++ b/scripts/__tests__/journey-qc.test.ts
@@ -675,15 +675,119 @@ describe('journey QC scripts', () => {
     ]);
 
     expect(bugs.status).toBe(0);
+    expect(bugs.stdout).toContain('# Journey bugs (1)');
     expect(bugs.stdout).toContain(
       'Journey step failed: combat-1v1/resolve-combat',
     );
+    expect(bugs.stdout).not.toContain(
+      '- [medium] combat-1v1: Injected failure for combat-1v1/resolve-combat',
+    );
+    expect(bugs.stdout).toContain('actor: combat-engine');
     expect(bugs.stdout).toContain('action: movement-preview,attack-resolution');
-    expect(bugs.stdout).toContain('validation: fail');
+    expect(bugs.stdout).toContain(
+      'state before: journey=combat-1v1 step=resolve-combat attempt=1 module=combat expected=combat-complete',
+    );
+    expect(bugs.stdout).toContain(
+      'state after: status=fail terminal=combat-complete artifacts=0 backing=synthetic-projection',
+    );
+    expect(bugs.stdout).toContain(
+      'rule: blocked via journey-qc - Injected failure for combat-1v1/resolve-combat',
+    );
+    expect(bugs.stdout).toContain(
+      'validation: fail event=journey.step_failed required=true failureKind=injected-failure',
+    );
     expect(bugs.stdout).toContain(
       'failure cause: Injected failure for combat-1v1/resolve-combat',
     );
     expect(bugs.stdout).toContain('logs: ');
+
+    const bugsJson = runNodeScript('scripts/qc/report-journey-bugs.mjs', [
+      '--since=latest',
+      '--min-severity=medium',
+      '--json',
+      `--evidence-dir=${evidenceDir}`,
+    ]);
+    expect(bugsJson.status).toBe(0);
+    const bugPackets = JSON.parse(bugsJson.stdout) as Array<{
+      severity: string;
+      summary: string;
+      triage?: {
+        logFingerprints: string[];
+      };
+    }>;
+    expect(bugPackets).toHaveLength(1);
+    expect(bugPackets[0]).toMatchObject({
+      severity: 'high',
+      summary: 'Journey step failed: combat-1v1/resolve-combat',
+    });
+    expect(bugPackets[0]?.triage?.logFingerprints[0]).toMatch(/^[a-f0-9]{8}$/);
+
+    const extractionLogs = runNodeScript('scripts/qc/search-journey-logs.mjs', [
+      '--run-id=latest',
+      '--event=bug.candidate_extracted',
+      '--json',
+      `--evidence-dir=${evidenceDir}`,
+    ]);
+    expect(extractionLogs.status).toBe(0);
+    const extractionEntries = JSON.parse(extractionLogs.stdout) as Array<{
+      fingerprint: string;
+      metadata: {
+        bugCount: number;
+        gatedBugCount: number;
+        severityGate: string;
+        triage: {
+          actor: string;
+          action: string;
+          stateAfter: { bugCount: number; gatedBugCount: number };
+          ruleDecision: { outcome: string };
+          evidenceRefs: string[];
+          nextDebuggingHint: string;
+        };
+      };
+    }>;
+    expect(extractionEntries).toHaveLength(1);
+    expect(extractionEntries[0]).toMatchObject({
+      metadata: {
+        bugCount: 1,
+        gatedBugCount: 1,
+        severityGate: 'medium',
+        triage: {
+          actor: 'journey-bug-extractor',
+          action: 'extract-bug-candidates',
+          stateAfter: { bugCount: 1, gatedBugCount: 1 },
+          ruleDecision: { outcome: 'blocked' },
+        },
+      },
+    });
+    expect(extractionEntries[0]?.metadata.triage.evidenceRefs).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('bugs.json'),
+        expect.stringContaining('report.md'),
+      ]),
+    );
+    expect(extractionEntries[0]?.metadata.triage.nextDebuggingHint).toContain(
+      'qc:journeys:bugs',
+    );
+
+    const extractionFingerprint = extractionEntries[0]?.fingerprint;
+    const extractionByFingerprint = runNodeScript(
+      'scripts/qc/search-journey-logs.mjs',
+      [
+        '--run-id=latest',
+        `--fingerprint=${extractionFingerprint}`,
+        '--json',
+        `--evidence-dir=${evidenceDir}`,
+      ],
+    );
+    expect(extractionByFingerprint.status).toBe(0);
+    const fingerprintEntries = JSON.parse(
+      extractionByFingerprint.stdout,
+    ) as Array<{ event: string; metadata: { triage?: { actor: string } } }>;
+    expect(fingerprintEntries).toHaveLength(1);
+    expect(fingerprintEntries[0]).toMatchObject({
+      event: 'bug.candidate_extracted',
+      metadata: { triage: { actor: 'journey-bug-extractor' } },
+    });
   });
 
   it('fails strict backing-required runs while preserving bug evidence', () => {

--- a/scripts/qc/journey-qc-core.mjs
+++ b/scripts/qc/journey-qc-core.mjs
@@ -1438,6 +1438,85 @@ function severityMeets(candidateSeverity, minimumSeverity) {
   );
 }
 
+function uniqueList(values) {
+  return [...new Set((values ?? []).filter(Boolean))];
+}
+
+function triageCompletenessScore(triage) {
+  if (!triage) return 0;
+  return [
+    'actor',
+    'action',
+    'stateBefore',
+    'stateAfter',
+    'ruleDecision',
+    'validationResult',
+    'failureCause',
+    'nextDebuggingHint',
+  ].reduce((score, field) => score + (triage[field] ? 1 : 0), 0);
+}
+
+function bugDedupeKey(bug) {
+  return [
+    bug.runId ?? '-',
+    bug.journeyId ?? '-',
+    bug.stepId ?? '-',
+    bug.triage?.failureCause ?? bug.summary ?? bug.fingerprint ?? '-',
+  ].join('|');
+}
+
+function mergeTriage(existing, incoming) {
+  if (!existing) return incoming;
+  if (!incoming) return existing;
+  const preferred =
+    triageCompletenessScore(incoming) > triageCompletenessScore(existing)
+      ? incoming
+      : existing;
+  const secondary = preferred === incoming ? existing : incoming;
+  return {
+    ...secondary,
+    ...preferred,
+    warnings: uniqueList([
+      ...(secondary.warnings ?? []),
+      ...(preferred.warnings ?? []),
+    ]),
+    evidenceRefs: uniqueList([
+      ...(secondary.evidenceRefs ?? []),
+      ...(preferred.evidenceRefs ?? []),
+    ]),
+    logFingerprints: uniqueList([
+      ...(secondary.logFingerprints ?? []),
+      ...(preferred.logFingerprints ?? []),
+    ]),
+  };
+}
+
+function mergeBugCandidates(existing, incoming) {
+  const existingRank = severityRank[existing.severity] ?? 0;
+  const incomingRank = severityRank[incoming.severity] ?? 0;
+  const preferred = incomingRank > existingRank ? incoming : existing;
+  const secondary = preferred === incoming ? existing : incoming;
+  return {
+    ...secondary,
+    ...preferred,
+    evidenceRefs: uniqueList([
+      ...(secondary.evidenceRefs ?? []),
+      ...(preferred.evidenceRefs ?? []),
+    ]),
+    triage: mergeTriage(secondary.triage, preferred.triage),
+  };
+}
+
+function dedupeBugCandidates(bugs) {
+  const byKey = new Map();
+  for (const bug of bugs) {
+    const key = bugDedupeKey(bug);
+    const existing = byKey.get(key);
+    byKey.set(key, existing ? mergeBugCandidates(existing, bug) : bug);
+  }
+  return [...byKey.values()];
+}
+
 export function extractBugCandidates(result, logs) {
   const bugs = [];
   const logsByStep = new Map();
@@ -1525,7 +1604,7 @@ export function extractBugCandidates(result, logs) {
       });
     }
   }
-  return bugs;
+  return dedupeBugCandidates(bugs);
 }
 
 export function executeRunPlan(runPlan, options = {}) {
@@ -1808,6 +1887,58 @@ function renderReport(runPlan, result, logs, bugs) {
   return `${lines.join('\n')}\n`;
 }
 
+function bugExtractionTriage({
+  runPlan,
+  bugs,
+  gatedBugCount,
+  gateSeverity,
+  bugPacketPath,
+  reportPath,
+}) {
+  const evidenceRefs = [bugPacketPath, reportPath].filter(Boolean);
+  return {
+    actor: 'journey-bug-extractor',
+    action: 'extract-bug-candidates',
+    stateBefore: {
+      runId: runPlan.runId,
+      journeyIds: runPlan.journeyIds,
+      severityGate: gateSeverity,
+    },
+    stateAfter: {
+      bugCount: bugs.length,
+      gatedBugCount,
+      highestSeverity:
+        bugs
+          .map((bug) => bug.severity)
+          .sort(
+            (left, right) =>
+              (severityRank[right] ?? 0) - (severityRank[left] ?? 0),
+          )[0] ?? null,
+    },
+    ruleDecision: {
+      outcome: gatedBugCount > 0 ? 'blocked' : 'accepted',
+      source: 'journey-qc',
+      reason:
+        gatedBugCount > 0
+          ? `${gatedBugCount} bug candidate(s) met severity gate ${gateSeverity}.`
+          : `No bug candidates met severity gate ${gateSeverity}.`,
+    },
+    validationResult: {
+      status: gatedBugCount > 0 ? 'fail' : 'pass',
+      event:
+        bugs.length > 0
+          ? 'bug.candidate_extracted'
+          : 'bug.extraction_completed',
+      severityGate: gateSeverity,
+    },
+    warnings: bugs.map((bug) => `${bug.severity}:${bug.summary}`),
+    evidenceRefs,
+    nextDebuggingHint:
+      `Run npm.cmd run qc:journeys:bugs -- --since=${runPlan.runId} ` +
+      `--min-severity=${gateSeverity} to inspect the bug packet.`,
+  };
+}
+
 export function resolveEvidenceRun(options = {}) {
   const catalog = loadJsonFile(journeyCatalogPath);
   const evidenceRoot = path.resolve(
@@ -1962,6 +2093,12 @@ export function runJourney(options) {
   const gatedBugCount = bugs.filter((bug) =>
     severityMeets(bug.severity, gateSeverity),
   ).length;
+  const bugPacketPath = toRepoRelative(
+    path.join(path.resolve(repoRoot, runPlan.evidenceDir), 'bugs.json'),
+  );
+  const reportPath = toRepoRelative(
+    path.join(path.resolve(repoRoot, runPlan.evidenceDir), 'report.md'),
+  );
   logs.push(
     logEntry({
       level: bugs.length > 0 ? 'warn' : 'info',
@@ -1975,7 +2112,19 @@ export function runJourney(options) {
       blocking: bugs.length > 0 ? gatedBugCount > 0 : undefined,
       runPlan,
       attempt: 0,
-      metadata: { bugCount: bugs.length },
+      metadata: {
+        bugCount: bugs.length,
+        gatedBugCount,
+        severityGate: gateSeverity,
+        triage: bugExtractionTriage({
+          runPlan,
+          bugs,
+          gatedBugCount,
+          gateSeverity,
+          bugPacketPath,
+          reportPath,
+        }),
+      },
     }),
   );
   const paths = writeEvidenceBundle(runPlan, result, logs, bugs);

--- a/scripts/qc/report-journey-bugs.mjs
+++ b/scripts/qc/report-journey-bugs.mjs
@@ -1,6 +1,80 @@
 #!/usr/bin/env node
 import { filterBugs, loadRunEvidence, parseArgs } from './journey-qc-core.mjs';
 
+function compactStateBefore(state) {
+  if (!state || typeof state !== 'object') return '-';
+  return [
+    state.runId ? `run=${state.runId}` : null,
+    state.journeyId ? `journey=${state.journeyId}` : null,
+    state.stepId ? `step=${state.stepId}` : null,
+    state.attempt !== undefined ? `attempt=${state.attempt}` : null,
+    state.module ? `module=${state.module}` : null,
+    state.expectedTerminalState
+      ? `expected=${state.expectedTerminalState}`
+      : null,
+    state.severityGate ? `severityGate=${state.severityGate}` : null,
+    state.parameterHash ? `parameterHash=${state.parameterHash}` : null,
+    Array.isArray(state.journeyIds)
+      ? `journeys=${state.journeyIds.join(',')}`
+      : null,
+  ]
+    .filter(Boolean)
+    .join(' ');
+}
+
+function compactStateAfter(state) {
+  if (!state || typeof state !== 'object') return '-';
+  return [
+    state.status ? `status=${state.status}` : null,
+    state.terminalState ? `terminal=${state.terminalState}` : null,
+    state.artifactCount !== undefined
+      ? `artifacts=${state.artifactCount}`
+      : null,
+    state.executionBacking ? `backing=${state.executionBacking}` : null,
+    state.syntheticBacking !== undefined
+      ? `synthetic=${state.syntheticBacking}`
+      : null,
+    state.executionEvidenceSource
+      ? `source=${state.executionEvidenceSource}`
+      : null,
+    state.bugCount !== undefined ? `bugs=${state.bugCount}` : null,
+    state.gatedBugCount !== undefined ? `gated=${state.gatedBugCount}` : null,
+    state.highestSeverity ? `highest=${state.highestSeverity}` : null,
+  ]
+    .filter(Boolean)
+    .join(' ');
+}
+
+function compactRuleDecision(ruleDecision) {
+  if (!ruleDecision) return '-';
+  return [
+    ruleDecision.outcome ?? '-',
+    ruleDecision.source ? `via ${ruleDecision.source}` : null,
+    ruleDecision.reason ? `- ${ruleDecision.reason}` : null,
+  ]
+    .filter(Boolean)
+    .join(' ');
+}
+
+function compactValidation(validationResult) {
+  if (!validationResult) return '-';
+  return [
+    validationResult.status ?? '-',
+    validationResult.event ? `event=${validationResult.event}` : null,
+    validationResult.required !== undefined
+      ? `required=${validationResult.required}`
+      : null,
+    validationResult.failureKind
+      ? `failureKind=${validationResult.failureKind}`
+      : null,
+    validationResult.severityGate
+      ? `severityGate=${validationResult.severityGate}`
+      : null,
+  ]
+    .filter(Boolean)
+    .join(' ');
+}
+
 const options = parseArgs(process.argv.slice(2));
 const evidence = loadRunEvidence({
   evidenceDir: options.evidenceDir,
@@ -17,10 +91,19 @@ if (options.json) {
     console.log(`  fingerprint: ${bug.fingerprint}`);
     console.log(`  evidence: ${(bug.evidenceRefs ?? []).join(', ') || 'none'}`);
     if (bug.triage) {
+      console.log(`  actor: ${bug.triage.actor ?? '-'}`);
       console.log(`  action: ${bug.triage.action ?? '-'}`);
       console.log(
-        `  validation: ${bug.triage.validationResult?.status ?? '-'}`,
+        `  state before: ${compactStateBefore(bug.triage.stateBefore)}`,
       );
+      console.log(`  state after: ${compactStateAfter(bug.triage.stateAfter)}`);
+      console.log(`  rule: ${compactRuleDecision(bug.triage.ruleDecision)}`);
+      console.log(
+        `  validation: ${compactValidation(bug.triage.validationResult)}`,
+      );
+      if ((bug.triage.warnings ?? []).length > 0) {
+        console.log(`  warnings: ${bug.triage.warnings.join(' | ')}`);
+      }
       if (bug.triage.failureCause) {
         console.log(`  failure cause: ${bug.triage.failureCause}`);
       }


### PR DESCRIPTION
## Summary
- Deduplicates journey bug extraction so matching failed-step and error-log candidates collapse into one canonical bug packet.
- Adds structured triage metadata to `bug.candidate_extracted` diagnostics, including bug count, gated count, severity gate, and evidence refs.
- Expands `qc:journeys:bugs` text output with actor, compact state before/after, rule decision, validation details, warnings, failure cause, next hint, and log fingerprints.
- Archives OpenSpec change `wave-03-journey-bug-triage-logging` into `journey-qc` and `logging-system` specs.

## Verification
- `npx.cmd jest --selectProjects unit --ci --runTestsByPath scripts/__tests__/journey-qc.test.ts --no-coverage`
- `npm.cmd run verify:qc:journeys`
- `npm.cmd run verify:qc`
- `npm.cmd run typecheck -- --pretty false`
- `npm.cmd run format:check`
- `npm.cmd run lint` (0 errors; existing warnings remain)
- `openspec.cmd validate --all --strict`
- `git diff --check`
- Commit hook: staged-file formatting/lint, TypeScript, and full `next build --webpack`

## Probe Evidence
- Before: `wave03-probe-failure` produced 2 bug candidates for one injected combat step failure.
- After: `wave03-postfix-failure` produced 1 canonical bug candidate and searchable `bug.candidate_extracted` triage.