### PR TITLE
Prove app routes recover beyond page loads

### DIFF
--- a/docs/qc/mekstation-qc-map.md
+++ b/docs/qc/mekstation-qc-map.md
@@ -146,12 +146,15 @@ flowchart TD
 1. `app-shell-navigation`
    - Wave 1 adds `verify:qc:app-shell` as the focused Chromium gate for
      primary route deep links, refresh recovery, shell chrome, route anchors,
-     critical console/page/network failures, settings hash navigation, and the
-     desktop History -> Replay Library route contract.
+     route-specific controls, empty/list state affordances, critical
+     console/page/network failures, settings hash navigation, and the desktop
+     History -> Replay Library route contract.
    - 2026-06-24 `verify:qc:app-shell` passed 17 checks and caught two real
      app-shell regressions before this lane moved forward: `/units` imported
      the unit-card barrel and leaked SQLite code into the browser, and
-     `/compare` logged reload-aborted catalog fetches as failures.
+     `/compare` logged reload-aborted catalog fetches as failures. The strict
+     route proof now also asserts each primary page exposes its expected
+     controls or empty/list recovery state after direct navigation and refresh.
    - Dynamic generated-ID session recovery is intentionally left to the
      campaign, combat continuity, multiplayer, and replay lanes where seeded
      state can prove recovery without weakening this static route sweep.

--- a/docs/qc/mekstation-qc-registry.json
+++ b/docs/qc/mekstation-qc-registry.json
@@ -53,7 +53,7 @@
       "evidence": [
         "docs/audits/2026-06-12-full-codebase-review.md",
         "2026-06-23 Chromium browser smoke passed `npx.cmd playwright test --project=chromium e2e/game.spec.ts --grep \"Game List Page\"`: `/gameplay/games` returned 200 and game-list navigation/new-game/empty-state checks passed after MatchLogService initializes SQLite on first server-side read.",
-        "2026-06-24 `npm.cmd run verify:qc:app-shell` passed 17 Chromium route/deep-link/refresh checks across dashboard, gameplay hub, quick game, pilots, forces, campaigns, encounters, games, compendium, custom units, customizer, compare, multiplayer, audit timeline, replay library, settings hash deep link, and desktop History -> Replay Library navigation. The proof caught and fixed `/units` browser SQLite leakage through the unit-card barrel import and `/compare` reload-abort logging.",
+        "2026-06-24 `npm.cmd run verify:qc:app-shell` passed 17 Chromium route/deep-link/refresh checks across dashboard, gameplay hub, quick game, pilots, forces, campaigns, encounters, games, compendium, custom units, customizer, compare, multiplayer, audit timeline, replay library, settings hash deep link, and desktop History -> Replay Library navigation. The proof now asserts route-specific controls plus empty/list state affordances after direct navigation and refresh, and previously caught `/units` browser SQLite leakage through the unit-card barrel import plus `/compare` reload-abort logging.",
         "Archived OpenSpec change 2026-06-21-fix-navigation-and-playability-deadends retired from activeChangeRefs on 2026-06-23.",
         "Archived OpenSpec change 2026-06-21-harden-desktop-and-api-security retired from activeChangeRefs on 2026-06-23."
       ],

--- a/e2e/app-shell-route-proof.spec.ts
+++ b/e2e/app-shell-route-proof.spec.ts
@@ -1,11 +1,24 @@
 import { expect, test, type Page } from '@playwright/test';
 
