### PR TITLE
Prove campaign combat continuity survives reload

### DIFF
--- a/docs/qc/mekstation-qc-map.md
+++ b/docs/qc/mekstation-qc-map.md
@@ -258,11 +258,12 @@ flowchart TD
      selectors now re-project from persisted `repairQueue` and
      `salvageAllocations` when the attached projection is absent.
    - Strict browser proof now covers organic campaign creation -> rostered
-     contract acceptance -> accepted mission reload, and seeded browser proof
-     covers post-battle repair, salvage, finances, and day advance after route
-     reloads. Remaining signoff is narrower now: tactical launch ->
-     post-combat save/load, true acquisition shopping UI, and browser-driven
-     6-10 contract campaign play.
+     contract acceptance -> accepted mission reload, seeded post-battle repair,
+     salvage, finances, and day advance after route reloads, plus campaign
+     encounter launch through auto-resolve and interactive concession into
+     post-battle review reload/application. Remaining signoff is narrower now:
+     true attack-driven tactical completion save/load, true acquisition
+     shopping UI, and browser-driven 6-10 contract campaign play.
 
 1. `integration-runner-interactive-parity`
    - Runner/interactive parity is still the highest-risk combat integration

--- a/docs/qc/mekstation-qc-registry.json
+++ b/docs/qc/mekstation-qc-registry.json
@@ -200,7 +200,7 @@
       "evidence": [
         "docs/audits/2026-06-12-full-codebase-review.md",
         "2026-06-23 Chromium browser smoke passed `npx.cmd playwright test --project=chromium e2e/encounter-flow.spec.ts --grep \"@smoke\"`: force creation, encounter creation/configuration, launch affordances, auto-resolve, and game-session creation checks passed.",
-        "2026-06-24 `npm.cmd run verify:qc:encounter-combat-continuity` passed 16 focused Jest checks plus Chromium proof that a routed campaign encounter auto-resolves, preserves campaign/mission/session linkage, queues a post-battle outcome, and applies it through the review screen into `processedBattleIds`.",
+        "2026-06-24 `npm.cmd run verify:qc:encounter-combat-continuity` passed 16 focused Jest checks plus 2 Chromium proofs: routed campaign encounter auto-resolve preserves campaign/mission/session linkage, and interactive pre-battle launch reaches the tactical session, concedes through the UI, survives post-battle review reload, applies the queued outcome, and keeps `processedBattleIds` after campaign route reload.",
         "Archived OpenSpec change 2026-06-21-fix-navigation-and-playability-deadends retired from activeChangeRefs on 2026-06-23."
       ],
       "gaps": [
@@ -968,7 +968,7 @@
         "2026-06-24 `npm.cmd run verify:qc:campaign-economy:browser` passed 11 Chromium tests: strict organic contract acceptance, strict post-battle economy browser route proof, and campaign-flow smoke, covering accepted mission reload plus dashboard, repair bay, salvage, finances, and day advance after full route reloads."
       ],
       "gaps": [
-        "Strict browser proof now covers organic campaign creation -> rostered contract acceptance -> accepted mission reload, and seeded browser proof covers post-battle repair, salvage, finances, and day advance after route reloads; tactical launch -> post-combat save/load remains a separate release-signoff lane.",
+        "Strict browser proof now covers organic campaign creation -> rostered contract acceptance -> accepted mission reload, seeded post-battle repair/salvage/finances/day-advance route reloads, and campaign encounter launch through auto-resolve plus interactive concession into post-battle review reload/application; true attack-driven tactical completion save/load remains a separate release-signoff lane.",
         "Acquisition contracts and processors are covered by focused tests; true shopping/acquisition browser UI remains a follow-up lane.",
         "Long-campaign stability is now protected by a dedicated QC surface; browser-driven 6-10 contract campaign signoff remains a separate UI lane."
       ]

--- a/e2e/encounter-combat-continuity.spec.ts
+++ b/e2e/encounter-combat-continuity.spec.ts
@@ -2,9 +2,9 @@
  * Strict encounter -> combat -> campaign continuity proof.
  *
  * This supplements the broader encounter smoke tests with a non-optional path:
- * a seeded campaign mission launches through the real pre-battle UI, auto
- * resolves, queues a campaign outcome, and applies that outcome from the
- * post-battle review screen.
+ * seeded campaign missions launch through the real pre-battle UI, queue
+ * campaign outcomes from both auto-resolve and interactive play, and apply
+ * those outcomes from the post-battle review screen.
  *
  * @tags @campaign @encounter @combat @smoke
  */
@@ -37,6 +37,13 @@ interface ContinuityProof {
     readonly scenarioId: string;
   }[];
   readonly processedBattleIds: readonly string[];
