### PR TITLE
Promote isometric tactical signoff

### DIFF
--- a/docs/qc/mekstation-qc-registry.json
+++ b/docs/qc/mekstation-qc-registry.json
@@ -497,7 +497,7 @@
       "parentId": "gameplay-tactical-map-combat",
       "riskTags": ["visual-legibility", "depth-sorting", "playability"],
       "qualityLenses": ["ui", "ux", "functionality"],
-      "coverageStatus": "partial",
+      "coverageStatus": "ready-with-scope",
       "claimIds": ["ui.tactical.isometric-25d"],
       "routes": ["/e2e/tactical-map"],
       "apis": [],
@@ -528,10 +528,11 @@
       "evidence": [
         "Prior review found rotation/depth/occlusion tests present and passing.",
         "2026-06-18 tactical review found discrete camera rotation, depth keys, elevated terrain stacks, and visibility halo/badge signaling in the isometric path.",
-        "2026-06-23 Wave 7 tactical projection parity manifest validates required tactical surfaces, commands, source anchors, browser-boundary coverage, and stale active-change refs."
+        "2026-06-23 Wave 7 tactical projection parity manifest validates required tactical surfaces, commands, source anchors, browser-boundary coverage, and stale active-change refs.",
+        "2026-06-25 focused isometric proof passed helper-level depth/rotation/occlusion checks plus Chromium visual smoke assertions for hidden/last-known contacts, foreground boost, occluder metadata, depth-key changes, elevated extrusion faces, and camera rotation."
       ],
       "gaps": [
-        "Hidden-unit outlines/ghosting still need screenshot-quality review for tall-elevation release signoff; the Wave 7 manifest guards isometric proof discoverability."
+        "Future camera or elevation changes must keep browser visual smoke and isometric helper tests covering hidden contacts, foreground boost, occluder metadata, depth-key changes, and extrusion faces."
       ]
     },
     {

--- a/docs/qc/mekstation-qc-validation-graph.json
+++ b/docs/qc/mekstation-qc-validation-graph.json
@@ -761,7 +761,7 @@
       "id": "surface:isometric-rotatable-25d",
       "kind": "surface",
       "label": "Rotatable Isometric 2.5D Battlefield",
-      "coverageStatus": "partial"
+      "coverageStatus": "ready-with-scope"
     },
     {
       "id": "state:isometric-rotatable-25d:lifecycle",
@@ -775,7 +775,8 @@
       "entries": [
         "Prior review found rotation/depth/occlusion tests present and passing.",
         "2026-06-18 tactical review found discrete camera rotation, depth keys, elevated terrain stacks, and visibility halo/badge signaling in the isometric path.",
-        "2026-06-23 Wave 7 tactical projection parity manifest validates required tactical surfaces, commands, source anchors, browser-boundary coverage, and stale active-change refs."
+        "2026-06-23 Wave 7 tactical projection parity manifest validates required tactical surfaces, commands, source anchors, browser-boundary coverage, and stale active-change refs.",
+        "2026-06-25 focused isometric proof passed helper-level depth/rotation/occlusion checks plus Chromium visual smoke assertions for hidden/last-known contacts, foreground boost, occluder metadata, depth-key changes, elevated extrusion faces, and camera rotation."
       ]
     },
     {
@@ -791,7 +792,7 @@
       "kind": "known-gap",
       "label": "Rotatable Isometric 2.5D Battlefield known gaps",
       "entries": [
-        "Hidden-unit outlines/ghosting still need screenshot-quality review for tall-elevation release signoff; the Wave 7 manifest guards isometric proof discoverability."
+        "Future camera or elevation changes must keep browser visual smoke and isometric helper tests covering hidden contacts, foreground boost, occluder metadata, depth-key changes, and extrusion faces."
       ]
     },
     {

--- a/scripts/qc/validate-wave3-encounter-tactical.mjs
+++ b/scripts/qc/validate-wave3-encounter-tactical.mjs
@@ -103,6 +103,7 @@ const requiredSurfaces = [
   {
     id: 'isometric-rotatable-25d',
     claimId: 'ui.tactical.isometric-25d',
+    allowedCoverageStatuses: ['ready-with-scope'],
     commandIncludes: [
       'HexMapDisplay.isometric.test.ts',
       'tactical-map-visual-smoke.spec.ts',
@@ -152,6 +153,10 @@ const defaultSourceAnchors = [
       'data-combat-invalid-reason',
       'data-isometric-visibility-rule',
       'data-isometric-camera-current-step',
+      'isometric-visibility-halo-occluded',
+      'isometric-scene-token-occluded',
+      'data-isometric-occluder-hex',
+      'fog-marker-hidden-contact',
       'shows selected weapon out of arc as blocked in browser',
     ],
   },


### PR DESCRIPTION
## Summary
- Promote `isometric-rotatable-25d` to `ready-with-scope` after focused helper and browser visual proof.
- Mirror the signoff evidence and future-change guard in the QC validation graph.
- Require the Wave 3 validator to keep hidden-contact, occluder, depth-key, extrusion, and camera-rotation anchors for isometric proof.

## Validation
- `npx.cmd jest --selectProjects unit --ci --runTestsByPath src/components/gameplay/HexMapDisplay/__tests__/HexMapDisplay.isometric.test.ts --no-coverage`
- `npx.cmd playwright test e2e/tactical-map-visual-smoke.spec.ts --project=chromium --reporter=line`
- `npm.cmd run qc:tactical:projection:validate`
- `npm.cmd run qc:run -- --claim=ui.tactical.isometric-25d --quick`
- `npm.cmd run qc:wave3:validate`
- `npm.cmd run qc:app-completion -- --json`
- `npx.cmd oxfmt --check scripts/qc/validate-wave3-encounter-tactical.mjs docs/qc/mekstation-qc-registry.json docs/qc/mekstation-qc-validation-graph.json`
- `git diff --check`