### PR TITLE
Guard Wave 3 top-down legibility signoff

### DIFF
--- a/docs/qc/mekstation-qc-registry.json
+++ b/docs/qc/mekstation-qc-registry.json
@@ -345,7 +345,7 @@
       "parentId": "gameplay-tactical-map-combat",
       "riskTags": ["visual-legibility", "accessibility", "playability"],
       "qualityLenses": ["ui", "ux", "accessibility"],
-      "coverageStatus": "partial",
+      "coverageStatus": "ready-with-scope",
       "claimIds": ["ui.tactical.topdown-legibility"],
       "routes": ["/e2e/tactical-map"],
       "apis": [],
@@ -379,10 +379,11 @@
       "evidence": [
         "2026-06-18 Playwright tactical-map visual smoke passed 60 Chromium tests.",
         "2026-06-18 tactical review found terrain/elevation badges, ARIA labels, text badges, dash/pattern overlays, and non-color-only projection status indicators.",
-        "2026-06-23 Wave 7 tactical projection parity manifest validates required tactical surfaces, commands, source anchors, browser-boundary coverage, and stale active-change refs."
+        "2026-06-23 Wave 7 tactical projection parity manifest validates required tactical surfaces, commands, source anchors, browser-boundary coverage, and stale active-change refs.",
+        "2026-06-24 top-down legibility proof is guarded by Wave 3 QC: terrain-label Jest and tactical-map Playwright visual smoke cover terrain labels, elevation badges, non-color overlay/status encodings, blocked/costly movement indicators, combat status badges, and screenshot contrast."
       ],
       "gaps": [
-        "Browser smoke remains the release-grade readability check; the Wave 7 manifest guards discoverability of the legibility proof surface."
+        "Keep tactical-map visual smoke and terrain-label Jest as the repeatable readability proof whenever terrain label, elevation badge, or overlay ownership changes."
       ]
     },
     {

--- a/scripts/__tests__/wave3-encounter-tactical-qc.test.ts
+++ b/scripts/__tests__/wave3-encounter-tactical-qc.test.ts
@@ -122,6 +122,37 @@ describe('Wave 3 encounter/tactical QC validator', () => {
     expect(result.stdout).toContain('e2e/encounter-flow.spec.ts');
   });
 
+  it('rejects top-down legibility coverage status regression', () => {
+    const registry = readJson<{
+      surfaces: Array<{
+        surfaceId: string;
+        coverageStatus?: string;
+      }>;
+    }>(path.join(repoRoot, 'docs/qc/mekstation-qc-registry.json'));
+    const topDownSurface = registry.surfaces.find(
+      (entry) => entry.surfaceId === 'topdown-hex-legibility',
+    );
+    expect(topDownSurface).toBeDefined();
+    topDownSurface!.coverageStatus = 'partial';
+
+    const registryPath = path.join(tempDir, 'registry.json');
+    writeJson(registryPath, registry);
+
+    const result = runValidator(['--json'], {
+      MEKSTATION_QC_REGISTRY_PATH: registryPath,
+    });
+
+    expect(result.status).toBe(1);
+    const manifest = JSON.parse(result.stdout) as {
+      errors: Array<{ code: string }>;
+    };
+    expect(manifest.errors).toContainEqual(
+      expect.objectContaining({
+        code: 'surface-coverage-status-regressed',
+      }),
+    );
+  });
+
   it('rejects permissive encounter smoke in the major capability scenario', () => {
     const majorScenarios = readJson<{
       scenarios: Array<{

--- a/scripts/qc/validate-wave3-encounter-tactical.mjs
+++ b/scripts/qc/validate-wave3-encounter-tactical.mjs
@@ -80,6 +80,7 @@ const requiredSurfaces = [
   {
     id: 'topdown-hex-legibility',
     claimId: 'ui.tactical.topdown-legibility',
+    allowedCoverageStatuses: ['ready-with-scope'],
     commandIncludes: [
       'HexMapDisplay.terrainLabels.01.test.tsx',
       'tactical-map-visual-smoke.spec.ts',
@@ -264,6 +265,24 @@ function validateSurface(contract, surfaceById, issues) {
         'surface-claim-missing',
         `${contract.id} must include claim ${contract.claimId}.`,
         { surfaceId: contract.id, claimId: contract.claimId },
+      ),
+    );
+  }
+
+  if (
+    contract.allowedCoverageStatuses &&
+    !contract.allowedCoverageStatuses.includes(surface.coverageStatus)
+  ) {
+    issues.push(
+      issue(
+        'error',
+        'surface-coverage-status-regressed',
+        `${contract.id} must keep coverageStatus in ${contract.allowedCoverageStatuses.join(', ')}.`,
+        {
+          surfaceId: contract.id,
+          coverageStatus: surface.coverageStatus,
+          allowedCoverageStatuses: contract.allowedCoverageStatuses,
+        },
       ),
     );
   }


### PR DESCRIPTION
## Summary
- Promotes `topdown-hex-legibility` to `ready-with-scope` using existing terrain-label Jest plus tactical-map visual browser proof.
- Adds a Wave 3 validator guard that fails if top-down legibility regresses back to `partial`.
- Rewords the QC registry gap as a repeatable proof maintenance note instead of a release-signoff gap.

## Evidence
- `npm.cmd test -- --watchAll=false --runTestsByPath scripts/__tests__/wave3-encounter-tactical-qc.test.ts --runInBand`
- `npm.cmd run qc:wave3:validate -- --json`
- `npx.cmd jest --selectProjects unit --ci --runTestsByPath src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.terrainLabels.01.test.tsx src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.terrainLabels.02.test.tsx src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.terrainLabels.03.test.tsx src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.terrainLabels.04.test.tsx --no-coverage --runInBand`
- `npx.cmd playwright test e2e/tactical-map-visual-smoke.spec.ts --project=chromium`
- `npm.cmd run qc:app-completion -- --json` now reports release gaps `30`, Wave 3 `9`, and `topdown-hex-legibility` gapCount `0`.
- `npm.cmd run qc:lifecycle:status -- --json` reports blockers `0`, warnings `0`.
- `npx.cmd oxfmt --check docs/qc/mekstation-qc-registry.json scripts/qc/validate-wave3-encounter-tactical.mjs scripts/__tests__/wave3-encounter-tactical-qc.test.ts`
- `git diff --check`

## Scope Note
This does not promote the broader tactical-map surface. Movement preview parity, combat preview parity, isometric hidden-unit ghosting, and broader Wave 3 tactical playability gaps remain tracked separately.