### PR TITLE
Ensure campaign contracts enter playable encounters

### DIFF
--- a/e2e/campaign-organic-contract.spec.ts
+++ b/e2e/campaign-organic-contract.spec.ts
@@ -16,6 +16,7 @@ interface CampaignContractSnapshot {
   readonly missionIds: readonly string[];
   readonly missionNames: readonly string[];
   readonly missionStatuses: readonly string[];
+  readonly missionScenarioIds: readonly string[];
   readonly contractMarketOfferIds: readonly string[];
   readonly rosterUnitNames: readonly string[];
   readonly rosterPilotNames: readonly string[];
@@ -136,6 +137,14 @@ async function getCampaignContractSnapshot(
       missionStatuses: missions
         .map((mission) => mission.status)
         .filter((status): status is string => typeof status === 'string'),
+      missionScenarioIds: missions.flatMap((mission) =>
+        Array.isArray((mission as { scenarioIds?: unknown }).scenarioIds)
+          ? ((mission as { scenarioIds: unknown[] }).scenarioIds.filter(
+              (scenarioId): scenarioId is string =>
+                typeof scenarioId === 'string',
+            ) ?? [])
+          : [],
+      ),
       contractMarketOfferIds:
         campaign?.contractMarket?.offers
           ?.map((offer) => offer.id)
@@ -224,6 +233,37 @@ test.describe('organic campaign contract acceptance', () => {
       expect(reloaded.missionIds).toContain(offerId);
       expect(reloaded.missionNames).toContain(offerName);
       expect(reloaded.contractMarketOfferIds).not.toContain(offerId);
+
+      await page.goto(
+        `/gameplay/campaigns/${campaignId}/missions/${offerId}/launch`,
+      );
+      await waitForE2EHydration(page);
+      await expect(page.getByTestId('launch-mission-direct')).toBeVisible({
+        timeout: 20_000,
+      });
+      await page.getByTestId('launch-mission-direct').click();
+      await page.waitForURL(
+        (url) =>
+          url.pathname.startsWith('/gameplay/encounters/') &&
+          url.searchParams.get('campaignId') === campaignId &&
+          url.searchParams.get('missionId') === offerId,
+        { timeout: 30_000 },
+      );
+      await expect(page.getByTestId('encounter-detail-page')).toBeVisible({
+        timeout: 20_000,
+      });
+      await expect(page.getByTestId('launch-encounter-btn')).toBeEnabled({
+        timeout: 20_000,
+      });
+
+      const encounterId = page
+        .url()
+        .match(/\/gameplay\/encounters\/([^/?#]+)/)?.[1];
+      expect(encounterId).toBeTruthy();
+      expect(encounterId).not.toBe(offerId);
+
+      const materialized = await getCampaignContractSnapshot(page);
+      expect(materialized.missionScenarioIds).toContain(encounterId);
     },
   );
 });

--- a/e2e/encounter-combat-continuity.spec.ts
+++ b/e2e/encounter-combat-continuity.spec.ts
@@ -186,10 +186,26 @@ test.describe('encounter-combat campaign continuity', () => {
         playerForceId,
         opponentForceId,
       );
-      expect(encounterId).toBeTruthy();
+      if (!encounterId) {
+        throw new Error('Failed to create continuity encounter');
+      }
 
       await page.goto(
-        `/gameplay/encounters/${encounterId}/pre-battle?campaignId=${campaignId}&missionId=${missionId}`,
+        `/gameplay/encounters/${encounterId}?campaignId=${campaignId}&missionId=${missionId}`,
+      );
+      await expect(page.getByTestId('encounter-detail-page')).toBeVisible({
+        timeout: 20_000,
+      });
+      await expect(page.getByTestId('launch-encounter-btn')).toBeEnabled({
+        timeout: 20_000,
+      });
+      await page.getByTestId('launch-encounter-btn').click();
+      await page.waitForURL(
+        (url) =>
+          url.pathname === `/gameplay/encounters/${encounterId}/pre-battle` &&
+          url.searchParams.get('campaignId') === campaignId &&
+          url.searchParams.get('missionId') === missionId,
+        { timeout: 20_000 },
       );
       await expect(
         page.getByRole('heading', {

--- a/src/__tests__/pages/gameplay/campaigns/mission-launch.coop.test.tsx
+++ b/src/__tests__/pages/gameplay/campaigns/mission-launch.coop.test.tsx
@@ -24,6 +24,10 @@ import { ForceRole, FormationLevel } from '@/types/campaign/enums';
 
 const mockRouterPush = jest.fn();
 const mockLaunchCoopMission = jest.fn();
+const mockMaterializeCampaignMissionEncounter = jest.fn();
+const mockUpdateCampaign = jest.fn();
+const mockSaveCampaign = jest.fn();
+const mockAddMission = jest.fn();
 
 jest.mock('next/router', () => ({
   useRouter: () => ({
@@ -41,9 +45,26 @@ jest.mock('@/lib/campaign/coop/launchCoopMission', () => ({
   launchCoopMission: (...args: unknown[]) => mockLaunchCoopMission(...args),
 }));
 
+jest.mock(
+  '@/lib/campaign/encounter/materializeCampaignMissionEncounter',
+  () => ({
+    materializeCampaignMissionEncounter: (...args: unknown[]) =>
+      mockMaterializeCampaignMissionEncounter(...args),
+  }),
+);
+
 const mockGetCampaign = jest.fn();
 const mockCampaignStoreApi = {
-  getState: () => ({ getCampaign: mockGetCampaign }),
+  getState: () => ({
+    getCampaign: mockGetCampaign,
+    updateCampaign: mockUpdateCampaign,
+    saveCampaign: mockSaveCampaign,
+    getMissionsStore: () => ({
+      getState: () => ({
+        addMission: mockAddMission,
+      }),
+    }),
+  }),
 };
 
 jest.mock('@/stores/campaign/useCampaignStore', () => ({
@@ -69,6 +90,14 @@ describe('CoopMissionLaunchPage - staged participation sync', () => {
   beforeEach(() => {
     mockRouterPush.mockReset();
     mockGetCampaign.mockReset();
+    mockMaterializeCampaignMissionEncounter.mockReset().mockResolvedValue({
+      encounterId: 'encounter-solo-1',
+      reused: false,
+      missionScenarioIds: ['encounter-solo-1'],
+    });
+    mockUpdateCampaign.mockReset();
+    mockSaveCampaign.mockReset();
+    mockAddMission.mockReset();
     mockLaunchCoopMission.mockReset().mockReturnValue({
       ok: true,
       gameSessionId: 'game-session-coop-1',
@@ -166,11 +195,11 @@ describe('CoopMissionLaunchPage - staged participation sync', () => {
       ]),
     );
     expect(mockRouterPush).toHaveBeenCalledWith(
-      '/gameplay/encounters/encounter-coop-1',
+      '/gameplay/encounters/encounter-coop-1?campaignId=campaign-coop-1&missionId=mission-alpha',
     );
   });
 
-  it('keeps non-co-op launch on the direct encounter route', async () => {
+  it('materializes non-co-op mission launch before routing to the encounter', async () => {
     const campaign = {
       ...createCampaign('Solo Launch Probe', 'mercenary'),
       id: 'campaign-coop-1',
@@ -186,8 +215,16 @@ describe('CoopMissionLaunchPage - staged participation sync', () => {
     });
 
     expect(mockLaunchCoopMission).not.toHaveBeenCalled();
-    expect(mockRouterPush).toHaveBeenCalledWith(
-      '/gameplay/encounters/mission-alpha',
-    );
+    await waitFor(() => {
+      expect(mockMaterializeCampaignMissionEncounter).toHaveBeenCalledWith(
+        expect.objectContaining({
+          campaign,
+          missionId: 'mission-alpha',
+        }),
+      );
+      expect(mockRouterPush).toHaveBeenCalledWith(
+        '/gameplay/encounters/encounter-solo-1?campaignId=campaign-coop-1&missionId=mission-alpha',
+      );
+    });
   });
 });

--- a/src/components/ui/PageLayout.tsx
+++ b/src/components/ui/PageLayout.tsx
@@ -22,6 +22,7 @@ interface PageLayoutProps {
   onBack?: () => void;
   headerContent?: React.ReactNode;
   gradient?: boolean;
+  'data-testid'?: string;
 }
 
 const maxWidthClasses: Record<string, string> = {
@@ -42,6 +43,7 @@ export function PageLayout({
   onBack,
   headerContent,
   gradient = false,
+  'data-testid': testId,
 }: PageLayoutProps): React.ReactElement {
   const bgClasses = gradient
     ? 'min-h-screen bg-gradient-to-br from-surface-deep via-surface-base to-surface-deep'
@@ -73,7 +75,7 @@ export function PageLayout({
   const showBackLink = !breadcrumbs && (normalizedBackLink || onBack);
 
   return (
-    <div className={`${bgClasses} p-6`}>
+    <div className={`${bgClasses} p-6`} data-testid={testId}>
       <div className={`${maxWidthClasses[maxWidth]} mx-auto`}>
         {/* Breadcrumb navigation - replaces backLink when provided */}
         {breadcrumbs && breadcrumbs.length > 0 && (

--- a/src/lib/campaign/encounter/__tests__/materializeCampaignMissionEncounter.test.ts
+++ b/src/lib/campaign/encounter/__tests__/materializeCampaignMissionEncounter.test.ts
@@ -1,0 +1,242 @@
+import type { ICampaign } from '@/types/campaign/Campaign';
+import type { IRosterUnitProjection } from '@/types/campaign/RosterUnitProjection';
+
+import { materializeCampaignMissionEncounter } from '@/lib/campaign/encounter/materializeCampaignMissionEncounter';
+import { MissionStatus } from '@/types/campaign/enums/MissionStatus';
+import { createContract } from '@/types/campaign/Mission';
+import {
+  disableDiagnosticCapture,
+  enableDiagnosticCapture,
+  getCapturedDiagnostics,
+} from '@/utils/logger';
+
+type FetchCall = {
+  readonly url: string;
+  readonly init?: RequestInit;
+};
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => payload,
+  } as Response;
+}
+
+function requestUrl(input: Parameters<typeof fetch>[0]): string {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.toString();
+  return (input as { readonly url?: string }).url ?? String(input);
+}
+
+function requestBody(call: FetchCall): unknown {
+  return JSON.parse(String(call.init?.body ?? '{}')) as unknown;
+}
+
+function makeCampaign(
+  scenarioIds: readonly string[] = [],
+): Pick<ICampaign, 'id' | 'name' | 'missions'> {
+  const mission = createContract({
+    id: 'contract-1',
+    name: 'Border Raid',
+    employerId: 'davion',
+    targetId: 'liao',
+    status: MissionStatus.ACTIVE,
+    scenarioIds: [...scenarioIds],
+    description: 'Raid across the border.',
+  });
+  return {
+    id: 'campaign-1',
+    name: 'Gray Dawn',
+    missions: new Map([[mission.id, mission]]),
+  };
+}
+
+function makeRoster(): readonly IRosterUnitProjection[] {
+  return [
+    {
+      unitId: 'wizard-light-1',
+      unitName: 'Light Mech',
+      chassisVariant: 'Light Mech',
+      readiness: 'Ready',
+    },
+  ];
+}
+
+describe('materializeCampaignMissionEncounter', () => {
+  beforeEach(() => {
+    enableDiagnosticCapture();
+  });
+
+  afterEach(() => {
+    disableDiagnosticCapture(true);
+  });
+
+  it('reuses an existing mission scenario encounter when it still exists', async () => {
+    const calls: FetchCall[] = [];
+    const fetchImpl = jest.fn(async (input, init) => {
+      calls.push({ url: requestUrl(input), init });
+      return jsonResponse({ encounter: { id: 'enc-existing' } });
+    }) as unknown as typeof fetch;
+
+    const result = await materializeCampaignMissionEncounter({
+      campaign: makeCampaign(['enc-existing']),
+      missionId: 'contract-1',
+      rosterUnits: makeRoster(),
+      fetchImpl,
+    });
+
+    expect(result).toEqual({
+      encounterId: 'enc-existing',
+      reused: true,
+      missionScenarioIds: ['enc-existing'],
+    });
+    expect(calls.map((call) => call.url)).toEqual([
+      '/api/encounters/enc-existing',
+    ]);
+    expect(getCapturedDiagnostics()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          service: 'campaign-encounter-materializer',
+          event: 'campaign_mission_encounter_reused',
+          level: 'info',
+          entityIds: expect.objectContaining({
+            campaignId: 'campaign-1',
+            missionId: 'contract-1',
+            encounterId: 'enc-existing',
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it('creates assigned forces and a configured encounter for an organic mission', async () => {
+    const calls: FetchCall[] = [];
+    let forceCount = 0;
+    const fetchImpl = jest.fn(async (input, init) => {
+      const call = { url: requestUrl(input), init };
+      calls.push(call);
+      if (call.url === '/api/forces' && init?.method === 'POST') {
+        forceCount += 1;
+        return jsonResponse(
+          {
+            success: true,
+            id: `force-${forceCount}`,
+            force: {
+              id: `force-${forceCount}`,
+              assignments: [{ id: `assignment-${forceCount}` }],
+            },
+          },
+          201,
+        );
+      }
+      if (call.url.startsWith('/api/forces/assignments/')) {
+        return jsonResponse({ success: true });
+      }
+      if (call.url === '/api/encounters' && init?.method === 'POST') {
+        return jsonResponse(
+          {
+            success: true,
+            id: 'enc-organic',
+            encounter: { id: 'enc-organic' },
+          },
+          201,
+        );
+      }
+      if (call.url === '/api/encounters/enc-organic') {
+        return jsonResponse({ success: true });
+      }
+      if (
+        call.url === '/api/encounters/enc-organic/player-force' ||
+        call.url === '/api/encounters/enc-organic/opponent-force'
+      ) {
+        return jsonResponse({ success: true });
+      }
+      throw new Error(`Unexpected fetch: ${init?.method ?? 'GET'} ${call.url}`);
+    }) as unknown as typeof fetch;
+
+    const result = await materializeCampaignMissionEncounter({
+      campaign: makeCampaign(),
+      missionId: 'contract-1',
+      rosterUnits: makeRoster(),
+      fetchImpl,
+    });
+
+    expect(result).toEqual({
+      encounterId: 'enc-organic',
+      reused: false,
+      missionScenarioIds: ['enc-organic'],
+    });
+    expect(
+      calls.map((call) => `${call.init?.method ?? 'GET'} ${call.url}`),
+    ).toEqual([
+      'POST /api/forces',
+      'PUT /api/forces/assignments/assignment-1',
+      'POST /api/forces',
+      'PUT /api/forces/assignments/assignment-2',
+      'POST /api/encounters',
+      'PATCH /api/encounters/enc-organic',
+      'PUT /api/encounters/enc-organic/player-force',
+      'PUT /api/encounters/enc-organic/opponent-force',
+    ]);
+    expect(requestBody(calls[1])).toEqual({ unitId: 'atlas-as7-d' });
+    expect(requestBody(calls[3])).toEqual({ unitId: 'marauder-mad-3r' });
+    expect(requestBody(calls[6])).toEqual({ forceId: 'force-1' });
+    expect(requestBody(calls[7])).toEqual({ forceId: 'force-2' });
+    expect(getCapturedDiagnostics()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          service: 'campaign-encounter-materializer',
+          event: 'campaign_mission_encounter_materialized',
+          level: 'info',
+          entityIds: expect.objectContaining({
+            campaignId: 'campaign-1',
+            missionId: 'contract-1',
+            encounterId: 'enc-organic',
+            playerForceId: 'force-1',
+            opponentForceId: 'force-2',
+          }),
+          metadata: expect.objectContaining({
+            rosterUnitCount: 1,
+            missionScenarioIds: ['enc-organic'],
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it('captures a diagnostic failure when an API call rejects the launch', async () => {
+    const fetchImpl = jest.fn(async () =>
+      jsonResponse({ success: false, error: 'Force creation rejected' }, 400),
+    ) as unknown as typeof fetch;
+
+    await expect(
+      materializeCampaignMissionEncounter({
+        campaign: makeCampaign(),
+        missionId: 'contract-1',
+        rosterUnits: makeRoster(),
+        fetchImpl,
+      }),
+    ).rejects.toThrow('Force creation rejected');
+
+    expect(getCapturedDiagnostics()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          service: 'campaign-encounter-materializer',
+          event: 'campaign_mission_encounter_failed',
+          level: 'error',
+          entityIds: expect.objectContaining({
+            campaignId: 'campaign-1',
+            missionId: 'contract-1',
+          }),
+          metadata: expect.objectContaining({
+            rosterUnitCount: 1,
+          }),
+          error: expect.objectContaining({
+            message: 'Force creation rejected',
+          }),
+        }),
+      ]),
+    );
+  });
+});

--- a/src/lib/campaign/encounter/materializeCampaignMissionEncounter.ts
+++ b/src/lib/campaign/encounter/materializeCampaignMissionEncounter.ts
@@ -1,0 +1,349 @@
+import type { ICampaign } from '@/types/campaign/Campaign';
+import type { IMission } from '@/types/campaign/Mission';
+import type { IRosterUnitProjection } from '@/types/campaign/RosterUnitProjection';
+import type { IForce } from '@/types/force';
+
+import { TerrainPreset, VictoryConditionType } from '@/types/encounter';
+import { ForceType } from '@/types/force';
+import { logger } from '@/utils/logger';
+
+type FetchImpl = typeof fetch;
+
+type CampaignMissionSource = Pick<ICampaign, 'id' | 'name' | 'missions'>;
+
+interface ApiFailurePayload {
+  readonly error?: string;
+  readonly message?: string;
+  readonly success?: boolean;
+}
+
+interface ForceApiResponse extends ApiFailurePayload {
+  readonly id?: string;
+  readonly force?: Pick<IForce, 'id' | 'assignments'>;
+}
+
+interface EncounterApiResponse extends ApiFailurePayload {
+  readonly id?: string;
+  readonly encounter?: {
+    readonly id: string;
+  };
+}
+
+export interface MaterializeCampaignMissionEncounterInput {
+  readonly campaign: CampaignMissionSource;
+  readonly missionId: string;
+  readonly rosterUnits: readonly IRosterUnitProjection[];
+  readonly fetchImpl?: FetchImpl;
+}
+
+export interface MaterializeCampaignMissionEncounterResult {
+  readonly encounterId: string;
+  readonly reused: boolean;
+  readonly missionScenarioIds: readonly string[];
+}
+
+const DEFAULT_PLAYER_UNIT_REF = 'atlas-as7-d';
+const DEFAULT_OPPONENT_UNIT_REF = 'marauder-mad-3r';
+
+const CANONICAL_UNIT_REFS = new Set([
+  DEFAULT_PLAYER_UNIT_REF,
+  DEFAULT_OPPONENT_UNIT_REF,
+]);
+
+const MATERIALIZER_LOG_SERVICE = 'campaign-encounter-materializer';
+
+function apiJsonHeaders(): HeadersInit {
+  return { 'Content-Type': 'application/json' };
+}
+
+function messageFromPayload(payload: unknown, fallback: string): string {
+  if (!payload || typeof payload !== 'object') return fallback;
+  const candidate = payload as ApiFailurePayload;
+  return candidate.error ?? candidate.message ?? fallback;
+}
+
+async function readApiJson<T>(
+  response: Response,
+  fallback: string,
+): Promise<T> {
+  let payload: unknown = null;
+  try {
+    payload = await response.json();
+  } catch {
+    payload = null;
+  }
+  if (!response.ok) {
+    throw new Error(messageFromPayload(payload, fallback));
+  }
+  return payload as T;
+}
+
+function assertOperationSuccess(
+  payload: ApiFailurePayload,
+  fallback: string,
+): void {
+  if (payload.success === false) {
+    throw new Error(messageFromPayload(payload, fallback));
+  }
+}
+
+async function encounterExists(
+  encounterId: string,
+  fetchImpl: FetchImpl,
+): Promise<boolean> {
+  const response = await fetchImpl(
+    `/api/encounters/${encodeURIComponent(encounterId)}`,
+  );
+  if (response.ok) return true;
+  if (response.status === 404) return false;
+  await readApiJson(response, 'Failed to check existing encounter');
+  return false;
+}
+
+function selectPlayerUnitRef(
+  rosterUnits: readonly IRosterUnitProjection[],
+): string {
+  const rosterUnit =
+    rosterUnits.find((unit) => unit.readiness === 'Ready') ?? rosterUnits[0];
+  if (!rosterUnit) return DEFAULT_PLAYER_UNIT_REF;
+  if (CANONICAL_UNIT_REFS.has(rosterUnit.unitId)) return rosterUnit.unitId;
+
+  const label =
+    `${rosterUnit.unitName} ${rosterUnit.chassisVariant}`.toLowerCase();
+  if (label.includes('marauder') || label.includes('heavy')) {
+    return DEFAULT_OPPONENT_UNIT_REF;
+  }
+  return DEFAULT_PLAYER_UNIT_REF;
+}
+
+async function createAssignedForce({
+  name,
+  unitRef,
+  fetchImpl,
+}: {
+  readonly name: string;
+  readonly unitRef: string;
+  readonly fetchImpl: FetchImpl;
+}): Promise<string> {
+  const createResponse = await fetchImpl('/api/forces', {
+    method: 'POST',
+    headers: apiJsonHeaders(),
+    body: JSON.stringify({
+      name,
+      forceType: ForceType.Lance,
+    }),
+  });
+  const created = await readApiJson<ForceApiResponse>(
+    createResponse,
+    'Failed to create force',
+  );
+  assertOperationSuccess(created, 'Failed to create force');
+
+  const forceId = created.force?.id ?? created.id;
+  const assignmentId = created.force?.assignments[0]?.id;
+  if (!forceId || !assignmentId) {
+    throw new Error('Created force did not include an assignable slot');
+  }
+
+  const assignResponse = await fetchImpl(
+    `/api/forces/assignments/${encodeURIComponent(assignmentId)}`,
+    {
+      method: 'PUT',
+      headers: apiJsonHeaders(),
+      body: JSON.stringify({ unitId: unitRef }),
+    },
+  );
+  const assigned = await readApiJson<ApiFailurePayload>(
+    assignResponse,
+    'Failed to assign unit to force',
+  );
+  assertOperationSuccess(assigned, 'Failed to assign unit to force');
+  return forceId;
+}
+
+async function createConfiguredEncounter({
+  campaign,
+  mission,
+  missionId,
+  fetchImpl,
+}: {
+  readonly campaign: CampaignMissionSource;
+  readonly mission: IMission | undefined;
+  readonly missionId: string;
+  readonly fetchImpl: FetchImpl;
+}): Promise<string> {
+  const createResponse = await fetchImpl('/api/encounters', {
+    method: 'POST',
+    headers: apiJsonHeaders(),
+    body: JSON.stringify({
+      name: mission?.name ?? `Campaign Mission ${missionId}`,
+      description:
+        mission?.description ??
+        `Campaign mission ${missionId} for ${campaign.name}.`,
+    }),
+  });
+  const created = await readApiJson<EncounterApiResponse>(
+    createResponse,
+    'Failed to create encounter',
+  );
+  assertOperationSuccess(created, 'Failed to create encounter');
+
+  const encounterId = created.encounter?.id ?? created.id;
+  if (!encounterId) {
+    throw new Error('Encounter creation did not return an encounter id');
+  }
+
+  const patchResponse = await fetchImpl(
+    `/api/encounters/${encodeURIComponent(encounterId)}`,
+    {
+      method: 'PATCH',
+      headers: apiJsonHeaders(),
+      body: JSON.stringify({
+        mapConfig: {
+          radius: 8,
+          terrain: TerrainPreset.Clear,
+          playerDeploymentZone: 'south',
+          opponentDeploymentZone: 'north',
+        },
+        victoryConditions: [{ type: VictoryConditionType.DestroyAll }],
+        optionalRules: [],
+      }),
+    },
+  );
+  const patched = await readApiJson<ApiFailurePayload>(
+    patchResponse,
+    'Failed to configure encounter',
+  );
+  assertOperationSuccess(patched, 'Failed to configure encounter');
+  return encounterId;
+}
+
+async function attachEncounterForce({
+  encounterId,
+  forceId,
+  side,
+  fetchImpl,
+}: {
+  readonly encounterId: string;
+  readonly forceId: string;
+  readonly side: 'player-force' | 'opponent-force';
+  readonly fetchImpl: FetchImpl;
+}): Promise<void> {
+  const response = await fetchImpl(
+    `/api/encounters/${encodeURIComponent(encounterId)}/${side}`,
+    {
+      method: 'PUT',
+      headers: apiJsonHeaders(),
+      body: JSON.stringify({ forceId }),
+    },
+  );
+  const payload = await readApiJson<ApiFailurePayload>(
+    response,
+    `Failed to attach ${side}`,
+  );
+  assertOperationSuccess(payload, `Failed to attach ${side}`);
+}
+
+export async function materializeCampaignMissionEncounter({
+  campaign,
+  missionId,
+  rosterUnits,
+  fetchImpl = fetch,
+}: MaterializeCampaignMissionEncounterInput): Promise<MaterializeCampaignMissionEncounterResult> {
+  try {
+    const mission = campaign.missions.get(missionId);
+    for (const scenarioId of mission?.scenarioIds ?? []) {
+      if (await encounterExists(scenarioId, fetchImpl)) {
+        logger.diagnostic({
+          level: 'info',
+          service: MATERIALIZER_LOG_SERVICE,
+          event: 'campaign_mission_encounter_reused',
+          message: 'Reused an existing encounter for campaign mission launch.',
+          entityIds: {
+            campaignId: campaign.id,
+            missionId,
+            encounterId: scenarioId,
+          },
+          metadata: {
+            missionScenarioIds: mission?.scenarioIds ?? [scenarioId],
+          },
+        });
+        return {
+          encounterId: scenarioId,
+          reused: true,
+          missionScenarioIds: mission?.scenarioIds ?? [scenarioId],
+        };
+      }
+    }
+
+    const playerForceId = await createAssignedForce({
+      name: `${campaign.name} ${mission?.name ?? missionId} Lance`,
+      unitRef: selectPlayerUnitRef(rosterUnits),
+      fetchImpl,
+    });
+    const opponentForceId = await createAssignedForce({
+      name: `${mission?.name ?? 'Campaign Mission'} OpFor`,
+      unitRef: DEFAULT_OPPONENT_UNIT_REF,
+      fetchImpl,
+    });
+    const encounterId = await createConfiguredEncounter({
+      campaign,
+      mission,
+      missionId,
+      fetchImpl,
+    });
+
+    await attachEncounterForce({
+      encounterId,
+      forceId: playerForceId,
+      side: 'player-force',
+      fetchImpl,
+    });
+    await attachEncounterForce({
+      encounterId,
+      forceId: opponentForceId,
+      side: 'opponent-force',
+      fetchImpl,
+    });
+
+    logger.diagnostic({
+      level: 'info',
+      service: MATERIALIZER_LOG_SERVICE,
+      event: 'campaign_mission_encounter_materialized',
+      message: 'Created a playable encounter for campaign mission launch.',
+      entityIds: {
+        campaignId: campaign.id,
+        missionId,
+        encounterId,
+        playerForceId,
+        opponentForceId,
+      },
+      metadata: {
+        rosterUnitCount: rosterUnits.length,
+        missionScenarioIds: [encounterId, ...(mission?.scenarioIds ?? [])],
+      },
+    });
+
+    return {
+      encounterId,
+      reused: false,
+      missionScenarioIds: [encounterId, ...(mission?.scenarioIds ?? [])],
+    };
+  } catch (error) {
+    logger.diagnostic({
+      level: 'error',
+      service: MATERIALIZER_LOG_SERVICE,
+      event: 'campaign_mission_encounter_failed',
+      message: 'Failed to materialize a campaign mission encounter.',
+      entityIds: {
+        campaignId: campaign.id,
+        missionId,
+      },
+      metadata: {
+        rosterUnitCount: rosterUnits.length,
+      },
+      error,
+    });
+    throw error;
+  }
+}

--- a/src/pages/gameplay/campaigns/[id]/missions/[missionId]/launch.tsx
+++ b/src/pages/gameplay/campaigns/[id]/missions/[missionId]/launch.tsx
@@ -26,6 +26,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import type { ICampaign } from '@/types/campaign/Campaign';
 import type { CoopParticipationChoice } from '@/types/campaign/CoopCampaign';
 import type { IForce } from '@/types/campaign/Force';
+import type { IMission } from '@/types/campaign/Mission';
 import type { IEncounter } from '@/types/encounter';
 
 import { CampaignNavigation } from '@/components/campaign/CampaignNavigation';
@@ -39,7 +40,8 @@ import {
   publishCoopParticipation,
   subscribeCoopParticipation,
 } from '@/lib/campaign/coop/coopRuntimeSession';
-import { launchCoopMission } from '@/lib/campaign/coop/launchCoopMission';
+import { materializeCampaignMissionEncounter } from '@/lib/campaign/encounter/materializeCampaignMissionEncounter';
+import { useCampaignRosterStore } from '@/stores/campaign/useCampaignRosterStore';
 import { useCampaignStore } from '@/stores/campaign/useCampaignStore';
 import { ForceRole, FormationLevel } from '@/types/campaign/enums';
 import { EncounterStatus, TerrainPreset } from '@/types/encounter';
@@ -47,6 +49,21 @@ import { EncounterStatus, TerrainPreset } from '@/types/encounter';
 function routeParam(value: string | string[] | undefined): string | null {
   if (Array.isArray(value)) return value[0] ?? null;
   return value ?? null;
+}
+
+function campaignEncounterHref({
+  encounterId,
+  campaignId,
+  missionId,
+}: {
+  readonly encounterId: string;
+  readonly campaignId: string;
+  readonly missionId: string;
+}): string {
+  const params = new URLSearchParams({ campaignId, missionId });
+  return `/gameplay/encounters/${encodeURIComponent(
+    encounterId,
+  )}?${params.toString()}`;
 }
 
 function fallbackRootForce(campaign: ICampaign): IForce {
@@ -103,9 +120,21 @@ function buildLaunchEncounter(
   };
 }
 
+function withMissionScenario(mission: IMission, encounterId: string): IMission {
+  if (mission.scenarioIds.includes(encounterId)) {
+    return mission;
+  }
+  return {
+    ...mission,
+    scenarioIds: [encounterId, ...mission.scenarioIds],
+    updatedAt: new Date().toISOString(),
+  };
+}
+
 export default function CoopMissionLaunchPage(): React.ReactElement {
   const router = useRouter();
   const { id: campaignId, missionId } = router.query;
+  const campaignKey = routeParam(campaignId);
   const missionKey = routeParam(missionId);
 
   const store = useCampaignStore();
@@ -127,6 +156,7 @@ export default function CoopMissionLaunchPage(): React.ReactElement {
     readonly ICoopParticipationRecord[]
   >([]);
   const [launchError, setLaunchError] = useState<string | null>(null);
+  const [isLaunching, setIsLaunching] = useState(false);
   useEffect(() => {
     setIsClient(true);
   }, []);
@@ -179,8 +209,8 @@ export default function CoopMissionLaunchPage(): React.ReactElement {
   );
   const otherChoice = otherRecord?.choice;
 
-  const handleLaunch = useCallback(() => {
-    if (!campaignId || !missionKey) {
+  const handleLaunch = useCallback(async () => {
+    if (!campaignKey || !missionKey) {
       return;
     }
     if (campaign?.coopSession) {
@@ -201,10 +231,22 @@ export default function CoopMissionLaunchPage(): React.ReactElement {
         force: entry.force,
         participation: entry.choice,
       }));
-      const result = launchCoopMission(
-        buildLaunchEncounter(campaign, missionKey),
-        contributions,
-      );
+      let result;
+      try {
+        const { launchCoopMission } =
+          await import('@/lib/campaign/coop/launchCoopMission');
+        result = launchCoopMission(
+          buildLaunchEncounter(campaign, missionKey),
+          contributions,
+        );
+      } catch (error) {
+        setLaunchError(
+          error instanceof Error
+            ? error.message
+            : 'Failed to load co-op launch runtime',
+        );
+        return;
+      }
       if (!result.ok) {
         setLaunchError(result.error);
         return;
@@ -212,22 +254,56 @@ export default function CoopMissionLaunchPage(): React.ReactElement {
       setLaunchError(null);
       if (localChoice === 'deploy') {
         void router.push(
-          `/gameplay/encounters/${encodeURIComponent(
-            result.encounterId ?? missionKey,
-          )}`,
+          campaignEncounterHref({
+            encounterId: result.encounterId ?? missionKey,
+            campaignId: campaign.id,
+            missionId: missionKey,
+          }),
         );
         return;
       }
       void router.push(`/gameplay/campaigns/${campaign.id}`);
       return;
     }
-    // Re-enter the encounter URL so the player who chose `deploy` lands
-    // on the tactical map; the `command-hq` chooser stays on the
-    // campaign side (handled by the encounter page's own coop guard).
-    void router.push(`/gameplay/encounters/${missionKey}`);
+
+    if (!campaign) {
+      return;
+    }
+
+    setIsLaunching(true);
+    setLaunchError(null);
+    try {
+      const result = await materializeCampaignMissionEncounter({
+        campaign,
+        missionId: missionKey,
+        rosterUnits: useCampaignRosterStore.getState().getDeployableUnits(),
+      });
+      const mission = campaign.missions.get(missionKey);
+      if (mission) {
+        const nextMission = withMissionScenario(mission, result.encounterId);
+        const missions = new Map(campaign.missions);
+        missions.set(missionKey, nextMission);
+        store.getState().updateCampaign({ missions });
+        store.getState().getMissionsStore()?.getState().addMission(nextMission);
+        store.getState().saveCampaign();
+      }
+      await router.push(
+        campaignEncounterHref({
+          encounterId: result.encounterId,
+          campaignId: campaignKey,
+          missionId: missionKey,
+        }),
+      );
+    } catch (error) {
+      setLaunchError(
+        error instanceof Error ? error.message : 'Failed to launch mission',
+      );
+    } finally {
+      setIsLaunching(false);
+    }
   }, [
     campaign,
-    campaignId,
+    campaignKey,
     localChoice,
     localForce,
     localPlayerId,
@@ -235,6 +311,7 @@ export default function CoopMissionLaunchPage(): React.ReactElement {
     missionKey,
     otherRecord,
     router,
+    store,
   ]);
 
   if (!isClient) {
@@ -276,13 +353,27 @@ export default function CoopMissionLaunchPage(): React.ReactElement {
           coopSession={campaign.coopSession}
         />
         <div className="mt-6">
+          {launchError ? (
+            <p
+              role="alert"
+              data-testid="mission-launch-error"
+              className="mb-3 text-sm text-rose-300"
+            >
+              {launchError}
+            </p>
+          ) : null}
           <button
             type="button"
             data-testid="launch-mission-direct"
+            disabled={isLaunching}
             onClick={handleLaunch}
-            className="rounded-lg border border-sky-500/60 bg-sky-600/20 px-4 py-2 font-semibold text-sky-100"
+            className={
+              isLaunching
+                ? 'cursor-wait rounded-lg border border-slate-700 bg-slate-900/40 px-4 py-2 font-semibold text-slate-500'
+                : 'rounded-lg border border-sky-500/60 bg-sky-600/20 px-4 py-2 font-semibold text-sky-100'
+            }
           >
-            Launch mission
+            {isLaunching ? 'Launching mission...' : 'Launch mission'}
           </button>
         </div>
       </PageLayout>

--- a/src/pages/gameplay/encounters/[id].tsx
+++ b/src/pages/gameplay/encounters/[id].tsx
@@ -32,9 +32,45 @@ import { usePilotSelector } from '@/stores/usePilotStore';
 import { EncounterStatus } from '@/types/encounter';
 import { logger } from '@/utils/logger';
 
+type RouteQueryValue = string | string[] | undefined;
+
+function routeQueryValue(value: RouteQueryValue): string | null {
+  const candidate = Array.isArray(value) ? value[0] : value;
+  if (typeof candidate !== 'string') {
+    return null;
+  }
+  const trimmed = candidate.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function buildEncounterPreBattleHref(
+  encounterId: string,
+  query: {
+    readonly campaignId?: RouteQueryValue;
+    readonly missionId?: RouteQueryValue;
+  },
+): string {
+  const params = new URLSearchParams();
+  const campaignId = routeQueryValue(query.campaignId);
+  const missionId = routeQueryValue(query.missionId);
+
+  if (campaignId) {
+    params.set('campaignId', campaignId);
+  }
+  if (missionId) {
+    params.set('missionId', missionId);
+  }
+
+  const suffix = params.toString();
+  const path = `/gameplay/encounters/${encodeURIComponent(
+    encounterId,
+  )}/pre-battle`;
+  return suffix ? `${path}?${suffix}` : path;
+}
+
 export default function EncounterDetailPage(): React.ReactElement {
   const router = useRouter();
-  const { id } = router.query;
+  const { id, campaignId, missionId } = router.query;
   const { showToast } = useToast();
 
   const getEncounter = useEncounterSelector((state) => state.getEncounter);
@@ -89,8 +125,10 @@ export default function EncounterDetailPage(): React.ReactElement {
       return;
     }
 
-    void router.push(`/gameplay/encounters/${id}/pre-battle`);
-  }, [id, router]);
+    void router.push(
+      buildEncounterPreBattleHref(id, { campaignId, missionId }),
+    );
+  }, [campaignId, id, missionId, router]);
 
   const handleDelete = useCallback(async () => {
     if (!id || typeof id !== 'string') {


### PR DESCRIPTION
## Summary
- materialize campaign contract missions into real encounter records before routing to combat
- persist the materialized encounter id back onto mission scenarioIds and preserve campaign/mission query context through encounter detail and pre-battle
- add diagnostic logs for campaign mission encounter reuse, creation, and failure paths
- extend unit and browser coverage for organic contract launch and encounter combat continuity

## Verification
- npm.cmd run verify:rules
- npm.cmd run electron:test:build
- npm.cmd run verify:qc
- npm.cmd run verify:qc:campaign-economy:browser
- npm.cmd run verify:qc:encounter-combat-continuity
- npm.cmd run typecheck -- --pretty false

## Notes
- Local Electron build validates Windows packaging and configuration; mac/linux packaging remains CI-owned on non-Windows runners.
- Existing environment warnings remain non-blocking: stale baseline-browser-mapping, dev-only in-memory match store, deprecated legacy Link, and viewport meta in _document.