### PR TITLE
Harden GM ledger core invariants

### DIFF
--- a/openspec/changes/archive/2026-06-23-wave-04-gm-ledger-core-hardening/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-23-wave-04-gm-ledger-core-hardening/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-23

--- a/openspec/changes/archive/2026-06-23-wave-04-gm-ledger-core-hardening/design.md
+++ b/openspec/changes/archive/2026-06-23-wave-04-gm-ledger-core-hardening/design.md
@@ -1,0 +1,37 @@
+## Context
+
+Wave 4 builds on existing intervention primitives in `src/lib/interventions`. The repo already has an `InterventionLedger`, `ActionLedger`, authority/redaction helpers, and a cascade preview pipeline. The remaining risk is not missing surface area; it is that edge paths can weaken the append-only contract before later GM combat/economy/time workflows rely on it.
+
+Current approval flow builds and appends an intervention record before confirming that the domain implementer can apply it. Current ledger read APIs also return shallow-copied arrays that still contain live record objects. Downstream UI and service code will read these projections frequently, so the core should make accidental mutation hard.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Ensure approval is atomic: no intervention or action-ledger record is appended unless the approved preview applies successfully.
+- Return immutable record snapshots from ledger reads/projections.
+- Add focused tests that capture the blocked-approval and snapshot immutability behavior.
+
+**Non-Goals:**
+- No new GM UI.
+- No new combat, post-combat, economy, repair, salvage, or time implementer behavior.
+- No persistence-store migration.
+- No public API route changes.
+
+## Decisions
+
+- Validate application before appending approved intervention records.
+  - Rationale: blocked or unsupported approval paths must leave the ledger unchanged. Applying first preserves the existing pure-state derivation model while preventing orphaned intervention records.
+  - Alternative considered: append first and add a compensating rollback marker. Rejected because it would create confusing canonical history for a command that never became approved state.
+
+- Freeze shallow record snapshots at ledger boundaries.
+  - Rationale: ledger record payloads are structured domain data, but the immediate append-only risk is callers replacing top-level fields on returned records. Shallow freezing is a small, dependency-free hardening step that preserves existing payload identity and avoids deep-clone surprises.
+  - Alternative considered: deep clone every payload. Rejected for this slice because domain payloads can include richer objects and future persistence boundaries should define deeper serialization rules explicitly.
+
+- Keep the public TypeScript API shape stable.
+  - Rationale: later waves already depend on these types and helpers. This wave should improve invariants without broad integration churn.
+
+## Risks / Trade-offs
+
+- Shallow freeze does not make nested domain payloads immutable. -> Add tests for top-level record mutation now; leave deep serialization/normalization to persistence or domain implementer waves.
+- Applying before appending assumes implementer `apply` is pure and returns derived state. -> Existing implementers/tests already follow this pattern; the approval pipeline will only append after `apply` reports success.
+- Existing consumers could rely on mutating returned record objects. -> That would violate the append-only contract; tests will lock the intended behavior.

--- a/openspec/changes/archive/2026-06-23-wave-04-gm-ledger-core-hardening/proposal.md
+++ b/openspec/changes/archive/2026-06-23-wave-04-gm-ledger-core-hardening/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The GM ledger core already exists, but Wave 4 needs it to be strong enough for downstream combat, economy, and time-cascade interventions. Approval paths must be atomic, and read/projection APIs must not allow accidental mutation of append-only ledger history.
+
+## What Changes
+
+- Harden GM cascade approval so blocked, stale, unsupported, or otherwise non-applied approvals append no intervention record and no action ledger record.
+- Harden intervention/action ledger read surfaces so callers receive immutable record snapshots rather than live mutable record objects.
+- Add focused regression tests for unsupported approval atomicity, action-ledger snapshot immutability, and intervention-ledger snapshot immutability.
+- Keep the existing ledger API shape; this is a compatibility hardening slice, not a new GM UI implementation.
+
+## Capabilities
+
+### New Capabilities
+- None.
+
+### Modified Capabilities
+- `gm-cascade-preview`: Approval MUST only append ledger records after the implementer successfully applies the approved preview.
+- `intervention-ledger-abstraction`: Ledger read/projection surfaces MUST preserve append-only history by preventing caller-side mutation of returned records.
+
+## Impact
+
+- Affected code: `src/lib/interventions/GmCascadePreviewPipeline.ts`, `src/lib/interventions/InterventionLedger.ts`, `src/lib/interventions/ActionLedger.ts`, and their Jest tests.
+- Affected specs: `gm-cascade-preview`, `intervention-ledger-abstraction`.
+- No new dependencies or public route changes.
+- Non-goals: full GM combat controls, UI shells, economy/time domain implementers, and campaign intervention screens remain later waves.

