### PR TITLE
Reduce encounter page-object maintenance drag

### DIFF
--- a/docs/qc/maintenance-warning-ledger.json
+++ b/docs/qc/maintenance-warning-ledger.json
@@ -33,9 +33,9 @@
       "follow-up": 0
     },
     "design-violation": {
-      "fixed": 11,
+      "fixed": 14,
       "accepted": 3,
-      "follow-up": 13
+      "follow-up": 10
     }
   },
   "entries": [
@@ -341,9 +341,13 @@
       "severity": "critical",
       "file": "e2e/pages/encounter.page.ts",
       "message": "class has 9 public methods",
-      "status": "follow-up",
-      "rationale": "Encounter page-object role should be decomposed with encounter E2E coverage preserved.",
-      "followUps": ["wave-12-e2e-page-object-split"]
+      "status": "fixed",
+      "rationale": "Encounter list page-object reads were split from workflow actions so the public browser-action surface stays narrow while preserving encounter coverage.",
+      "fixedEvidence": [
+        "2026-06-27 `node scripts/maintenance/scan-maintenance.mjs --json` reported no findings for e2e/pages/encounter.page.ts and design-violation counts dropped from critical=7/high=6 to critical=4/high=6.",
+        "2026-06-27 `npx.cmd tsc --noEmit --pretty false --project tsconfig.json` passed.",
+        "2026-06-27 full Chromium `npx.cmd playwright test e2e/encounter.spec.ts --project=chromium --workers=1` passed 22 checks with the existing clone test skipped."
+      ]
     },
     {
       "key": "design-violation|critical|e2e/pages/encounter.page.ts|class has 25 public methods",
@@ -351,9 +355,13 @@
       "severity": "critical",
       "file": "e2e/pages/encounter.page.ts",
       "message": "class has 25 public methods",
-      "status": "follow-up",
-      "rationale": "Encounter page-object role should be decomposed with encounter E2E coverage preserved.",
-      "followUps": ["wave-12-e2e-page-object-split"]
+      "status": "fixed",
+      "rationale": "Unused encounter detail scaffolding was removed so the page object exposes only the tested delete-dialog actions.",
+      "fixedEvidence": [
+        "2026-06-27 `node scripts/maintenance/scan-maintenance.mjs --json` reported no findings for e2e/pages/encounter.page.ts and design-violation counts dropped from critical=7/high=6 to critical=4/high=6.",
+        "2026-06-27 `npx.cmd tsc --noEmit --pretty false --project tsconfig.json` passed.",
+        "2026-06-27 full Chromium `npx.cmd playwright test e2e/encounter.spec.ts --project=chromium --workers=1` passed 22 checks with the existing clone test skipped."
+      ]
     },
     {
       "key": "design-violation|critical|e2e/pages/encounter.page.ts|class has 13 public methods",
@@ -361,9 +369,13 @@
       "severity": "critical",
       "file": "e2e/pages/encounter.page.ts",
       "message": "class has 13 public methods",
-      "status": "follow-up",
-      "rationale": "Encounter page-object role should be decomposed with encounter E2E coverage preserved.",
-      "followUps": ["wave-12-e2e-page-object-split"]
+      "status": "fixed",
+      "rationale": "Encounter create form filling, submission, and read-only validation helpers were split into narrow classes.",
+      "fixedEvidence": [
+        "2026-06-27 `node scripts/maintenance/scan-maintenance.mjs --json` reported no findings for e2e/pages/encounter.page.ts and design-violation counts dropped from critical=7/high=6 to critical=4/high=6.",
+        "2026-06-27 `npx.cmd tsc --noEmit --pretty false --project tsconfig.json` passed.",
+        "2026-06-27 full Chromium `npx.cmd playwright test e2e/encounter.spec.ts --project=chromium --workers=1` passed 22 checks with the existing clone test skipped."
+      ]
     },
     {
       "key": "design-violation|critical|e2e/pages/force.page.ts|class has 8 public methods",

--- a/docs/qc/mekstation-qc-map.md
+++ b/docs/qc/mekstation-qc-map.md
@@ -382,6 +382,9 @@ flowchart TD
      BV assertions.
    - Unit handler design-violation findings are cleared; remaining handler
      work is test file-bloat and near-duplicate extraction.
+   - Encounter page-object design-violation findings are cleared after the list,
+     detail, and create helpers were split into narrow read/submission/action
+     surfaces; full Chromium encounter E2E coverage still passes.
    - HexMapDisplay, movement utilities, and physical attack utilities have
      had first-pass complexity/design cleanup, but each still has active
      raw critical/high queues.

--- a/docs/qc/mekstation-qc-registry.json
+++ b/docs/qc/mekstation-qc-registry.json
@@ -1601,6 +1601,7 @@
         "2026-06-27 campaign page-object maintenance slice removed obsolete CampaignDetailPage helpers, split campaign list reads from navigation, and reduced repo-wide design-violation findings from critical=15/high=7 to critical=13/high=6; typecheck and the full Chromium campaign spec passed.",
         "2026-06-27 compendium page-object maintenance slice removed unused detail-page scaffolds, split unit/equipment read helpers from browser actions, and reduced repo-wide design-violation findings from critical=13/high=6 to critical=10/high=6; typecheck and the full Chromium compendium spec passed.",
         "2026-06-27 force page-object maintenance slice removed unused force detail/list/create helpers, split list/create read and submission helpers from browser actions, and reduced repo-wide design-violation findings from critical=10/high=6 to critical=7/high=6; typecheck and the full Chromium force spec passed.",
+        "2026-06-27 encounter page-object maintenance slice removed unused encounter detail scaffolds, split list reads and create-page submission/read helpers from browser actions, and reduced repo-wide design-violation findings from critical=7/high=6 to critical=4/high=6; typecheck and the full Chromium encounter spec passed.",
         "docs/qc/maintenance-baseline.json",
         "docs/qc/maintenance-warning-ledger.json",
         "scripts/qc/validate-maintenance-warning-ledger.mjs"

--- a/docs/qc/mekstation-qc-validation-graph.json
+++ b/docs/qc/mekstation-qc-validation-graph.json
@@ -1647,6 +1647,7 @@
         "2026-06-27 campaign page-object maintenance slice removed obsolete CampaignDetailPage helpers, split campaign list reads from navigation, and reduced repo-wide design-violation findings from critical=15/high=7 to critical=13/high=6; typecheck and the full Chromium campaign spec passed.",
         "2026-06-27 compendium page-object maintenance slice removed unused detail-page scaffolds, split unit/equipment read helpers from browser actions, and reduced repo-wide design-violation findings from critical=13/high=6 to critical=10/high=6; typecheck and the full Chromium compendium spec passed.",
         "2026-06-27 force page-object maintenance slice removed unused force detail/list/create helpers, split list/create read and submission helpers from browser actions, and reduced repo-wide design-violation findings from critical=10/high=6 to critical=7/high=6; typecheck and the full Chromium force spec passed.",
+        "2026-06-27 encounter page-object maintenance slice removed unused encounter detail scaffolds, split list reads and create-page submission/read helpers from browser actions, and reduced repo-wide design-violation findings from critical=7/high=6 to critical=4/high=6; typecheck and the full Chromium encounter spec passed.",
         "docs/qc/maintenance-baseline.json",
         "docs/qc/maintenance-warning-ledger.json",
         "scripts/qc/validate-maintenance-warning-ledger.mjs"

--- a/e2e/encounter.spec.ts
+++ b/e2e/encounter.spec.ts
@@ -20,8 +20,11 @@ import {
 import { createTestForce, deleteForce } from './fixtures/force';
 import {
   EncounterListPage,
+  EncounterListReadPage,
   EncounterDetailPage,
   EncounterCreatePage,
+  EncounterCreateReadPage,
+  EncounterCreateSubmitPage,
 } from './pages/encounter.page';
 
 // =============================================================================
@@ -49,9 +52,11 @@ async function waitForStoreReady(page: Page): Promise<void> {
 
 test.describe('Encounter List Page @smoke @encounter', () => {
   let listPage: EncounterListPage;
+  let listReadPage: EncounterListReadPage;
 
   test.beforeEach(async ({ page }) => {
     listPage = new EncounterListPage(page);
+    listReadPage = new EncounterListReadPage(page);
     await listPage.navigate();
     await waitForStoreReady(page);
   });
@@ -67,11 +72,11 @@ test.describe('Encounter List Page @smoke @encounter', () => {
   test('shows encounters or empty state correctly', async ({ page }) => {
     // Note: This test verifies UI consistency - either cards OR empty state should show
     // We can't guarantee empty state in parallel test runs
-    const cardCount = await listPage.getCardCount();
+    const cardCount = await listReadPage.getCardCount();
 
     if (cardCount === 0) {
       // When there are no encounters, empty state should be visible
-      const emptyVisible = await listPage.isEmptyStateVisible();
+      const emptyVisible = await listReadPage.isEmptyStateVisible();
       const showingZero = await page
         .getByText(/Showing 0 encounter/i)
         .isVisible();
@@ -110,7 +115,7 @@ test.describe('Encounter List Page @smoke @encounter', () => {
       .waitFor({ state: 'visible', timeout: 10000 });
 
     // Encounter should appear in list
-    const names = await listPage.getEncounterNames();
+    const names = await listReadPage.getEncounterNames();
     expect(names).toContain('Test Encounter Alpha');
 
     // Cleanup
@@ -137,7 +142,7 @@ test.describe('Encounter List Page @smoke @encounter', () => {
     await listPage.searchEncounters('Alpha');
 
     // Should only show Alpha encounters
-    const names = await listPage.getEncounterNames();
+    const names = await listReadPage.getEncounterNames();
     expect(names).toContain('Alpha Engagement');
     expect(names).toContain('Alpha Duel');
     expect(names).not.toContain('Beta Skirmish');
@@ -164,7 +169,7 @@ test.describe('Encounter List Page @smoke @encounter', () => {
     await page.getByTestId('status-option-draft').click();
 
     // Should still show the encounter
-    const names = await listPage.getEncounterNames();
+    const names = await listReadPage.getEncounterNames();
     expect(names).toContain('Filter Test Encounter');
 
     // Click Ready filter - encounter should disappear (it's in Draft)
@@ -173,7 +178,7 @@ test.describe('Encounter List Page @smoke @encounter', () => {
     // Wait for UI to update
     await page.waitForTimeout(300);
 
-    const namesAfterFilter = await listPage.getEncounterNames();
+    const namesAfterFilter = await listReadPage.getEncounterNames();
     expect(namesAfterFilter).not.toContain('Filter Test Encounter');
 
     // Cleanup
@@ -188,10 +193,14 @@ test.describe('Encounter List Page @smoke @encounter', () => {
 test.describe('Encounter Creation @smoke @encounter', () => {
   let listPage: EncounterListPage;
   let createPage: EncounterCreatePage;
+  let createReadPage: EncounterCreateReadPage;
+  let createSubmitPage: EncounterCreateSubmitPage;
 
   test.beforeEach(async ({ page }) => {
     listPage = new EncounterListPage(page);
     createPage = new EncounterCreatePage(page);
+    createReadPage = new EncounterCreateReadPage(page);
+    createSubmitPage = new EncounterCreateSubmitPage(page);
     await listPage.navigate();
     await waitForStoreReady(page);
   });
@@ -208,7 +217,7 @@ test.describe('Encounter Creation @smoke @encounter', () => {
     await createPage.fillName('Simple E2E Encounter');
 
     // Submit
-    await createPage.submit();
+    await createSubmitPage.submit();
 
     // Should redirect to encounter detail
     await expect(page).toHaveURL(/\/gameplay\/encounters\/[^/]+$/);
@@ -225,7 +234,7 @@ test.describe('Encounter Creation @smoke @encounter', () => {
     await page.getByTestId('template-skirmish').click();
 
     // Submit
-    await createPage.submit();
+    await createSubmitPage.submit();
 
     // Should redirect to encounter detail
     await expect(page).toHaveURL(/\/gameplay\/encounters\/[^/]+$/);
@@ -244,7 +253,7 @@ test.describe('Encounter Creation @smoke @encounter', () => {
     await expect(page).toHaveURL(/\/gameplay\/encounters\/create$/);
 
     // Check for error message or that we're still on the page
-    const hasError = await createPage.hasFieldError('name');
+    const hasError = await createReadPage.hasFieldError('name');
     const stillOnCreatePage = await page
       .getByText(/Encounter Name/i)
       .isVisible();
@@ -256,7 +265,7 @@ test.describe('Encounter Creation @smoke @encounter', () => {
     await createPage.fillName('Encounter to Cancel');
 
     // Click cancel
-    await createPage.cancel();
+    await createSubmitPage.cancel();
 
     // Should return to list
     await expect(page).toHaveURL(/\/gameplay\/encounters$/);
@@ -268,12 +277,10 @@ test.describe('Encounter Creation @smoke @encounter', () => {
 // =============================================================================
 
 test.describe('Encounter Detail Page @encounter', () => {
-  let _detailPage: EncounterDetailPage;
   let listPage: EncounterListPage;
   let encounterId: string | null;
 
   test.beforeEach(async ({ page }) => {
-    _detailPage = new EncounterDetailPage(page);
     listPage = new EncounterListPage(page);
 
     // Navigate to list first to ensure store is initialized
@@ -459,12 +466,10 @@ test.describe('Encounter Deletion @encounter', () => {
 
 test.describe('Encounter Validation @encounter', () => {
   let listPage: EncounterListPage;
-  let _detailPage: EncounterDetailPage;
   let encounterId: string | null;
 
   test.beforeEach(async ({ page }) => {
     listPage = new EncounterListPage(page);
-    _detailPage = new EncounterDetailPage(page);
     await listPage.navigate();
     await waitForStoreReady(page);
 

--- a/e2e/pages/encounter.page.ts
+++ b/e2e/pages/encounter.page.ts
@@ -1,11 +1,4 @@
-import type { Page as _Page } from '@playwright/test';
-
-import { expect as _expect } from '@playwright/test';
-
 import { BasePage } from './base.page';
-
-// Re-export to silence unused warnings (types kept for documentation)
-void _expect;
 
 /**
  * Page object for the encounter list page (/gameplay/encounters).
@@ -20,15 +13,6 @@ export class EncounterListPage extends BasePage {
   async navigate(): Promise<void> {
     await this.page.goto(this.url);
     await this.waitForReady();
-  }
-
-  /**
-   * Get the count of encounter cards displayed.
-   */
-  async getCardCount(): Promise<number> {
-    // Cards use testid pattern: encounter-card-{id}
-    const cards = this.page.locator('[data-testid^="encounter-card-"]');
-    return cards.count();
   }
 
   /**
@@ -58,31 +42,24 @@ export class EncounterListPage extends BasePage {
     await this.fillByTestId('encounter-search', query);
     await this.page.waitForTimeout(300);
   }
+}
+
+/**
+ * Read-only assertions for the encounter list page.
+ */
+export class EncounterListReadPage extends BasePage {
+  /**
+   * Get the count of encounter cards displayed.
+   */
+  async getCardCount(): Promise<number> {
+    return this.page.locator('[data-testid^="encounter-card-"]').count();
+  }
 
   /**
    * Get all encounter names displayed.
    */
   async getEncounterNames(): Promise<string[]> {
-    const names = this.getByTestId('encounter-name');
-    return names.allTextContents();
-  }
-
-  /**
-   * Filter encounters by status.
-   * @param status - The status to filter by (e.g., 'active', 'completed', 'pending')
-   */
-  async filterByStatus(status: string): Promise<void> {
-    await this.clickByTestId('status-filter');
-    await this.clickByTestId(`status-option-${status}`);
-  }
-
-  /**
-   * Filter encounters by type.
-   * @param type - The encounter type
-   */
-  async filterByType(type: string): Promise<void> {
-    await this.clickByTestId('type-filter');
-    await this.clickByTestId(`type-option-${type}`);
+    return this.getByTestId('encounter-name').allTextContents();
   }
 
   /**
@@ -95,167 +72,9 @@ export class EncounterListPage extends BasePage {
 
 /**
  * Page object for the encounter detail page (/gameplay/encounters/[id]).
- * Provides methods to interact with encounter details.
+ * Provides methods for currently tested encounter detail actions.
  */
 export class EncounterDetailPage extends BasePage {
-  /**
-   * Navigate to a specific encounter's detail page.
-   * @param id - The encounter ID
-   */
-  async navigate(id: string): Promise<void> {
-    await this.page.goto(`/gameplay/encounters/${id}`);
-    await this.waitForReady();
-  }
-
-  /**
-   * Get the encounter name.
-   */
-  async getName(): Promise<string> {
-    return this.getTextByTestId('encounter-name');
-  }
-
-  /**
-   * Get the encounter status.
-   */
-  async getStatus(): Promise<string> {
-    return this.getTextByTestId('encounter-status');
-  }
-
-  /**
-   * Get the encounter type.
-   */
-  async getType(): Promise<string> {
-    return this.getTextByTestId('encounter-type');
-  }
-
-  /**
-   * Get the current turn number.
-   */
-  async getCurrentTurn(): Promise<number> {
-    const turnText = await this.getTextByTestId('encounter-turn');
-    return parseInt(turnText, 10);
-  }
-
-  /**
-   * Get the current phase.
-   */
-  async getCurrentPhase(): Promise<string> {
-    return this.getTextByTestId('encounter-phase');
-  }
-
-  /**
-   * Click the map tab.
-   */
-  async clickMapTab(): Promise<void> {
-    await this.clickByTestId('tab-map');
-  }
-
-  /**
-   * Click the units tab.
-   */
-  async clickUnitsTab(): Promise<void> {
-    await this.clickByTestId('tab-units');
-  }
-
-  /**
-   * Click the log tab.
-   */
-  async clickLogTab(): Promise<void> {
-    await this.clickByTestId('tab-log');
-  }
-
-  /**
-   * Click the objectives tab.
-   */
-  async clickObjectivesTab(): Promise<void> {
-    await this.clickByTestId('tab-objectives');
-  }
-
-  /**
-   * Select a unit on the battlefield.
-   * @param unitId - The unit ID
-   */
-  async selectUnit(unitId: string): Promise<void> {
-    await this.clickByTestId(`unit-${unitId}`);
-  }
-
-  /**
-   * Click a hex on the map.
-   * @param hexId - The hex coordinates (e.g., '1203')
-   */
-  async clickHex(hexId: string): Promise<void> {
-    await this.clickByTestId(`hex-${hexId}`);
-  }
-
-  /**
-   * End the current phase.
-   */
-  async endPhase(): Promise<void> {
-    await this.clickByTestId('end-phase-btn');
-  }
-
-  /**
-   * End the current turn.
-   */
-  async endTurn(): Promise<void> {
-    await this.clickByTestId('end-turn-btn');
-    await this.clickByTestId('confirm-end-turn-btn');
-  }
-
-  /**
-   * Open the action menu for a unit.
-   * @param unitId - The unit ID
-   */
-  async openUnitActionMenu(unitId: string): Promise<void> {
-    await this.clickByTestId(`unit-actions-${unitId}`);
-  }
-
-  /**
-   * Execute a movement action.
-   * @param unitId - The unit ID
-   * @param targetHex - The target hex coordinates
-   */
-  async moveUnit(unitId: string, targetHex: string): Promise<void> {
-    await this.selectUnit(unitId);
-    await this.clickByTestId('action-move');
-    await this.clickHex(targetHex);
-    await this.clickByTestId('confirm-move-btn');
-  }
-
-  /**
-   * Execute an attack action.
-   * @param attackerId - The attacking unit ID
-   * @param targetId - The target unit ID
-   */
-  async attackUnit(attackerId: string, targetId: string): Promise<void> {
-    await this.selectUnit(attackerId);
-    await this.clickByTestId('action-attack');
-    await this.selectUnit(targetId);
-    await this.clickByTestId('confirm-attack-btn');
-  }
-
-  /**
-   * Click the pause encounter button.
-   */
-  async pauseEncounter(): Promise<void> {
-    await this.clickByTestId('pause-encounter-btn');
-  }
-
-  /**
-   * Click the resume encounter button.
-   */
-  async resumeEncounter(): Promise<void> {
-    await this.clickByTestId('resume-encounter-btn');
-  }
-
-  /**
-   * Click the end encounter button.
-   */
-  async endEncounter(): Promise<void> {
-    await this.clickByTestId('end-encounter-btn');
-    await this.clickByTestId('confirm-end-encounter-btn');
-  }
-
   /**
    * Click the delete encounter button.
    */
@@ -277,25 +96,11 @@ export class EncounterDetailPage extends BasePage {
   async cancelDelete(): Promise<void> {
     await this.clickByTestId('cancel-delete-btn');
   }
-
-  /**
-   * Open the replay controls.
-   */
-  async openReplayControls(): Promise<void> {
-    await this.clickByTestId('replay-controls-btn');
-  }
-
-  /**
-   * Save the encounter state.
-   */
-  async saveEncounter(): Promise<void> {
-    await this.clickByTestId('save-encounter-btn');
-  }
 }
 
 /**
  * Page object for the encounter create page (/gameplay/encounters/create).
- * Provides methods to create a new encounter.
+ * Provides methods to fill the encounter creation form.
  */
 export class EncounterCreatePage extends BasePage {
   readonly url = '/gameplay/encounters/create';
@@ -323,62 +128,12 @@ export class EncounterCreatePage extends BasePage {
   async fillDescription(description: string): Promise<void> {
     await this.fillByTestId('encounter-description-input', description);
   }
+}
 
-  /**
-   * Select an encounter type.
-   * @param type - The encounter type (e.g., 'skirmish', 'campaign', 'scenario')
-   */
-  async selectType(type: string): Promise<void> {
-    await this.clickByTestId('type-select');
-    await this.clickByTestId(`type-option-${type}`);
-  }
-
-  /**
-   * Select a map for the encounter.
-   * @param mapId - The map ID
-   */
-  async selectMap(mapId: string): Promise<void> {
-    await this.clickByTestId('map-select');
-    await this.clickByTestId(`map-option-${mapId}`);
-  }
-
-  /**
-   * Add a force to the encounter.
-   * @param forceId - The force ID to add
-   * @param team - The team to assign (e.g., 'attacker', 'defender')
-   */
-  async addForce(forceId: string, team: string): Promise<void> {
-    await this.clickByTestId('add-force-btn');
-    await this.clickByTestId(`force-option-${forceId}`);
-    await this.clickByTestId(`team-option-${team}`);
-    await this.clickByTestId('confirm-add-force-btn');
-  }
-
-  /**
-   * Remove a force from the encounter.
-   * @param forceId - The force ID to remove
-   */
-  async removeForce(forceId: string): Promise<void> {
-    await this.clickByTestId(`remove-force-${forceId}`);
-  }
-
-  /**
-   * Set victory conditions.
-   * @param condition - The victory condition type
-   */
-  async setVictoryCondition(condition: string): Promise<void> {
-    await this.clickByTestId('victory-condition-select');
-    await this.clickByTestId(`victory-option-${condition}`);
-  }
-
-  /**
-   * Set the turn limit.
-   * @param turns - The maximum number of turns
-   */
-  async setTurnLimit(turns: number): Promise<void> {
-    await this.fillByTestId('turn-limit-input', turns.toString());
-  }
-
+/**
+ * Submission controls for the encounter create page.
+ */
+export class EncounterCreateSubmitPage extends BasePage {
   /**
    * Submit the create encounter form.
    */
@@ -394,29 +149,17 @@ export class EncounterCreatePage extends BasePage {
   async cancel(): Promise<void> {
     await this.clickAndWaitForNavigation(this.getByTestId('cancel-btn'));
   }
+}
 
+/**
+ * Read-only validation helpers for the encounter create page.
+ */
+export class EncounterCreateReadPage extends BasePage {
   /**
    * Check if form validation error is displayed.
    * @param field - The field name to check for errors
    */
   async hasFieldError(field: string): Promise<boolean> {
     return this.isVisibleByTestId(`${field}-error`);
-  }
-
-  /**
-   * Create an encounter with the given details (convenience method).
-   * @param name - The encounter name
-   * @param type - The encounter type
-   * @param mapId - The map ID
-   */
-  async createEncounter(
-    name: string,
-    type: string,
-    mapId: string,
-  ): Promise<void> {
-    await this.fillName(name);
-    await this.selectType(type);
-    await this.selectMap(mapId);
-    await this.submit();
   }
 }

--- a/e2e/pages/index.ts
+++ b/e2e/pages/index.ts
@@ -43,8 +43,11 @@ export {
 // Encounter pages
 export {
   EncounterListPage,
+  EncounterListReadPage,
   EncounterDetailPage,
   EncounterCreatePage,
+  EncounterCreateReadPage,
+  EncounterCreateSubmitPage,
 } from './encounter.page';
 
 // Customizer pages


### PR DESCRIPTION
## Summary
- split encounter page-object read, submission, and action helpers into narrower classes
- removed unused encounter detail/create scaffolding while keeping tested browser interactions
- moved the three encounter page-object maintenance-ledger findings from follow-up to fixed and updated QC evidence

## Evidence
- npx.cmd tsc --noEmit --pretty false --project tsconfig.json
- npx.cmd playwright test e2e/encounter.spec.ts --project=chromium --workers=1 (22 passed, 1 existing skipped clone test)
- node scripts/qc/validate-maintenance-warning-ledger.mjs
- npm.cmd run verify:qc:maintenance
- npm.cmd run qc:validate
- npm.cmd run qc:lifecycle:status
- npm.cmd run qc:app-completion -- --json
- npm.cmd run format:check
- git diff --check
- commit hook full npm build

## Notes
- Release signoff still has maintenance-code-health active-review; this slice reduces live design-violation critical findings from critical=7/high=6 to critical=4/high=6 and ledger status from fixed=13/follow-up=31 to fixed=16/follow-up=28.