### PR TITLE
Tighten Wave 3 scenario proof contract

### DIFF
--- a/docs/qc/mekstation-major-capability-scenarios.json
+++ b/docs/qc/mekstation-major-capability-scenarios.json
@@ -179,11 +179,19 @@
           "id": "force-encounter-browser-flow",
           "tier": "standard",
           "required": true,
-          "command": "npx.cmd playwright test e2e/force.spec.ts e2e/encounter.spec.ts e2e/encounter-flow.spec.ts --project=chromium",
+          "command": "npx.cmd playwright test e2e/force.spec.ts e2e/encounter.spec.ts --project=chromium",
+          "evidence": ["e2e/force.spec.ts", "e2e/encounter.spec.ts"]
+        },
+        {
+          "id": "strict-encounter-combat-continuity",
+          "tier": "standard",
+          "required": true,
+          "command": "npm.cmd run verify:qc:encounter-combat-continuity",
           "evidence": [
-            "e2e/force.spec.ts",
-            "e2e/encounter.spec.ts",
-            "e2e/encounter-flow.spec.ts"
+            "src/components/gameplay/pages/preBattle/__tests__/usePreBattleLaunch.test.ts",
+            "src/components/gameplay/pages/preBattle/__tests__/preBattleLaunchLinkage.test.ts",
+            "src/__tests__/integration/campaignCombatLoop.test.ts",
+            "e2e/encounter-combat-continuity.spec.ts"
           ]
         },
         {
@@ -199,7 +207,7 @@
         }
       ],
       "notes": [
-        "The previous single EncounterService command is retained as part of this wider continuity scenario."
+        "The previous permissive encounter-flow smoke is historical context only; strict continuity must launch a campaign encounter, reach combat, queue post-battle outcome state, reload review, and apply the outcome."
       ]
     },
     {

--- a/scripts/__tests__/wave3-encounter-tactical-qc.test.ts
+++ b/scripts/__tests__/wave3-encounter-tactical-qc.test.ts
@@ -60,12 +60,14 @@ describe('Wave 3 encounter/tactical QC validator', () => {
       status: string;
       packageScripts: unknown[];
       surfaces: unknown[];
+      majorScenarioContracts: unknown[];
       anchors: unknown[];
       legacySmokeLeakCount: number;
     };
     expect(manifest.status).toBe('pass');
     expect(manifest.packageScripts).toHaveLength(5);
     expect(manifest.surfaces).toHaveLength(8);
+    expect(manifest.majorScenarioContracts).toHaveLength(1);
     expect(manifest.anchors).toHaveLength(3);
     expect(manifest.legacySmokeLeakCount).toBe(0);
   });
@@ -116,6 +118,48 @@ describe('Wave 3 encounter/tactical QC validator', () => {
     };
     expect(manifest.errors).toContainEqual(
       expect.objectContaining({ code: 'legacy-smoke-release-leak' }),
+    );
+    expect(result.stdout).toContain('e2e/encounter-flow.spec.ts');
+  });
+
+  it('rejects permissive encounter smoke in the major capability scenario', () => {
+    const majorScenarios = readJson<{
+      scenarios: Array<{
+        id: string;
+        checks?: Array<{
+          command?: string;
+          evidence?: string[];
+        }>;
+      }>;
+    }>(
+      path.join(repoRoot, 'docs/qc/mekstation-major-capability-scenarios.json'),
+    );
+    const forceScenario = majorScenarios.scenarios.find(
+      (entry) => entry.id === 'MC-04-force-pilot-encounter-setup',
+    );
+    expect(forceScenario).toBeDefined();
+    forceScenario!.checks = [
+      ...(forceScenario!.checks ?? []),
+      {
+        command:
+          'npx.cmd playwright test e2e/encounter-flow.spec.ts --project=chromium',
+        evidence: ['e2e/encounter-flow.spec.ts'],
+      },
+    ];
+
+    const majorScenariosPath = path.join(tempDir, 'major-scenarios.json');
+    writeJson(majorScenariosPath, majorScenarios);
+
+    const result = runValidator(['--json'], {
+      MEKSTATION_MAJOR_SCENARIOS_PATH: majorScenariosPath,
+    });
+
+    expect(result.status).toBe(1);
+    const manifest = JSON.parse(result.stdout) as {
+      errors: Array<{ code: string }>;
+    };
+    expect(manifest.errors).toContainEqual(
+      expect.objectContaining({ code: 'major-scenario-legacy-smoke-leak' }),
     );
     expect(result.stdout).toContain('e2e/encounter-flow.spec.ts');
   });

