### PR TITLE
Prove app shell route recovery

### DIFF
--- a/docs/qc/mekstation-qc-map.md
+++ b/docs/qc/mekstation-qc-map.md
@@ -59,6 +59,7 @@ npm.cmd run qc:journeys:bugs -- --since=latest --min-severity=medium
 npm.cmd run qc:logs -- --run-id=latest --level=warn,error
 npm.cmd run qc:logs -- --run-id=latest --level=warn,error --exclude-probes
 npm.cmd run verify:qc:scenarios
+npm.cmd run verify:qc:app-shell
 npm.cmd run verify:qc:journeys
 npm.cmd run verify:qc:ui-flow-shell
 npm.cmd run verify:qc:gm:campaign-ledger
@@ -141,6 +142,19 @@ flowchart TD
 
 ## Current Hot Lanes
 
+1. `app-shell-navigation`
+   - Wave 1 adds `verify:qc:app-shell` as the focused Chromium gate for
+     primary route deep links, refresh recovery, shell chrome, route anchors,
+     critical console/page/network failures, settings hash navigation, and the
+     desktop History -> Replay Library route contract.
+   - 2026-06-24 `verify:qc:app-shell` passed 17 checks and caught two real
+     app-shell regressions before this lane moved forward: `/units` imported
+     the unit-card barrel and leaked SQLite code into the browser, and
+     `/compare` logged reload-aborted catalog fetches as failures.
+   - Dynamic generated-ID session recovery is intentionally left to the
+     campaign, combat continuity, multiplayer, and replay lanes where seeded
+     state can prove recovery without weakening this static route sweep.
+
 1. `gameplay-tactical-map-combat`
    - Tactical map is the primary explanation layer; Wave 7 adds a fast
      projection parity manifest that validates required tactical surfaces,
@@ -153,7 +167,7 @@ flowchart TD
      unit scenarios and Playwright visual smoke for deeper behavior/visual
      signoff.
 
-2. `simulation-combat-validation`
+1. `simulation-combat-validation`
    - BattleMech unresolved validation gaps are currently 0 by
      `validate:combat:gaps -- --format=summary`.
    - Current out-of-scope combat rows are 147 by
@@ -175,7 +189,7 @@ flowchart TD
      out-of-scope rows; the focused physical/ejection UI command slice passed
      11 suites / 78 tests.
 
-3. `post-combat-base-economy-gm-ledger`
+1. `post-combat-base-economy-gm-ledger`
    - Wave 8 lives under `campaign-economy-progression` and proves the
      ledger-backed GM correction layer for post-combat, salvage, repair,
      merchant reversals, inventory, funds, and base unit state roots.
@@ -191,7 +205,7 @@ flowchart TD
      inventory/base-unit, net-effect projection, redaction, and manual-takeover
      cases.
 
-4. `time-cascade-gm-ledger`
+1. `time-cascade-gm-ledger`
    - Wave 9 lives under `campaign-economy-progression` and proves the
      ledger-backed GM time-cascade layer for date advancement, optional
      travel, repair progression, contract windows, market refreshes, finance
@@ -208,7 +222,7 @@ flowchart TD
      public/private redaction, external-effect projection, and manual-takeover
      cases.
 
-5. `long-campaign-stability`
+1. `long-campaign-stability`
    - `long-campaign-stability` is the Wave 11 guard for deterministic 6-10
      contract campaign repeatability. Validate metadata wiring first with
      `qc:campaign-long:validate`; use `verify:qc:campaign-long` when you also
@@ -220,7 +234,7 @@ flowchart TD
      2 runs, 0 drift, 0 stability bug candidates, 8/8 save round trips, and
      manifest-confirmed UI checkpoint linkage with `browserExecuted=false`.
 
-6. `integration-runner-interactive-parity`
+1. `integration-runner-interactive-parity`
    - Runner/interactive parity is still the highest-risk combat integration
      lane, especially physical attack commit and phase-driver behavior.
    - 2026-06-23 runner/interactive parity passed 3 suites / 109 tactical
@@ -228,11 +242,11 @@ flowchart TD
      physical/ejection command slice proving physical declaration/resolution,
      phase advancement, and utility eject coverage.
 
-7. `multiplayer-coop-sync`
+1. `multiplayer-coop-sync`
    - Current dirty worktree includes multiplayer API and fog test edits.
    - Treat those edits as external work until validated.
 
