### PR TITLE
Prove packaged multiplayer reconnect durability

### DIFF
--- a/docs/qc/mekstation-qc-map.md
+++ b/docs/qc/mekstation-qc-map.md
@@ -320,8 +320,10 @@ flowchart TD
      API fog/spectate contracts, server reconnect/spectator/fog behavior, turn
      ownership, and the Phase 4 capstone host/join/reconnect/outcome flow.
    - Wave 4 folds this multiplayer gate plus `verify:qc:replay-recovery` into
-     `verify:qc:wave4`; true two-window vault-auth and packaged-runtime
-     kill/reconnect remain release-signoff checks rather than hidden blockers.
+     `verify:qc:wave4`; `validate:multiplayer:packaged-socket` now proves
+     packaged-runtime kill/reconnect against the durable match store, while
+     true two-window vault-auth remains a release-signoff check rather than a
+     hidden blocker.
 
 1. `desktop-api-security`
    - The 2026-06-23 desktop lane now proves the packaged runtime path with

--- a/docs/qc/mekstation-qc-registry.json
+++ b/docs/qc/mekstation-qc-registry.json
@@ -1283,22 +1283,23 @@
         "npm.cmd run verify:qc:multiplayer-reliability",
         "npm.cmd run verify:qc:multiplayer:contracts",
         "npm.cmd run verify:qc:multiplayer:browser",
+        "npm.cmd run validate:multiplayer:packaged-socket",
         "npm.cmd run qc:wave4:validate"
       ],
       "manualChecks": [
-        "Run a true two-window/vault-auth host and guest session, join by invite code, and verify live turn handoff plus fog-limited guest state.",
-        "Kill/restart the packaged runtime during an active match and verify reconnect durability against the persistent match store."
+        "Run a true two-window/vault-auth host and guest session, join by invite code, and verify live turn handoff plus fog-limited guest state."
       ],
       "evidence": [
         "docs/audits/2026-06-12-full-codebase-review.md",
         "2026-06-23 Chromium browser smoke passed `npx.cmd playwright test --project=chromium e2e/playtest-coop-route-smoke.spec.ts`: host co-op campaign mounts dashboard/personnel/mech-bay/hiring/contract-market/finances with co-op badge, and single-player campaign hides co-op surfaces.",
         "2026-06-24 `verify:qc:multiplayer-reliability` groups browser route smoke, mock P2P sync, co-op route mounting, API fog/spectate contracts, server host/reconnect/spectator/fog behavior, turn ownership, and the Phase 4 capstone host/join/reconnect/outcome flow.",
-        "2026-06-24 Wave 4 validator requires multiplayer aggregate scripts plus route, contract, and capstone source anchors while leaving two-browser and packaged runtime boundaries in their existing gap fields.",
+        "2026-06-25 `npm.cmd run validate:multiplayer:packaged-socket` passed after `npm.cmd run build`: packaged server socket upgrade/replay succeeded, the process restarted against the same durable SQLite match store, the same match replayed after reconnect, and the co-op runtime proposal committed.",
+        "2026-06-25 Wave 4 validator requires multiplayer aggregate scripts plus route, contract, capstone source anchors, and the packaged socket command while keeping live host/guest identity play tracked separately.",
         "Archived OpenSpec change 2026-06-21-reconcile-multiplayer-coop-reality retired from activeChangeRefs on 2026-06-23.",
         "Archived OpenSpec change 2026-06-21-harden-desktop-and-api-security retired from activeChangeRefs on 2026-06-23."
       ],
       "gaps": [
-        "Automated coverage proves route/mock harness, server/API contracts, reconnect, spectator, fog, turn-authority, and capstone host/join recovery; true two-window vault-auth live play and packaged-runtime kill/reconnect remain release-signoff checks."
+        "Automated coverage proves route/mock harness, server/API contracts, reconnect, spectator, fog, turn-authority, capstone host/join recovery, and packaged runtime kill/reconnect against the durable match store; true two-window vault-auth live play remains the release-signoff check."
       ]
     },
     {

--- a/docs/qc/mekstation-qc-validation-graph.json
+++ b/docs/qc/mekstation-qc-validation-graph.json
@@ -1373,6 +1373,7 @@
         "docs/audits/2026-06-12-full-codebase-review.md",
         "2026-06-23 Chromium browser smoke passed `npx.cmd playwright test --project=chromium e2e/playtest-coop-route-smoke.spec.ts`: host co-op campaign mounts dashboard/personnel/mech-bay/hiring/contract-market/finances with co-op badge, and single-player campaign hides co-op surfaces.",
         "2026-06-24 `verify:qc:multiplayer-reliability` groups browser route smoke, mock P2P sync, co-op route mounting, API fog/spectate contracts, server host/reconnect/spectator/fog behavior, turn ownership, and the Phase 4 capstone host/join/reconnect/outcome flow.",
+        "2026-06-25 `npm.cmd run validate:multiplayer:packaged-socket` passed after `npm.cmd run build`: packaged server socket upgrade/replay succeeded, the process restarted against the same durable SQLite match store, the same match replayed after reconnect, and the co-op runtime proposal committed.",
         "Archived OpenSpec change 2026-06-21-reconcile-multiplayer-coop-reality retired from activeChangeRefs on 2026-06-23.",
         "Archived OpenSpec change 2026-06-21-harden-desktop-and-api-security retired from activeChangeRefs on 2026-06-23."
       ]
