### PR TITLE
Make app shell route readiness enforceable

### DIFF
--- a/docs/qc/mekstation-qc-registry.json
+++ b/docs/qc/mekstation-qc-registry.json
@@ -9,7 +9,7 @@
       "parentId": null,
       "riskTags": ["playability", "discoverability", "regression"],
       "qualityLenses": ["usability", "ux", "functionality", "accessibility"],
-      "coverageStatus": "partial",
+      "coverageStatus": "ready-with-scope",
       "routes": [
         "/",
         "/onboarding",
@@ -53,6 +53,7 @@
       "commands": [
         "npm.cmd run lint",
         "npm.cmd run typecheck -- --pretty false",
+        "npm.cmd run qc:validate",
         "npm.cmd run verify:qc:app-shell"
       ],
       "manualChecks": [
@@ -65,10 +66,11 @@
         "2026-06-23 Chromium browser smoke passed `npx.cmd playwright test --project=chromium e2e/game.spec.ts --grep \"Game List Page\"`: `/gameplay/games` returned 200 and game-list navigation/new-game/empty-state checks passed after MatchLogService initializes SQLite on first server-side read.",
         "2026-06-24 `npm.cmd run verify:qc:app-shell` passed 28 Chromium checks across dashboard, onboarding, gameplay hub, quick game, pilots, forces, campaigns, encounters, games, repair, compendium hub/units/equipment/rules, custom units, create routes for pilots/forces/campaigns/encounters, customizer, compare, multiplayer, audit timeline, replay library, settings, settings hash deep link, desktop dropdown route alignment, and mobile bottom navigation active-state alignment. The proof asserts route-specific controls plus empty/list state affordances after direct navigation and refresh, and previously caught `/units` browser SQLite leakage through the unit-card barrel import plus `/compare` reload-abort logging.",
         "Archived OpenSpec change 2026-06-21-fix-navigation-and-playability-deadends retired from activeChangeRefs on 2026-06-23.",
-        "Archived OpenSpec change 2026-06-21-harden-desktop-and-api-security retired from activeChangeRefs on 2026-06-23."
+        "Archived OpenSpec change 2026-06-21-harden-desktop-and-api-security retired from activeChangeRefs on 2026-06-23.",
+        "2026-06-24 `npm.cmd run qc:validate` now resolves every QC registry route against `src/pages`, including dynamic and hash routes, so stale route names such as `/replays` and `/gameplay/[id]` fail before app-completion accounting."
       ],
       "gaps": [
-        "Generated-ID active-session recovery remains out of scope for the static/list route sweep and is tracked by the campaign, combat continuity, and replay recovery lanes."
+        "Generated-ID active-session recovery is intentionally covered by campaign, combat continuity, and replay recovery surfaces; app-shell scope is route identity, refresh, deep-link, empty/error states, and route-name manifest validation."
       ]
     },
     {
@@ -237,7 +239,7 @@
       ],
       "coverageStatus": "partial",
       "claimIds": ["ui.tactical"],
