### PR TITLE
Keep QC graph statuses honest

### DIFF
--- a/docs/qc/mekstation-qc-validation-graph.json
+++ b/docs/qc/mekstation-qc-validation-graph.json
@@ -332,7 +332,7 @@
       "id": "surface:app-shell-navigation",
       "kind": "surface",
       "label": "App Shell, Navigation, Settings, PWA",
-      "coverageStatus": "partial"
+      "coverageStatus": "ready-with-scope"
     },
     {
       "id": "state:app-shell-navigation:lifecycle",
@@ -633,7 +633,7 @@
       "id": "surface:topdown-hex-legibility",
       "kind": "surface",
       "label": "Top-Down Hex Legibility",
-      "coverageStatus": "partial"
+      "coverageStatus": "ready-with-scope"
     },
     {
       "id": "state:topdown-hex-legibility:lifecycle",
@@ -1137,7 +1137,7 @@
       "id": "surface:campaign-economy-progression",
       "kind": "surface",
       "label": "Campaign Economy, Repair, Salvage, Progression",
-      "coverageStatus": "partial"
+      "coverageStatus": "ready-with-scope"
     },
     {
       "id": "state:campaign-economy-progression:lifecycle",
@@ -1183,7 +1183,7 @@
       "id": "surface:long-campaign-stability",
       "kind": "surface",
       "label": "Long Campaign Stability",
-      "coverageStatus": "partial"
+      "coverageStatus": "ready-with-scope"
     },
     {
       "id": "state:long-campaign-stability:lifecycle",
@@ -1227,7 +1227,7 @@
       "id": "surface:post-combat-base-economy-gm-ledger",
       "kind": "surface",
       "label": "Post-Combat Base Economy GM Ledger",
-      "coverageStatus": "partial"
+      "coverageStatus": "ready-with-scope"
     },
     {
       "id": "state:post-combat-base-economy-gm-ledger:lifecycle",
@@ -1290,7 +1290,7 @@
       "id": "surface:time-cascade-gm-ledger",
       "kind": "surface",
       "label": "Time Cascade GM Ledger",
-      "coverageStatus": "partial"
+      "coverageStatus": "ready-with-scope"
     },
     {
       "id": "state:time-cascade-gm-ledger:lifecycle",

--- a/scripts/__tests__/journey-qc.test.ts
+++ b/scripts/__tests__/journey-qc.test.ts
@@ -70,6 +70,28 @@ describe('journey QC scripts', () => {
     );
   });
 
+  it('fails validation when a graph surface coverage status drifts from the registry', () => {
+    const graph = readJson<{
+      nodes: Array<{ id: string; coverageStatus?: string }>;
+    }>(path.join(repoRoot, 'docs/qc/mekstation-qc-validation-graph.json'));
+    const appShellNode = graph.nodes.find(
+      (node) => node.id === 'surface:app-shell-navigation',
+    );
+    expect(appShellNode).toBeDefined();
+    appShellNode!.coverageStatus = 'partial';
+    const graphPath = path.join(evidenceDir, 'drifted-surface-status.json');
+    writeJson(graphPath, graph);
+
+    const result = runNodeScript('scripts/qc/validate-journey-qc.mjs', [], {
+      MEKSTATION_QC_VALIDATION_GRAPH_PATH: graphPath,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain(
+      'Graph surface node surface:app-shell-navigation coverageStatus=partial does not match registry coverageStatus=ready-with-scope',
+    );
+  });
+
   it('fails validation when a catalog diagnostic event is missing from the logging map', () => {
     const loggingMap = readJson<{
       paths: Array<{ events: string[] }>;

--- a/scripts/qc/journey-qc-core.mjs
+++ b/scripts/qc/journey-qc-core.mjs
@@ -445,6 +445,7 @@ export function validateValidationGraph(graph, catalog, registry = null) {
   if (!Array.isArray(graph.nodes) || !Array.isArray(graph.edges)) return issues;
 
   const nodeIds = new Set();
+  const nodesById = new Map();
   for (const [index, node] of graph.nodes.entries()) {
     const label = node.id || `nodes[${index}]`;
     if (typeof node.id !== 'string' || node.id.trim() === '') {
@@ -453,6 +454,7 @@ export function validateValidationGraph(graph, catalog, registry = null) {
     if (nodeIds.has(node.id))
       issues.push(issue('error', `${label}: duplicate node id.`));
     nodeIds.add(node.id);
+    nodesById.set(node.id, node);
     if (!graphKinds.has(node.kind))
       issues.push(issue('error', `${label}: invalid kind ${node.kind}.`));
     if (typeof node.label !== 'string' || node.label.trim() === '') {
@@ -517,6 +519,18 @@ export function validateValidationGraph(graph, catalog, registry = null) {
           issue(
             'error',
             `Graph missing registry surface node ${surfaceNodeId}.`,
+          ),
+        );
+      }
+      const surfaceNode = nodesById.get(surfaceNodeId);
+      if (
+        surfaceNode &&
+        surfaceNode.coverageStatus !== surface.coverageStatus
+      ) {
+        issues.push(
+          issue(
+            'error',
+            `Graph surface node ${surfaceNodeId} coverageStatus=${surfaceNode.coverageStatus} does not match registry coverageStatus=${surface.coverageStatus}.`,
           ),
         );
       }


### PR DESCRIPTION
## Summary
- Align stale QC validation graph surface statuses with the registry for app shell, top-down legibility, campaign economy, long campaign, post-combat GM ledger, and time-cascade GM ledger.
- Add validation so `surface:*` graph node `coverageStatus` must match the QC registry.
- Add a regression test that mutates the graph status and expects journey QC validation to fail.

## Evidence
- `npm.cmd test -- --watchAll=false --runTestsByPath scripts/__tests__/journey-qc.test.ts --runInBand`
- `npm.cmd run qc:journeys:validate -- --json`
- `npm.cmd run qc:lifecycle:status -- --json`
- `npm.cmd run qc:validate`
- `npm.cmd run qc:app-completion -- --json`
- `npx.cmd oxfmt --check docs/qc/mekstation-qc-validation-graph.json scripts/qc/journey-qc-core.mjs scripts/__tests__/journey-qc.test.ts`
- `git diff --check`

## Scope note
`qc:app-completion` still honestly reports 30 release signoff gaps; this PR only fixes QC graph drift and prevents that drift from recurring.