### PR TITLE
Fix release ledger accounting

### DIFF
--- a/scripts/__tests__/app-completion-gate.test.ts
+++ b/scripts/__tests__/app-completion-gate.test.ts
@@ -20,13 +20,18 @@ const requiredSurfaceIds = [
   'gameplay-tactical-map-combat',
   'simulation-combat-validation',
   'battlemech-combat-catalog-validation',
+  'behavior-class-combat-rules',
+  'integration-runner-interactive-parity',
+  'physical-weapon-runtime-boundary',
   'non-battlemech-combat-scope-matrix',
+  'compendium-unit-data',
   'customizer-construction-bv-export',
   'multiplayer-coop-sync',
   'replay-audit-history',
   'desktop-api-security',
   'maintenance-code-health',
   'openspec-ci-quality',
+  'known-gap-honesty-audit',
 ];
 
 function makeTempDir(prefix: string): string {
@@ -218,5 +223,64 @@ describe('app completion gate validator', () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('Release signoff gaps: 0');
     expect(result.stderr).toBe('');
+  });
+
+  it('buckets child combat partials into the priority release summary', () => {
+    const env = writeFixtureSet(tempDir, false);
+    const registry = JSON.parse(
+      fs.readFileSync(env.MEKSTATION_QC_REGISTRY_PATH, 'utf-8'),
+    );
+    const behaviorSurface = registry.surfaces.find(
+      (surface: { surfaceId: string }) =>
+        surface.surfaceId === 'behavior-class-combat-rules',
+    );
+    behaviorSurface.coverageStatus = 'partial';
+    writeJson(env.MEKSTATION_QC_REGISTRY_PATH, registry);
+
+    const result = runValidator(['--json'], env);
+    const report = JSON.parse(result.stdout);
+    const wave3 = report.priority.find(
+      (wave: { wave: string }) => wave.wave === 'Wave 3',
+    );
+
+    expect(result.status).toBe(0);
+    expect(report.releaseGaps).toEqual([
+      {
+        surfaceId: 'behavior-class-combat-rules',
+        kind: 'coverage-status',
+        detail: 'coverageStatus=partial',
+      },
+    ]);
+    expect(wave3.releaseGapCount).toBe(1);
+    expect(wave3.surfaces).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          surfaceId: 'behavior-class-combat-rules',
+          gapCount: 1,
+        }),
+      ]),
+    );
+  });
+
+  it('does not count positive knownLimitations evidence as a release gap', () => {
+    const env = writeFixtureSet(tempDir, false);
+    const registry = JSON.parse(
+      fs.readFileSync(env.MEKSTATION_QC_REGISTRY_PATH, 'utf-8'),
+    );
+    const catalogSurface = registry.surfaces.find(
+      (surface: { surfaceId: string }) =>
+        surface.surfaceId === 'battlemech-combat-catalog-validation',
+    );
+    catalogSurface.evidence = [
+      'Catalog review confirmed knownLimitations bypass coverage in the BattleMech lane.',
+    ];
+    writeJson(env.MEKSTATION_QC_REGISTRY_PATH, registry);
+
+    const result = runValidator(['--json'], env);
+    const report = JSON.parse(result.stdout);
+
+    expect(result.status).toBe(0);
+    expect(report.releaseGaps).toEqual([]);
+    expect(report.summary.releaseSignoff.gaps).toBe(0);
   });
 });

--- a/scripts/qc/validate-app-completion-gate.mjs
+++ b/scripts/qc/validate-app-completion-gate.mjs
@@ -73,13 +73,18 @@ const requiredSurfaceIds = [
   'gameplay-tactical-map-combat',
   'simulation-combat-validation',
   'battlemech-combat-catalog-validation',
+  'behavior-class-combat-rules',
+  'integration-runner-interactive-parity',
+  'physical-weapon-runtime-boundary',
   'non-battlemech-combat-scope-matrix',
+  'compendium-unit-data',
   'customizer-construction-bv-export',
   'multiplayer-coop-sync',
   'replay-audit-history',
   'desktop-api-security',
   'maintenance-code-health',
   'openspec-ci-quality',
+  'known-gap-honesty-audit',
 ];
 
 const priorityWaves = [
@@ -110,6 +115,9 @@ const priorityWaves = [
       'combat-preview-engine-agreement',
       'isometric-rotatable-25d',
       'simulation-combat-validation',
+      'behavior-class-combat-rules',
+      'integration-runner-interactive-parity',
+      'physical-weapon-runtime-boundary',
     ],
   },
   {
@@ -137,6 +145,9 @@ const priorityWaves = [
 
 const releaseGapPattern =
   /release|release-grade|signoff|browser-driven|browserExecuted=false|true two-window|packaged-runtime|security audit|explicit skips|separate UI lane|screenshot-quality|manual takeover|knownLimitations bypass/i;
+
+const evidenceReleaseGapPattern =
+  /release|release-grade|signoff|browser-driven|browserExecuted=false|true two-window|packaged-runtime|security audit|explicit skips|separate UI lane|screenshot-quality|manual takeover/i;
 
 function parseArgs(argv) {
   const options = {
@@ -377,7 +388,9 @@ function releaseGapsForSurface(surface) {
 
   for (const field of ['gaps', 'manualChecks', 'evidence']) {
     for (const value of surface[field] ?? []) {
-      if (!releaseGapPattern.test(String(value))) continue;
+      const pattern =
+        field === 'evidence' ? evidenceReleaseGapPattern : releaseGapPattern;
+      if (!pattern.test(String(value))) continue;
       gaps.push({
         surfaceId: surface.surfaceId,
         kind: field,


### PR DESCRIPTION
## Summary
- bucket combat child partials in the app-completion priority waves so the release summary accounts for all raw gaps
- add compendium, known-gap, and combat child surfaces to required release surface accounting
- avoid counting positive knownLimitations evidence as a release gap while preserving gap/manual-check detection

## Verification
- npm.cmd test -- --watchAll=false --runTestsByPath scripts/__tests__/app-completion-gate.test.ts scripts/__tests__/qc-registry.test.ts --runInBand
- npm.cmd run qc:validate
- npm.cmd run qc:app-completion
- npm.cmd run typecheck -- --pretty false
- npm.cmd run format:check
- npm.cmd run lint
- npm.cmd run verify:app-completion

## Notes
- verify:app-completion:release intentionally remains failing because 17 release-signoff gaps are now reported truthfully.