+type RouteRole = Parameters<Page['getByRole']>[0];
+
+interface RouteAffordance {
+  readonly label: string;
+  readonly role?: RouteRole;
+  readonly name?: string | RegExp;
+  readonly testId?: string | RegExp;
+  readonly selector?: string;
+  readonly text?: string | RegExp;
+}
+
 interface RouteProof {
   readonly path: string;
   readonly label: string;
   readonly pageTitle?: string;
   readonly heading?: string | RegExp;
   readonly text?: string | RegExp;
+  readonly affordances?: readonly RouteAffordance[];
+  readonly stateAffordances?: readonly RouteAffordance[];
 }
 
 interface RouteMonitor {
@@ -18,45 +31,214 @@ const primaryRoutes: readonly RouteProof[] = [
     label: 'dashboard',
     heading: /MekStation/i,
     text: /Compendium|Unit Builder|Gameplay/i,
+    affordances: [
+      { label: 'browse menu', role: 'button', name: /Browse/i },
+      { label: 'tools menu', role: 'button', name: /Tools/i },
+      { label: 'gameplay menu', role: 'button', name: /Gameplay/i },
+      { label: 'compendium card', role: 'link', name: /Compendium/i },
+      { label: 'custom units card', role: 'link', name: /My Units/i },
+      { label: 'unit builder card', role: 'link', name: /Unit Builder/i },
+    ],
   },
-  { path: '/gameplay', label: 'gameplay hub', pageTitle: 'Gameplay' },
-  { path: '/gameplay/quick', label: 'quick game', heading: 'Quick Game' },
+  {
+    path: '/gameplay',
+    label: 'gameplay hub',
+    pageTitle: 'Gameplay',
+    affordances: [
+      { label: 'quick game route card', role: 'link', name: /Quick Game/i },
+      { label: 'campaigns route card', role: 'link', name: /Campaigns/i },
+      { label: 'encounters route card', role: 'link', name: /Encounters/i },
+      { label: 'forces route card', role: 'link', name: /Forces/i },
+    ],
+  },
+  {
+    path: '/gameplay/quick',
+    label: 'quick game',
+    heading: 'Quick Game',
+    affordances: [
+      {
+        label: 'quick game setup CTA',
+        role: 'button',
+        name: /Start Quick Game Setup/i,
+      },
+    ],
+  },
   {
     path: '/gameplay/pilots',
     label: 'pilot roster',
     pageTitle: 'Pilot Roster',
+    affordances: [
+      { label: 'pilot search', role: 'textbox', name: /Search pilots/i },
+      { label: 'create pilot CTA', role: 'button', name: /Create Pilot/i },
+      { label: 'active-only filter', role: 'button', name: /Active Only/i },
+    ],
+    stateAffordances: [
+      { label: 'pilot count state', text: /Showing \d+ pilots?/i },
+      { label: 'pilot empty state', text: /No pilots/i },
+    ],
   },
   {
     path: '/gameplay/forces',
     label: 'force roster',
     pageTitle: 'Force Roster',
+    affordances: [
+      { label: 'force search', testId: 'force-search' },
+      { label: 'create force CTA', testId: 'create-force-btn' },
+    ],
+    stateAffordances: [
+      { label: 'force empty state', testId: 'forces-empty-state' },
+      { label: 'force cards', selector: '[data-testid^="force-card-"]' },
+    ],
   },
-  { path: '/gameplay/campaigns', label: 'campaigns', pageTitle: 'Campaigns' },
+  {
+    path: '/gameplay/campaigns',
+    label: 'campaigns',
+    pageTitle: 'Campaigns',
+    affordances: [
+      { label: 'create campaign CTA', testId: 'create-campaign-btn' },
+    ],
+    stateAffordances: [
+      { label: 'campaign empty state', testId: 'campaigns-empty-state' },
+      { label: 'campaign cards', selector: '[data-testid^="campaign-card-"]' },
+    ],
+  },
   {
     path: '/gameplay/encounters',
     label: 'encounters',
     pageTitle: 'Encounters',
+    affordances: [
+      { label: 'encounter search', testId: 'encounter-search' },
+      { label: 'encounter status filter', testId: 'status-filter' },
+      { label: 'create encounter CTA', testId: 'create-encounter-btn' },
+    ],
+    stateAffordances: [
+      { label: 'encounter empty state', testId: 'encounters-empty-state' },
+      {
+        label: 'encounter cards',
+        selector: '[data-testid^="encounter-card-"]',
+      },
+    ],
   },
-  { path: '/gameplay/games', label: 'games', pageTitle: 'Games' },
-  { path: '/compendium', label: 'compendium', heading: 'COMPENDIUM' },
-  { path: '/units', label: 'custom units', pageTitle: 'Custom Units' },
-  { path: '/customizer', label: 'customizer', heading: 'No Units Open' },
-  { path: '/compare', label: 'unit comparison', pageTitle: 'Unit Comparison' },
-  { path: '/multiplayer', label: 'multiplayer', heading: 'Multiplayer' },
+  {
+    path: '/gameplay/games',
+    label: 'games',
+    pageTitle: 'Games',
+    affordances: [
+      { label: 'demo game CTA', testId: 'new-game-btn' },
+      { label: 'network lobby create', role: 'button', name: /Create Lobby/i },
+      {
+        label: 'network room code input',
+        role: 'textbox',
+        name: /Networked 1v1 room code/i,
+      },
+    ],
+    stateAffordances: [
+      { label: 'games empty state', testId: 'games-empty-state' },
+      { label: 'game cards', selector: '[data-testid^="game-card-"]' },
+    ],
+  },
+  {
+    path: '/compendium',
+    label: 'compendium',
+    heading: 'COMPENDIUM',
+    affordances: [
+      { label: 'compendium search', testId: 'compendium-search' },
+      { label: 'units section', testId: 'compendium-units-section' },
+      { label: 'equipment section', testId: 'compendium-equipment-section' },
+      { label: 'rules section', testId: 'compendium-rules-section' },
+    ],
+  },
+  {
+    path: '/units',
+    label: 'custom units',
+    pageTitle: 'Custom Units',
+    affordances: [
+      { label: 'custom unit search', role: 'textbox', name: /Search units/i },
+      { label: 'create unit CTA', role: 'link', name: /Create Unit/i },
+      { label: 'filter toggle', role: 'button', name: /Filters/i },
+    ],
+    stateAffordances: [
+      { label: 'custom unit empty state', text: /No custom units yet/i },
+      { label: 'custom unit card or row', selector: '[data-testid^="unit-"]' },
+      { label: 'custom unit table', role: 'table' },
+    ],
+  },
+  {
+    path: '/customizer',
+    label: 'customizer',
+    heading: 'No Units Open',
+    affordances: [
+      { label: 'customizer new unit CTA', role: 'button', name: /New Unit/i },
+      {
+        label: 'customizer library load CTA',
+        role: 'button',
+        name: /Load from Library/i,
+      },
+    ],
+  },
+  {
+    path: '/compare',
+    label: 'unit comparison',
+    pageTitle: 'Unit Comparison',
+    affordances: [
+      {
+        label: 'compare search',
+        role: 'textbox',
+        name: /Search units to compare/i,
+      },
+    ],
+  },
+  {
+    path: '/multiplayer',
+    label: 'multiplayer',
+    heading: 'Multiplayer',
+    affordances: [
+      {
+        label: 'vault identity recovery link',
+        role: 'link',
+        name: /Set up vault identity/i,
+      },
+      {
+        label: 'password input',
+        selector: 'input[placeholder="Vault password"]',
+      },
+      { label: 'create match heading', role: 'heading', name: /Create match/i },
+      { label: 'join match heading', role: 'heading', name: /Join match/i },
+    ],
+  },
   {
     path: '/audit/timeline',
     label: 'event timeline',
     pageTitle: 'Event Timeline',
+    affordances: [
+      { label: 'timeline refresh', role: 'button', name: /Refresh timeline/i },
+      { label: 'timeline search', role: 'textbox', name: /Search events/i },
+    ],
   },
   {
     path: '/replay-library',
     label: 'replay library',
     pageTitle: 'Replay Library',
+    affordances: [{ label: 'source filter', testId: 'source-filter' }],
+    stateAffordances: [
+      { label: 'replay empty state', testId: 'replay-library-empty' },
+      { label: 'quick game recovery CTA', testId: 'empty-state-quick-game' },
+      { label: 'encounter recovery CTA', testId: 'empty-state-encounters' },
+      { label: 'replay rows', selector: '[data-testid^="replay-row-"]' },
+    ],
   },
   {
     path: '/settings#vault',
     label: 'settings vault hash',
     pageTitle: 'Settings',
+    affordances: [
+      { label: 'vault settings panel', role: 'button', name: /Vault/i },
+      {
+        label: 'appearance settings panel',
+        role: 'button',
+        name: /Appearance/i,
+      },
+    ],
   },
 ];
 