--- a/openspec/changes/archive/2026-06-23-wave-04-gm-ledger-core-hardening/specs/gm-cascade-preview/spec.md
+++ b/openspec/changes/archive/2026-06-23-wave-04-gm-ledger-core-hardening/specs/gm-cascade-preview/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: Approval and Cancellation
+
+The system SHALL append an intervention record only after GM approval and successful application by the registered domain implementer. Cancelling a preview, blocking a preview, or failing to apply an approved preview SHALL append no intervention and SHALL leave state unchanged.
+
+#### Scenario: Approval appends accepted intervention
+- **GIVEN** a ready GM intervention preview
+- **WHEN** the GM approves the preview and the registered domain implementer applies it
+- **THEN** the system SHALL append the approved intervention to canonical history
+- **AND** the derived game state SHALL reflect the approved net effect
+
+#### Scenario: Cancellation appends nothing
+- **GIVEN** a ready GM intervention preview
+- **WHEN** the GM cancels the preview
+- **THEN** no intervention record SHALL be appended
+- **AND** derived game state SHALL remain unchanged
+
+#### Scenario: Unsupported approval appends nothing
+- **GIVEN** a ready GM intervention preview whose domain cannot be applied by a registered implementer
+- **WHEN** the GM attempts to approve the preview
+- **THEN** the approval result SHALL be blocked
+- **AND** no intervention ledger record SHALL be appended
+- **AND** no action ledger record SHALL be appended
+- **AND** derived game state SHALL remain unchanged

--- a/openspec/changes/archive/2026-06-23-wave-04-gm-ledger-core-hardening/specs/intervention-ledger-abstraction/spec.md
+++ b/openspec/changes/archive/2026-06-23-wave-04-gm-ledger-core-hardening/specs/intervention-ledger-abstraction/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: Immutable Ledger Read Snapshots
+
+The intervention ledger system SHALL preserve append-only history by returning immutable top-level record snapshots from read and projection APIs. Callers SHALL NOT be able to mutate canonical ledger record fields through arrays or records returned by ledger reads.
+
+#### Scenario: Intervention ledger records cannot be mutated through reads
+- **GIVEN** an approved intervention record has been appended
+- **WHEN** a caller reads intervention ledger records and attempts to mutate a returned record field
+- **THEN** the canonical ledger record SHALL remain unchanged
+
+#### Scenario: Action ledger projections cannot be mutated through reads
+- **GIVEN** normal and GM intervention actions have been appended to the shared action ledger
+- **WHEN** a caller reads player-public or GM-private projections and attempts to mutate a returned record field
+- **THEN** the canonical action ledger record SHALL remain unchanged

--- a/openspec/changes/archive/2026-06-23-wave-04-gm-ledger-core-hardening/tasks.md
+++ b/openspec/changes/archive/2026-06-23-wave-04-gm-ledger-core-hardening/tasks.md
@@ -1,0 +1,16 @@
+## 1. Approval Atomicity
+
+- [x] 1.1 Add regression coverage proving unsupported approval appends no intervention record and no action ledger record.
+- [x] 1.2 Update the GM cascade approval pipeline to apply first and append only after successful application.
+
+## 2. Ledger Snapshot Hardening
+
+- [x] 2.1 Add intervention-ledger tests proving read snapshots cannot mutate canonical record fields.
+- [x] 2.2 Add action-ledger tests proving raw reads and public/private projections cannot mutate canonical record fields.
+- [x] 2.3 Update ledger read/projection helpers to return immutable top-level record snapshots.
+
+## 3. Validation
+
+- [x] 3.1 Run targeted intervention ledger Jest tests.
+- [x] 3.2 Validate the OpenSpec change strictly.
+- [x] 3.3 Run the broader QC/OpenSpec validation surface needed before archive and PR.