-8. `desktop-api-security`
+1. `desktop-api-security`
    - The 2026-06-23 desktop lane now proves the packaged runtime path with
      `npm.cmd run electron:test:build`: Next production build, Electron
      TypeScript, standalone native rebuild, Electron `better-sqlite3` runtime
@@ -241,7 +255,7 @@ flowchart TD
      `.next/standalone` native modules so the package no longer ships a
      host-Node ABI binding into Electron's Node runtime.
 
-9. `maintenance-code-health`
+1. `maintenance-code-health`
    - Full maintenance scanner pass is active with a reviewed `src` regression
      baseline; the current `src` scanner gate has 0 critical/high findings.
    - Use `maintain:scan:gate` to block new `src` critical/high findings, and

--- a/docs/qc/mekstation-qc-registry.json
+++ b/docs/qc/mekstation-qc-registry.json
@@ -10,7 +10,24 @@
       "riskTags": ["playability", "discoverability", "regression"],
       "qualityLenses": ["usability", "ux", "functionality", "accessibility"],
       "coverageStatus": "partial",
-      "routes": ["/", "/gameplay", "/settings"],
+      "routes": [
+        "/",
+        "/gameplay",
+        "/gameplay/quick",
+        "/gameplay/pilots",
+        "/gameplay/forces",
+        "/gameplay/campaigns",
+        "/gameplay/encounters",
+        "/gameplay/games",
+        "/compendium",
+        "/units",
+        "/customizer",
+        "/compare",
+        "/multiplayer",
+        "/audit/timeline",
+        "/replay-library",
+        "/settings#vault"
+      ],
       "apis": [],
       "desktopSurfaces": ["electron shell"],
       "modules": ["src/pages", "src/components/ui", "src/components/common"],
@@ -26,7 +43,7 @@
       "commands": [
         "npm.cmd run lint",
         "npm.cmd run typecheck -- --pretty false",
-        "npx.cmd playwright test --project=chromium"
+        "npm.cmd run verify:qc:app-shell"
       ],
       "manualChecks": [
         "Launch from first screen to each primary workflow",
@@ -36,11 +53,12 @@
       "evidence": [
         "docs/audits/2026-06-12-full-codebase-review.md",
         "2026-06-23 Chromium browser smoke passed `npx.cmd playwright test --project=chromium e2e/game.spec.ts --grep \"Game List Page\"`: `/gameplay/games` returned 200 and game-list navigation/new-game/empty-state checks passed after MatchLogService initializes SQLite on first server-side read.",
+        "2026-06-24 `npm.cmd run verify:qc:app-shell` passed 17 Chromium route/deep-link/refresh checks across dashboard, gameplay hub, quick game, pilots, forces, campaigns, encounters, games, compendium, custom units, customizer, compare, multiplayer, audit timeline, replay library, settings hash deep link, and desktop History -> Replay Library navigation. The proof caught and fixed `/units` browser SQLite leakage through the unit-card barrel import and `/compare` reload-abort logging.",
         "Archived OpenSpec change 2026-06-21-fix-navigation-and-playability-deadends retired from activeChangeRefs on 2026-06-23.",
         "Archived OpenSpec change 2026-06-21-harden-desktop-and-api-security retired from activeChangeRefs on 2026-06-23."
       ],
       "gaps": [
-        "Recent audit called out navigation/playability dead ends and refresh-loss risks."
+        "Generated-ID active-session recovery remains out of scope for the static/list route sweep and is tracked by the campaign, combat continuity, and replay recovery lanes."
       ]
     },
     {

--- a/docs/qc/mekstation-qc-validation-graph.json
+++ b/docs/qc/mekstation-qc-validation-graph.json
@@ -330,6 +330,7 @@
       "label": "Registry evidence for App Shell, Navigation, Settings, PWA",
       "entries": [
         "docs/audits/2026-06-12-full-codebase-review.md",
+        "2026-06-24 `npm.cmd run verify:qc:app-shell` passed 17 Chromium route/deep-link/refresh checks across dashboard, gameplay hub, quick game, pilots, forces, campaigns, encounters, games, compendium, custom units, customizer, compare, multiplayer, audit timeline, replay library, settings hash deep link, and desktop History -> Replay Library navigation. The proof caught and fixed `/units` browser SQLite leakage through the unit-card barrel import and `/compare` reload-abort logging.",
         "Archived OpenSpec change 2026-06-21-fix-navigation-and-playability-deadends retired from activeChangeRefs on 2026-06-23.",
         "Archived OpenSpec change 2026-06-21-harden-desktop-and-api-security retired from activeChangeRefs on 2026-06-23."
       ]
@@ -349,7 +350,7 @@
       "kind": "known-gap",
       "label": "App Shell, Navigation, Settings, PWA known gaps",
       "entries": [
-        "Recent audit called out navigation/playability dead ends and refresh-loss risks."
+        "Generated-ID active-session recovery remains out of scope for the static/list route sweep and is tracked by the campaign, combat continuity, and replay recovery lanes."
       ]
     },
     {
@@ -363,9 +364,9 @@
       "label": "npm.cmd run typecheck -- --pretty false"
     },
     {
-      "id": "command:npx-cmd-playwright-test-project-chromium",
+      "id": "command:verify-qc-app-shell",
       "kind": "command",
-      "label": "npx.cmd playwright test --project=chromium"
+      "label": "npm.cmd run verify:qc:app-shell"
     },
     {
       "id": "surface:compendium-unit-data",
@@ -1962,11 +1963,11 @@
     },
     {
       "from": "state:app-shell-navigation:lifecycle",
-      "to": "command:npx-cmd-playwright-test-project-chromium",
+      "to": "command:verify-qc-app-shell",
       "relation": "validated-by"
     },
     {
-      "from": "command:npx-cmd-playwright-test-project-chromium",
+      "from": "command:verify-qc-app-shell",
       "to": "evidence:app-shell-navigation:registry",
       "relation": "produces"
     },

