### PR TITLE
Reduce campaign page-object maintenance debt

### DIFF
--- a/docs/qc/maintenance-warning-ledger.json
+++ b/docs/qc/maintenance-warning-ledger.json
@@ -33,9 +33,9 @@
       "follow-up": 0
     },
     "design-violation": {
-      "fixed": 2,
+      "fixed": 5,
       "accepted": 3,
-      "follow-up": 22
+      "follow-up": 19
     }
   },
   "entries": [
@@ -257,9 +257,13 @@
       "severity": "critical",
       "file": "e2e/pages/campaign.page.ts",
       "message": "class has 12 public methods",
-      "status": "follow-up",
-      "rationale": "Campaign page-object role should be decomposed with campaign E2E coverage preserved.",
-      "followUps": ["wave-12-e2e-page-object-split"]
+      "status": "fixed",
+      "rationale": "Obsolete campaign detail page-object helpers were removed after the active dashboard-route browser spec confirmed they are not part of current campaign E2E coverage.",
+      "fixedEvidence": [
+        "2026-06-27 `node scripts/maintenance/scan-maintenance.mjs --json` reported no findings for e2e/pages/campaign.page.ts and design-violation counts dropped from critical=15/high=7 to critical=13/high=6.",
+        "2026-06-27 `npx.cmd tsc --noEmit --pretty false --project tsconfig.json` passed.",
+        "2026-06-27 full Chromium `npx.cmd playwright test e2e/campaign.spec.ts --project=chromium --workers=1` passed 12 checks with 3 existing skipped mission-tree cases."
+      ]
     },
     {
       "key": "design-violation|critical|e2e/pages/campaign.page.ts|class has 9 public methods",
@@ -267,9 +271,13 @@
       "severity": "critical",
       "file": "e2e/pages/campaign.page.ts",
       "message": "class has 9 public methods",
-      "status": "follow-up",
-      "rationale": "Campaign page-object role should be decomposed with campaign E2E coverage preserved.",
-      "followUps": ["wave-12-e2e-page-object-split"]
+      "status": "fixed",
+      "rationale": "Unused campaign creation helpers were removed so the create page object exposes only browser-tested wizard interactions.",
+      "fixedEvidence": [
+        "2026-06-27 `node scripts/maintenance/scan-maintenance.mjs --json` reported no findings for e2e/pages/campaign.page.ts and design-violation counts dropped from critical=15/high=7 to critical=13/high=6.",
+        "2026-06-27 `npx.cmd tsc --noEmit --pretty false --project tsconfig.json` passed.",
+        "2026-06-27 full Chromium `npx.cmd playwright test e2e/campaign.spec.ts --project=chromium --workers=1` passed 12 checks with 3 existing skipped mission-tree cases."
+      ]
     },
     {
       "key": "design-violation|critical|e2e/pages/compendium.page.ts|class has 8 public methods",
@@ -441,9 +449,13 @@
       "severity": "high",
       "file": "e2e/pages/campaign.page.ts",
       "message": "class has 7 public methods",
-      "status": "follow-up",
-      "rationale": "Campaign page-object role should be decomposed with campaign E2E coverage preserved.",
-      "followUps": ["wave-12-e2e-page-object-split"]
+      "status": "fixed",
+      "rationale": "Campaign list navigation and read helpers are now separate page objects so each class has a narrow public workflow surface.",
+      "fixedEvidence": [
+        "2026-06-27 `node scripts/maintenance/scan-maintenance.mjs --json` reported no findings for e2e/pages/campaign.page.ts and design-violation counts dropped from critical=15/high=7 to critical=13/high=6.",
+        "2026-06-27 `npx.cmd tsc --noEmit --pretty false --project tsconfig.json` passed.",
+        "2026-06-27 full Chromium `npx.cmd playwright test e2e/campaign.spec.ts --project=chromium --workers=1` passed 12 checks with 3 existing skipped mission-tree cases."
+      ]
     },
     {
       "key": "design-violation|high|e2e/pages/game.page.ts|class has 5 public methods",

--- a/docs/qc/mekstation-qc-registry.json
+++ b/docs/qc/mekstation-qc-registry.json
@@ -1597,6 +1597,7 @@
         "qc:select now supports structured --module and --submodule filters for on-demand QC routing.",
         "2026-06-18 Metis organization pass gave a no-kill verdict for registry-as-source, map-as-navigation, and audit-as-dated-narrative structure.",
         "2026-06-27 e2e page-object maintenance slice reduced repo-wide design-violation critical findings from 17 to 15 by protecting BasePage helper methods and pruning unused AerospaceCustomizerPage scaffold methods; typecheck and 10 focused Chromium customizer checks passed.",
+        "2026-06-27 campaign page-object maintenance slice removed obsolete CampaignDetailPage helpers, split campaign list reads from navigation, and reduced repo-wide design-violation findings from critical=15/high=7 to critical=13/high=6; typecheck and the full Chromium campaign spec passed.",
         "docs/qc/maintenance-baseline.json",
         "docs/qc/maintenance-warning-ledger.json",
         "scripts/qc/validate-maintenance-warning-ledger.mjs"

--- a/docs/qc/mekstation-qc-validation-graph.json
+++ b/docs/qc/mekstation-qc-validation-graph.json
@@ -1643,6 +1643,7 @@
         "qc:select now supports structured --module and --submodule filters for on-demand QC routing.",
         "2026-06-18 Metis organization pass gave a no-kill verdict for registry-as-source, map-as-navigation, and audit-as-dated-narrative structure.",
         "2026-06-27 e2e page-object maintenance slice reduced repo-wide design-violation critical findings from 17 to 15 by protecting BasePage helper methods and pruning unused AerospaceCustomizerPage scaffold methods; typecheck and 10 focused Chromium customizer checks passed.",
+        "2026-06-27 campaign page-object maintenance slice removed obsolete CampaignDetailPage helpers, split campaign list reads from navigation, and reduced repo-wide design-violation findings from critical=15/high=7 to critical=13/high=6; typecheck and the full Chromium campaign spec passed.",
         "docs/qc/maintenance-baseline.json",
         "docs/qc/maintenance-warning-ledger.json",
         "scripts/qc/validate-maintenance-warning-ledger.mjs"

--- a/e2e/campaign.spec.ts
+++ b/e2e/campaign.spec.ts
@@ -10,7 +10,11 @@
 import { test, expect, type Page } from '@playwright/test';
 
 import { createTestCampaign, deleteCampaign } from './fixtures/campaign';
-import { CampaignListPage, CampaignCreatePage } from './pages/campaign.page';
+import {
+  CampaignCreatePage,
+  CampaignListPage,
+  CampaignListReadPage,
+} from './pages/campaign.page';
 
 // =============================================================================
 // Test Configuration
@@ -37,9 +41,11 @@ async function waitForStoreReady(page: Page): Promise<void> {
 
 test.describe('Campaign List Page @smoke @campaign', () => {
   let listPage: CampaignListPage;
+  let listReadPage: CampaignListReadPage;
 
   test.beforeEach(async ({ page }) => {
     listPage = new CampaignListPage(page);
+    listReadPage = new CampaignListReadPage(page);
     await listPage.navigate();
     await waitForStoreReady(page);
   });
@@ -54,9 +60,9 @@ test.describe('Campaign List Page @smoke @campaign', () => {
 
   test('displays empty state when no campaigns exist', async () => {
     // Should show empty state or no campaign cards
-    const cardCount = await listPage.getCardCount();
+    const cardCount = await listReadPage.getCardCount();
     if (cardCount === 0) {
-      const emptyVisible = await listPage.isEmptyStateVisible();
+      const emptyVisible = await listReadPage.isEmptyStateVisible();
       expect(emptyVisible).toBe(true);
     }
   });
@@ -77,7 +83,7 @@ test.describe('Campaign List Page @smoke @campaign', () => {
     await listPage.navigate();
 
     // Campaign should appear in list
-    const names = await listPage.getCampaignNames();
+    const names = await listReadPage.getCampaignNames();
     expect(names).toContain('Test Campaign Alpha');
 
     // Cleanup
@@ -93,14 +99,14 @@ test.describe('Campaign List Page @smoke @campaign', () => {
 
     await listPage.navigate();
 
-    let names = await listPage.getCampaignNames();
+    let names = await listReadPage.getCampaignNames();
     expect(names).toContain('Alpha Strike Force');
 
     const id = await createTestCampaign(page, { name: 'Beta Recon Unit' });
 
     await listPage.navigate();
 
-    names = await listPage.getCampaignNames();
+    names = await listReadPage.getCampaignNames();
     expect(names).toContain('Beta Recon Unit');
     expect(names).not.toContain('Alpha Strike Force');
 

--- a/e2e/pages/campaign.page.ts
+++ b/e2e/pages/campaign.page.ts
@@ -7,158 +7,40 @@ import { BasePage } from './base.page';
 export class CampaignListPage extends BasePage {
   readonly url = '/gameplay/campaigns';
 
-  /**
-   * Navigate to the campaign list page.
-   */
   async navigate(): Promise<void> {
     await this.page.goto(this.url);
     await this.waitForReady();
   }
 
-  /**
-   * Get the count of campaign cards displayed.
-   */
-  async getCardCount(): Promise<number> {
-    const cards = this.page.locator('[data-testid^="campaign-card-"]');
-    return cards.count();
-  }
-
-  /**
-   * Click the create campaign button.
-   */
   async clickCreateButton(): Promise<void> {
     await this.clickAndWaitForNavigation(
       this.getByTestId('create-campaign-btn'),
     );
   }
 
-  /**
-   * Click a specific campaign card by ID.
-   * @param id - The campaign ID
-   */
   async clickCampaignCard(id: string): Promise<void> {
     await this.clickAndWaitForNavigation(
       this.getByTestId(`campaign-card-${id}`),
     );
   }
+}
 
-  /**
-   * Search campaigns by query string.
-   * @param query - The search query
-   */
-  async searchCampaigns(query: string): Promise<void> {
-    await this.fillByTestId('campaign-search', query);
-    // Wait for search results to update
-    await this.page.waitForTimeout(300);
+/**
+ * Read-only helpers for the campaign list page.
+ */
+export class CampaignListReadPage extends BasePage {
+  async getCardCount(): Promise<number> {
+    const cards = this.page.locator('[data-testid^="campaign-card-"]');
+    return cards.count();
   }
 
-  /**
-   * Get all campaign names displayed.
-   */
   async getCampaignNames(): Promise<string[]> {
     const names = this.page.locator('[data-testid^="campaign-card-"] h3');
     return names.allTextContents();
   }
 
-  /**
-   * Check if empty state is displayed.
-   */
   async isEmptyStateVisible(): Promise<boolean> {
     return this.isVisibleByTestId('campaigns-empty-state');
-  }
-}
-
-/**
- * Page object for the campaign detail page (/gameplay/campaigns/[id]).
- * Provides methods to interact with campaign details.
- */
-export class CampaignDetailPage extends BasePage {
-  /**
-   * Navigate to a specific campaign's detail page.
-   * @param id - The campaign ID
-   */
-  async navigate(id: string): Promise<void> {
-    await this.page.goto(`/gameplay/campaigns/${id}`);
-    await this.waitForReady();
-  }
-
-  /**
-   * Get the campaign name (from page title).
-   */
-  async getName(): Promise<string> {
-    return this.getTextByTestId('page-title');
-  }
-
-  /**
-   * Get the campaign status.
-   */
-  async getStatus(): Promise<string> {
-    return this.getTextByTestId('campaign-status');
-  }
-
-  /**
-   * Get the campaign description.
-   */
-  async getDescription(): Promise<string> {
-    return this.getTextByTestId('campaign-description');
-  }
-
-  /**
-   * Click the audit tab.
-   */
-  async clickAuditTab(): Promise<void> {
-    await this.clickByTestId('tab-audit');
-  }
-
-  /**
-   * Click the overview tab.
-   */
-  async clickOverviewTab(): Promise<void> {
-    await this.clickByTestId('tab-overview');
-  }
-
-  /**
-   * Click the forces tab.
-   */
-  async clickForcesTab(): Promise<void> {
-    await this.clickByTestId('tab-forces');
-  }
-
-  /**
-   * Click start mission button for a specific mission.
-   * @param missionId - The mission ID
-   */
-  async clickStartMission(missionId: string): Promise<void> {
-    await this.clickByTestId(`start-mission-${missionId}`);
-  }
-
-  /**
-   * Click the delete campaign button.
-   */
-  async clickDelete(): Promise<void> {
-    await this.clickByTestId('delete-campaign-btn');
-  }
-
-  /**
-   * Confirm the delete action in the confirmation dialog.
-   */
-  async confirmDelete(): Promise<void> {
-    await this.clickByTestId('confirm-delete-btn');
-    await this.page.waitForURL(/\/gameplay\/campaigns$/);
-  }
-
-  /**
-   * Cancel the delete action in the confirmation dialog.
-   */
-  async cancelDelete(): Promise<void> {
-    await this.clickByTestId('cancel-delete-btn');
-  }
-
-  /**
-   * Click the edit campaign button.
-   */
-  async clickEdit(): Promise<void> {
-    await this.clickByTestId('edit-campaign-btn');
   }
 }
 
@@ -169,88 +51,20 @@ export class CampaignDetailPage extends BasePage {
 export class CampaignCreatePage extends BasePage {
   readonly url = '/gameplay/campaigns/create';
 
-  /**
-   * Navigate to the campaign create page.
-   */
   async navigate(): Promise<void> {
     await this.page.goto(this.url);
     await this.waitForReady();
   }
 
-  /**
-   * Fill the campaign name field.
-   * @param name - The campaign name
-   */
   async fillName(name: string): Promise<void> {
     await this.fillByTestId('campaign-name-input', name);
   }
 
-  /**
-   * Fill the campaign description field.
-   * @param description - The campaign description
-   */
   async fillDescription(description: string): Promise<void> {
     await this.fillByTestId('campaign-description-input', description);
   }
 
-  /**
-   * Select a difficulty level.
-   * @param difficulty - The difficulty level (e.g., 'easy', 'normal', 'hard')
-   */
-  async selectDifficulty(difficulty: string): Promise<void> {
-    await this.clickByTestId('difficulty-select');
-    await this.clickByTestId(`difficulty-option-${difficulty}`);
-  }
-
-  /**
-   * Select a ruleset.
-   * @param ruleset - The ruleset identifier
-   */
-  async selectRuleset(ruleset: string): Promise<void> {
-    await this.clickByTestId('ruleset-select');
-    await this.clickByTestId(`ruleset-option-${ruleset}`);
-  }
-
-  /**
-   * Submit the create campaign form.
-   */
-  async submit(): Promise<void> {
-    await this.clickAndWaitForNavigation(
-      this.getByTestId('submit-campaign-btn'),
-    );
-  }
-
-  /**
-   * Cancel campaign creation.
-   */
-  async cancel(): Promise<void> {
-    await this.clickAndWaitForNavigation(this.getByTestId('cancel-btn'));
-  }
-
-  /**
-   * Check if form validation error is displayed.
-   * @param field - The field name to check for errors
-   */
   async hasFieldError(field: string): Promise<boolean> {
     return this.isVisibleByTestId(`${field}-error`);
-  }
-
-  /**
-   * Create a campaign with the given details (convenience method).
-   * @param name - The campaign name
-   * @param description - The campaign description
-   * @param difficulty - Optional difficulty level
-   */
-  async createCampaign(
-    name: string,
-    description: string,
-    difficulty?: string,
-  ): Promise<void> {
-    await this.fillName(name);
-    await this.fillDescription(description);
-    if (difficulty) {
-      await this.selectDifficulty(difficulty);
-    }
-    await this.submit();
   }
 }

--- a/e2e/pages/index.ts
+++ b/e2e/pages/index.ts
@@ -7,16 +7,15 @@
  *
  * @example
  * ```typescript
- * import { CampaignListPage, CampaignDetailPage } from './pages';
+ * import { CampaignListPage, CampaignListReadPage } from './pages';
  *
- * test('view campaign details', async ({ page }) => {
+ * test('view campaigns', async ({ page }) => {
  *   const listPage = new CampaignListPage(page);
+ *   const listReadPage = new CampaignListReadPage(page);
  *   await listPage.navigate();
- *   await listPage.clickCampaignCard('campaign-123');
  *
- *   const detailPage = new CampaignDetailPage(page);
- *   const name = await detailPage.getName();
- *   expect(name).toBe('My Campaign');
+ *   const names = await listReadPage.getCampaignNames();
+ *   expect(names).toContain('My Campaign');
  * });
  * ```
  */
@@ -26,9 +25,9 @@ export { BasePage } from './base.page';
 
 // Campaign pages
 export {
-  CampaignListPage,
-  CampaignDetailPage,
   CampaignCreatePage,
+  CampaignListPage,
+  CampaignListReadPage,
 } from './campaign.page';
 
 // Force pages


### PR DESCRIPTION
## Summary
- remove obsolete campaign detail page-object helpers for the unmounted legacy tabbed surface
- split campaign list read helpers from navigation/actions so campaign page-object classes stay narrow
- update the maintenance ledger, QC registry, and validation graph with the campaign page-object evidence

## Validation
- npx.cmd tsc --noEmit --pretty false --project tsconfig.json
- npx.cmd playwright test e2e/campaign.spec.ts --project=chromium --workers=1
- npm.cmd run format:check
- npm.cmd run qc:validate
- node scripts/qc/validate-maintenance-warning-ledger.mjs
- npm.cmd run qc:lifecycle:status
- npm.cmd run qc:app-completion -- --json
- node scripts/maintenance/scan-maintenance.mjs --json targeted summary
- git diff --check

## Notes
- qc:app-completion still reports the expected maintenance-code-health release gap because 37 ledger follow-up entries remain.