+}
+
+interface CampaignEncounterContext {
+  readonly campaignId: string;
+  readonly missionId: string;
+  readonly encounterId: string;
+  readonly encounterName: string;
 }
 
 test.setTimeout(90_000);
@@ -116,6 +123,40 @@ async function createAssignedLance({
   return forceId!;
 }
 
+async function createCampaignEncounter(
+  page: Page,
+  label: string,
+): Promise<CampaignEncounterContext> {
+  const campaignId = await createMinimalCampaign(page);
+  const missionId = `mission-${Date.now()}-${label
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')}`;
+  const playerForceId = await createAssignedLance({
+    page,
+    forceName: `${label} Player Lance`,
+    pilotName: `${label} Player Pilot`,
+    unitId: PLAYER_UNIT_ID,
+  });
+  const opponentForceId = await createAssignedLance({
+    page,
+    forceName: `${label} Opponent Lance`,
+    pilotName: `${label} Opponent Pilot`,
+    unitId: OPPONENT_UNIT_ID,
+  });
+  const encounterName = `${label} Encounter`;
+  const encounterId = await createEncounterWithForces(
+    page,
+    encounterName,
+    playerForceId,
+    opponentForceId,
+  );
+  if (!encounterId) {
+    throw new Error(`Failed to create ${label} encounter`);
+  }
+
+  return { campaignId, missionId, encounterId, encounterName };
+}
+
 async function getContinuityProof(page: Page): Promise<ContinuityProof> {
   return page.evaluate(() => {
     const stores = (
@@ -166,29 +207,8 @@ test.describe('encounter-combat campaign continuity', () => {
       await page.goto('/gameplay');
       await waitForE2EStores(page);
 
-      const campaignId = await createMinimalCampaign(page);
-      const missionId = `mission-${Date.now()}`;
-      const playerForceId = await createAssignedLance({
-        page,
-        forceName: 'Continuity Player Lance',
-        pilotName: 'Continuity Player Pilot',
-        unitId: PLAYER_UNIT_ID,
-      });
-      const opponentForceId = await createAssignedLance({
-        page,
-        forceName: 'Continuity Opponent Lance',
-        pilotName: 'Continuity Opponent Pilot',
-        unitId: OPPONENT_UNIT_ID,
-      });
-      const encounterId = await createEncounterWithForces(
-        page,
-        'Continuity Mission Encounter',
-        playerForceId,
-        opponentForceId,
-      );
-      if (!encounterId) {
-        throw new Error('Failed to create continuity encounter');
-      }
+      const { campaignId, missionId, encounterId, encounterName } =
+        await createCampaignEncounter(page, 'Continuity Auto');
 
       await page.goto(
         `/gameplay/encounters/${encounterId}?campaignId=${campaignId}&missionId=${missionId}`,
@@ -209,7 +229,7 @@ test.describe('encounter-combat campaign continuity', () => {
       );
       await expect(
         page.getByRole('heading', {
-          name: 'Pre-Battle: Continuity Mission Encounter',
+          name: `Pre-Battle: ${encounterName}`,
         }),
       ).toBeVisible({
         timeout: 20_000,
@@ -241,7 +261,7 @@ test.describe('encounter-combat campaign continuity', () => {
       expect(queued.pendingBattleOutcomes).toContainEqual({
         matchId: queued.sessionId!,
         contractId: missionId,
-        scenarioId: encounterId!,
+        scenarioId: encounterId,
       });
 
       await page.goto(`/gameplay/games/${queued.sessionId}/review`);
@@ -261,6 +281,131 @@ test.describe('encounter-combat campaign continuity', () => {
         expect.objectContaining({ matchId: queued.sessionId }),
       );
       expect(applied.processedBattleIds).toContain(queued.sessionId);
+    },
+  );
+
+  test(
+    'interactive pre-battle launch queues, reloads, and applies a campaign outcome',
+    { tag: ['@campaign', '@encounter', '@combat', '@smoke'] },
+    async ({ page }) => {
+      await page.goto('/gameplay');
+      await waitForE2EStores(page);
+
+      const { campaignId, missionId, encounterId, encounterName } =
+        await createCampaignEncounter(page, 'Continuity Interactive');
+
+      await page.goto(
+        `/gameplay/encounters/${encounterId}?campaignId=${campaignId}&missionId=${missionId}`,
+      );
+      await expect(page.getByTestId('encounter-detail-page')).toBeVisible({
+        timeout: 20_000,
+      });
+      await page.getByTestId('launch-encounter-btn').click();
+      await page.waitForURL(
+        (url) =>
+          url.pathname === `/gameplay/encounters/${encounterId}/pre-battle` &&
+          url.searchParams.get('campaignId') === campaignId &&
+          url.searchParams.get('missionId') === missionId,
+        { timeout: 20_000 },
+      );
+      await expect(
+        page.getByRole('heading', {
+          name: `Pre-Battle: ${encounterName}`,
+        }),
+      ).toBeVisible({
+        timeout: 20_000,
+      });
+      await expect(page.getByTestId('play-manually-btn')).toBeEnabled();
+
+      await page.getByTestId('play-manually-btn').click();
+      await page.waitForURL(
+        new RegExp(
+          `/gameplay/games/[^?]+\\?campaignId=${campaignId}&missionId=${missionId}`,
+        ),
+        { timeout: 30_000 },
+      );
+      await expect(page.getByTestId('game-session')).toBeVisible({
+        timeout: 20_000,
+      });
+      await expect(page.getByTestId('tactical-action-dock')).toBeVisible({
+        timeout: 20_000,
+      });
+
+      const launched = await getContinuityProof(page);
+      expect(launched.sessionId).toBeTruthy();
+      expect(launched.config).toMatchObject({
+        campaignId,
+        contractId: missionId,
+        scenarioId: encounterId,
+        encounterId,
+      });
+      expect(launched.pendingBattleOutcomes).not.toContainEqual(
+        expect.objectContaining({ matchId: launched.sessionId }),
+      );
+
+      await expect(page.getByTestId('concede-button')).toBeEnabled();
+      await page.getByTestId('concede-button').click();
+      await expect(page.getByTestId('concede-confirm-text')).toContainText(
+        'Concede match?',
+      );
+      await page.getByTestId('concede-confirm').click();
+      await page.waitForURL(
+        new RegExp(`/gameplay/games/${launched.sessionId}/victory`),
+        { timeout: 20_000 },
+      );
+
+      await expect
+        .poll(async () => {
+          const queued = await getContinuityProof(page);
+          return queued.pendingBattleOutcomes.some(
+            (outcome) =>
+              outcome.matchId === launched.sessionId &&
+              outcome.contractId === missionId &&
+              outcome.scenarioId === encounterId,
+          );
+        })
+        .toBe(true);
+
+      await page.goto(`/gameplay/games/${launched.sessionId}/review`);
+      await expect(page.getByTestId('post-battle-review-screen')).toBeVisible({
+        timeout: 20_000,
+      });
+      await page.reload();
+      await waitForE2EStores(page);
+      await expect(page.getByTestId('post-battle-review-screen')).toBeVisible({
+        timeout: 20_000,
+      });
+
+      const queuedAfterReload = await getContinuityProof(page);
+      expect(queuedAfterReload.pendingBattleOutcomes).toContainEqual({
+        matchId: launched.sessionId!,
+        contractId: missionId,
+        scenarioId: encounterId,
+      });
+
+      await page.getByTestId('apply-outcome-cta').click();
+      await page.waitForURL(
+        new RegExp(
+          `/gameplay/campaigns/${campaignId}\\?pendingBattle=${launched.sessionId}`,
+        ),
+        { timeout: 20_000 },
+      );
+
+      const applied = await getContinuityProof(page);
+      expect(applied.pendingBattleOutcomes).not.toContainEqual(
+        expect.objectContaining({ matchId: launched.sessionId }),
+      );
+      expect(applied.processedBattleIds).toContain(launched.sessionId);
+
+      await page.reload();
+      await waitForE2EStores(page);
+      const appliedAfterReload = await getContinuityProof(page);
+      expect(appliedAfterReload.pendingBattleOutcomes).not.toContainEqual(
+        expect.objectContaining({ matchId: launched.sessionId }),
+      );
+      expect(appliedAfterReload.processedBattleIds).toContain(
+        launched.sessionId!,
+      );
     },
   );
 });


### PR DESCRIPTION
## Summary
- add a strict interactive campaign encounter browser proof that launches from pre-battle into the tactical session, concedes through the UI, reloads post-battle review, applies the outcome, and confirms processedBattleIds survives reload
- keep the existing auto-resolve continuity proof and share seeded campaign/encounter setup helpers
- update the QC map and registry to record the new coverage and keep full attack-driven tactical completion as an explicit remaining signoff lane

## Validation
- npm.cmd exec -- oxfmt --check e2e/encounter-combat-continuity.spec.ts docs/qc/mekstation-qc-map.md docs/qc/mekstation-qc-registry.json
- npm.cmd run typecheck -- --pretty false
- npm.cmd run verify:qc:encounter-combat-continuity
- npm.cmd run qc:validate
- npm.cmd run qc:lifecycle:status
- npm.cmd run qc:journeys:validate
- npm.cmd run qc:ui-flow-shell:validate
- npm.cmd run verify:qc

## Remaining explicit gap
- full attack-driven tactical battle completion into campaign post-battle application remains a separate release-signoff lane