### PR TITLE
Keep Wave 4 BV reports compact and repeatable

### DIFF
--- a/scripts/__tests__/wave4-bv-report-output.test.ts
+++ b/scripts/__tests__/wave4-bv-report-output.test.ts
@@ -1,0 +1,97 @@
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const NPX = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+const AEROSPACE_SCRIPT = path.resolve(
+  process.cwd(),
+  'scripts/validate-aerospace-bv.ts',
+);
+const INFANTRY_SCRIPT = path.resolve(
+  process.cwd(),
+  'scripts/validate-infantry-bv.ts',
+);
+
+interface AerospaceReport {
+  readonly generatedAt: string;
+  readonly omittedUnreferencedUnits: number;
+  readonly stats: {
+    readonly total: number;
+    readonly compared: number;
+  };
+  readonly units: readonly { readonly canonicalBV: number | null }[];
+}
+
+interface InfantryReport {
+  readonly generatedAt: string;
+  readonly totalPlatoons: number;
+  readonly omittedWithoutMulBV: number;
+  readonly parityCoverage: {
+    readonly withMulBV: number;
+  };
+  readonly platoons: readonly { readonly mulBV: number | null }[];
+}
+
+function makeTempFile(name: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wave4-bv-report-'));
+  return path.join(dir, name);
+}
+
+function runScript(scriptPath: string, outputPath: string) {
+  return spawnSync(NPX, ['tsx', scriptPath, '--output', outputPath], {
+    cwd: process.cwd(),
+    encoding: 'utf-8',
+    shell: process.platform === 'win32',
+  });
+}
+
+function readJson<T>(outputPath: string): T {
+  return JSON.parse(fs.readFileSync(outputPath, 'utf-8')) as T;
+}
+
+describe('Wave 4 BV report output', () => {
+  jest.setTimeout(90_000);
+
+  it('keeps aerospace reports compact while retaining coverage counts', () => {
+    const outputPath = makeTempFile('aerospace-report.json');
+    const result = runScript(AEROSPACE_SCRIPT, outputPath);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+
+    const report = readJson<AerospaceReport>(outputPath);
+    expect(report.generatedAt).toBe('1970-01-01T00:00:00.000Z');
+    expect(report.stats.total).toBeGreaterThan(0);
+    expect(report.units).toHaveLength(report.stats.compared);
+    expect(report.omittedUnreferencedUnits + report.units.length).toBe(
+      report.stats.total,
+    );
+    expect(
+      report.units.every((unit) => {
+        return unit.canonicalBV !== null;
+      }),
+    ).toBe(true);
+  });
+
+  it('keeps infantry reports compact while retaining platoon counts', () => {
+    const outputPath = makeTempFile('infantry-report.json');
+    const result = runScript(INFANTRY_SCRIPT, outputPath);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+
+    const report = readJson<InfantryReport>(outputPath);
+    expect(report.generatedAt).toBe('1970-01-01T00:00:00.000Z');
+    expect(report.totalPlatoons).toBeGreaterThan(0);
+    expect(report.platoons).toHaveLength(report.parityCoverage.withMulBV);
+    expect(report.omittedWithoutMulBV + report.platoons.length).toBe(
+      report.totalPlatoons,
+    );
+    expect(
+      report.platoons.every((platoon) => {
+        return platoon.mulBV !== null;
+      }),
+    ).toBe(true);
+  });
+});

--- a/scripts/__tests__/wave4-bv-report-output.test.ts
+++ b/scripts/__tests__/wave4-bv-report-output.test.ts
@@ -33,17 +33,34 @@ interface InfantryReport {
   readonly platoons: readonly { readonly mulBV: number | null }[];
 }
 
+function makeTempDir(prefix = 'wave4-bv-report-'): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
 function makeTempFile(name: string): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wave4-bv-report-'));
+  const dir = makeTempDir();
   return path.join(dir, name);
 }
 