--- a/openspec/specs/gm-cascade-preview/spec.md
+++ b/openspec/specs/gm-cascade-preview/spec.md
@@ -17,11 +17,11 @@ The system SHALL compute a cascade preview before applying any GM intervention. 
 
 ### Requirement: Approval and Cancellation
 
-The system SHALL append an intervention record only after GM approval. Cancelling a preview SHALL append no intervention and SHALL leave state unchanged.
+The system SHALL append an intervention record only after GM approval and successful application by the registered domain implementer. Cancelling a preview, blocking a preview, or failing to apply an approved preview SHALL append no intervention and SHALL leave state unchanged.
 
 #### Scenario: Approval appends accepted intervention
 - **GIVEN** a ready GM intervention preview
-- **WHEN** the GM approves the preview
+- **WHEN** the GM approves the preview and the registered domain implementer applies it
 - **THEN** the system SHALL append the approved intervention to canonical history
 - **AND** the derived game state SHALL reflect the approved net effect
 
@@ -29,6 +29,14 @@ The system SHALL append an intervention record only after GM approval. Cancellin
 - **GIVEN** a ready GM intervention preview
 - **WHEN** the GM cancels the preview
 - **THEN** no intervention record SHALL be appended
+- **AND** derived game state SHALL remain unchanged
+
+#### Scenario: Unsupported approval appends nothing
+- **GIVEN** a ready GM intervention preview whose domain cannot be applied by a registered implementer
+- **WHEN** the GM attempts to approve the preview
+- **THEN** the approval result SHALL be blocked
+- **AND** no intervention ledger record SHALL be appended
+- **AND** no action ledger record SHALL be appended
 - **AND** derived game state SHALL remain unchanged
 
 ### Requirement: Conflict and Manual Takeover Result
@@ -78,7 +86,6 @@ The preview pipeline SHALL represent post-combat and base-economy corrections wi
 - **WHEN** the GM attempts normal preview approval
 - **THEN** the approval pipeline SHALL return blocked
 - **AND** no intervention ledger record or action ledger record SHALL be appended
-
 ### Requirement: Time Cascade Preview Shape
 
 The preview pipeline SHALL represent accumulated time cascades with public net effect, GM-private context, affected campaign state references, projected time effects, generated day summaries, and conflicts before commit.

--- a/openspec/specs/intervention-ledger-abstraction/spec.md
+++ b/openspec/specs/intervention-ledger-abstraction/spec.md
@@ -116,3 +116,17 @@ The intervention ledger SHALL allow a `time` campaign-domain implementer to shar
 - **WHEN** the preview is not approved
 - **THEN** the intervention ledger SHALL append no time-cascade record
 - **AND** the action ledger SHALL append no GM intervention action
+
+### Requirement: Immutable Ledger Read Snapshots
+
+The intervention ledger system SHALL preserve append-only history by returning immutable top-level record snapshots from read and projection APIs. Callers SHALL NOT be able to mutate canonical ledger record fields through arrays or records returned by ledger reads.
+
+#### Scenario: Intervention ledger records cannot be mutated through reads
+- **GIVEN** an approved intervention record has been appended
+- **WHEN** a caller reads intervention ledger records and attempts to mutate a returned record field
+- **THEN** the canonical ledger record SHALL remain unchanged
+
+#### Scenario: Action ledger projections cannot be mutated through reads
+- **GIVEN** normal and GM intervention actions have been appended to the shared action ledger
+- **WHEN** a caller reads player-public or GM-private projections and attempts to mutate a returned record field
+- **THEN** the canonical action ledger record SHALL remain unchanged

