### PR TITLE
Close Wave 3 simulation validation accounting

### DIFF
--- a/docs/qc/mekstation-qc-registry.json
+++ b/docs/qc/mekstation-qc-registry.json
@@ -546,7 +546,7 @@
       "parentId": null,
       "riskTags": ["rules-parity", "catalog-drift", "known-gap-honesty"],
       "qualityLenses": ["functionality", "rules-parity", "test-quality"],
-      "coverageStatus": "partial",
+      "coverageStatus": "ready-with-scope",
       "claimIds": ["combat.validation"],
       "routes": [],
       "apis": [],
@@ -591,10 +591,11 @@
         "2026-06-23 Wave 10 catalog/rules QC gate validates current combat parity surfaces, source anchors, stale active-change refs, zero unresolved BattleMech gaps, and the explicit 147-row non-BattleMech out-of-scope split.",
         "2026-06-18 damage source refs were repinned after the damage finalizer/location helper split; validate:combat reran green at 76 suites / 2648 tests.",
         "2026-06-18 integration review confirmed older unresolved BattleMech helper/unsupported audit wording is stale against current live validators.",
-        "2026-06-24 Wave 3 validator requires combat rules gates alongside encounter continuity and tactical UX checkpoint commands."
+        "2026-06-24 Wave 3 validator requires combat rules gates alongside encounter continuity and tactical UX checkpoint commands.",
+        "2026-06-25 focused simulation combat proof passed `qc:run -- --surface=simulation-combat-validation --quick`: catalog/rules parity, `validate:combat` at 76 suites / 2034 tests, zero unresolved BattleMech gaps, strict OpenSpec 211/211, and Wave 3 gate validation."
       ],
       "gaps": [
-        "BattleMech validation is green with explicit non-BattleMech scope splits; remaining interactive physical command availability and phase-driver parity concerns should be tracked as concrete failing evidence, not stale active-change refs."
+        "Future simulation combat validation changes must keep catalog/rules parity, `validate:combat`, zero unresolved BattleMech gaps, strict OpenSpec, and Wave 3 gates green; remaining narrower concerns stay tracked on child surfaces."
       ]
     },
     {

--- a/docs/qc/mekstation-qc-validation-graph.json
+++ b/docs/qc/mekstation-qc-validation-graph.json
@@ -803,7 +803,7 @@
       "id": "surface:simulation-combat-validation",
       "kind": "surface",
       "label": "Simulation And Combat Validation",
-      "coverageStatus": "partial"
+      "coverageStatus": "ready-with-scope"
     },
     {
       "id": "state:simulation-combat-validation:lifecycle",
@@ -820,7 +820,8 @@
         "2026-06-18 combat review: validate:combat passed 76 suites / 2648 tests; gap summary total 0.",
         "2026-06-23 Wave 10 catalog/rules QC gate validates current combat parity surfaces, source anchors, stale active-change refs, zero unresolved BattleMech gaps, and the explicit 147-row non-BattleMech out-of-scope split.",
         "2026-06-18 damage source refs were repinned after the damage finalizer/location helper split; validate:combat reran green at 76 suites / 2648 tests.",
-        "2026-06-18 integration review confirmed older unresolved BattleMech helper/unsupported audit wording is stale against current live validators."
+        "2026-06-18 integration review confirmed older unresolved BattleMech helper/unsupported audit wording is stale against current live validators.",
+        "2026-06-25 focused simulation combat proof passed `qc:run -- --surface=simulation-combat-validation --quick`: catalog/rules parity, `validate:combat` at 76 suites / 2034 tests, zero unresolved BattleMech gaps, strict OpenSpec 211/211, and Wave 3 gate validation."
       ]
     },
     {
@@ -836,7 +837,7 @@
       "kind": "known-gap",
       "label": "Simulation And Combat Validation known gaps",
       "entries": [
-        "BattleMech validation is green with explicit non-BattleMech scope splits; remaining interactive physical command availability and phase-driver parity concerns should be tracked as concrete failing evidence, not stale active-change refs."
+        "Future simulation combat validation changes must keep catalog/rules parity, `validate:combat`, zero unresolved BattleMech gaps, strict OpenSpec, and Wave 3 gates green; remaining narrower concerns stay tracked on child surfaces."
       ]
     },
     {

--- a/scripts/qc/validate-wave3-encounter-tactical.mjs
+++ b/scripts/qc/validate-wave3-encounter-tactical.mjs
@@ -116,6 +116,7 @@ const requiredSurfaces = [
   {
     id: 'simulation-combat-validation',
     claimId: 'combat.validation',
+    allowedCoverageStatuses: ['ready-with-scope'],
     commandIncludes: [
       'validate:combat:gaps -- --format=summary --expect-total=0',
       'openspec validate --all --strict',


### PR DESCRIPTION
## Summary
- Promote the parent simulation combat validation surface to ready-with-scope after the parent gate proved repeatable.
- Add 2026-06-25 focused evidence for catalog/rules parity, validate:combat, zero unresolved BattleMech gaps, strict OpenSpec, and Wave 3 validation.
- Guard the parent status in the Wave 3 validator while leaving narrower child partial surfaces intact.

## Validation
- npm.cmd run qc:run -- --surface=simulation-combat-validation --quick
- npm.cmd run qc:wave3:validate
- npm.cmd run qc:app-completion -- --json
- npm.cmd run qc:lifecycle:status -- --json
- npx.cmd oxfmt --check docs/qc/mekstation-qc-registry.json docs/qc/mekstation-qc-validation-graph.json scripts/qc/validate-wave3-encounter-tactical.mjs
- git diff --check