### PR TITLE
Reduce compendium page-object maintenance debt

### DIFF
--- a/docs/qc/maintenance-warning-ledger.json
+++ b/docs/qc/maintenance-warning-ledger.json
@@ -33,9 +33,9 @@
       "follow-up": 0
     },
     "design-violation": {
-      "fixed": 5,
+      "fixed": 8,
       "accepted": 3,
-      "follow-up": 19
+      "follow-up": 16
     }
   },
   "entries": [
@@ -285,9 +285,13 @@
       "severity": "critical",
       "file": "e2e/pages/compendium.page.ts",
       "message": "class has 8 public methods",
-      "status": "follow-up",
-      "rationale": "Compendium page-object role should be decomposed with compendium browser coverage preserved.",
-      "followUps": ["wave-12-e2e-page-object-split"]
+      "status": "fixed",
+      "rationale": "Compendium hub helpers were reduced to used behavior and protected page-load plumbing while preserving full compendium browser coverage.",
+      "fixedEvidence": [
+        "2026-06-27 `node scripts/maintenance/scan-maintenance.mjs --json` reported no findings for e2e/pages/compendium.page.ts and design-violation counts dropped from critical=13/high=6 to critical=10/high=6.",
+        "2026-06-27 `npx.cmd tsc --noEmit --pretty false --project tsconfig.json` passed.",
+        "2026-06-27 full Chromium `npx.cmd playwright test e2e/compendium.spec.ts --project=chromium --workers=1` passed 32 checks."
+      ]
     },
     {
       "key": "design-violation|critical|e2e/pages/compendium.page.ts|class has 12 public methods",
@@ -295,9 +299,13 @@
       "severity": "critical",
       "file": "e2e/pages/compendium.page.ts",
       "message": "class has 12 public methods",
-      "status": "follow-up",
-      "rationale": "Compendium page-object role should be decomposed with compendium browser coverage preserved.",
-      "followUps": ["wave-12-e2e-page-object-split"]
+      "status": "fixed",
+      "rationale": "Unit browser action helpers now keep only used navigation/search/filter behavior; read-only assertions moved to UnitBrowserReadPage.",
+      "fixedEvidence": [
+        "2026-06-27 `node scripts/maintenance/scan-maintenance.mjs --json` reported no findings for e2e/pages/compendium.page.ts and design-violation counts dropped from critical=13/high=6 to critical=10/high=6.",
+        "2026-06-27 `npx.cmd tsc --noEmit --pretty false --project tsconfig.json` passed.",
+        "2026-06-27 full Chromium `npx.cmd playwright test e2e/compendium.spec.ts --project=chromium --workers=1` passed 32 checks."
+      ]
     },
     {
       "key": "design-violation|critical|e2e/pages/compendium.page.ts|class has 11 public methods",
@@ -305,9 +313,13 @@
       "severity": "critical",
       "file": "e2e/pages/compendium.page.ts",
       "message": "class has 11 public methods",
-      "status": "follow-up",
-      "rationale": "Compendium page-object role should be decomposed with compendium browser coverage preserved.",
-      "followUps": ["wave-12-e2e-page-object-split"]
+      "status": "fixed",
+      "rationale": "Equipment browser action helpers now keep only used navigation/search/filter/click behavior; read-only assertions moved to EquipmentBrowserReadPage.",
+      "fixedEvidence": [
+        "2026-06-27 `node scripts/maintenance/scan-maintenance.mjs --json` reported no findings for e2e/pages/compendium.page.ts and design-violation counts dropped from critical=13/high=6 to critical=10/high=6.",
+        "2026-06-27 `npx.cmd tsc --noEmit --pretty false --project tsconfig.json` passed.",
+        "2026-06-27 full Chromium `npx.cmd playwright test e2e/compendium.spec.ts --project=chromium --workers=1` passed 32 checks."
+      ]
     },
     {
       "key": "design-violation|critical|e2e/pages/customizer.page.ts|class has 42 public methods",

--- a/docs/qc/mekstation-qc-registry.json
+++ b/docs/qc/mekstation-qc-registry.json
@@ -1598,6 +1598,7 @@
         "2026-06-18 Metis organization pass gave a no-kill verdict for registry-as-source, map-as-navigation, and audit-as-dated-narrative structure.",
         "2026-06-27 e2e page-object maintenance slice reduced repo-wide design-violation critical findings from 17 to 15 by protecting BasePage helper methods and pruning unused AerospaceCustomizerPage scaffold methods; typecheck and 10 focused Chromium customizer checks passed.",
         "2026-06-27 campaign page-object maintenance slice removed obsolete CampaignDetailPage helpers, split campaign list reads from navigation, and reduced repo-wide design-violation findings from critical=15/high=7 to critical=13/high=6; typecheck and the full Chromium campaign spec passed.",
+        "2026-06-27 compendium page-object maintenance slice removed unused detail-page scaffolds, split unit/equipment read helpers from browser actions, and reduced repo-wide design-violation findings from critical=13/high=6 to critical=10/high=6; typecheck and the full Chromium compendium spec passed.",
         "docs/qc/maintenance-baseline.json",
         "docs/qc/maintenance-warning-ledger.json",
         "scripts/qc/validate-maintenance-warning-ledger.mjs"

--- a/docs/qc/mekstation-qc-validation-graph.json
+++ b/docs/qc/mekstation-qc-validation-graph.json
@@ -1644,6 +1644,7 @@
         "2026-06-18 Metis organization pass gave a no-kill verdict for registry-as-source, map-as-navigation, and audit-as-dated-narrative structure.",
         "2026-06-27 e2e page-object maintenance slice reduced repo-wide design-violation critical findings from 17 to 15 by protecting BasePage helper methods and pruning unused AerospaceCustomizerPage scaffold methods; typecheck and 10 focused Chromium customizer checks passed.",
         "2026-06-27 campaign page-object maintenance slice removed obsolete CampaignDetailPage helpers, split campaign list reads from navigation, and reduced repo-wide design-violation findings from critical=15/high=7 to critical=13/high=6; typecheck and the full Chromium campaign spec passed.",
+        "2026-06-27 compendium page-object maintenance slice removed unused detail-page scaffolds, split unit/equipment read helpers from browser actions, and reduced repo-wide design-violation findings from critical=13/high=6 to critical=10/high=6; typecheck and the full Chromium compendium spec passed.",
         "docs/qc/maintenance-baseline.json",
         "docs/qc/maintenance-warning-ledger.json",
         "scripts/qc/validate-maintenance-warning-ledger.mjs"

--- a/e2e/compendium.spec.ts
+++ b/e2e/compendium.spec.ts
@@ -12,7 +12,13 @@
 
 import { test, expect } from '@playwright/test';
 
-import { CompendiumPage, UnitBrowserPage, EquipmentBrowserPage } from './pages';
+import {
+  CompendiumPage,
+  EquipmentBrowserPage,
+  EquipmentBrowserReadPage,
+  UnitBrowserPage,
+  UnitBrowserReadPage,
+} from './pages';
 
 // ============================================================================
 // Compendium Hub Tests
@@ -137,10 +143,11 @@ test.describe('Unit Browser @compendium', () => {
 
   test('search filters units', async ({ page }) => {
     const unitBrowser = new UnitBrowserPage(page);
+    const unitBrowserRead = new UnitBrowserReadPage(page);
     await unitBrowser.goto();
 
     // Get initial count (shown in subtitle)
-    const _initialSubtitle = await unitBrowser.getSubtitleText();
+    const _initialSubtitle = await unitBrowserRead.getSubtitleText();
 
     // Search for something specific
     await unitBrowser.search('atlas');
@@ -149,12 +156,13 @@ test.describe('Unit Browser @compendium', () => {
     await page.waitForTimeout(500);
 
     // The count should change (or stay same if no units match)
-    const _filteredSubtitle = await unitBrowser.getSubtitleText();
+    const _filteredSubtitle = await unitBrowserRead.getSubtitleText();
     // We can't guarantee results, but the search should work without errors
   });
 
   test('filter button toggles filter panel', async ({ page }) => {
     const unitBrowser = new UnitBrowserPage(page);
+    const unitBrowserRead = new UnitBrowserReadPage(page);
     await unitBrowser.goto();
 
     // Filter panel should be hidden initially
@@ -175,13 +183,14 @@ test.describe('Unit Browser @compendium', () => {
 
   test('view mode toggle works', async ({ page }) => {
     const unitBrowser = new UnitBrowserPage(page);
+    const unitBrowserRead = new UnitBrowserReadPage(page);
     await unitBrowser.goto();
 
     // Default should be table view
     const table = page.locator('table');
 
     // If there are units, table should be visible
-    const hasUnits = await unitBrowser.getDisplayedUnitCount();
+    const hasUnits = await unitBrowserRead.getDisplayedUnitCount();
     if (hasUnits > 0) {
       await expect(table).toBeVisible();
     }
@@ -189,10 +198,11 @@ test.describe('Unit Browser @compendium', () => {
 
   test('empty state displays when no units', async ({ page }) => {
     const unitBrowser = new UnitBrowserPage(page);
+    const unitBrowserRead = new UnitBrowserReadPage(page);
     await unitBrowser.goto();
 
     // Check if empty state or units are displayed
-    const hasUnits = await unitBrowser.getDisplayedUnitCount();
+    const hasUnits = await unitBrowserRead.getDisplayedUnitCount();
 
     if (hasUnits === 0) {
       // Empty state should be visible
@@ -208,10 +218,11 @@ test.describe('Unit Browser @compendium', () => {
 
   test('pagination displays when many units', async ({ page }) => {
     const unitBrowser = new UnitBrowserPage(page);
+    const unitBrowserRead = new UnitBrowserReadPage(page);
     await unitBrowser.goto();
 
     // Check the subtitle for total count
-    const subtitleText = await unitBrowser.getSubtitleText();
+    const subtitleText = await unitBrowserRead.getSubtitleText();
     const match = subtitleText.match(/(\d+)/);
 
     if (match) {
@@ -231,6 +242,7 @@ test.describe('Unit Browser @compendium', () => {
 test.describe('Equipment Browser @compendium', () => {
   test('equipment page loads', async ({ page }) => {
     const equipmentBrowser = new EquipmentBrowserPage(page);
+    const equipmentBrowserRead = new EquipmentBrowserReadPage(page);
     await equipmentBrowser.goto();
 
     // Verify page title
@@ -244,13 +256,14 @@ test.describe('Equipment Browser @compendium', () => {
 
   test('equipment is loaded from API', async ({ page }) => {
     const equipmentBrowser = new EquipmentBrowserPage(page);
+    const equipmentBrowserRead = new EquipmentBrowserReadPage(page);
     await equipmentBrowser.goto();
 
     // Wait for API response
     await page.waitForTimeout(500);
 
     // Check subtitle for item count
-    const subtitleText = await equipmentBrowser.getSubtitleText();
+    const subtitleText = await equipmentBrowserRead.getSubtitleText();
     const match = subtitleText.match(/(\d+)/);
 
     // Should have some equipment items
@@ -262,6 +275,7 @@ test.describe('Equipment Browser @compendium', () => {
 
   test('search filters equipment', async ({ page }) => {
     const equipmentBrowser = new EquipmentBrowserPage(page);
+    const equipmentBrowserRead = new EquipmentBrowserReadPage(page);
     await equipmentBrowser.goto();
 
     // Search for "laser"
@@ -269,7 +283,8 @@ test.describe('Equipment Browser @compendium', () => {
     await page.waitForTimeout(500);
 
     // Get the count of displayed items
-    const displayedCount = await equipmentBrowser.getDisplayedEquipmentCount();
+    const displayedCount =
+      await equipmentBrowserRead.getDisplayedEquipmentCount();
 
     // Should have some laser-related equipment
     // (The exact count depends on the catalog data)
@@ -280,12 +295,13 @@ test.describe('Equipment Browser @compendium', () => {
     await page.waitForTimeout(500);
 
     // Should show all items again
-    const allCount = await equipmentBrowser.getDisplayedEquipmentCount();
+    const allCount = await equipmentBrowserRead.getDisplayedEquipmentCount();
     expect(allCount).toBeGreaterThanOrEqual(displayedCount);
   });
 
   test('filter button toggles filter panel', async ({ page }) => {
     const equipmentBrowser = new EquipmentBrowserPage(page);
+    const equipmentBrowserRead = new EquipmentBrowserReadPage(page);
     await equipmentBrowser.goto();
 
     // Click filter button
@@ -299,6 +315,7 @@ test.describe('Equipment Browser @compendium', () => {
 
   test('category filter works', async ({ page }) => {
     const equipmentBrowser = new EquipmentBrowserPage(page);
+    const equipmentBrowserRead = new EquipmentBrowserReadPage(page);
     await equipmentBrowser.goto();
 
     // Open filters
@@ -311,7 +328,8 @@ test.describe('Equipment Browser @compendium', () => {
     const categorySelect = page.getByLabel(/filter by category/i);
     if (await categorySelect.isVisible()) {
       // Get count before filtering
-      const _countBefore = await equipmentBrowser.getDisplayedEquipmentCount();
+      const _countBefore =
+        await equipmentBrowserRead.getDisplayedEquipmentCount();
 
       // Filter by Energy Weapon (if option exists)
       try {
@@ -319,7 +337,8 @@ test.describe('Equipment Browser @compendium', () => {
         await page.waitForTimeout(300);
 
         // Results should change or stay same, but no errors should occur
-        const countAfter = await equipmentBrowser.getDisplayedEquipmentCount();
+        const countAfter =
+          await equipmentBrowserRead.getDisplayedEquipmentCount();
         // Count may be same, less, or zero - all valid
         expect(countAfter).toBeGreaterThanOrEqual(0);
       } catch {
@@ -330,6 +349,7 @@ test.describe('Equipment Browser @compendium', () => {
 
   test('empty state displays when no results', async ({ page }) => {
     const equipmentBrowser = new EquipmentBrowserPage(page);
+    const equipmentBrowserRead = new EquipmentBrowserReadPage(page);
     await equipmentBrowser.goto();
 
     // Wait for initial load
@@ -343,7 +363,8 @@ test.describe('Equipment Browser @compendium', () => {
     const emptyStateVisible = await page
       .getByText(/no equipment found/i)
       .isVisible();
-    const displayCount = await equipmentBrowser.getDisplayedEquipmentCount();
+    const displayCount =
+      await equipmentBrowserRead.getDisplayedEquipmentCount();
 
     // Either empty state is shown or no items are displayed
     expect(emptyStateVisible || displayCount === 0).toBeTruthy();
@@ -351,12 +372,13 @@ test.describe('Equipment Browser @compendium', () => {
 
   test('clicking equipment row navigates to detail', async ({ page }) => {
     const equipmentBrowser = new EquipmentBrowserPage(page);
+    const equipmentBrowserRead = new EquipmentBrowserReadPage(page);
     await equipmentBrowser.goto();
 
     // Wait for equipment to load
     await page.waitForTimeout(500);
 
-    const itemCount = await equipmentBrowser.getDisplayedEquipmentCount();
+    const itemCount = await equipmentBrowserRead.getDisplayedEquipmentCount();
     if (itemCount > 0) {
       // Click first equipment item
       await equipmentBrowser.clickEquipment(0);

--- a/e2e/pages/compendium.page.ts
+++ b/e2e/pages/compendium.page.ts
@@ -64,7 +64,7 @@ export class CompendiumPage extends BasePage {
     await this.waitForPageLoad();
   }
 
-  async waitForPageLoad(): Promise<void> {
+  protected async waitForPageLoad(): Promise<void> {
     // Wait for page content to load - use heading as indicator
     await this.page
       .getByRole('heading', { name: /compendium/i })
@@ -75,39 +75,6 @@ export class CompendiumPage extends BasePage {
   async search(query: string): Promise<void> {
     const searchInput = this.page.getByPlaceholder(/search/i);
     await searchInput.fill(query);
-  }
-
-  async clearSearch(): Promise<void> {
-    const clearButton = this.page.getByRole('button', {
-      name: /clear search/i,
-    });
-    if (await clearButton.isVisible()) {
-      await clearButton.click();
-    }
-  }
-
-  async navigateToUnits(): Promise<void> {
-    await this.unitDatabaseCard.click();
-    // Wait for navigation to complete
-    await this.page.waitForURL(/\/compendium\/units/, { timeout: 10000 });
-  }
-
-  async navigateToEquipment(): Promise<void> {
-    await this.equipmentCatalogCard.click();
-    // Wait for navigation to complete
-    await this.page.waitForURL(/\/compendium\/equipment/, { timeout: 10000 });
-  }
-
-  async navigateToRuleSection(sectionId: string): Promise<void> {
-    // Find the card by its title text
-    const ruleCard = this.page
-      .locator('a')
-      .filter({ hasText: new RegExp(sectionId, 'i') })
-      .first();
-    await ruleCard.click();
-    await this.page.waitForURL(new RegExp(`/compendium/rules/${sectionId}`), {
-      timeout: 10000,
-    });
   }
 
   async getRuleSectionCount(): Promise<number> {
@@ -186,7 +153,7 @@ export class UnitBrowserPage extends BasePage {
     await this.waitForPageLoad();
   }
 
-  async waitForPageLoad(): Promise<void> {
+  protected async waitForPageLoad(): Promise<void> {
     // Wait for the page to load - use heading as indicator
     await this.page
       .getByRole('heading', { name: /unit database/i })
@@ -203,51 +170,18 @@ export class UnitBrowserPage extends BasePage {
   async openFilters(): Promise<void> {
     await this.filterButton.click();
   }
+}
 
-  async filterByUnitType(type: string): Promise<void> {
-    await this.openFilters();
-    await this.unitTypeFilter.selectOption({ label: type });
-  }
-
-  async filterByTechBase(techBase: string): Promise<void> {
-    await this.openFilters();
-    await this.techBaseFilter.selectOption({ label: techBase });
-  }
-
-  async filterByWeightClass(weightClass: string): Promise<void> {
-    await this.openFilters();
-    await this.weightClassFilter.selectOption({ label: weightClass });
-  }
-
-  async clearFilters(): Promise<void> {
-    if (await this.clearFiltersButton.isVisible()) {
-      await this.clearFiltersButton.click();
-    }
-  }
-
-  async setViewMode(mode: 'grid' | 'list' | 'table'): Promise<void> {
-    const button = this.page.getByRole('button', {
-      name: new RegExp(mode, 'i'),
-    });
-    await button.click();
-  }
-
+/**
+ * Read-only helpers for the unit browser page.
+ */
+export class UnitBrowserReadPage extends BasePage {
   async getDisplayedUnitCount(): Promise<number> {
     // Try table rows first (default view), then cards
-    const tableCount = await this.unitTableRows.count();
+    const tableCount = await this.page.locator('table tbody tr').count();
     if (tableCount > 0) return tableCount;
 
-    return await this.unitCards.count();
-  }
-
-  async clickUnit(index: number = 0): Promise<void> {
-    // Click a unit in the list (works for table or card view)
-    const tableRows = this.unitTableRows;
-    if ((await tableRows.count()) > 0) {
-      await tableRows.nth(index).click();
-    } else {
-      await this.unitCards.nth(index).click();
-    }
+    return await this.page.locator('[data-testid^="unit-card-"]').count();
   }
 
   async getSubtitleText(): Promise<string> {
@@ -319,7 +253,7 @@ export class EquipmentBrowserPage extends BasePage {
     await this.waitForPageLoad();
   }
 
-  async waitForPageLoad(): Promise<void> {
+  protected async waitForPageLoad(): Promise<void> {
     // Wait for the page to load - use heading as indicator
     await this.page
       .getByRole('heading', { name: /equipment catalog/i })
@@ -337,45 +271,26 @@ export class EquipmentBrowserPage extends BasePage {
     await this.filterButton.click();
   }
 
-  async filterByCategory(category: string): Promise<void> {
-    await this.openFilters();
-    await this.categoryFilter.selectOption({ label: category });
-  }
-
-  async filterByTechBase(techBase: string): Promise<void> {
-    await this.openFilters();
-    await this.techBaseFilter.selectOption({ label: techBase });
-  }
-
-  async clearFilters(): Promise<void> {
-    if (await this.clearFiltersButton.isVisible()) {
-      await this.clearFiltersButton.click();
-    }
-  }
-
-  async setViewMode(mode: 'grid' | 'list' | 'table'): Promise<void> {
-    const button = this.page.getByRole('button', {
-      name: new RegExp(mode, 'i'),
-    });
-    await button.click();
-  }
-
-  async getDisplayedEquipmentCount(): Promise<number> {
-    // Try table rows first (default view), then cards
-    const tableCount = await this.equipmentTableRows.count();
-    if (tableCount > 0) return tableCount;
-
-    return await this.equipmentCards.count();
-  }
-
   async clickEquipment(index: number = 0): Promise<void> {
-    // Click an equipment item in the list
     const tableRows = this.equipmentTableRows;
     if ((await tableRows.count()) > 0) {
       await tableRows.nth(index).click();
     } else {
       await this.equipmentCards.nth(index).click();
     }
+  }
+}
+
+/**
+ * Read-only helpers for the equipment browser page.
+ */
+export class EquipmentBrowserReadPage extends BasePage {
+  async getDisplayedEquipmentCount(): Promise<number> {
+    // Try table rows first (default view), then cards
+    const tableCount = await this.page.locator('table tbody tr').count();
+    if (tableCount > 0) return tableCount;
+
+    return await this.page.locator('[data-testid^="equipment-card-"]').count();
   }
 
   async getSubtitleText(): Promise<string> {
@@ -385,149 +300,5 @@ export class EquipmentBrowserPage extends BasePage {
       .filter({ hasText: /items?$/i })
       .first();
     return (await subtitleElement.textContent()) || '';
-  }
-}
-
-/**
- * Rules Reference Page
- * View construction rules for a specific section.
- */
-export class RulesReferencePage extends BasePage {
-  // Page elements
-  readonly title: Locator;
-  readonly breadcrumbs: Locator;
-  readonly backButton: Locator;
-  readonly content: Locator;
-
-  constructor(page: Page) {
-    super(page);
-
-    this.title = page.getByTestId('rules-page-title');
-    this.breadcrumbs = page.getByTestId('rules-breadcrumbs');
-    this.backButton = page.getByRole('link', { name: /back/i });
-    this.content = page.getByTestId('rules-content');
-  }
-
-  async goto(sectionId: string): Promise<void> {
-    await this.page.goto(`/compendium/rules/${sectionId}`);
-    await this.waitForPageLoad();
-  }
-
-  async waitForPageLoad(): Promise<void> {
-    // Wait for page content
-    await this.page.locator('main').first().waitFor();
-  }
-
-  async goBack(): Promise<void> {
-    await this.page.goBack();
-  }
-}
-
-/**
- * Unit Detail Page
- * View full specifications for a single unit.
- */
-export class UnitDetailPage extends BasePage {
-  readonly title: Locator;
-  readonly breadcrumbs: Locator;
-  readonly unitTypeBadge: Locator;
-  readonly techBaseBadge: Locator;
-  readonly weightClassBadge: Locator;
-  readonly editButton: Locator;
-
-  // Stats sections
-  readonly physicalPropertiesCard: Locator;
-  readonly movementCard: Locator;
-  readonly armorCard: Locator;
-  readonly heatManagementCard: Locator;
-  readonly equipmentTable: Locator;
-  readonly quirksSection: Locator;
-  readonly unitInfoCard: Locator;
-
-  constructor(page: Page) {
-    super(page);
-
-    this.title = page.getByTestId('unit-detail-title');
-    this.breadcrumbs = page.getByTestId('unit-detail-breadcrumbs');
-    this.unitTypeBadge = page.getByTestId('unit-type-badge');
-    this.techBaseBadge = page.getByTestId('tech-base-badge');
-    this.weightClassBadge = page.getByTestId('weight-class-badge');
-    this.editButton = page.getByRole('link', { name: /edit/i });
-
-    // Stats sections
-    this.physicalPropertiesCard = page.getByTestId('unit-physical-properties');
-    this.movementCard = page.getByTestId('unit-movement');
-    this.armorCard = page.getByTestId('unit-armor');
-    this.heatManagementCard = page.getByTestId('unit-heat-management');
-    this.equipmentTable = page.getByTestId('unit-equipment-table');
-    this.quirksSection = page.getByTestId('unit-quirks');
-    this.unitInfoCard = page.getByTestId('unit-info');
-  }
-
-  async goto(unitId: string): Promise<void> {
-    await this.page.goto(`/compendium/units/${encodeURIComponent(unitId)}`);
-    await this.waitForPageLoad();
-  }
-
-  async waitForPageLoad(): Promise<void> {
-    // Wait for page to load
-    await this.page.locator('main').first().waitFor();
-  }
-
-  async clickEdit(): Promise<void> {
-    await this.editButton.click();
-    await this.page.waitForURL(/\/customizer/);
-  }
-}
-
-/**
- * Equipment Detail Page
- * View full specifications for a single equipment item.
- */
-export class EquipmentDetailPage extends BasePage {
-  readonly title: Locator;
-  readonly breadcrumbs: Locator;
-  readonly categoryBadge: Locator;
-  readonly techBaseBadge: Locator;
-  readonly rulesLevelBadge: Locator;
-
-  // Stats sections
-  readonly physicalPropertiesCard: Locator;
-  readonly availabilityCard: Locator;
-  readonly combatStatsCard: Locator;
-  readonly rangeProfileCard: Locator;
-  readonly specialRulesSection: Locator;
-  readonly descriptionSection: Locator;
-
-  constructor(page: Page) {
-    super(page);
-
-    this.title = page.getByTestId('equipment-detail-title');
-    this.breadcrumbs = page.getByTestId('equipment-detail-breadcrumbs');
-    this.categoryBadge = page.getByTestId('equipment-category-badge');
-    this.techBaseBadge = page.getByTestId('tech-base-badge');
-    this.rulesLevelBadge = page.getByTestId('rules-level-badge');
-
-    // Stats sections
-    this.physicalPropertiesCard = page.getByTestId(
-      'equipment-physical-properties',
-    );
-    this.availabilityCard = page.getByTestId('equipment-availability');
-    this.combatStatsCard = page.getByTestId('equipment-combat-stats');
-    this.rangeProfileCard = page.getByTestId('equipment-range-profile');
-    this.specialRulesSection = page.getByTestId('equipment-special-rules');
-    this.descriptionSection = page.getByTestId('equipment-description');
-  }
-
-  async goto(equipmentId: string): Promise<void> {
-    await this.page.goto(
-      `/compendium/equipment/${encodeURIComponent(equipmentId)}`,
-    );
-    await this.waitForPageLoad();
-  }
-
-  async waitForPageLoad(): Promise<void> {
-    // Wait for page to load
-    await this.page.locator('main').first().waitFor();
   }
 }

--- a/e2e/pages/index.ts
+++ b/e2e/pages/index.ts
@@ -46,11 +46,10 @@ export { CustomizerPage, AerospaceCustomizerPage } from './customizer.page';
 // Compendium pages
 export {
   CompendiumPage,
-  UnitBrowserPage,
   EquipmentBrowserPage,
-  RulesReferencePage,
-  UnitDetailPage,
-  EquipmentDetailPage,
+  EquipmentBrowserReadPage,
+  UnitBrowserPage,
+  UnitBrowserReadPage,
 } from './compendium.page';
 
 // Repair pages


### PR DESCRIPTION
## Summary
- prune unused compendium page-object helpers and detail-page scaffolds
- split unit/equipment read assertions into narrow read helper page objects
- mark the three compendium design-violation ledger entries fixed and add QC registry/graph evidence

## Validation
- npm.cmd run format:check
- npx.cmd tsc --noEmit --pretty false --project tsconfig.json
- npx.cmd playwright test e2e/compendium.spec.ts --project=chromium --workers=1
- npm.cmd run verify:qc:maintenance
- npm.cmd run qc:lifecycle:status
- npm.cmd run qc:app-completion -- --json
- node scripts/qc/validate-maintenance-warning-ledger.mjs
- npm.cmd run qc:validate
- git diff --check
- pre-commit hook: lint-staged, TypeScript, full Next build