@@ -1382,8 +1383,7 @@
       "kind": "evidence",
       "label": "Manual/browser evidence for Multiplayer, Co-op, P2P Sync",
       "entries": [
-        "Run a true two-window/vault-auth host and guest session, join by invite code, and verify live turn handoff plus fog-limited guest state.",
-        "Kill/restart the packaged runtime during an active match and verify reconnect durability against the persistent match store."
+        "Run a true two-window/vault-auth host and guest session, join by invite code, and verify live turn handoff plus fog-limited guest state."
       ]
     },
     {
@@ -1391,7 +1391,7 @@
       "kind": "known-gap",
       "label": "Multiplayer, Co-op, P2P Sync known gaps",
       "entries": [
-        "Automated coverage proves route/mock harness, server/API contracts, reconnect, spectator, fog, turn-authority, and capstone host/join recovery; true two-window vault-auth live play and packaged-runtime kill/reconnect remain release-signoff checks."
+        "Automated coverage proves route/mock harness, server/API contracts, reconnect, spectator, fog, turn-authority, capstone host/join recovery, and packaged runtime kill/reconnect against the durable match store; true two-window vault-auth live play remains the release-signoff check."
       ]
     },
     {

--- a/scripts/qc/validate-wave4-scope-recovery.mjs
+++ b/scripts/qc/validate-wave4-scope-recovery.mjs
@@ -131,6 +131,7 @@ const requiredSurfaces = [
       'verify:qc:multiplayer-reliability',
       'verify:qc:multiplayer:contracts',
       'verify:qc:multiplayer:browser',
+      'validate:multiplayer:packaged-socket',
       'qc:wave4:validate',
     ],
     testIncludes: [
@@ -144,10 +145,10 @@ const requiredSurfaces = [
       'reconnectionFlow.test.ts',
       'fogOfWar.test.ts',
     ],
-    manualIncludes: ['true two-window/vault-auth', 'packaged runtime'],
+    manualIncludes: ['true two-window/vault-auth'],
     gapIncludes: [
       'true two-window vault-auth live play',
-      'packaged-runtime kill/reconnect',
+      'packaged runtime kill/reconnect against the durable match store',
     ],
   },
   {

--- a/scripts/validate-multiplayer-packaged-socket.mjs
+++ b/scripts/validate-multiplayer-packaged-socket.mjs
@@ -386,6 +386,26 @@ async function openAndJoin(wsUrl, wireToken, playerId, matchId, getOutput) {
   return kinds;
 }
 
+async function startPackagedServer(npmExecutable) {
+  const child = spawn(npmExecutable, ['run', 'start'], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      PORT: String(port),
+      HOSTNAME: host,
+      NODE_ENV: 'production',
+      MULTIPLAYER_SOCKET_TRACE: '1',
+      MULTIPLAYER_STORE: process.env.MULTIPLAYER_STORE ?? 'durable',
+      MULTIPLAYER_DB_PATH: dbPath,
+    },
+    shell: process.platform === 'win32',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const getOutput = captureServerOutput(child);
+  await waitForServer(child, getOutput);
+  return { child, getOutput };
+}
+
 function runCoopRuntimeSmoke(match) {
   const executable = process.platform === 'win32' ? 'npx.cmd' : 'npx';
   const result = spawnSync(
@@ -428,45 +448,50 @@ async function main() {
   assertHydratedStandaloneServer();
 
   const npmExecutable = process.platform === 'win32' ? 'npm.cmd' : 'npm';
-  const child = spawn(npmExecutable, ['run', 'start'], {
-    cwd: process.cwd(),
-    env: {
-      ...process.env,
-      PORT: String(port),
-      HOSTNAME: host,
-      NODE_ENV: 'production',
-      MULTIPLAYER_SOCKET_TRACE: '1',
-      MULTIPLAYER_STORE: process.env.MULTIPLAYER_STORE ?? 'durable',
-      MULTIPLAYER_DB_PATH: dbPath,
-    },
-    shell: process.platform === 'win32',
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
-  const getOutput = captureServerOutput(child);
+  let child = null;
 
   try {
-    await waitForServer(child, getOutput);
+    const firstServer = await startPackagedServer(npmExecutable);
+    child = firstServer.child;
     const { wireToken, playerId } = await issueWireToken();
-    const match = await createMatch(wireToken, playerId, getOutput);
+    const match = await createMatch(wireToken, playerId, firstServer.getOutput);
     const kinds = await openAndJoin(
       match.wsUrl,
       wireToken,
       playerId,
       match.matchId,
-      getOutput,
+      firstServer.getOutput,
     );
     const coopRuntime = runCoopRuntimeSmoke(match);
+
+    stopServer(child);
+    child = null;
+    await delay(500);
+
+    const restartedServer = await startPackagedServer(npmExecutable);
+    child = restartedServer.child;
+    const reconnectFrames = await openAndJoin(
+      match.wsUrl,
+      wireToken,
+      playerId,
+      match.matchId,
+      restartedServer.getOutput,
+    );
+
     console.log(
       JSON.stringify(
         {
           ok: true,
           packagedMultiplayerReachability: 'socket-upgrade-and-replay-ok',
+          packagedRestartReconnect:
+            'same-match-replay-after-process-restart-ok',
           startScript: 'npm run start',
           baseUrl,
           dbPath,
           matchId: match.matchId,
           roomCode: match.roomCode,
           frames: kinds,
+          reconnectFrames,
           coopRuntime,
         },
         null,
@@ -474,7 +499,7 @@ async function main() {
       ),
     );
   } finally {
-    stopServer(child);
+    if (child) stopServer(child);
     await delay(100);
     for (const suffix of ['', '-wal', '-shm']) {
       try {


### PR DESCRIPTION
## Summary
- Extend the packaged multiplayer socket validator to restart the packaged server and reconnect to the same match through the durable match store.
- Record the packaged reconnect proof in the QC registry, validation graph, and QC map.
- Update the Wave 4 validator so packaged reconnect is an automated proof while true two-window/vault-auth play remains the manual release-signoff boundary.

## Validation
- npm.cmd run build
- npm.cmd run validate:multiplayer:packaged-socket
- npx.cmd oxfmt --check scripts/validate-multiplayer-packaged-socket.mjs docs/qc/mekstation-qc-registry.json docs/qc/mekstation-qc-validation-graph.json docs/qc/mekstation-qc-map.md scripts/qc/validate-wave4-scope-recovery.mjs
- npm.cmd run lint -- scripts/validate-multiplayer-packaged-socket.mjs scripts/qc/validate-wave4-scope-recovery.mjs
- npm.cmd run qc:validate
- npm.cmd run qc:wave4:validate
- npm.cmd run qc:lifecycle:status
- npm.cmd run qc:app-completion -- --json
- git diff --check
- git diff --cached --check

## Remaining
- True two-window/vault-auth host and guest browser session remains a multiplayer release-signoff gap.
- Overall app-completion release gaps remain at 18.