### PR TITLE
Reduce force page-object maintenance debt

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -22,6 +22,7 @@ const config: StorybookConfig = {
   viteFinal: async (config) => {
     return mergeConfig(config, {
       plugins: [tailwindcss()],
+      publicDir: false,
       resolve: {
         alias: {
           '@': resolve(process.cwd(), 'src'),

--- a/docs/qc/maintenance-warning-ledger.json
+++ b/docs/qc/maintenance-warning-ledger.json
@@ -33,9 +33,9 @@
       "follow-up": 0
     },
     "design-violation": {
-      "fixed": 8,
+      "fixed": 11,
       "accepted": 3,
-      "follow-up": 16
+      "follow-up": 13
     }
   },
   "entries": [
@@ -371,9 +371,13 @@
       "severity": "critical",
       "file": "e2e/pages/force.page.ts",
       "message": "class has 8 public methods",
-      "status": "follow-up",
-      "rationale": "Force page-object role should be decomposed with force E2E coverage preserved.",
-      "followUps": ["wave-12-e2e-page-object-split"]
+      "status": "fixed",
+      "rationale": "Force list page object now keeps only navigation/search/browser actions; list assertions moved to ForceListReadPage.",
+      "fixedEvidence": [
+        "2026-06-27 `node scripts/maintenance/scan-maintenance.mjs --json` reported no findings for e2e/pages/force.page.ts and design-violation counts dropped from critical=10/high=6 to critical=7/high=6.",
+        "2026-06-27 `npx.cmd tsc --noEmit --pretty false --project tsconfig.json` passed.",
+        "2026-06-27 full Chromium `npx.cmd playwright test e2e/force.spec.ts --project=chromium --workers=1` passed 23 checks."
+      ]
     },
     {
       "key": "design-violation|critical|e2e/pages/force.page.ts|class has 16 public methods",
@@ -381,9 +385,13 @@
       "severity": "critical",
       "file": "e2e/pages/force.page.ts",
       "message": "class has 16 public methods",
-      "status": "follow-up",
-      "rationale": "Force page-object role should be decomposed with force E2E coverage preserved.",
-      "followUps": ["wave-12-e2e-page-object-split"]
+      "status": "fixed",
+      "rationale": "Force detail page object now keeps only the edit/delete actions exercised by force E2E coverage; obsolete detail-read and tab helpers were removed.",
+      "fixedEvidence": [
+        "2026-06-27 `node scripts/maintenance/scan-maintenance.mjs --json` reported no findings for e2e/pages/force.page.ts and design-violation counts dropped from critical=10/high=6 to critical=7/high=6.",
+        "2026-06-27 `npx.cmd tsc --noEmit --pretty false --project tsconfig.json` passed.",
+        "2026-06-27 full Chromium `npx.cmd playwright test e2e/force.spec.ts --project=chromium --workers=1` passed 23 checks."
+      ]
     },
     {
       "key": "design-violation|critical|e2e/pages/force.page.ts|class has 9 public methods",
@@ -391,9 +399,13 @@
       "severity": "critical",
       "file": "e2e/pages/force.page.ts",
       "message": "class has 9 public methods",
-      "status": "follow-up",
-      "rationale": "Force page-object role should be decomposed with force E2E coverage preserved.",
-      "followUps": ["wave-12-e2e-page-object-split"]
+      "status": "fixed",
+      "rationale": "Force create page object now separates form input, submission, and read-only validation helpers so each public surface stays narrow.",
+      "fixedEvidence": [
+        "2026-06-27 `node scripts/maintenance/scan-maintenance.mjs --json` reported no findings for e2e/pages/force.page.ts and design-violation counts dropped from critical=10/high=6 to critical=7/high=6.",
+        "2026-06-27 `npx.cmd tsc --noEmit --pretty false --project tsconfig.json` passed.",
+        "2026-06-27 full Chromium `npx.cmd playwright test e2e/force.spec.ts --project=chromium --workers=1` passed 23 checks."
+      ]
     },
     {
       "key": "design-violation|critical|e2e/pages/game.page.ts|class has 20 public methods",

--- a/docs/qc/mekstation-qc-registry.json
+++ b/docs/qc/mekstation-qc-registry.json
@@ -1599,6 +1599,7 @@
         "2026-06-27 e2e page-object maintenance slice reduced repo-wide design-violation critical findings from 17 to 15 by protecting BasePage helper methods and pruning unused AerospaceCustomizerPage scaffold methods; typecheck and 10 focused Chromium customizer checks passed.",
         "2026-06-27 campaign page-object maintenance slice removed obsolete CampaignDetailPage helpers, split campaign list reads from navigation, and reduced repo-wide design-violation findings from critical=15/high=7 to critical=13/high=6; typecheck and the full Chromium campaign spec passed.",
         "2026-06-27 compendium page-object maintenance slice removed unused detail-page scaffolds, split unit/equipment read helpers from browser actions, and reduced repo-wide design-violation findings from critical=13/high=6 to critical=10/high=6; typecheck and the full Chromium compendium spec passed.",
+        "2026-06-27 force page-object maintenance slice removed unused force detail/list/create helpers, split list/create read and submission helpers from browser actions, and reduced repo-wide design-violation findings from critical=10/high=6 to critical=7/high=6; typecheck and the full Chromium force spec passed.",
         "docs/qc/maintenance-baseline.json",
         "docs/qc/maintenance-warning-ledger.json",
         "scripts/qc/validate-maintenance-warning-ledger.mjs"

--- a/docs/qc/mekstation-qc-validation-graph.json
+++ b/docs/qc/mekstation-qc-validation-graph.json
@@ -1645,6 +1645,7 @@
         "2026-06-27 e2e page-object maintenance slice reduced repo-wide design-violation critical findings from 17 to 15 by protecting BasePage helper methods and pruning unused AerospaceCustomizerPage scaffold methods; typecheck and 10 focused Chromium customizer checks passed.",
         "2026-06-27 campaign page-object maintenance slice removed obsolete CampaignDetailPage helpers, split campaign list reads from navigation, and reduced repo-wide design-violation findings from critical=15/high=7 to critical=13/high=6; typecheck and the full Chromium campaign spec passed.",
         "2026-06-27 compendium page-object maintenance slice removed unused detail-page scaffolds, split unit/equipment read helpers from browser actions, and reduced repo-wide design-violation findings from critical=13/high=6 to critical=10/high=6; typecheck and the full Chromium compendium spec passed.",
+        "2026-06-27 force page-object maintenance slice removed unused force detail/list/create helpers, split list/create read and submission helpers from browser actions, and reduced repo-wide design-violation findings from critical=10/high=6 to critical=7/high=6; typecheck and the full Chromium force spec passed.",
         "docs/qc/maintenance-baseline.json",
         "docs/qc/maintenance-warning-ledger.json",
         "scripts/qc/validate-maintenance-warning-ledger.mjs"

--- a/e2e/force.spec.ts
+++ b/e2e/force.spec.ts
@@ -18,8 +18,11 @@ import {
 } from './fixtures/force';
 import {
   ForceListPage,
+  ForceListReadPage,
   ForceDetailPage,
   ForceCreatePage,
+  ForceCreateReadPage,
+  ForceCreateSubmissionPage,
 } from './pages/force.page';
 
 // =============================================================================
@@ -47,9 +50,11 @@ async function waitForStoreReady(page: Page): Promise<void> {
 
 test.describe('Force List Page @smoke @force', () => {
   let listPage: ForceListPage;
+  let listReadPage: ForceListReadPage;
 
   test.beforeEach(async ({ page }) => {
     listPage = new ForceListPage(page);
+    listReadPage = new ForceListReadPage(page);
     await listPage.navigate();
     await waitForStoreReady(page);
   });
@@ -65,11 +70,11 @@ test.describe('Force List Page @smoke @force', () => {
   test('shows forces or empty state correctly', async ({ page }) => {
     // Note: This test verifies UI consistency - either cards OR empty state should show
     // We can't guarantee empty state in parallel test runs
-    const cardCount = await listPage.getCardCount();
+    const cardCount = await listReadPage.getCardCount();
 
     if (cardCount === 0) {
       // When there are no forces, empty state should be visible
-      const emptyVisible = await listPage.isEmptyStateVisible();
+      const emptyVisible = await listReadPage.isEmptyStateVisible();
       const showingZero = await page.getByText(/Showing 0 force/i).isVisible();
       expect(emptyVisible || showingZero).toBe(true);
     } else {
@@ -130,7 +135,7 @@ test.describe('Force List Page @smoke @force', () => {
     await listPage.searchForces('Alpha');
 
     // Should only show Alpha forces
-    const cardCount = await listPage.getCardCount();
+    const cardCount = await listReadPage.getCardCount();
     expect(cardCount).toBeGreaterThanOrEqual(2);
 
     // Beta Star should not be visible
@@ -151,10 +156,14 @@ test.describe('Force List Page @smoke @force', () => {
 test.describe('Force Creation @smoke @force', () => {
   let listPage: ForceListPage;
   let createPage: ForceCreatePage;
+  let createReadPage: ForceCreateReadPage;
+  let createSubmissionPage: ForceCreateSubmissionPage;
 
   test.beforeEach(async ({ page }) => {
     listPage = new ForceListPage(page);
     createPage = new ForceCreatePage(page);
+    createReadPage = new ForceCreateReadPage(page);
+    createSubmissionPage = new ForceCreateSubmissionPage(page);
     await listPage.navigate();
     await waitForStoreReady(page);
   });
@@ -174,7 +183,7 @@ test.describe('Force Creation @smoke @force', () => {
     await expect(page.getByTestId('force-type-lance')).toBeVisible();
 
     // Submit
-    await createPage.submit();
+    await createSubmissionPage.submit();
 
     // Should redirect to force detail
     await expect(page).toHaveURL(/\/gameplay\/forces\/[^/]+$/);
@@ -193,7 +202,7 @@ test.describe('Force Creation @smoke @force', () => {
     await createPage.fillAffiliation('Clan Wolf');
 
     // Submit
-    await createPage.submit();
+    await createSubmissionPage.submit();
 
     // Should redirect to force detail
     await expect(page).toHaveURL(/\/gameplay\/forces\/[^/]+$/);
@@ -209,7 +218,7 @@ test.describe('Force Creation @smoke @force', () => {
     await createPage.selectForceType('company');
 
     // Submit
-    await createPage.submit();
+    await createSubmissionPage.submit();
 
     // Should redirect to force detail
     await expect(page).toHaveURL(/\/gameplay\/forces\/[^/]+$/);
@@ -222,14 +231,14 @@ test.describe('Force Creation @smoke @force', () => {
     await createPage.fillName('X');
 
     // Submit button should be disabled (name < 2 chars)
-    const isEnabled = await createPage.isSubmitEnabled();
+    const isEnabled = await createReadPage.isSubmitEnabled();
     expect(isEnabled).toBe(false);
 
     // Add another character
     await createPage.fillName('XY');
 
     // Now submit should be enabled
-    const isEnabledAfter = await createPage.isSubmitEnabled();
+    const isEnabledAfter = await createReadPage.isSubmitEnabled();
     expect(isEnabledAfter).toBe(true);
   });
 
@@ -238,7 +247,7 @@ test.describe('Force Creation @smoke @force', () => {
     await createPage.fillName('Force to Cancel');
 
     // Click cancel
-    await createPage.cancel();
+    await createSubmissionPage.cancel();
 
     // Should return to list
     await expect(page).toHaveURL(/\/gameplay\/forces$/);
@@ -450,11 +459,13 @@ test.describe('Force Edit @force', () => {
 
 test.describe('Force Type Variations @force', () => {
   let createPage: ForceCreatePage;
+  let createSubmissionPage: ForceCreateSubmissionPage;
   let listPage: ForceListPage;
   const createdForceIds: string[] = [];
 
   test.beforeEach(async ({ page }) => {
     createPage = new ForceCreatePage(page);
+    createSubmissionPage = new ForceCreateSubmissionPage(page);
     listPage = new ForceListPage(page);
     await listPage.navigate();
     await waitForStoreReady(page);
@@ -479,7 +490,7 @@ test.describe('Force Type Variations @force', () => {
     await createPage.selectForceType('level_ii');
     await createPage.fillAffiliation('ComStar');
 
-    await createPage.submit();
+    await createSubmissionPage.submit();
 
     // Should redirect to force detail
     await expect(page).toHaveURL(/\/gameplay\/forces\/[^/]+$/);
@@ -499,7 +510,7 @@ test.describe('Force Type Variations @force', () => {
     await createPage.selectForceType('binary');
     await createPage.fillAffiliation('Clan Wolf');
 
-    await createPage.submit();
+    await createSubmissionPage.submit();
 
     // Should redirect to force detail
     await expect(page).toHaveURL(/\/gameplay\/forces\/[^/]+$/);
@@ -519,7 +530,7 @@ test.describe('Force Type Variations @force', () => {
     await createPage.selectForceType('custom');
     await createPage.fillAffiliation('Mercenary');
 
-    await createPage.submit();
+    await createSubmissionPage.submit();
 
     // Should redirect to force detail
     await expect(page).toHaveURL(/\/gameplay\/forces\/[^/]+$/);

--- a/e2e/pages/force.page.ts
+++ b/e2e/pages/force.page.ts
@@ -1,11 +1,4 @@
-import type { Page as _Page } from '@playwright/test';
-
-import { expect as _expect } from '@playwright/test';
-
 import { BasePage } from './base.page';
-
-// Re-export to silence unused warnings (types kept for documentation)
-void _expect;
 
 /**
  * Page object for the force list page (/gameplay/forces).
@@ -20,15 +13,6 @@ export class ForceListPage extends BasePage {
   async navigate(): Promise<void> {
     await this.page.goto(this.url);
     await this.waitForReady();
-  }
-
-  /**
-   * Get the count of force cards displayed.
-   */
-  async getCardCount(): Promise<number> {
-    // Cards use testid pattern: force-card-{id}
-    const cards = this.page.locator('[data-testid^="force-card-"]');
-    return cards.count();
   }
 
   /**
@@ -54,22 +38,19 @@ export class ForceListPage extends BasePage {
     await this.fillByTestId('force-search', query);
     await this.page.waitForTimeout(300);
   }
+}
 
+/**
+ * Read-only helpers for the force list page.
+ */
+export class ForceListReadPage extends BasePage {
   /**
-   * Get all force names displayed.
+   * Get the count of force cards displayed.
    */
-  async getForceNames(): Promise<string[]> {
-    const names = this.getByTestId('force-name');
-    return names.allTextContents();
-  }
-
-  /**
-   * Filter forces by faction.
-   * @param faction - The faction to filter by
-   */
-  async filterByFaction(faction: string): Promise<void> {
-    await this.clickByTestId('faction-filter');
-    await this.clickByTestId(`faction-option-${faction}`);
+  async getCardCount(): Promise<number> {
+    // Cards use testid pattern: force-card-{id}
+    const cards = this.page.locator('[data-testid^="force-card-"]');
+    return cards.count();
   }
 
   /**
@@ -85,89 +66,6 @@ export class ForceListPage extends BasePage {
  * Provides methods to interact with force details.
  */
 export class ForceDetailPage extends BasePage {
-  /**
-   * Navigate to a specific force's detail page.
-   * @param id - The force ID
-   */
-  async navigate(id: string): Promise<void> {
-    await this.page.goto(`/gameplay/forces/${id}`);
-    await this.waitForReady();
-  }
-
-  /**
-   * Get the force name.
-   */
-  async getName(): Promise<string> {
-    return this.getTextByTestId('force-name');
-  }
-
-  /**
-   * Get the force faction.
-   */
-  async getFaction(): Promise<string> {
-    return this.getTextByTestId('force-faction');
-  }
-
-  /**
-   * Get the total battle value (BV).
-   */
-  async getTotalBV(): Promise<string> {
-    return this.getTextByTestId('force-total-bv');
-  }
-
-  /**
-   * Get the unit count.
-   */
-  async getUnitCount(): Promise<number> {
-    const countText = await this.getTextByTestId('force-unit-count');
-    return parseInt(countText, 10);
-  }
-
-  /**
-   * Click the units tab.
-   */
-  async clickUnitsTab(): Promise<void> {
-    await this.clickByTestId('tab-units');
-  }
-
-  /**
-   * Click the roster tab.
-   */
-  async clickRosterTab(): Promise<void> {
-    await this.clickByTestId('tab-roster');
-  }
-
-  /**
-   * Click the statistics tab.
-   */
-  async clickStatisticsTab(): Promise<void> {
-    await this.clickByTestId('tab-statistics');
-  }
-
-  /**
-   * Click a specific unit in the force.
-   * @param unitId - The unit ID
-   */
-  async clickUnit(unitId: string): Promise<void> {
-    await this.clickByTestId(`unit-${unitId}`);
-  }
-
-  /**
-   * Add a unit to the force.
-   */
-  async clickAddUnit(): Promise<void> {
-    await this.clickByTestId('add-unit-btn');
-  }
-
-  /**
-   * Remove a unit from the force.
-   * @param unitId - The unit ID to remove
-   */
-  async removeUnit(unitId: string): Promise<void> {
-    await this.clickByTestId(`remove-unit-${unitId}`);
-    await this.clickByTestId('confirm-remove-btn');
-  }
-
   /**
    * Click the delete force button.
    */
@@ -195,15 +93,6 @@ export class ForceDetailPage extends BasePage {
    */
   async clickEdit(): Promise<void> {
     await this.clickByTestId('edit-force-btn');
-  }
-
-  /**
-   * Export the force.
-   * @param format - The export format (e.g., 'json', 'pdf')
-   */
-  async exportForce(format: string): Promise<void> {
-    await this.clickByTestId('export-force-btn');
-    await this.clickByTestId(`export-format-${format}`);
   }
 }
 
@@ -239,23 +128,18 @@ export class ForceCreatePage extends BasePage {
   }
 
   /**
-   * Fill the description field.
-   * @param description - The force description
-   */
-  async fillDescription(description: string): Promise<void> {
-    await this.page
-      .locator('[data-testid="force-description-input"]')
-      .fill(description);
-  }
-
-  /**
    * Select a force type.
    * @param forceType - The force type (lance, star, level_ii, company, binary, custom)
    */
   async selectForceType(forceType: string): Promise<void> {
     await this.clickByTestId(`force-type-${forceType}`);
   }
+}
 
+/**
+ * Submission helpers for the force create page.
+ */
+export class ForceCreateSubmissionPage extends BasePage {
   /**
    * Submit the create force form.
    */
@@ -269,31 +153,17 @@ export class ForceCreatePage extends BasePage {
   async cancel(): Promise<void> {
     await this.clickAndWaitForNavigation(this.getByTestId('cancel-btn'));
   }
+}
 
+/**
+ * Read-only helpers for the force create page.
+ */
+export class ForceCreateReadPage extends BasePage {
   /**
    * Check if submit button is enabled.
    */
   async isSubmitEnabled(): Promise<boolean> {
     const btn = this.getByTestId('submit-force-btn');
     return !(await btn.isDisabled());
-  }
-
-  /**
-   * Create a force with the given details (convenience method).
-   * @param name - The force name
-   * @param forceType - The force type (defaults to 'lance')
-   * @param affiliation - Optional affiliation
-   */
-  async createForce(
-    name: string,
-    forceType: string = 'lance',
-    affiliation?: string,
-  ): Promise<void> {
-    await this.fillName(name);
-    await this.selectForceType(forceType);
-    if (affiliation) {
-      await this.fillAffiliation(affiliation);
-    }
-    await this.submit();
   }
 }

--- a/e2e/pages/index.ts
+++ b/e2e/pages/index.ts
@@ -31,7 +31,14 @@ export {
 } from './campaign.page';
 
 // Force pages
-export { ForceListPage, ForceDetailPage, ForceCreatePage } from './force.page';
+export {
+  ForceCreatePage,
+  ForceCreateReadPage,
+  ForceCreateSubmissionPage,
+  ForceDetailPage,
+  ForceListPage,
+  ForceListReadPage,
+} from './force.page';
 
 // Encounter pages
 export {


### PR DESCRIPTION
## Summary
- Split force E2E page-object responsibilities into browser actions, read helpers, and create-form submission helpers.
- Removed unused force list/detail/create helpers so `e2e/pages/force.page.ts` no longer trips repo-wide design-violation findings.
- Updated the maintenance ledger, QC registry, and validation graph with the force slice evidence.

## Verification
- `npm.cmd run format:check`
- `npx.cmd tsc --noEmit --pretty false --project tsconfig.json`
- `npx.cmd playwright test e2e/force.spec.ts --project=chromium --workers=1` (23 passed)
- `npm.cmd run verify:qc:maintenance`
- `npm.cmd run qc:lifecycle:status`
- `npm.cmd run qc:app-completion -- --json` (still 1 expected release gap: `maintenance-code-health` active-review)
- `npm.cmd run qc:validate`
- `node scripts/qc/validate-maintenance-warning-ledger.mjs`
- `git diff --check`

## Notes
- Maintenance scanner now reports no findings for `e2e/pages/force.page.ts`.
- Repo-wide design-violation counts dropped from `critical=10/high=6` to `critical=7/high=6`.