--- a/src/lib/interventions/ActionLedger.ts
+++ b/src/lib/interventions/ActionLedger.ts
@@ -106,10 +106,13 @@ export class ActionLedger {
   private append<TPublic, TPrivate, TDomainPayload>(
     input: IActionLedgerAppendInput<TPublic, TPrivate, TDomainPayload>,
   ): IActionLedgerRecord<TPublic, TPrivate, TDomainPayload> {
-    const record: IActionLedgerRecord<TPublic, TPrivate, TDomainPayload> = {
+    const record = freezeRecord({
       ...input,
+      targetRefs: freezeRefs(input.targetRefs),
+      causedBy: freezeOptionalRefs(input.causedBy),
+      supersedes: freezeOptionalRefs(input.supersedes),
       sequence: this.nextSequence,
-    };
+    });
 
     this.nextSequence += 1;
     this.records.push(record);
@@ -119,7 +122,7 @@ export class ActionLedger {
   private toPlayerProjection<TPublic>(
     record: IActionLedgerRecord,
   ): IPlayerVisibleActionLedgerRecord<TPublic> {
-    return {
+    return freezeRecord({
       id: record.id,
       sequence: record.sequence,
       recordKind: record.recordKind,
@@ -128,23 +131,37 @@ export class ActionLedger {
       domain: record.domain,
       action: record.action,
       status: record.status,
-      targetRefs: record.targetRefs,
+      targetRefs: freezeRefs(record.targetRefs),
       publicEffect: record.publicEffect as TPublic,
-      causedBy: record.causedBy,
-      supersedes: record.supersedes,
+      causedBy: freezeOptionalRefs(record.causedBy),
+      supersedes: freezeOptionalRefs(record.supersedes),
       interventionRecordId: record.interventionRecordId,
       createdAt: record.createdAt,
       approvedAt: record.approvedAt,
-    };
+    });
   }
 
   private toGmProjection<TPublic, TPrivate, TDomainPayload>(
     record: IActionLedgerRecord,
   ): IGmVisibleActionLedgerRecord<TPublic, TPrivate, TDomainPayload> {
-    return {
+    return freezeRecord({
       ...this.toPlayerProjection<TPublic>(record),
       privateMetadata: record.privateMetadata as TPrivate | undefined,
       domainPayload: record.domainPayload as TDomainPayload | undefined,
-    };
+    });
   }
+}
+
+function freezeRefs(refs: readonly string[]): readonly string[] {
+  return Object.freeze([...refs]);
+}
+
+function freezeOptionalRefs(
+  refs?: readonly string[],
+): readonly string[] | undefined {
+  return refs ? freezeRefs(refs) : undefined;
+}
+
+function freezeRecord<TRecord extends object>(record: TRecord): TRecord {
+  return Object.freeze(record);
 }

--- a/src/lib/interventions/GmCascadePreviewPipeline.ts
+++ b/src/lib/interventions/GmCascadePreviewPipeline.ts
@@ -200,27 +200,26 @@ export function approveGmCascadePreview<
   }
 
   const record = buildApprovedRecord(input);
-  ledger.appendApprovedRecord(record);
   const applyResult = ledger.apply(record, state);
 
   if (applyResult.status === 'unsupported') {
     return {
       status: 'blocked',
       state,
-      appended: true,
-      record,
+      appended: false,
       reason: applyResult.reason,
     };
   }
 
+  const appendedRecord = ledger.appendApprovedRecord(record);
   const actionLedgerRecord =
-    input.actionLedger?.appendGmInterventionRecord(record);
+    input.actionLedger?.appendGmInterventionRecord(appendedRecord);
 
   return {
     status: 'approved',
     state: applyResult.state,
     appended: true,
-    record,
+    record: appendedRecord,
     actionLedgerRecord,
   };
 }

--- a/src/lib/interventions/InterventionLedger.ts
+++ b/src/lib/interventions/InterventionLedger.ts
@@ -72,8 +72,9 @@ export class InterventionLedger<TState = unknown> {
       );
     }
 