@@ -171,6 +353,77 @@ async function expectRouteAnchor(page: Page, route: RouteProof): Promise<void> {
       })
       .toBe(true);
   }
+
+  for (const affordance of route.affordances ?? []) {
+    await expectRouteAffordance(page, affordance);
+  }
+
+  if (route.stateAffordances) {
+    await expectAnyRouteAffordance(page, route.stateAffordances);
+  }
+}
+
+function routeAffordanceLocator(page: Page, affordance: RouteAffordance) {
+  if (affordance.testId) {
+    return page.getByTestId(affordance.testId).first();
+  }
+  if (affordance.selector) {
+    return page.locator(affordance.selector).first();
+  }
+  if (affordance.role) {
+    return page
+      .getByRole(
+        affordance.role,
+        affordance.name ? { name: affordance.name } : undefined,
+      )
+      .first();
+  }
+  if (affordance.text) {
+    return page.getByText(affordance.text).first();
+  }
+  throw new Error(`Route affordance ${affordance.label} has no locator`);
+}
+
+async function routeAffordanceVisible(
+  page: Page,
+  affordance: RouteAffordance,
+): Promise<boolean> {
+  const locator = routeAffordanceLocator(page, affordance);
+  if ((await locator.count()) === 0) return false;
+  return locator.isVisible().catch(() => false);
+}
+
+async function expectRouteAffordance(
+  page: Page,
+  affordance: RouteAffordance,
+): Promise<void> {
+  await expect(
+    routeAffordanceLocator(page, affordance),
+    `Missing route affordance: ${affordance.label}`,
+  ).toBeVisible();
+}
+
+async function expectAnyRouteAffordance(
+  page: Page,
+  affordances: readonly RouteAffordance[],
+): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        for (const affordance of affordances) {
+          if (await routeAffordanceVisible(page, affordance)) {
+            return affordance.label;
+          }
+        }
+        return null;
+      },
+      {
+        message: `Expected at least one route state affordance: ${affordances
+          .map((affordance) => affordance.label)
+          .join(', ')}`,
+      },
+    )
+    .not.toBeNull();
 }
 
 async function expectShellAndRoute(


### PR DESCRIPTION
## Summary
- Strengthens `verify:qc:app-shell` from route/page-title checks into route-specific control and empty/list state proof across the 17 primary app shell routes.
- Adds reusable affordance assertions for role, test id, selector, and text-based route checkpoints after direct navigation and refresh.
- Updates the QC registry/map evidence so future app-shell reviews know this lane proves controls and recoverable state, not just page loads.

## Validation
- `npm.cmd exec -- oxfmt --check e2e/app-shell-route-proof.spec.ts docs/qc/mekstation-qc-registry.json docs/qc/mekstation-qc-map.md`
- `npm.cmd run typecheck -- --pretty false`
- `npm.cmd run verify:qc:app-shell` (17 Chromium checks passed)
- `npm.cmd run qc:validate`
- `npm.cmd run qc:lifecycle:status`
- `npm.cmd run verify:qc`
- `npm.cmd run verify:rules`

## Not Tested
- Electron package build was not rerun for this browser-only app-shell proof slice.