--- a/scripts/qc/validate-wave3-encounter-tactical.mjs
+++ b/scripts/qc/validate-wave3-encounter-tactical.mjs
@@ -12,6 +12,9 @@ const packageJsonPath =
 const registryPath =
   process.env.MEKSTATION_QC_REGISTRY_PATH ??
   path.join(repoRoot, 'docs', 'qc', 'mekstation-qc-registry.json');
+const majorScenariosPath =
+  process.env.MEKSTATION_MAJOR_SCENARIOS_PATH ??
+  path.join(repoRoot, 'docs', 'qc', 'mekstation-major-capability-scenarios.json');
 const sourceAnchorsPath =
   process.env.MEKSTATION_WAVE3_SOURCE_ANCHORS_PATH ?? null;
 
@@ -110,6 +113,15 @@ const requiredSurfaces = [
 
 const legacyPermissiveSmokePaths = ['e2e/encounter-flow.spec.ts'];
 
+const requiredMajorScenarioContracts = [
+  {
+    id: 'MC-04-force-pilot-encounter-setup',
+    commandIncludes: ['verify:qc:encounter-combat-continuity'],
+    evidenceIncludes: ['e2e/encounter-combat-continuity.spec.ts'],
+    forbiddenIncludes: legacyPermissiveSmokePaths,
+  },
+];
+
 const defaultSourceAnchors = [
   {
     id: 'strict-encounter-continuity-proof',
@@ -178,6 +190,20 @@ function allSurfaceText(surface) {
       ...(surface.evidence ?? []),
       ...(surface.gaps ?? []),
       ...(surface.manualChecks ?? []),
+    ].join('\n'),
+  );
+}
+
+function allMajorScenarioText(scenario) {
+  return normalizeSlash(
+    [
+      scenario.realisticFlow ?? '',
+      ...(scenario.successCriteria ?? []),
+      ...(scenario.notes ?? []),
+      ...(scenario.checks ?? []).flatMap((check) => [
+        check.command ?? '',
+        ...(check.evidence ?? []),
+      ]),
     ].join('\n'),
   );
 }
@@ -341,16 +367,86 @@ function validateSourceAnchor(anchor, issues) {
   };
 }
 