-    this.records.push(record);
-    return record;
+    const immutableRecord = freezeInterventionRecord(record);
+    this.records.push(immutableRecord);
+    return immutableRecord;
   }
 
   apply(
@@ -123,4 +124,25 @@ export class InterventionLedger<TState = unknown> {
     const { unsupportedReason = defaultUnsupportedReason } = this.options;
     return unsupportedReason(domain);
   }
+}
+
+function freezeInterventionRecord(
+  record: IInterventionLedgerRecord,
+): IInterventionLedgerRecord {
+  return Object.freeze({
+    ...record,
+    targetRefs: freezeRefs(record.targetRefs),
+    causedBy: freezeOptionalRefs(record.causedBy),
+    supersedes: freezeOptionalRefs(record.supersedes),
+  });
+}
+
+function freezeRefs(refs: readonly string[]): readonly string[] {
+  return Object.freeze([...refs]);
+}
+
+function freezeOptionalRefs(
+  refs?: readonly string[],
+): readonly string[] | undefined {
+  return refs ? freezeRefs(refs) : undefined;
 }

--- a/src/lib/interventions/__tests__/ActionLedger.test.ts
+++ b/src/lib/interventions/__tests__/ActionLedger.test.ts
@@ -155,5 +155,69 @@ describe('ActionLedger', () => {
     records.pop();
 
     expect(ledger.getRecords()).toHaveLength(1);
+
+    const [record] = ledger.getRecords() as IActionLedgerRecord[];
+    expect(Object.isFrozen(record)).toBe(true);
+    expect(Object.isFrozen(record.targetRefs)).toBe(true);
+
+    try {
+      (record as { action: string }).action = 'mutated-action';
+    } catch {
+      // Frozen records may throw in strict mode.
+    }
+    try {
+      (record.targetRefs as string[]).push('phase:combat');
+    } catch {
+      // Frozen arrays may throw in strict mode.
+    }
+
+    expect(ledger.getRecords()[0]).toMatchObject({
+      action: 'phase-started',
+      targetRefs: ['phase:movement'],
+    });
+  });
+
+  it('returns immutable player and GM projections that cannot mutate canonical records', () => {
+    const ledger = new ActionLedger();
+    ledger.appendNormalAction({
+      id: 'normal-action-1',
+      actorId: 'player-1',
+      domain: 'combat',
+      action: 'move',
+      targetRefs: ['unit:atlas-1'],
+      publicEffect: {
+        summary: 'Atlas moved.',
+        changedStateRefs: ['unit:atlas-1'],
+      },
+      createdAt: '2026-06-22T00:00:00.000Z',
+    });
+    ledger.appendGmInterventionRecord(makeGmInterventionRecord());
+
+    const playerProjection = ledger.projectForPlayer<IGmPublicEffect>();
+    const gmProjection = ledger.projectForGm<
+      IGmPublicEffect,
+      IGmPrivateMetadata,
+      TestDomainPayload
+    >();
+
+    expect(Object.isFrozen(playerProjection[1])).toBe(true);
+    expect(Object.isFrozen(playerProjection[1].targetRefs)).toBe(true);
+    expect(Object.isFrozen(gmProjection[1])).toBe(true);
+
+    try {
+      (playerProjection[1] as { action: string }).action = 'mutated-action';
+    } catch {
+      // Frozen projection mutation may throw.
+    }
+    try {
+      (gmProjection[1] as { action: string }).action = 'gm-mutated-action';
+    } catch {
+      // Frozen projection mutation may throw.
+    }
+
+    expect(ledger.getRecords()[1]).toMatchObject({
+      action: 'fix',
+      targetRefs: ['unit:atlas-1'],
+    });
   });
 });