-      "routes": ["/gameplay/[id]", "/e2e/tactical-map"],
+      "routes": ["/gameplay/games/[id]", "/e2e/tactical-map"],
       "apis": [],
       "desktopSurfaces": [],
       "modules": [
@@ -293,7 +295,7 @@
       "qualityLenses": ["usability", "ux", "rules-parity"],
       "coverageStatus": "partial",
       "claimIds": ["ui.tactical.rules-explanation"],
-      "routes": ["/gameplay/[id]", "/e2e/tactical-map"],
+      "routes": ["/gameplay/games/[id]", "/e2e/tactical-map"],
       "apis": [],
       "desktopSurfaces": [],
       "modules": [
@@ -388,7 +390,7 @@
       "qualityLenses": ["functionality", "rules-parity", "ux"],
       "coverageStatus": "partial",
       "claimIds": ["ui.tactical.movement-preview"],
-      "routes": ["/gameplay/[id]", "/e2e/tactical-map"],
+      "routes": ["/gameplay/games/[id]", "/e2e/tactical-map"],
       "apis": [],
       "desktopSurfaces": [],
       "modules": [
@@ -437,7 +439,7 @@
       "qualityLenses": ["functionality", "rules-parity", "ux"],
       "coverageStatus": "partial",
       "claimIds": ["ui.tactical.combat-preview"],
-      "routes": ["/gameplay/[id]", "/e2e/tactical-map"],
+      "routes": ["/gameplay/games/[id]", "/e2e/tactical-map"],
       "apis": [],
       "desktopSurfaces": [],
       "modules": [
@@ -691,7 +693,7 @@
         "combat.integration.objectives",
         "combat.integration.physical-dispatch"
       ],
-      "routes": ["/gameplay/[id]"],
+      "routes": ["/gameplay/games/[id]"],
       "apis": [],
       "desktopSurfaces": [],
       "modules": [
@@ -745,7 +747,7 @@
       "qualityLenses": ["functionality", "rules-parity", "test-quality"],
       "coverageStatus": "partial",
       "claimIds": ["combat.physical-boundary"],
-      "routes": ["/gameplay/[id]"],
+      "routes": ["/gameplay/games/[id]"],
       "apis": [],
       "desktopSurfaces": [],
       "modules": [
@@ -794,7 +796,7 @@
       "qualityLenses": ["functionality", "rules-parity", "test-quality"],
       "coverageStatus": "ready-with-scope",
       "claimIds": ["combat.ejection.lifecycle"],
-      "routes": ["/gameplay/[id]"],
+      "routes": ["/gameplay/games/[id]"],
       "apis": [],
       "desktopSurfaces": [],
       "modules": [
@@ -1193,7 +1195,7 @@
       "riskTags": ["playability", "networking", "state-sync", "security"],
       "qualityLenses": ["functionality", "ux", "security", "test-quality"],
       "coverageStatus": "partial",
-      "routes": ["/gameplay/campaigns", "/gameplay/[id]"],
+      "routes": ["/gameplay/campaigns", "/gameplay/games/[id]"],
       "apis": [
         "/api/multiplayer/matches",
         "/api/multiplayer/matches/[id]",
@@ -1253,7 +1255,7 @@
       "riskTags": ["determinism", "auditability", "state-recovery"],
       "qualityLenses": ["functionality", "test-quality", "ux"],
       "coverageStatus": "partial",
-      "routes": ["/replays", "/gameplay/[id]"],
+      "routes": ["/replay-library", "/gameplay/games/[id]"],
       "apis": ["/api/replay-library/encounter"],
       "desktopSurfaces": [],
       "modules": [

--- a/scripts/__tests__/qc-registry.test.ts
+++ b/scripts/__tests__/qc-registry.test.ts
@@ -77,4 +77,27 @@ describe('QC registry validator', () => {
     );
     expect(result.stdout).toContain('2026-06-23-retired-change');
   });
+
+  it('rejects registry routes that no longer resolve to Next pages', () => {
+    const registry = readJson<{
+      surfaces: Array<{ surfaceId: string; routes: string[] }>;
+    }>(path.join(repoRoot, 'docs/qc/mekstation-qc-registry.json'));
+    const surface = registry.surfaces.find(
+      (entry) => entry.surfaceId === 'app-shell-navigation',
+    );
+    expect(surface).toBeDefined();
+    surface!.routes = ['/replays'];
+
+    const registryPath = path.join(tempDir, 'registry.json');
+    writeJson(registryPath, registry);
+
+    const result = runValidator({
+      MEKSTATION_QC_REGISTRY_PATH: registryPath,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain(
+      'app-shell-navigation: routes[0] does not resolve to a Next.js page route: /replays',
+    );
+  });
 });

--- a/scripts/qc/validate-qc-registry.mjs
+++ b/scripts/qc/validate-qc-registry.mjs
@@ -133,6 +133,7 @@ function collectRepoEntries(dir = repoRoot, prefix = '') {
 
 const repoEntries = collectRepoEntries();
 const repoEntrySet = new Set(repoEntries);
+const pageRoutePatterns = collectPageRoutePatterns();
 
 function repoReferenceExists(reference) {
   const normalized = toRepoRelativePath(reference.trim());
@@ -143,6 +144,92 @@ function repoReferenceExists(reference) {
   }
 
   return repoEntrySet.has(normalized);
+}
+
+function pathWithoutExtension(filePath) {
+  return filePath.replace(/\.(?:tsx?|jsx?)$/, '');
+}
+
+function pageRouteFromFile(filePath) {
+  const normalized = toRepoRelativePath(filePath);
+  if (!normalized.startsWith('src/pages/')) return null;
+  if (normalized.startsWith('src/pages/api/')) return null;
+  if (!/\.(?:tsx?|jsx?)$/.test(normalized)) return null;
+
+  const pagePath = pathWithoutExtension(normalized.slice('src/pages/'.length));
+  const segments = pagePath.split('/').filter(Boolean);
+  const lastSegment = segments.at(-1);
+
+  if (lastSegment === '_app' || lastSegment === '_document') return null;
+  if (lastSegment === 'index') {
+    segments.pop();
+  }
+
+  return segments.length === 0 ? '/' : `/${segments.join('/')}`;
+}
+
+function routePatternToRegex(routePattern) {
+  if (routePattern === '/') return /^\/$/;
+
+  const segments = routePattern.split('/').filter(Boolean);
+  let pattern = '^';
+
+  for (const segment of segments) {
+    if (/^\[\[\.\.\.[^\]]+\]\]$/.test(segment)) {
+      pattern += '(?:/.*)?';
+      continue;
+    }
+    if (/^\[\.\.\.[^\]]+\]$/.test(segment)) {
+      pattern += '/.+';
+      continue;
+    }
+    if (/^\[[^\]]+\]$/.test(segment)) {
+      pattern += '/[^/]+';
+      continue;
+    }
+    pattern += `/${escapeRegExp(segment)}`;
+  }
+
+  return new RegExp(`${pattern}$`);
+}
+
+function collectPageRoutePatterns() {
+  return repoEntries
+    .map(pageRouteFromFile)
+    .filter(Boolean)
+    .map((routePattern) => ({
+      routePattern,
+      matcher: routePatternToRegex(routePattern),
+    }));
+}
+
+function normalizeRouteReference(route) {
+  return route.split(/[?#]/)[0] || '/';
+}
+
+function routeReferenceExists(route) {
+  const normalized = normalizeRouteReference(route.trim());
+  return pageRoutePatterns.some(({ matcher }) => matcher.test(normalized));
+}
+
+function validateRouteReference(label, index, value, issues) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    issues.push(fail(`${label}: routes[${index}] must be a non-empty string.`));
+    return;
+  }
+
+  if (!value.startsWith('/')) {
+    issues.push(fail(`${label}: routes[${index}] must start with "/".`));
+    return;
+  }
+
+  if (!routeReferenceExists(value)) {
+    issues.push(
+      fail(
+        `${label}: routes[${index}] does not resolve to a Next.js page route: ${value}`,
+      ),
+    );
+  }
 }
 
 function validatePathReference(label, field, index, value, issues) {
@@ -259,6 +346,12 @@ function validate(registry) {
 
       for (const [pathIndex, value] of surface[field].entries()) {
         validatePathReference(label, field, pathIndex, value, issues);
+      }
+    }
+
+    if (Array.isArray(surface.routes)) {
+      for (const [routeIndex, value] of surface.routes.entries()) {
+        validateRouteReference(label, routeIndex, value, issues);
       }
     }
 


### PR DESCRIPTION
## Summary
- validates QC registry route entries against concrete Next.js pages, including dynamic and hash routes
- promotes the app-shell navigation QC surface to ready-with-scope after browser route proof and route-manifest validation
- replaces stale abstract route labels like /replays and /gameplay/[id] with current page routes

## Verification
- npm.cmd run qc:validate
- npm.cmd test -- --watchAll=false --runTestsByPath scripts/__tests__/qc-registry.test.ts --runInBand
- npx.cmd oxfmt --check scripts/qc/validate-qc-registry.mjs scripts/__tests__/qc-registry.test.ts docs/qc/mekstation-qc-registry.json
- npm.cmd run qc:app-completion
- npm.cmd run qc:lifecycle:status
- npm.cmd run verify:qc:app-shell
- npm.cmd run typecheck
- git diff --check
- pre-commit full npm.cmd run build