+function validateMajorScenario(contract, scenarioById, issues) {
+  const scenario = scenarioById.get(contract.id);
+  if (!scenario) {
+    issues.push(
+      issue(
+        'error',
+        'major-scenario-missing',
+        `Required Wave 3 major scenario ${contract.id} is missing.`,
+        { scenarioId: contract.id },
+      ),
+    );
+    return null;
+  }
+
+  for (const token of contract.commandIncludes ?? []) {
+    if (!scenario.checks?.some((check) => check.command?.includes(token))) {
+      issues.push(
+        issue(
+          'error',
+          'major-scenario-command-missing',
+          `${contract.id} must include a check command containing ${token}.`,
+          { scenarioId: contract.id, token },
+        ),
+      );
+    }
+  }
+
+  for (const token of contract.evidenceIncludes ?? []) {
+    if (
+      !scenario.checks?.some((check) =>
+        check.evidence?.some((evidencePath) => evidencePath.includes(token)),
+      )
+    ) {
+      issues.push(
+        issue(
+          'error',
+          'major-scenario-evidence-missing',
+          `${contract.id} must include scenario evidence ${token}.`,
+          { scenarioId: contract.id, token },
+        ),
+      );
+    }
+  }
+
+  const text = allMajorScenarioText(scenario);
+  const legacySmokeLeaks = (contract.forbiddenIncludes ?? []).filter((token) =>
+    text.includes(token),
+  );
+  for (const legacyPath of legacySmokeLeaks) {
+    issues.push(
+      issue(
+        'error',
+        'major-scenario-legacy-smoke-leak',
+        `${contract.id} must not use permissive ${legacyPath} as major capability proof.`,
+        { scenarioId: contract.id, legacyPath },
+      ),
+    );
+  }
+
+  return {
+    scenarioId: contract.id,
+    checkCount: scenario.checks?.length ?? 0,
+    legacySmokeLeaks,
+  };
+}
+
 function buildManifest() {
   const issues = [];
   const packageJson = readJson(packageJsonPath);
   const registry = readJson(registryPath);
+  const majorScenarios = readJson(majorScenariosPath);
   const sourceAnchors = sourceAnchorsPath
     ? readJson(sourceAnchorsPath)
     : defaultSourceAnchors;
   const scripts = packageJson.scripts ?? {};
   const surfaceById = new Map(
     registry.surfaces.map((surface) => [surface.surfaceId, surface]),
+  );
+  const scenarioById = new Map(
+    (majorScenarios.scenarios ?? []).map((scenario) => [scenario.id, scenario]),
   );
 
   const packageScripts = requiredPackageScripts.map((contract) =>
@@ -362,8 +458,14 @@ function buildManifest() {
   const anchors = sourceAnchors.map((anchor) =>
     validateSourceAnchor(anchor, issues),
   );
+  const majorScenarioContracts = requiredMajorScenarioContracts
+    .map((contract) => validateMajorScenario(contract, scenarioById, issues))
+    .filter(Boolean);
   const legacySmokeLeakCount = surfaces.reduce(
     (total, surface) => total + surface.legacySmokeLeaks.length,
+    0,
+  ) + majorScenarioContracts.reduce(
+    (total, scenario) => total + scenario.legacySmokeLeaks.length,
     0,
   );
   const errors = issues.filter((item) => item.severity === 'error');
@@ -374,12 +476,17 @@ function buildManifest() {
     status: errors.length > 0 ? 'fail' : 'pass',
     packageJsonPath: normalizeSlash(path.relative(repoRoot, packageJsonPath)),
     registryPath: normalizeSlash(path.relative(repoRoot, registryPath)),
+    majorScenariosPath: normalizeSlash(
+      path.relative(repoRoot, majorScenariosPath),
+    ),
     requiredPackageScriptCount: requiredPackageScripts.length,
     requiredSurfaceCount: requiredSurfaces.length,
+    requiredMajorScenarioCount: requiredMajorScenarioContracts.length,
     sourceAnchorCount: sourceAnchors.length,
     legacySmokeLeakCount,
     packageScripts,
     surfaces,
+    majorScenarioContracts,
     anchors,
     errors,
     warnings,

--- a/scripts/qc/validate-wave3-encounter-tactical.mjs
+++ b/scripts/qc/validate-wave3-encounter-tactical.mjs
@@ -14,7 +14,12 @@ const registryPath =
   path.join(repoRoot, 'docs', 'qc', 'mekstation-qc-registry.json');
 const majorScenariosPath =
   process.env.MEKSTATION_MAJOR_SCENARIOS_PATH ??
-  path.join(repoRoot, 'docs', 'qc', 'mekstation-major-capability-scenarios.json');
+  path.join(
+    repoRoot,
+    'docs',
+    'qc',
+    'mekstation-major-capability-scenarios.json',
+  );
 const sourceAnchorsPath =
   process.env.MEKSTATION_WAVE3_SOURCE_ANCHORS_PATH ?? null;
 
@@ -461,13 +466,15 @@ function buildManifest() {
   const majorScenarioContracts = requiredMajorScenarioContracts
     .map((contract) => validateMajorScenario(contract, scenarioById, issues))
     .filter(Boolean);
-  const legacySmokeLeakCount = surfaces.reduce(
-    (total, surface) => total + surface.legacySmokeLeaks.length,
-    0,
-  ) + majorScenarioContracts.reduce(
-    (total, scenario) => total + scenario.legacySmokeLeaks.length,
-    0,
-  );
+  const legacySmokeLeakCount =
+    surfaces.reduce(
+      (total, surface) => total + surface.legacySmokeLeaks.length,
+      0,
+    ) +
+    majorScenarioContracts.reduce(
+      (total, scenario) => total + scenario.legacySmokeLeaks.length,
+      0,
+    );
   const errors = issues.filter((item) => item.severity === 'error');
   const warnings = issues.filter((item) => item.severity === 'warning');
 


### PR DESCRIPTION
## Summary
- Splits MC-04 major capability proof so broad force/encounter browser smoke no longer includes the permissive legacy `encounter-flow` spec.
- Adds `verify:qc:encounter-combat-continuity` as the required strict encounter-to-combat-to-campaign continuity proof for MC-04.
- Extends the Wave 3 validator to inspect the major capability scenario catalog and reject legacy permissive encounter smoke there too.

## Validation
- `npm.cmd test -- --watchAll=false --runTestsByPath scripts/__tests__/wave3-encounter-tactical-qc.test.ts --runInBand`
- `npm.cmd run qc:wave3:validate -- --json`
- `npm.cmd run qc:scenarios:validate`
- `npm.cmd run verify:qc:encounter-combat-continuity`
- `npm.cmd run qc:app-completion -- --json`
- `npm.cmd run qc:lifecycle:status -- --json`
- `npm.cmd run lint -- scripts/qc/validate-wave3-encounter-tactical.mjs scripts/__tests__/wave3-encounter-tactical-qc.test.ts`
- `git diff --check`
- commit hook also ran `npm run build`

## Remaining Scope
- Wave 3 remains partial with 11 release gaps in `qc:app-completion`; this PR strengthens proof routing and does not promote tactical/browser release readiness.
- Full `verify:qc:wave3` and full `verify:qc` are left to CI because the change is contract/catalog-only.