### PR TITLE
Promote strict encounter continuity proof

### DIFF
--- a/docs/qc/mekstation-qc-registry.json
+++ b/docs/qc/mekstation-qc-registry.json
@@ -177,7 +177,7 @@
       "parentId": null,
       "riskTags": ["setup-flow", "data-integrity", "playability"],
       "qualityLenses": ["functionality", "ux", "rules-parity"],
-      "coverageStatus": "partial",
+      "coverageStatus": "ready-with-scope",
       "routes": ["/gameplay/encounters", "/gameplay/campaigns"],
       "apis": ["/api/replay-library/encounter"],
       "desktopSurfaces": [],
@@ -219,6 +219,7 @@
         "2026-06-23 legacy encounter smoke passed force creation, encounter creation/configuration, launch affordances, auto-resolve, and game-session creation checks; this is superseded by strict continuity proof and is not sufficient for Wave 3 proof.",
         "2026-06-24 `npm.cmd run verify:qc:encounter-combat-continuity` passed 16 focused Jest checks plus 3 Chromium proofs: routed campaign encounter auto-resolve preserves campaign/mission/session linkage; interactive pre-battle launch reaches the tactical session, concedes through the UI, survives post-battle review reload, applies the queued outcome, and keeps `processedBattleIds` after campaign route reload; and attack-driven weapon destruction completes a tactical session through real engine resolution into queued post-battle review reload/application.",
         "2026-06-24 Wave 3 validator requires strict encounter continuity proof and rejects permissive encounter smoke as Wave 3 proof.",
+        "2026-06-24 `npm.cmd run qc:wave3:validate` passed with force-pilot-encounter-setup bound to ready-with-scope, strict encounter continuity command/test coverage, and zero legacy encounter-flow smoke leaks.",
         "Archived OpenSpec change 2026-06-21-fix-navigation-and-playability-deadends retired from activeChangeRefs on 2026-06-23."
       ],
       "gaps": [

--- a/docs/qc/mekstation-qc-validation-graph.json
+++ b/docs/qc/mekstation-qc-validation-graph.json
@@ -500,7 +500,7 @@
       "id": "surface:force-pilot-encounter-setup",
       "kind": "surface",
       "label": "Force, Pilot, Scenario, Encounter Setup",
-      "coverageStatus": "partial"
+      "coverageStatus": "ready-with-scope"
     },
     {
       "id": "state:force-pilot-encounter-setup:lifecycle",
@@ -513,6 +513,8 @@
       "label": "Registry evidence for Force, Pilot, Scenario, Encounter Setup",
       "entries": [
         "docs/audits/2026-06-12-full-codebase-review.md",
+        "2026-06-24 `npm.cmd run verify:qc:encounter-combat-continuity` passed 16 focused Jest checks plus 3 Chromium proofs: routed campaign encounter auto-resolve preserves campaign/mission/session linkage; interactive pre-battle launch reaches the tactical session, concedes through the UI, survives post-battle review reload, applies the queued outcome, and keeps `processedBattleIds` after campaign route reload; and attack-driven weapon destruction completes a tactical session through real engine resolution into queued post-battle review reload/application.",
+        "2026-06-24 `npm.cmd run qc:wave3:validate` passed with force-pilot-encounter-setup bound to ready-with-scope, strict encounter continuity command/test coverage, and zero legacy encounter-flow smoke leaks.",
         "Archived OpenSpec change 2026-06-21-fix-navigation-and-playability-deadends retired from activeChangeRefs on 2026-06-23."
       ]
     },
@@ -529,13 +531,18 @@
       "kind": "known-gap",
       "label": "Force, Pilot, Scenario, Encounter Setup known gaps",
       "entries": [
-        "Setup routes must prove playable continuity into tactical combat and campaign post-battle flows."
+        "Broader setup continuity still needs authored multi-unit, custom-scenario, and non-1v1 campaign variants beyond the seeded 1v1 browser proof."
       ]
     },
     {
       "id": "command:npm-cmd-test-watchall-false-runtestsbypath-src-services-encounter-tests-encounterservice-test-ts",
       "kind": "command",
       "label": "npm.cmd test -- --watchAll=false --runTestsByPath src/services/encounter/__tests__/EncounterService.test.ts"
+    },
+    {
+      "id": "command:npm-cmd-run-verify-qc-encounter-combat-continuity",
+      "kind": "command",
+      "label": "npm.cmd run verify:qc:encounter-combat-continuity"
     },
     {
       "id": "surface:gameplay-tactical-map-combat",
@@ -2176,6 +2183,16 @@
     },
     {
       "from": "command:npm-cmd-test-watchall-false-runtestsbypath-src-services-encounter-tests-encounterservice-test-ts",
+      "to": "evidence:force-pilot-encounter-setup:registry",
+      "relation": "produces"
+    },
+    {
+      "from": "state:force-pilot-encounter-setup:lifecycle",
+      "to": "command:npm-cmd-run-verify-qc-encounter-combat-continuity",
+      "relation": "validated-by"
+    },
+    {
+      "from": "command:npm-cmd-run-verify-qc-encounter-combat-continuity",
       "to": "evidence:force-pilot-encounter-setup:registry",
       "relation": "produces"
     },

--- a/scripts/qc/validate-wave3-encounter-tactical.mjs
+++ b/scripts/qc/validate-wave3-encounter-tactical.mjs
@@ -55,6 +55,7 @@ const requiredPackageScripts = [
 const requiredSurfaces = [
   {
     id: 'force-pilot-encounter-setup',
+    allowedCoverageStatuses: ['ready-with-scope'],
     commandIncludes: ['verify:qc:encounter-combat-continuity'],
     testIncludes: ['e2e/encounter-combat-continuity.spec.ts'],
     gapIncludes: ['multi-unit', 'custom-scenario', 'non-1v1'],


### PR DESCRIPTION
## Summary
- Promotes force/pilot encounter setup to ready-with-scope using the strict encounter-combat continuity proof.
- Connects the strict continuity command into the QC validation graph so lifecycle routing sees it as proof for the surface.
- Keeps the remaining multi-unit, custom-scenario, and non-1v1 setup continuity gap explicit.

## Validation
- npm.cmd run qc:wave3:validate
- npm.cmd run qc:journeys:validate -- --json
- npm.cmd run qc:lifecycle:status -- --json
- npm.cmd run qc:app-completion -- --json
- npx.cmd oxfmt --check scripts/qc/validate-wave3-encounter-tactical.mjs docs/qc/mekstation-qc-registry.json docs/qc/mekstation-qc-validation-graph.json
- git diff --check
- npm.cmd run verify:qc:encounter-combat-continuity

## Remaining Scope
- Full verify:qc:wave3 tactical projection/visual suite remains broader Wave 3 follow-up.
- App-completion still reports 26 release gaps after this slice.