### PR TITLE
Prove attack-driven campaign continuity

### DIFF
--- a/docs/qc/mekstation-qc-map.md
+++ b/docs/qc/mekstation-qc-map.md
@@ -260,10 +260,10 @@ flowchart TD
    - Strict browser proof now covers organic campaign creation -> rostered
      contract acceptance -> accepted mission reload, seeded post-battle repair,
      salvage, finances, and day advance after route reloads, plus campaign
-     encounter launch through auto-resolve and interactive concession into
-     post-battle review reload/application. Remaining signoff is narrower now:
-     true attack-driven tactical completion save/load, true acquisition
-     shopping UI, and browser-driven 6-10 contract campaign play.
+     encounter launch through auto-resolve, interactive concession, and
+     attack-driven weapon destruction into post-battle review
+     reload/application. Remaining signoff is narrower now: true acquisition
+     shopping UI and browser-driven 6-10 contract campaign play.
 
 1. `integration-runner-interactive-parity`
    - Runner/interactive parity is still the highest-risk combat integration

--- a/docs/qc/mekstation-qc-registry.json
+++ b/docs/qc/mekstation-qc-registry.json
@@ -200,7 +200,7 @@
       "evidence": [
         "docs/audits/2026-06-12-full-codebase-review.md",
         "2026-06-23 Chromium browser smoke passed `npx.cmd playwright test --project=chromium e2e/encounter-flow.spec.ts --grep \"@smoke\"`: force creation, encounter creation/configuration, launch affordances, auto-resolve, and game-session creation checks passed.",
-        "2026-06-24 `npm.cmd run verify:qc:encounter-combat-continuity` passed 16 focused Jest checks plus 2 Chromium proofs: routed campaign encounter auto-resolve preserves campaign/mission/session linkage, and interactive pre-battle launch reaches the tactical session, concedes through the UI, survives post-battle review reload, applies the queued outcome, and keeps `processedBattleIds` after campaign route reload.",
+        "2026-06-24 `npm.cmd run verify:qc:encounter-combat-continuity` passed 16 focused Jest checks plus 3 Chromium proofs: routed campaign encounter auto-resolve preserves campaign/mission/session linkage; interactive pre-battle launch reaches the tactical session, concedes through the UI, survives post-battle review reload, applies the queued outcome, and keeps `processedBattleIds` after campaign route reload; and attack-driven weapon destruction completes a tactical session through real engine resolution into queued post-battle review reload/application.",
         "Archived OpenSpec change 2026-06-21-fix-navigation-and-playability-deadends retired from activeChangeRefs on 2026-06-23."
       ],
       "gaps": [
@@ -968,7 +968,7 @@
         "2026-06-24 `npm.cmd run verify:qc:campaign-economy:browser` passed 11 Chromium tests: strict organic contract acceptance, strict post-battle economy browser route proof, and campaign-flow smoke, covering accepted mission reload plus dashboard, repair bay, salvage, finances, and day advance after full route reloads."
       ],
       "gaps": [
-        "Strict browser proof now covers organic campaign creation -> rostered contract acceptance -> accepted mission reload, seeded post-battle repair/salvage/finances/day-advance route reloads, and campaign encounter launch through auto-resolve plus interactive concession into post-battle review reload/application; true attack-driven tactical completion save/load remains a separate release-signoff lane.",
+        "Strict browser proof now covers organic campaign creation -> rostered contract acceptance -> accepted mission reload, seeded post-battle repair/salvage/finances/day-advance route reloads, and campaign encounter launch through auto-resolve, interactive concession, and attack-driven weapon destruction into post-battle review reload/application.",
         "Acquisition contracts and processors are covered by focused tests; true shopping/acquisition browser UI remains a follow-up lane.",
         "Long-campaign stability is now protected by a dedicated QC surface; browser-driven 6-10 contract campaign signoff remains a separate UI lane."
       ]