--- a/e2e/app-shell-route-proof.spec.ts
+++ b/e2e/app-shell-route-proof.spec.ts
@@ -1,0 +1,235 @@
+import { expect, test, type Page } from '@playwright/test';
+
+interface RouteProof {
+  readonly path: string;
+  readonly label: string;
+  readonly pageTitle?: string;
+  readonly heading?: string | RegExp;
+  readonly text?: string | RegExp;
+}
+
+interface RouteMonitor {
+  readonly assertClean: (routeLabel: string) => void;
+}
+
+const primaryRoutes: readonly RouteProof[] = [
+  {
+    path: '/',
+    label: 'dashboard',
+    heading: /MekStation/i,
+    text: /Compendium|Unit Builder|Gameplay/i,
+  },
+  { path: '/gameplay', label: 'gameplay hub', pageTitle: 'Gameplay' },
+  { path: '/gameplay/quick', label: 'quick game', heading: 'Quick Game' },
+  {
+    path: '/gameplay/pilots',
+    label: 'pilot roster',
+    pageTitle: 'Pilot Roster',
+  },
+  {
+    path: '/gameplay/forces',
+    label: 'force roster',
+    pageTitle: 'Force Roster',
+  },
+  { path: '/gameplay/campaigns', label: 'campaigns', pageTitle: 'Campaigns' },
+  {
+    path: '/gameplay/encounters',
+    label: 'encounters',
+    pageTitle: 'Encounters',
+  },
+  { path: '/gameplay/games', label: 'games', pageTitle: 'Games' },
+  { path: '/compendium', label: 'compendium', heading: 'COMPENDIUM' },
+  { path: '/units', label: 'custom units', pageTitle: 'Custom Units' },
+  { path: '/customizer', label: 'customizer', heading: 'No Units Open' },
+  { path: '/compare', label: 'unit comparison', pageTitle: 'Unit Comparison' },
+  { path: '/multiplayer', label: 'multiplayer', heading: 'Multiplayer' },
+  {
+    path: '/audit/timeline',
+    label: 'event timeline',
+    pageTitle: 'Event Timeline',
+  },
+  {
+    path: '/replay-library',
+    label: 'replay library',
+    pageTitle: 'Replay Library',
+  },
+  {
+    path: '/settings#vault',
+    label: 'settings vault hash',
+    pageTitle: 'Settings',
+  },
+];
+
+function isBenignConsoleError(text: string): boolean {
+  return [
+    'favicon',
+    'service-worker',
+    'legacyBehavior',
+    'codemod',
+    'ERR_ABORTED',
+    '__playwright_e2e_ready__',
+  ].some((fragment) => text.includes(fragment));
+}
+
+function isIgnoredRequestFailure(url: string, errorText: string): boolean {
+  if (errorText.includes('ERR_ABORTED')) return true;
+  if (url.includes('/_next/webpack-hmr')) return true;
+  if (url.includes('/favicon')) return true;
+  if (url.includes('/analytics')) return true;
+  return false;
+}
+
+function installRouteMonitor(page: Page): RouteMonitor {
+  const consoleErrors: string[] = [];
+  const pageErrors: string[] = [];
+  const failedRequests: string[] = [];
+  const badResponses: string[] = [];
+
+  page.on('console', (message) => {
+    if (message.type() !== 'error') return;
+
+    const text = message.text();
+    if (!isBenignConsoleError(text)) {
+      consoleErrors.push(text);
+    }
+  });
+
+  page.on('pageerror', (error) => {
+    pageErrors.push(error.message);
+  });
+
+  page.on('requestfailed', (request) => {
+    const url = request.url();
+    const errorText = request.failure()?.errorText ?? '';
+    if (!isIgnoredRequestFailure(url, errorText)) {
+      failedRequests.push(`${request.method()} ${url} ${errorText}`.trim());
+    }
+  });
+
+  page.on('response', (response) => {
+    const url = response.url();
+    const status = response.status();
+    if (
+      status >= 500 &&
+      url.startsWith('http://localhost:3600') &&
+      !url.includes('/__playwright_e2e_ready__')
+    ) {
+      badResponses.push(`${status} ${url}`);
+    }
+  });
+
+  return {
+    assertClean(routeLabel) {
+      expect(
+        consoleErrors,
+        `${routeLabel} emitted critical console errors`,
+      ).toEqual([]);
+      expect(pageErrors, `${routeLabel} emitted page errors`).toEqual([]);
+      expect(
+        failedRequests,
+        `${routeLabel} had failed network requests`,
+      ).toEqual([]);
+      expect(badResponses, `${routeLabel} had 5xx responses`).toEqual([]);
+    },
+  };
+}
+
+async function expectCurrentPath(
+  page: Page,
+  expectedPath: string,
+): Promise<void> {
+  await expect
+    .poll(() => {
+      const url = new URL(page.url());
+      return `${url.pathname}${url.search}${url.hash}`;
+    })
+    .toBe(expectedPath);
+}
+
+async function expectRouteAnchor(page: Page, route: RouteProof): Promise<void> {
+  if (route.pageTitle) {
+    await expect(page.getByTestId('page-title')).toContainText(route.pageTitle);
+  }
+
+  if (route.heading) {
+    await expect(
+      page.getByRole('heading', { name: route.heading }).first(),
+    ).toBeVisible();
+  }
+
+  if (route.text) {
+    const matches = page.getByText(route.text);
+    await expect
+      .poll(async () => {
+        const count = await matches.count();
+        for (let index = 0; index < count; index += 1) {
+          if (await matches.nth(index).isVisible()) {
+            return true;
+          }
+        }
+        return false;
+      })
+      .toBe(true);
+  }
+}
+
+async function expectShellAndRoute(
+  page: Page,
+  route: RouteProof,
+): Promise<void> {
+  await expect(page.locator('header').first()).toBeVisible();
+  await expect(
+    page.getByRole('link', { name: /MekStation/i }).first(),
+  ).toBeVisible();
+  await expect(page.locator('body')).not.toContainText(
+    /This page could not be found|Application error/i,
+  );
+  await expectCurrentPath(page, route.path);
+  await expectRouteAnchor(page, route);
+}
+
+test.describe('App shell route proof @app-shell', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  for (const route of primaryRoutes) {
+    test(`${route.label} deep-links and survives refresh`, async ({ page }) => {
+      const monitor = installRouteMonitor(page);
+
+      await page.goto(route.path, { waitUntil: 'domcontentloaded' });
+      await expectShellAndRoute(page, route);
+
+      await page.reload({ waitUntil: 'domcontentloaded' });
+      await expectShellAndRoute(page, route);
+
+      await page.waitForTimeout(250);
+      monitor.assertClean(route.label);
+    });
+  }
+
+  test('desktop history navigation routes to replay library', async ({
+    page,
+  }) => {
+    const monitor = installRouteMonitor(page);
+    const replayLibraryRoute = primaryRoutes.find(
+      (route) => route.path === '/replay-library',
+    );
+
+    expect(replayLibraryRoute).toBeDefined();
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await page.getByRole('button', { name: 'History' }).click();
+
+    const replayLink = page.getByRole('menuitem', { name: 'Replay Library' });
+    await expect(replayLink).toBeVisible();
+    await expect(replayLink).toHaveAttribute('href', '/replay-library');
+
+    await replayLink.click();
+    await expectShellAndRoute(page, replayLibraryRoute!);
+
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await expectShellAndRoute(page, replayLibraryRoute!);
+
+    await page.waitForTimeout(250);
+    monitor.assertClean('replay library nav alignment');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "qc:lifecycle:status": "node scripts/qc/report-lifecycle-qc-status.mjs",
     "qc:logging:validate": "node scripts/qc/validate-journey-qc.mjs --logging-only=true",
     "verify:qc:scenarios": "npm run qc:scenarios -- --tier=standard",
+    "verify:qc:app-shell": "npx playwright test --project=chromium e2e/app-shell-route-proof.spec.ts --workers=1",
     "verify:qc:journeys": "npm run qc:journeys:validate && npm run qc:journeys -- --journey=all --tier=smoke",
     "verify:qc:ui-flow-shell": "npm run qc:ui-flow-shell:validate && npm run qc:ui-flow-shell -- --journey=all --json",
     "verify:qc:gm:campaign-ledger": "npm run qc:gm:campaign-ledger:validate && npm.cmd test -- --watchAll=false --runTestsByPath scripts/__tests__/gm-campaign-ledger-qc.test.ts src/lib/interventions/__tests__/GmCampaignInterventionImplementer.test.ts src/lib/interventions/__tests__/GmCampaignInterventionBoundaries.test.ts",

--- a/src/pages-modules/units/list.views.tsx
+++ b/src/pages-modules/units/list.views.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'next/router';
 import type { UnitEntry } from '@/pages-modules/units/list.types';
 
 import { Badge, TechBaseBadge } from '@/components/ui';
-import { UnitCardCompact } from '@/components/unit-card';
+import { UnitCardCompact } from '@/components/unit-card/UnitCardCompact';
 import {
   getUnitTypeDisplay,
   getWeightClassDisplay,

--- a/src/pages/compare/index.tsx
+++ b/src/pages/compare/index.tsx
@@ -23,9 +23,13 @@ export default function ComparePage(): React.ReactElement {
   const [catalogLoading, setCatalogLoading] = useState(true);
 
   useEffect(() => {
+    const controller = new AbortController();
+
     async function fetchCatalog() {
       try {
-        const response = await fetch('/api/catalog');
+        const response = await fetch('/api/catalog', {
+          signal: controller.signal,
+        });
         const data = (await response.json()) as {
           success: boolean;
           data?: IUnitEntry[];
@@ -34,12 +38,16 @@ export default function ComparePage(): React.ReactElement {
           setCatalog(data.data || []);
         }
       } catch (err) {
+        if (controller.signal.aborted) return;
         logger.error('Failed to fetch catalog:', err);
       } finally {
+        if (controller.signal.aborted) return;
         setCatalogLoading(false);
       }
     }
     fetchCatalog();
+
+    return () => controller.abort();
   }, []);
 
   const filteredCatalog = catalog


### PR DESCRIPTION
## Summary
- Add a focused Chromium app-shell route proof for primary routes, refresh recovery, settings hash deep link, and History -> Replay Library navigation.
- Fix the /units browser-only route by importing UnitCardCompact from the leaf module instead of the unit-card barrel that pulls SQLite code into the browser.
- Treat /compare catalog fetch aborts during reload as cancellation instead of critical console failures.
- Wire the new verify:qc:app-shell command into the QC registry, validation graph, and QC map.

## Verification
- npm.cmd run verify:qc:app-shell
- npm.cmd run qc:validate
- npm.cmd run qc:journeys:validate
- npm.cmd run qc:lifecycle:status
- npm.cmd run qc:logging:validate
- npm.cmd run qc:graph -- --query=app-shell-navigation
- npm.cmd run typecheck -- --pretty false
- npm.cmd run format:check
- git diff --check
- git diff --cached --check

## Not tested
- Full E2E suite
- Dynamic generated-ID active gameplay/session recovery, which remains tracked by campaign/combat/replay continuity lanes