--- a/src/lib/interventions/__tests__/GmCascadePreviewPipeline.test.ts
+++ b/src/lib/interventions/__tests__/GmCascadePreviewPipeline.test.ts
@@ -1,5 +1,6 @@
 import type {
   IGmAuthorityContext,
+  IGmCascadePreview,
   IGmPrivateMetadata,
   IGmPublicEffect,
   IInterventionLedgerCommand,
@@ -334,6 +335,56 @@ describe('GM cascade preview pipeline', () => {
       state,
       appended: false,
     });
+    expect(ledger.getRecords()).toEqual([]);
+    expect(actionLedger.getRecords()).toEqual([]);
+  });
+
+  it('blocks stale unsupported approval without appending intervention or action records', () => {
+    const ledger = new InterventionLedger<TestState>();
+    const actionLedger = new ActionLedger();
+    const state = makeState();
+    const preview: IGmCascadePreview<
+      IGmPrivateMetadata,
+      IGmPublicEffect,
+      TestDomainPayload
+    > = {
+      interventionId: 'gm-int-stale-unsupported',
+      status: 'ready',
+      domain: 'combat',
+      kind: 'fix',
+      actorId: 'gm-1',
+      targetRefs: ['unit:atlas-1'],
+      affectedStateRefs: ['unit:atlas-1', 'state:value'],
+      privateMetadata: {
+        reason: 'GM-only stale preview reason.',
+      },
+      publicEffect: {
+        summary: 'Value corrected.',
+        changedStateRefs: ['state:value', 'unit:atlas-1'],
+      },
+      domainPayload: {
+        delta: 3,
+        projectedEvents: [],
+      },
+      projectedEvents: [],
+      conflicts: [],
+      causedBy: ['player-attack-1'],
+      supersedes: ['player-attack-1'],
+    };
+
+    const result = approveGmCascadePreview({
+      ledger,
+      actionLedger,
+      preview,
+      state,
+    });
+
+    expect(result).toMatchObject({
+      status: 'blocked',
+      appended: false,
+      state,
+    });
+    expect(result.reason).toContain('combat');
     expect(ledger.getRecords()).toEqual([]);
     expect(actionLedger.getRecords()).toEqual([]);
   });

--- a/src/lib/interventions/__tests__/InterventionLedger.test.ts
+++ b/src/lib/interventions/__tests__/InterventionLedger.test.ts
@@ -193,7 +193,35 @@ describe('InterventionLedger', () => {
       causedBy: ['event-prior'],
       supersedes: ['event-old-damage'],
     });
-    expect(records[0]).toBe(record);
+    expect(records[0]).toEqual(record);
+  });
+
+  it('returns immutable read snapshots so callers cannot mutate canonical record fields', () => {
+    const ledger = new InterventionLedger<CounterState>();
+    const record = makeRecord();
+
+    ledger.appendApprovedRecord(record);
+    const records = ledger.getRecords() as IInterventionLedgerRecord[];
+
+    expect(Object.isFrozen(records[0])).toBe(true);
+    expect(Object.isFrozen(records[0].targetRefs)).toBe(true);
+
+    try {
+      (records[0] as { id: string }).id = 'mutated-id';
+    } catch {
+      // Strict-mode runtimes throw for frozen assignment; either way,
+      // canonical ledger state must remain unchanged.
+    }
+    try {
+      (records[0].targetRefs as string[]).push('unit-2');
+    } catch {
+      // Frozen array mutation may throw.
+    }
+
+    expect(ledger.getRecords()[0]).toMatchObject({
+      id: 'gm-int-1',
+      targetRefs: ['unit-1'],
+    });
   });
 
   it('rejects non-approved records from the append-only approved ledger path', () => {


### PR DESCRIPTION
## Summary
- harden GM cascade approval so unsupported/non-applied approvals append no intervention or action ledger records
- freeze top-level action/intervention ledger records and causality arrays at read/projection boundaries
- archive the Wave 4 OpenSpec packet and update `gm-cascade-preview` plus `intervention-ledger-abstraction`

## Validation
- `npx.cmd jest --selectProjects unit --ci --runTestsByPath src/lib/interventions/__tests__/ActionLedger.test.ts src/lib/interventions/__tests__/InterventionLedger.test.ts src/lib/interventions/__tests__/GmCascadePreviewPipeline.test.ts --no-coverage`
- `openspec.cmd validate wave-04-gm-ledger-core-hardening --strict`
- `openspec.cmd validate --all --strict`
- `npm.cmd run typecheck -- --pretty false`
- `npm.cmd run verify:qc:journeys`
- `npm.cmd run qc:logging:validate`
- `npm.cmd run validate:combat:gaps -- --format=summary`
- `npm.cmd run format:check`
- `npm.cmd run lint` (existing warning-only baseline, 0 errors)
- `npm.cmd run verify:qc`
- commit hook: lint-staged, TypeScript, full `next build --webpack`