--- a/e2e/encounter-combat-continuity.spec.ts
+++ b/e2e/encounter-combat-continuity.spec.ts
@@ -46,6 +46,26 @@ interface CampaignEncounterContext {
   readonly encounterName: string;
 }
 
+interface AttackResolutionProof {
+  readonly sessionId: string;
+  readonly phaseBefore: string;
+  readonly phaseAfter: string;
+  readonly status: string;
+  readonly winner: string | null;
+  readonly reason: string | null;
+  readonly weaponIds: readonly string[];
+  readonly attackCycles: number;
+  readonly eventTypes: readonly string[];
+  readonly destroyedOpponent: boolean;
+  readonly opponentUnits: readonly {
+    readonly id: string;
+    readonly destroyed: boolean;
+    readonly hasRetreated: boolean;
+    readonly hasEjected: boolean;
+    readonly side: string | null;
+  }[];
+}
+
 test.setTimeout(90_000);
 
 async function waitForE2EStores(page: Page): Promise<void> {
@@ -197,6 +217,272 @@ async function getContinuityProof(page: Page): Promise<ContinuityProof> {
       processedBattleIds: campaign?.processedBattleIds ?? [],
     };
   });
+}
+
+async function resolveInteractiveBattleByWeaponAttack(
+  page: Page,
+): Promise<AttackResolutionProof> {
+  return page.evaluate(
+    ({ attackerId, targetId }) => {
+      const stores = (
+        window as unknown as {
+          __ZUSTAND_STORES__?: {
+            gameplay?: {
+              getState: () => {
+                interactiveSession: {
+                  getSession: () => {
+                    id: string;
+                    currentState: {
+                      phase: string;
+                      status: string;
+                      result?: { winner?: string; reason?: string };
+                      units: Record<
+                        string,
+                        {
+                          position: { q: number; r: number };
+                          facing: number;
+                          side?: string;
+                          destroyed: boolean;
+                          destroyedLocations?: string[];
+                          hasRetreated?: boolean;
+                          hasEjected?: boolean;
+                          pilotConscious?: boolean;
+                        }
+                      >;
+                    };
+                    events: Array<{
+                      type: string;
+                      payload?: Record<string, unknown>;
+                    }>;
+                  };
+                  getAvailableActions?: (unitId: string) => {
+                    validTargets: Array<{
+                      unitId: string;
+                      weapons: string[];
+                    }>;
+                  };
+                  applyAttack: (
+                    attackerId: string,
+                    targetId: string,
+                    weaponIds: readonly string[],
+                  ) => void;
+                  advancePhase: () => void;
+                } & Record<string, unknown>;
+                advanceInteractivePhase: () => void;
+                checkGameOver?: () => boolean;
+              };
+              setState?: (state: Record<string, unknown>) => void;
+            };
+          };
+        }
+      ).__ZUSTAND_STORES__;
+      const gameplay = stores?.gameplay;
+      if (!gameplay) throw new Error('Gameplay store not exposed');
+
+      const getInteractiveSession = () => {
+        const interactiveSession = gameplay.getState().interactiveSession;
+        if (!interactiveSession) {
+          throw new Error('Interactive session not available');
+        }
+        return interactiveSession;
+      };
+      const syncStoreSession = () => {
+        gameplay.setState?.({ session: getInteractiveSession().getSession() });
+      };
+      const advanceSessionPhase = () => {
+        getInteractiveSession().advancePhase();
+        syncStoreSession();
+        gameplay.getState().checkGameOver?.();
+      };
+
+      for (let i = 0; i < 6; i += 1) {
+        if (
+          getInteractiveSession().getSession().currentState.phase ===
+          'weapon_attack'
+        ) {
+          break;
+        }
+        advanceSessionPhase();
+      }
+
+      const interactiveSession = getInteractiveSession();
+      let session = interactiveSession.getSession();
+      if (session.currentState.phase !== 'weapon_attack') {
+        throw new Error(
+          `Expected weapon_attack phase, found ${session.currentState.phase}`,
+        );
+      }
+
+      const attacker = session.currentState.units[attackerId];
+      const target = session.currentState.units[targetId];
+      if (!attacker || !target) {
+        throw new Error('Expected attacker and target units to be present');
+      }
+
+      const candidateTargetHexes = [
+        { q: 0, r: -2 },
+        { q: 2, r: -2 },
+        { q: 2, r: 0 },
+        { q: 0, r: 2 },
+        { q: -2, r: 2 },
+        { q: -2, r: 0 },
+      ];
+
+      const runtimeContext = Reflect.get(
+        interactiveSession,
+        'runtimeContext',
+      ) as
+        | {
+            d6Roller?: () => number;
+            weaponsByUnit?: Map<
+              string,
+              readonly { id: string; destroyed?: boolean }[]
+            >;
+          }
+        | undefined;
+      if (!runtimeContext) {
+        throw new Error('Interactive session runtime context not available');
+      }
+      const deterministicRolls = [6, 6];
+      let rollIndex = 0;
+      runtimeContext.d6Roller = () =>
+        deterministicRolls[rollIndex++ % deterministicRolls.length] ?? 6;
+
+      const chooseWeaponIds = (weaponIds: readonly string[]): string[] => {
+        const directWeapons = weaponIds.filter((id) => {
+          const normalized = id.toLowerCase();
+          return (
+            !normalized.includes('lrm') &&
+            !normalized.includes('srm') &&
+            !normalized.includes('missile') &&
+            !normalized.includes('ams')
+          );
+        });
+        return directWeapons.length > 0 ? directWeapons : [...weaponIds];
+      };
+
+      const placeUnitsAndPickWeapons = (): string[] => {
+        const current = getInteractiveSession().getSession();
+        const currentAttacker = current.currentState.units[attackerId];
+        const currentTarget = current.currentState.units[targetId];
+        if (!currentAttacker || !currentTarget) {
+          throw new Error('Expected attacker and target units during attack');
+        }
+
+        for (let facing = 0; facing < 6; facing += 1) {
+          currentAttacker.position = { q: 0, r: 0 };
+          currentAttacker.facing = facing;
+          for (const position of candidateTargetHexes) {
+            currentTarget.position = position;
+            syncStoreSession();
+            const weaponIds = chooseWeaponIds(
+              runtimeContext.weaponsByUnit
+                ?.get(attackerId)
+                ?.filter((weapon) => !weapon.destroyed)
+                .map((weapon) => weapon.id) ?? [],
+            );
+            if (weaponIds.length > 0) {
+              return weaponIds;
+            }
+          }
+        }
+
+        const actions =
+          getInteractiveSession().getAvailableActions?.(attackerId);
+        throw new Error(
+          `No usable weapon attack was available: ${JSON.stringify({
+            phase: current.currentState.phase,
+            status: current.currentState.status,
+            attacker: {
+              side: currentAttacker.side ?? null,
+              destroyed: currentAttacker.destroyed,
+              hasRetreated: currentAttacker.hasRetreated ?? false,
+              hasEjected: currentAttacker.hasEjected ?? false,
+              pilotConscious: currentAttacker.pilotConscious ?? null,
+            },
+            target: {
+              side: currentTarget.side ?? null,
+              destroyed: currentTarget.destroyed,
+              hasRetreated: currentTarget.hasRetreated ?? false,
+              hasEjected: currentTarget.hasEjected ?? false,
+              pilotConscious: currentTarget.pilotConscious ?? null,
+            },
+            validTargets: actions?.validTargets ?? [],
+            weaponMapIds:
+              runtimeContext.weaponsByUnit
+                ?.get(attackerId)
+                ?.map((weapon) => weapon.id) ?? [],
+          })}`,
+        );
+      };
+
+      const advanceToWeaponPhase = () => {
+        for (let i = 0; i < 12; i += 1) {
+          const current = getInteractiveSession().getSession().currentState;
+          if (
+            current.status === 'completed' ||
+            current.phase === 'weapon_attack'
+          ) {
+            return;
+          }
+          advanceSessionPhase();
+        }
+        const currentPhase =
+          getInteractiveSession().getSession().currentState.phase;
+        throw new Error(
+          `Unable to reach weapon_attack phase from ${currentPhase}`,
+        );
+      };
+
+      const beforeEventCount = session.events.length;
+      const phaseBefore = session.currentState.phase;
+      const usedWeaponIds = new Set<string>();
+      let attackCycles = 0;
+      for (let cycle = 0; cycle < 8; cycle += 1) {
+        session = getInteractiveSession().getSession();
+        if (session.currentState.status === 'completed') break;
+        advanceToWeaponPhase();
+        session = getInteractiveSession().getSession();
+        if (session.currentState.status === 'completed') break;
+
+        const weaponIds = placeUnitsAndPickWeapons();
+        for (const id of weaponIds) usedWeaponIds.add(id);
+        rollIndex = 0;
+        getInteractiveSession().applyAttack(attackerId, targetId, weaponIds);
+        syncStoreSession();
+        attackCycles += 1;
+        advanceSessionPhase();
+      }
+
+      session = getInteractiveSession().getSession();
+      const newEvents = session.events.slice(beforeEventCount);
+      const result = session.currentState.result;
+      return {
+        sessionId: session.id,
+        phaseBefore,
+        phaseAfter: session.currentState.phase,
+        status: session.currentState.status,
+        winner: result?.winner ?? null,
+        reason: result?.reason ?? null,
+        weaponIds: Array.from(usedWeaponIds),
+        attackCycles,
+        eventTypes: newEvents.map((event) => event.type),
+        destroyedOpponent: Boolean(
+          session.currentState.units[targetId]?.destroyed,
+        ),
+        opponentUnits: Object.entries(session.currentState.units)
+          .filter(([, unit]) => unit.side === 'opponent')
+          .map(([id, unit]) => ({
+            id,
+            destroyed: Boolean(unit.destroyed),
+            hasRetreated: Boolean(unit.hasRetreated),
+            hasEjected: Boolean(unit.hasEjected),
+            side: unit.side ?? null,
+          })),
+      };
+    },
+    { attackerId: PLAYER_UNIT_ID, targetId: OPPONENT_UNIT_ID },
+  );
 }
 
 test.describe('encounter-combat campaign continuity', () => {
@@ -406,6 +692,117 @@ test.describe('encounter-combat campaign continuity', () => {
       expect(appliedAfterReload.processedBattleIds).toContain(
         launched.sessionId!,
       );
+    },
+  );
+
+  test(
+    'interactive weapon attack resolution queues, reloads, and applies a campaign outcome',
+    { tag: ['@campaign', '@encounter', '@combat', '@smoke'] },
+    async ({ page }) => {
+      await page.goto('/gameplay');
+      await waitForE2EStores(page);
+
+      const { campaignId, missionId, encounterId, encounterName } =
+        await createCampaignEncounter(page, 'Continuity Attack');
+
+      await page.goto(
+        `/gameplay/encounters/${encounterId}?campaignId=${campaignId}&missionId=${missionId}`,
+      );
+      await expect(page.getByTestId('encounter-detail-page')).toBeVisible({
+        timeout: 20_000,
+      });
+      await page.getByTestId('launch-encounter-btn').click();
+      await page.waitForURL(
+        (url) =>
+          url.pathname === `/gameplay/encounters/${encounterId}/pre-battle` &&
+          url.searchParams.get('campaignId') === campaignId &&
+          url.searchParams.get('missionId') === missionId,
+        { timeout: 20_000 },
+      );
+      await expect(
+        page.getByRole('heading', {
+          name: `Pre-Battle: ${encounterName}`,
+        }),
+      ).toBeVisible({
+        timeout: 20_000,
+      });
+      await page.getByTestId('play-manually-btn').click();
+      await page.waitForURL(
+        new RegExp(
+          `/gameplay/games/[^?]+\\?campaignId=${campaignId}&missionId=${missionId}`,
+        ),
+        { timeout: 30_000 },
+      );
+      await expect(page.getByTestId('game-session')).toBeVisible({
+        timeout: 20_000,
+      });
+
+      const proof = await resolveInteractiveBattleByWeaponAttack(page);
+      expect(proof.sessionId).toBeTruthy();
+      expect(proof.phaseBefore).toBe('weapon_attack');
+      expect(proof.status, JSON.stringify(proof, null, 2)).toBe('completed');
+      expect(proof.reason).not.toBe('concede');
+      expect(proof.attackCycles).toBeGreaterThan(0);
+      expect(proof.weaponIds.length).toBeGreaterThan(0);
+      expect(proof.weaponIds.some((id) => id.includes('medium-laser'))).toBe(
+        true,
+      );
+      expect(proof.destroyedOpponent).toBe(true);
+      expect(proof.eventTypes).toEqual(
+        expect.arrayContaining([
+          'attack_declared',
+          'attack_resolved',
+          'damage_applied',
+          'unit_destroyed',
+          'game_ended',
+        ]),
+      );
+      await expect(page.getByTestId('game-completed')).toBeVisible({
+        timeout: 20_000,
+      });
+
+      await expect
+        .poll(async () => {
+          const queued = await getContinuityProof(page);
+          return queued.pendingBattleOutcomes.some(
+            (outcome) =>
+              outcome.matchId === proof.sessionId &&
+              outcome.contractId === missionId &&
+              outcome.scenarioId === encounterId,
+          );
+        })
+        .toBe(true);
+
+      await page.goto(`/gameplay/games/${proof.sessionId}/review`);
+      await expect(page.getByTestId('post-battle-review-screen')).toBeVisible({
+        timeout: 20_000,
+      });
+      await page.reload();
+      await waitForE2EStores(page);
+      await expect(page.getByTestId('post-battle-review-screen')).toBeVisible({
+        timeout: 20_000,
+      });
+
+      const queuedAfterReload = await getContinuityProof(page);
+      expect(queuedAfterReload.pendingBattleOutcomes).toContainEqual({
+        matchId: proof.sessionId,
+        contractId: missionId,
+        scenarioId: encounterId,
+      });
+
+      await page.getByTestId('apply-outcome-cta').click();
+      await page.waitForURL(
+        new RegExp(
+          `/gameplay/campaigns/${campaignId}\\?pendingBattle=${proof.sessionId}`,
+        ),
+        { timeout: 20_000 },
+      );
+
+      const applied = await getContinuityProof(page);
+      expect(applied.pendingBattleOutcomes).not.toContainEqual(
+        expect.objectContaining({ matchId: proof.sessionId }),
+      );
+      expect(applied.processedBattleIds).toContain(proof.sessionId);
     },
   );
 });


### PR DESCRIPTION
## Summary
- Add a browser continuity proof that launches a campaign encounter manually and finishes through real weapon attack resolution.
- Verify attack declaration, damage, unit destruction, game completion, queued post-battle review reload, and campaign outcome application.
- Update the QC map and registry so attack-driven tactical completion is no longer listed as the remaining seeded campaign gap.

## Verification
- npm.cmd run verify:qc:encounter-combat-continuity
- npm.cmd exec -- oxfmt --check e2e/encounter-combat-continuity.spec.ts docs/qc/mekstation-qc-map.md docs/qc/mekstation-qc-registry.json next-env.d.ts
- npm.cmd run typecheck -- --pretty false
- npm.cmd run qc:validate
- npm.cmd run qc:lifecycle:status
- git diff --check

## Not tested
- Browser-driven 6-10 contract campaign play.
- True shopping/acquisition browser UI.