-function runScript(scriptPath: string, outputPath: string) {
-  return spawnSync(NPX, ['tsx', scriptPath, '--output', outputPath], {
-    cwd: process.cwd(),
-    encoding: 'utf-8',
-    shell: process.platform === 'win32',
-  });
+function runScript(
+  scriptPath: string,
+  outputPath: string,
+  extraArgs: readonly string[] = [],
+) {
+  return spawnSync(
+    NPX,
+    ['tsx', scriptPath, ...extraArgs, '--output', outputPath],
+    {
+      cwd: process.cwd(),
+      encoding: 'utf-8',
+      shell: process.platform === 'win32',
+    },
+  );
+}
+
+function writeJson(filePath: string, data: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2), 'utf-8');
 }
 
 function readJson<T>(outputPath: string): T {
@@ -55,18 +72,35 @@ describe('Wave 4 BV report output', () => {
 
   it('keeps aerospace reports compact while retaining coverage counts', () => {
     const outputPath = makeTempFile('aerospace-report.json');
-    const result = runScript(AEROSPACE_SCRIPT, outputPath);
+    const cacheDir = makeTempDir('wave4-aero-cache-');
+    writeJson(path.join(cacheDir, 'referenced-aero.json'), {
+      bv: 42,
+      id: 'referenced-aero',
+      name: 'Referenced Aero',
+    });
+    writeJson(path.join(cacheDir, 'unreferenced-aero.json'), {
+      id: 'unreferenced-aero',
+      name: 'Unreferenced Aero',
+    });
+
+    const result = runScript(AEROSPACE_SCRIPT, outputPath, [
+      '--aero-cache',
+      cacheDir,
+    ]);
 
     expect(result.status).toBe(0);
     expect(result.stderr).toBe('');
 
     const report = readJson<AerospaceReport>(outputPath);
     expect(report.generatedAt).toBe('1970-01-01T00:00:00.000Z');
-    expect(report.stats.total).toBeGreaterThan(0);
+    expect(report.stats.total).toBe(2);
+    expect(report.stats.compared).toBe(1);
+    expect(report.omittedUnreferencedUnits).toBe(1);
     expect(report.units).toHaveLength(report.stats.compared);
     expect(report.omittedUnreferencedUnits + report.units.length).toBe(
       report.stats.total,
     );
+    expect(report.units[0]?.canonicalBV).toBe(42);
     expect(
       report.units.every((unit) => {
         return unit.canonicalBV !== null;

--- a/scripts/validate-aerospace-bv.ts
+++ b/scripts/validate-aerospace-bv.ts
@@ -336,7 +336,7 @@ function computeUnitParity(
 function writeReport(outputPath: string, report: AerospaceParityReport): void {
   const outDir = path.dirname(outputPath);
   fs.mkdirSync(outDir, { recursive: true });
-  fs.writeFileSync(outputPath, JSON.stringify(report, null, 2), 'utf8');
+  fs.writeFileSync(outputPath, JSON.stringify(report, null, 2) + '\n', 'utf8');
 }
 
 function generatedAtTimestamp(): string {

--- a/scripts/validate-aerospace-bv.ts
+++ b/scripts/validate-aerospace-bv.ts
@@ -51,6 +51,8 @@ interface CLIOptions {
   help: boolean;
 }
 
+const STABLE_GENERATED_AT = '1970-01-01T00:00:00.000Z';
+
 /**
  * Default search locations for canonical aerospace unit JSON files.
  * The harness probes each path in order; the first one that exists and
@@ -159,6 +161,10 @@ interface AerospaceParityReport {
   readonly source?: string;
   /** Individual aerospace parity rows (empty when status === 'deferred'). */
   readonly units: ReadonlyArray<AerospaceParityRow>;
+  /** Number of loaded rows omitted because they had no canonical BV reference. */
+  readonly omittedUnreferencedUnits?: number;
+  /** Number of JSON files skipped because they could not be parsed. */
+  readonly unparseableUnits?: number;
   /** Aggregate stats (populated only when status === 'ok'). */
   readonly stats?: {
     readonly total: number;
@@ -166,6 +172,8 @@ interface AerospaceParityReport {
     readonly exact: number;
     readonly within1pct: number;
     readonly within5pct: number;
+    readonly unparseableUnits: number;
+    readonly omittedUnreferencedUnits: number;
     readonly outliers: ReadonlyArray<AerospaceParityRow>;
   };
 }
@@ -303,7 +311,7 @@ function computeUnitParity(
     // equipment / armor fields default to safe zero values so a partial
     // unit JSON still produces a structured (but small) BV.
     const breakdown = calculateAerospaceBVFromUnit(
-      unit as Parameters<typeof calculateAerospaceBVFromUnit>[0],
+      unit as unknown as Parameters<typeof calculateAerospaceBVFromUnit>[0],
     );
     computedBV = breakdown.final;
   } catch {
@@ -331,18 +339,33 @@ function writeReport(outputPath: string, report: AerospaceParityReport): void {
   fs.writeFileSync(outputPath, JSON.stringify(report, null, 2), 'utf8');
 }
 
+function generatedAtTimestamp(): string {
+  return process.env.MEKSTATION_VALIDATION_GENERATED_AT ?? STABLE_GENERATED_AT;
+}
+
+function reportRowsForReferenceCoverage(
+  rows: readonly AerospaceParityRow[],
+): readonly AerospaceParityRow[] {
+  return rows.filter((row) => row.canonicalBV !== null);
+}
+
 // =============================================================================
 // Main
 // =============================================================================
 
-function main(): void {
-  const options = parseArgs();
+function buildReport(options: CLIOptions): AerospaceParityReport {
   if (options.help) {
     printHelp();
-    return;
+    return {
+      schemaVersion: 1,
+      status: 'deferred',
+      reason: 'help requested',
+      generatedAt: generatedAtTimestamp(),
+      units: [],
+    };
   }
 
-  const generatedAt = new Date().toISOString();
+  const generatedAt = generatedAtTimestamp();
   const cacheRoot = locateCache(options.aeroCachePaths);
 
   if (!cacheRoot) {
@@ -359,13 +382,7 @@ function main(): void {
       generatedAt,
       units: [],
     };
-    writeReport(options.outputPath, report);
-    // eslint-disable-next-line no-console
-    console.log(
-      `[validate-aerospace-bv] Emitted deferred report at ${options.outputPath} ` +
-        `(no aerospace MUL cache found).`,
-    );
-    return;
+    return report;
   }
 
   // Cache present — walk it and compute parity rows.
@@ -401,8 +418,10 @@ function main(): void {
       : compared.length === rows.length
         ? 'full'
         : 'partial';
+  const referencedRows = reportRowsForReferenceCoverage(rows);
+  const omittedUnreferencedUnits = rows.length - referencedRows.length;
 
-  const report: AerospaceParityReport = {
+  return {
     schemaVersion: 1,
     status: 'ok',
     reason:
@@ -412,24 +431,51 @@ function main(): void {
     coverage,
     generatedAt,
     source: cacheRoot,
-    units: rows,
+    units: referencedRows,
+    omittedUnreferencedUnits,
+    unparseableUnits: skipped,
     stats: {
       total: rows.length,
       compared: compared.length,
       exact,
       within1pct,
       within5pct,
+      unparseableUnits: skipped,
+      omittedUnreferencedUnits,
       outliers,
     },
   };
+}
+
+function main(): void {
+  const options = parseArgs();
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  const report = buildReport(options);
   writeReport(options.outputPath, report);
+
   // eslint-disable-next-line no-console
-  console.log(
-    `[validate-aerospace-bv] Loaded ${rows.length} units from ${cacheRoot} ` +
-      `(${compared.length} with canonical BV, ${skipped} unparseable).`,
-  );
+  if (report.status === 'deferred') {
+    console.log(
+      `[validate-aerospace-bv] Emitted deferred report at ${options.outputPath} ` +
+        `(no aerospace MUL cache found).`,
+    );
+  } else {
+    console.log(
+      `[validate-aerospace-bv] Loaded ${report.stats?.total ?? 0} units ` +
+        `(${report.stats?.compared ?? 0} with canonical BV, ` +
+        `${report.omittedUnreferencedUnits ?? 0} omitted from row output).`,
+    );
+  }
   // eslint-disable-next-line no-console
   console.log(`[validate-aerospace-bv] Report: ${options.outputPath}`);
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+export { buildReport, parseArgs, reportRowsForReferenceCoverage };

--- a/scripts/validate-infantry-bv.ts
+++ b/scripts/validate-infantry-bv.ts
@@ -73,8 +73,17 @@ interface InfantryBVReport {
     readonly reason: string;
     readonly trackedBy: string;
   };
+  /** Number of platoons scanned but omitted because they have no MUL BV. */
+  readonly omittedWithoutMulBV: number;
   readonly platoons: readonly PlatoonReportEntry[];
 }
+
+interface CLIOptions {
+  readonly outputPath: string;
+  readonly help: boolean;
+}
+
+const STABLE_GENERATED_AT = '1970-01-01T00:00:00.000Z';
 
 // =============================================================================
 // Fixture loading
@@ -87,6 +96,52 @@ const INFANTRY_DATA_DIR = path.resolve(
   'units',
   'infantry',
 );
+
+function parseArgs(): CLIOptions {
+  const args = process.argv.slice(2);
+  const defaultOutputPath = path.resolve(
+    process.cwd(),
+    'validation-output',
+    'infantry-bv-validation-report.json',
+  );
+  let outputPath = defaultOutputPath;
+  let help = false;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    switch (arg) {
+      case '--output':
+        outputPath = path.resolve(args[++i] || defaultOutputPath);
+        break;
+      case '--help':
+      case '-h':
+        help = true;
+        break;
+      default:
+        break;
+    }
+  }
+
+  return { outputPath, help };
+}
+
+function printHelp(): void {
+  // eslint-disable-next-line no-console
+  console.log(`
+Infantry BV Parity Validation
+
+Usage:
+  npx tsx scripts/validate-infantry-bv.ts [options]
+
+Options:
+  --output <path>      Output JSON report path
+  --help, -h           Show this help message
+`);
+}
+
+function generatedAtTimestamp(): string {
+  return process.env.MEKSTATION_VALIDATION_GENERATED_AT ?? STABLE_GENERATED_AT;
+}
 
 /**
  * Recursively gather every `*.json` under `public/data/units/infantry/`.
@@ -162,7 +217,10 @@ function fixtureName(data: InfantryFixtureFile, filePath: string): string {
   if (typeof data.name === 'string' && data.name.trim()) return data.name;
 
   const fromChassisModel = [data.chassis, data.model]
-    .filter((part): part is string => typeof part === 'string' && part.trim())
+    .filter(
+      (part): part is string =>
+        typeof part === 'string' && part.trim().length > 0,
+    )
     .join(' ');
   return fromChassisModel || path.basename(filePath, '.json');
 }
@@ -391,10 +449,11 @@ function buildReport(): InfantryBVReport {
   const withinFive = platoons.filter(
     (p) => p.deltaPct !== null && Math.abs(p.deltaPct) <= 5,
   ).length;
+  const referencedPlatoons = platoons.filter((p) => p.mulBV !== null);
 
   return {
     version: '1',
-    generatedAt: new Date().toISOString(),
+    generatedAt: generatedAtTimestamp(),
     totalPlatoons: platoons.length,
     parityCoverage: {
       withMulBV,
@@ -407,7 +466,8 @@ function buildReport(): InfantryBVReport {
       trackedBy:
         'openspec/changes/add-infantry-battle-value/tasks.md (task 7.2 deferred)',
     },
-    platoons,
+    omittedWithoutMulBV: platoons.length - referencedPlatoons.length,
+    platoons: referencedPlatoons,
   };
 }
 
@@ -415,17 +475,27 @@ function buildReport(): InfantryBVReport {
  * Entry point — writes the report to `validation-output/infantry-bv-validation-report.json`.
  */
 function main(): void {
+  const options = parseArgs();
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
   const report = buildReport();
-  const outDir = path.resolve(process.cwd(), 'validation-output');
+  const outDir = path.dirname(options.outputPath);
   if (!fs.existsSync(outDir)) {
     fs.mkdirSync(outDir, { recursive: true });
   }
-  const outPath = path.join(outDir, 'infantry-bv-validation-report.json');
+  const outPath = options.outputPath;
   fs.writeFileSync(outPath, JSON.stringify(report, null, 2) + '\n', 'utf-8');
 
   // Minimal summary on stdout — mirrors existing BV harness ergonomics.
   console.log('[validate-infantry-bv] Report written: ' + outPath);
   console.log('[validate-infantry-bv] Platoons: ' + report.totalPlatoons);
+  console.log(
+    '[validate-infantry-bv] Omitted without MUL BV: ' +
+      report.omittedWithoutMulBV,
+  );
   console.log(
     '[validate-infantry-bv] With MUL BV: ' +
       report.parityCoverage.withMulBV +
@@ -452,4 +522,4 @@ if (require.main === module) {
   main();
 }
 
-export { buildReport, loadFixture, gatherInfantryFixtureFiles };
+export { buildReport, loadFixture, gatherInfantryFixtureFiles, parseArgs };

--- a/validation-output/aerospace-bv-validation-report.json
+++ b/validation-output/aerospace-bv-validation-report.json
@@ -1,8 +1,21 @@
 {
   "schemaVersion": 1,
-  "status": "deferred",
-  "reason": "aerospace MUL cache not yet available — checked: E:\\Projects\\MekStation\\.claude\\worktrees\\agent-aero-bv\\public\\data\\units\\aerospace_units, E:\\Projects\\MekStation\\.claude\\worktrees\\agent-aero-bv\\public\\data\\units\\aerospacefighters, E:\\Projects\\MekStation\\.claude\\worktrees\\agent-aero-bv\\public\\data\\units\\aerospace",
+  "status": "ok",
+  "reason": "Loaded 612 aerospace units; none expose a canonical BV.",
   "coverage": "no_mul_data",
-  "generatedAt": "2026-04-24T22:30:56.577Z",
-  "units": []
+  "generatedAt": "1970-01-01T00:00:00.000Z",
+  "source": "E:\\Projects\\MekStation\\public\\data\\units\\aerospace",
+  "units": [],
+  "omittedUnreferencedUnits": 612,
+  "unparseableUnits": 0,
+  "stats": {
+    "total": 612,
+    "compared": 0,
+    "exact": 0,
+    "within1pct": 0,
+    "within5pct": 0,
+    "unparseableUnits": 0,
+    "omittedUnreferencedUnits": 612,
+    "outliers": []
+  }
 }

--- a/validation-output/infantry-bv-validation-report.json
+++ b/validation-output/infantry-bv-validation-report.json
@@ -1,7 +1,7 @@
 {
   "version": "1",
-  "generatedAt": "2026-04-24T19:42:16.455Z",
-  "totalPlatoons": 3,
+  "generatedAt": "1970-01-01T00:00:00.000Z",
+  "totalPlatoons": 1795,
   "parityCoverage": {
     "withMulBV": 0,
     "withinOnePercent": 0,
@@ -11,78 +11,6 @@
     "reason": "MUL BV cache for conventional infantry platoons is partial. Fixtures without a mulBV field emit delta/deltaPct as null; once the MegaMek MUL extract is seeded under public/data/units/infantry/, each fixture should gain a mulBV value and delta coverage will rise automatically.",
     "trackedBy": "openspec/changes/add-infantry-battle-value/tasks.md (task 7.2 deferred)"
   },
-  "platoons": [
-    {
-      "id": "inf-foot-rifle-28",
-      "name": "Foot Rifle Platoon",
-      "source": "public\\data\\units\\infantry\\foot-rifle-platoon.json",
-      "computedBV": 0,
-      "mulBV": null,
-      "delta": null,
-      "deltaPct": null,
-      "breakdown": {
-        "perTrooper": 0,
-        "motiveMultiplier": 1,
-        "antiMechMultiplier": 1,
-        "fieldGunBV": 0,
-        "platoonBV": 0,
-        "pilotMultiplier": 1,
-        "final": 0,
-        "primaryBV": 0,
-        "secondaryBV": 0,
-        "armorKitBV": 0,
-        "fieldGunWeaponBV": 0,
-        "fieldGunAmmoBV": 0,
-        "troopers": 28
-      }
-    },
-    {
-      "id": "inf-jump-srm-21",
-      "name": "Jump SRM Platoon",
-      "source": "public\\data\\units\\infantry\\jump-srm-platoon.json",
-      "computedBV": 51,
-      "mulBV": null,
-      "delta": null,
-      "deltaPct": null,
-      "breakdown": {
-        "perTrooper": 2,
-        "motiveMultiplier": 1.1,
-        "antiMechMultiplier": 1.1,
-        "fieldGunBV": 0,
-        "platoonBV": 50.82000000000001,
-        "pilotMultiplier": 1,
-        "final": 51,
-        "primaryBV": 0,
-        "secondaryBV": 0,
-        "armorKitBV": 2,
-        "fieldGunWeaponBV": 0,
-        "fieldGunAmmoBV": 0,
-        "troopers": 21
-      }
-    },
-    {
-      "id": "inf-mechanized-tracked-20",
-      "name": "Mechanized Tracked Rifle Platoon",
-      "source": "public\\data\\units\\infantry\\mechanized-tracked-platoon.json",
-      "computedBV": 0,
-      "mulBV": null,
-      "delta": null,
-      "deltaPct": null,
-      "breakdown": {
-        "perTrooper": 0,
-        "motiveMultiplier": 1.15,
-        "antiMechMultiplier": 1,
-        "fieldGunBV": 0,
-        "platoonBV": 0,
-        "pilotMultiplier": 1,
-        "final": 0,
-        "primaryBV": 0,
-        "secondaryBV": 0,
-        "armorKitBV": 0,
-        "fieldGunWeaponBV": 0,
-        "fieldGunAmmoBV": 0,
-        "troopers": 20
-      }
-    }
-  ]
+  "omittedWithoutMulBV": 1795,
+  "platoons": []
 }


### PR DESCRIPTION
## Summary
- keep aerospace and infantry BV validation reports compact by only committing rows with canonical BV references
- retain full live scan counts for aerospace and infantry fixtures in the report summaries
- add a regression test that runs both harnesses against temp outputs and verifies compact deterministic report behavior

## Validation
- npx.cmd jest --selectProjects unit --ci --runTestsByPath scripts/__tests__/wave4-bv-report-output.test.ts --no-coverage
- npm.cmd run verify:qc:wave4:customizer-data
- npm.cmd run qc:wave4:validate
- npm.cmd run typecheck -- --pretty false
- npm.cmd run lint -- scripts/validate-aerospace-bv.ts scripts/validate-infantry-bv.ts scripts/__tests__/wave4-bv-report-output.test.ts
- npx.cmd oxfmt --check scripts/validate-aerospace-bv.ts scripts/validate-infantry-bv.ts scripts/__tests__/wave4-bv-report-output.test.ts validation-output/aerospace-bv-validation-report.json validation-output/infantry-bv-validation-report.json
- git diff --check

## Notes
- Full release signoff still reports 18 app-completion gaps; this PR stabilizes the Wave 4 BV evidence surface rather than closing all Wave 4 product gaps.