### PR TITLE
Clear e2e page-object design debt

### DIFF
--- a/docs/qc/maintenance-warning-ledger.json
+++ b/docs/qc/maintenance-warning-ledger.json
@@ -33,9 +33,9 @@
       "follow-up": 0
     },
     "design-violation": {
-      "fixed": 14,
+      "fixed": 18,
       "accepted": 3,
-      "follow-up": 10
+      "follow-up": 6
     }
   },
   "entries": [
@@ -425,9 +425,13 @@
       "severity": "critical",
       "file": "e2e/pages/game.page.ts",
       "message": "class has 20 public methods",
-      "status": "follow-up",
-      "rationale": "Game page-object role should be decomposed with gameplay E2E coverage preserved.",
-      "followUps": ["wave-12-e2e-page-object-split"]
+      "status": "fixed",
+      "rationale": "Game session page-object helpers were split into status, turn, map, command, and unit roles so the tactical browser surface remains readable without a broad public method class.",
+      "fixedEvidence": [
+        "2026-06-27 `npm.cmd run maintain:scan -- --scope=e2e/pages/game.page.ts --json` reported no findings.",
+        "2026-06-27 `npx.cmd tsc --noEmit --pretty false --project tsconfig.json` passed.",
+        "2026-06-27 affected Chromium `npx.cmd playwright test e2e/game.spec.ts e2e/combat.spec.ts e2e/repair.spec.ts e2e/gameplay-layout-slots.spec.ts e2e/tactical-action-menu.spec.ts --project=chromium --workers=1` passed 121 checks."
+      ]
     },
     {
       "key": "design-violation|critical|e2e/pages/game.page.ts|class has 11 public methods",
@@ -435,9 +439,13 @@
       "severity": "critical",
       "file": "e2e/pages/game.page.ts",
       "message": "class has 11 public methods",
-      "status": "follow-up",
-      "rationale": "Game page-object role should be decomposed with gameplay E2E coverage preserved.",
-      "followUps": ["wave-12-e2e-page-object-split"]
+      "status": "fixed",
+      "rationale": "Game replay helpers were split into replay navigation, read-only assertions, transport controls, and timeline jump controls.",
+      "fixedEvidence": [
+        "2026-06-27 `npm.cmd run maintain:scan -- --scope=e2e/pages/game.page.ts --json` reported no findings.",
+        "2026-06-27 `npx.cmd tsc --noEmit --pretty false --project tsconfig.json` passed.",
+        "2026-06-27 affected Chromium `npx.cmd playwright test e2e/game.spec.ts e2e/combat.spec.ts e2e/repair.spec.ts e2e/gameplay-layout-slots.spec.ts e2e/tactical-action-menu.spec.ts --project=chromium --workers=1` passed 121 checks."
+      ]
     },
     {
       "key": "design-violation|critical|e2e/pages/repair.page.ts|class has 44 public methods",
@@ -445,9 +453,13 @@
       "severity": "critical",
       "file": "e2e/pages/repair.page.ts",
       "message": "class has 44 public methods",
-      "status": "follow-up",
-      "rationale": "Repair page object is a broad workflow surface and needs a dedicated split with repair E2E coverage preserved.",
-      "followUps": ["wave-12-e2e-page-object-split"]
+      "status": "fixed",
+      "rationale": "Repair bay helpers were split into stats, filters, list, assessment, item selection, cost, queue, header, and error roles while preserving repair E2E coverage.",
+      "fixedEvidence": [
+        "2026-06-27 `npm.cmd run maintain:scan -- --scope=e2e/pages/repair.page.ts --json` reported no findings.",
+        "2026-06-27 `npx.cmd tsc --noEmit --pretty false --project tsconfig.json` passed.",
+        "2026-06-27 affected Chromium `npx.cmd playwright test e2e/game.spec.ts e2e/combat.spec.ts e2e/repair.spec.ts e2e/gameplay-layout-slots.spec.ts e2e/tactical-action-menu.spec.ts --project=chromium --workers=1` passed 121 checks."
+      ]
     },
     {
       "key": "design-violation|critical|scripts/performance/measure-bundle-size.js|class has 11 public methods",
@@ -499,9 +511,13 @@
       "severity": "high",
       "file": "e2e/pages/game.page.ts",
       "message": "class has 5 public methods",
-      "status": "follow-up",
-      "rationale": "Game page-object role should be decomposed with gameplay E2E coverage preserved.",
-      "followUps": ["wave-12-e2e-page-object-split"]
+      "status": "fixed",
+      "rationale": "Game list page-object reads were split from list navigation and card actions, clearing the remaining high-severity page-object method-count finding.",
+      "fixedEvidence": [
+        "2026-06-27 `npm.cmd run maintain:scan -- --scope=e2e/pages/game.page.ts --json` reported no findings.",
+        "2026-06-27 `npx.cmd tsc --noEmit --pretty false --project tsconfig.json` passed.",
+        "2026-06-27 affected Chromium `npx.cmd playwright test e2e/game.spec.ts e2e/combat.spec.ts e2e/repair.spec.ts e2e/gameplay-layout-slots.spec.ts e2e/tactical-action-menu.spec.ts --project=chromium --workers=1` passed 121 checks."
+      ]
     },
     {
       "key": "design-violation|high|scripts/audit-megamek-board-import.ts|switch statement has 9 cases",

--- a/docs/qc/mekstation-qc-map.md
+++ b/docs/qc/mekstation-qc-map.md
@@ -361,9 +361,10 @@ flowchart TD
    - Use `maintain:scan:gate` to block new `src` critical/high findings, and
      use `node scripts/qc/validate-maintenance-warning-ledger.mjs` to confirm
      repo-wide Wave 12 findings are fixed, accepted, or follow-up tracked.
-   - Repo-wide non-`src` script, desktop, and e2e page-object findings remain
-     in `docs/qc/maintenance-warning-ledger.json` instead of being treated as
-     hidden pass/fail suppressions.
+   - Repo-wide non-`src` script and desktop findings remain in
+     `docs/qc/maintenance-warning-ledger.json` instead of being treated as
+     hidden pass/fail suppressions; current e2e page-object design findings
+     are cleared.
    - Stale TODOs are currently zero actionable findings after explanatory e2e
      comments were rewritten and recent skipped-test `fixme` trackers stayed
      explicit.
@@ -385,6 +386,10 @@ flowchart TD
    - Encounter page-object design-violation findings are cleared after the list,
      detail, and create helpers were split into narrow read/submission/action
      surfaces; full Chromium encounter E2E coverage still passes.
+   - Game and repair page-object design findings are cleared after tactical
+     session, replay, and repair bay helpers were split into narrow role
+     classes; 121 affected Chromium game/combat/repair/layout/action-menu
+     checks pass.
    - HexMapDisplay, movement utilities, and physical attack utilities have
      had first-pass complexity/design cleanup, but each still has active
      raw critical/high queues.

--- a/docs/qc/mekstation-qc-registry.json
+++ b/docs/qc/mekstation-qc-registry.json
@@ -1602,13 +1602,14 @@
         "2026-06-27 compendium page-object maintenance slice removed unused detail-page scaffolds, split unit/equipment read helpers from browser actions, and reduced repo-wide design-violation findings from critical=13/high=6 to critical=10/high=6; typecheck and the full Chromium compendium spec passed.",
         "2026-06-27 force page-object maintenance slice removed unused force detail/list/create helpers, split list/create read and submission helpers from browser actions, and reduced repo-wide design-violation findings from critical=10/high=6 to critical=7/high=6; typecheck and the full Chromium force spec passed.",
         "2026-06-27 encounter page-object maintenance slice removed unused encounter detail scaffolds, split list reads and create-page submission/read helpers from browser actions, and reduced repo-wide design-violation findings from critical=7/high=6 to critical=4/high=6; typecheck and the full Chromium encounter spec passed.",
+        "2026-06-27 game/repair page-object maintenance slice split tactical session, replay, and repair bay helpers into narrow role classes, clearing the remaining e2e page-object design findings and reducing repo-wide design-violation findings from critical=4/high=6 to critical=1/high=5; typecheck and 121 affected Chromium checks passed.",
         "docs/qc/maintenance-baseline.json",
         "docs/qc/maintenance-warning-ledger.json",
         "scripts/qc/validate-maintenance-warning-ledger.mjs"
       ],
       "gaps": [
         "Scanner report is grouped as a regression baseline; avoid broad refactors until findings are selected as validated remediation waves.",
-        "Repo-wide non-src script, desktop, and e2e page-object findings remain ledger-tracked as accepted or follow-up debt.",
+        "Repo-wide non-src script and desktop findings remain ledger-tracked as accepted or follow-up debt; current e2e page-object design findings are cleared.",
         "Passing maintain:scan:gate only proves the src regression gate; use the maintenance warning ledger validator for Wave 12 repo-wide accounting."
       ]
     }

--- a/docs/qc/mekstation-qc-validation-graph.json
+++ b/docs/qc/mekstation-qc-validation-graph.json
@@ -1648,6 +1648,7 @@
         "2026-06-27 compendium page-object maintenance slice removed unused detail-page scaffolds, split unit/equipment read helpers from browser actions, and reduced repo-wide design-violation findings from critical=13/high=6 to critical=10/high=6; typecheck and the full Chromium compendium spec passed.",
         "2026-06-27 force page-object maintenance slice removed unused force detail/list/create helpers, split list/create read and submission helpers from browser actions, and reduced repo-wide design-violation findings from critical=10/high=6 to critical=7/high=6; typecheck and the full Chromium force spec passed.",
         "2026-06-27 encounter page-object maintenance slice removed unused encounter detail scaffolds, split list reads and create-page submission/read helpers from browser actions, and reduced repo-wide design-violation findings from critical=7/high=6 to critical=4/high=6; typecheck and the full Chromium encounter spec passed.",
+        "2026-06-27 game/repair page-object maintenance slice split tactical session, replay, and repair bay helpers into narrow role classes, clearing the remaining e2e page-object design findings and reducing repo-wide design-violation findings from critical=4/high=6 to critical=1/high=5; typecheck and 121 affected Chromium checks passed.",
         "docs/qc/maintenance-baseline.json",
         "docs/qc/maintenance-warning-ledger.json",
         "scripts/qc/validate-maintenance-warning-ledger.mjs"
@@ -1668,7 +1669,7 @@
       "label": "Maintenance Code Health known gaps",
       "entries": [
         "Scanner report is grouped as a regression baseline; avoid broad refactors until findings are selected as validated remediation waves.",
-        "Repo-wide non-src script, desktop, and e2e page-object findings remain ledger-tracked as accepted or follow-up debt.",
+        "Repo-wide non-src script and desktop findings remain ledger-tracked as accepted or follow-up debt; current e2e page-object design findings are cleared.",
         "Passing maintain:scan:gate only proves the src regression gate; use the maintenance warning ledger validator for Wave 12 repo-wide accounting."
       ]
     },

--- a/e2e/combat.spec.ts
+++ b/e2e/combat.spec.ts
@@ -60,7 +60,7 @@ test.describe('Record Sheet Display @smoke @combat', () => {
 
   test('shows no unit selected initially', async () => {
     // Initially no unit should be selected
-    const noUnitVisible = await sessionPage.isNoUnitSelectedVisible();
+    const noUnitVisible = await sessionPage.units.isNoUnitSelectedVisible();
     expect(noUnitVisible).toBe(true);
   });
 

--- a/e2e/game.spec.ts
+++ b/e2e/game.spec.ts
@@ -21,6 +21,7 @@ import {
 } from './fixtures/game';
 import {
   GameListPage,
+  GameListReadPage,
   GameSessionPage,
   GameReplayPage,
 } from './pages/game.page';
@@ -50,9 +51,11 @@ async function waitForStoreReady(page: Page): Promise<void> {
 
 test.describe('Game List Page @smoke @game', () => {
   let listPage: GameListPage;
+  let listReadPage: GameListReadPage;
 
   test.beforeEach(async ({ page }) => {
     listPage = new GameListPage(page);
+    listReadPage = new GameListReadPage(page);
     await listPage.navigate();
     await waitForStoreReady(page);
   });
@@ -67,10 +70,10 @@ test.describe('Game List Page @smoke @game', () => {
 
   test('shows games or empty state correctly', async ({ page }) => {
     // Either show game cards or empty state
-    const cardCount = await listPage.getCardCount();
+    const cardCount = await listReadPage.getCardCount();
 
     if (cardCount === 0) {
-      const emptyVisible = await listPage.isEmptyStateVisible();
+      const emptyVisible = await listReadPage.isEmptyStateVisible();
       // Empty state or just no cards
       expect(cardCount).toBe(0);
       // We don't strictly require empty state - page may just be empty
@@ -103,8 +106,8 @@ test.describe('Demo Game Session @smoke @game', () => {
     await sessionPage.waitForGameLoaded();
 
     // Should not show loading or error state
-    const isLoading = await sessionPage.isLoading();
-    const hasError = await sessionPage.hasError();
+    const isLoading = await sessionPage.status.isLoading();
+    const hasError = await sessionPage.status.hasError();
 
     expect(isLoading).toBe(false);
     expect(hasError).toBe(false);
@@ -127,7 +130,7 @@ test.describe('Demo Game Session @smoke @game', () => {
     await expect(page.getByTestId('tactical-turn-rail')).toBeVisible();
 
     // Demo starts at weapon attack phase
-    const phaseName = await sessionPage.getPhaseName();
+    const phaseName = await sessionPage.turn.getPhaseName();
     expect(phaseName.toLowerCase()).toContain('weapon');
   });
 
@@ -135,7 +138,7 @@ test.describe('Demo Game Session @smoke @game', () => {
     await sessionPage.waitForGameLoaded();
 
     // Turn number should be visible
-    const turnNumber = await sessionPage.getTurnNumber();
+    const turnNumber = await sessionPage.turn.getTurnNumber();
     // Demo starts at turn 3
     expect(turnNumber).toContain('3');
   });
@@ -144,7 +147,7 @@ test.describe('Demo Game Session @smoke @game', () => {
     await sessionPage.waitForGameLoaded();
 
     // Hex map should be visible
-    const mapVisible = await sessionPage.isHexMapVisible();
+    const mapVisible = await sessionPage.map.isHexMapVisible();
     expect(mapVisible).toBe(true);
 
     // Map panel should exist
@@ -155,7 +158,7 @@ test.describe('Demo Game Session @smoke @game', () => {
     await sessionPage.waitForGameLoaded();
 
     // The tactical action dock (Wave 7.2 command surface) should be visible
-    const actionBarVisible = await sessionPage.isActionBarVisible();
+    const actionBarVisible = await sessionPage.commands.isActionBarVisible();
     expect(actionBarVisible).toBe(true);
   });
 
@@ -163,10 +166,10 @@ test.describe('Demo Game Session @smoke @game', () => {
     await sessionPage.waitForGameLoaded();
 
     // Both demo units should have tokens visible
-    const playerUnitVisible = await sessionPage.isUnitTokenVisible(
+    const playerUnitVisible = await sessionPage.units.isUnitTokenVisible(
       DEMO_UNITS.PLAYER.id,
     );
-    const opponentUnitVisible = await sessionPage.isUnitTokenVisible(
+    const opponentUnitVisible = await sessionPage.units.isUnitTokenVisible(
       DEMO_UNITS.OPPONENT.id,
     );
 
@@ -216,7 +219,7 @@ test.describe('Unit Selection @game', () => {
     await expect
       .poll(
         async () => {
-          await sessionPage.clickUnitToken(DEMO_UNITS.PLAYER.id);
+          await sessionPage.units.clickUnitToken(DEMO_UNITS.PLAYER.id);
           const state = await getGameplayState(page);
           return state?.ui.selectedUnitId ?? null;
         },
@@ -227,7 +230,7 @@ test.describe('Unit Selection @game', () => {
 
   test('record sheet panel shows no unit selected initially', async () => {
     // Initially no unit should be selected
-    const noUnitVisible = await sessionPage.isNoUnitSelectedVisible();
+    const noUnitVisible = await sessionPage.units.isNoUnitSelectedVisible();
     expect(noUnitVisible).toBe(true);
   });
 });
@@ -260,12 +263,12 @@ test.describe('Zoom Controls @game', () => {
 
   test('can click zoom buttons without error', async () => {
     // Just verify they're clickable without errors
-    await sessionPage.clickZoomIn();
-    await sessionPage.clickZoomOut();
-    await sessionPage.clickResetView();
+    await sessionPage.map.clickZoomIn();
+    await sessionPage.map.clickZoomOut();
+    await sessionPage.map.clickResetView();
 
     // Map should still be visible
-    const mapVisible = await sessionPage.isHexMapVisible();
+    const mapVisible = await sessionPage.map.isHexMapVisible();
     expect(mapVisible).toBe(true);
   });
 });
@@ -294,14 +297,17 @@ test.describe('Action Bar @game', () => {
   test('end-phase command is available', async () => {
     // The legacy 'skip' action maps to the dock's End Phase command
     // (heatEndCommands.ts: phaseConstraints include WeaponAttack).
-    const isVisible = await sessionPage.isActionVisible('heat-end.end-phase');
+    const isVisible =
+      await sessionPage.commands.isActionVisible('heat-end.end-phase');
     expect(isVisible).toBe(true);
   });
 
   test('clear-attacks command is available in weapon attack phase', async () => {
     // Demo starts at weapon_attack phase; the dock surfaces the weapon
     // family there (weaponAttackCommands.ts).
-    const isVisible = await sessionPage.isActionVisible('weapon.clear-attacks');
+    const isVisible = await sessionPage.commands.isActionVisible(
+      'weapon.clear-attacks',
+    );
     expect(isVisible).toBe(true);
   });
 
@@ -444,7 +450,7 @@ test.describe('Game Replay Page @game', () => {
     await replayPage.navigate('demo');
     await replayPage.waitForReplayLoaded();
 
-    const controlsVisible = await replayPage.areControlsVisible();
+    const controlsVisible = await replayPage.read.areControlsVisible();
     expect(controlsVisible).toBe(true);
   });
 
@@ -597,7 +603,7 @@ test.describe('Phase Transitions @game', () => {
 
     // Verify at least one expected action is available
     for (const action of expectedActions) {
-      const isVisible = await sessionPage.isActionVisible(action);
+      const isVisible = await sessionPage.commands.isActionVisible(action);
       expect(isVisible).toBe(true);
     }
   });
@@ -636,7 +642,7 @@ test.describe('Game Error Handling @game', () => {
     await page.waitForTimeout(1000);
 
     // Should show error state
-    const hasError = await sessionPage.hasError();
+    const hasError = await sessionPage.status.hasError();
     expect(hasError).toBe(true);
   });
 

--- a/e2e/pages/game.page.ts
+++ b/e2e/pages/game.page.ts
@@ -1,53 +1,37 @@
-import type { Page as _Page } from '@playwright/test';
-
-import { expect as _expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
 
 import { BasePage } from './base.page';
 
-// Re-export to silence unused warnings (types kept for documentation)
-void _expect;
-
 /**
  * Page object for the games list page (/gameplay/games).
- * Provides methods to interact with the game listing.
+ * Provides navigation and list actions.
  */
 export class GameListPage extends BasePage {
   readonly url = '/gameplay/games';
 
-  /**
-   * Navigate to the games list page.
-   */
   async navigate(): Promise<void> {
     await this.page.goto(this.url);
     await this.waitForReady();
   }
 
-  /**
-   * Get the count of game cards displayed.
-   */
+  async clickNewGameButton(): Promise<void> {
+    await this.clickAndWaitForNavigation(this.getByTestId('new-game-btn'));
+  }
+
+  async clickGameCard(id: string): Promise<void> {
+    await this.clickAndWaitForNavigation(this.getByTestId(`game-card-${id}`));
+  }
+}
+
+/**
+ * Read-only helpers for the games list page.
+ */
+export class GameListReadPage extends BasePage {
   async getCardCount(): Promise<number> {
     const cards = this.page.locator('[data-testid^="game-card-"]');
     return cards.count();
   }
 
-  /**
-   * Click the new game button.
-   */
-  async clickNewGameButton(): Promise<void> {
-    await this.clickAndWaitForNavigation(this.getByTestId('new-game-btn'));
-  }
-
-  /**
-   * Click a specific game card by ID.
-   * @param id - The game ID
-   */
-  async clickGameCard(id: string): Promise<void> {
-    await this.clickAndWaitForNavigation(this.getByTestId(`game-card-${id}`));
-  }
-
-  /**
-   * Check if empty state is displayed.
-   */
   async isEmptyStateVisible(): Promise<boolean> {
     return this.isVisibleByTestId('games-empty-state');
   }
@@ -55,87 +39,77 @@ export class GameListPage extends BasePage {
 
 /**
  * Page object for the game session page (/gameplay/games/[id]).
- * Provides methods to interact with an active game.
  */
 export class GameSessionPage extends BasePage {
-  /**
-   * Navigate to a specific game session.
-   * @param id - The game ID (use 'demo' for demo session)
-   */
+  readonly status: GameSessionStatusPage;
+  readonly turn: GameSessionTurnPage;
+  readonly map: GameSessionMapPage;
+  readonly commands: GameSessionCommandPage;
+  readonly units: GameSessionUnitPage;
+
+  constructor(page: Page) {
+    super(page);
+    this.status = new GameSessionStatusPage(page);
+    this.turn = new GameSessionTurnPage(page);
+    this.map = new GameSessionMapPage(page);
+    this.commands = new GameSessionCommandPage(page);
+    this.units = new GameSessionUnitPage(page);
+  }
+
   async navigate(id: string = 'demo'): Promise<void> {
     await this.page.goto(`/gameplay/games/${id}`);
     await this.waitForReady();
   }
 
-  /**
-   * Wait for the game session to load.
-   */
   async waitForGameLoaded(): Promise<void> {
-    // Wait for loading to disappear and game content to appear
     await this.page.waitForSelector('[data-testid="game-session"]', {
       timeout: 15000,
     });
   }
+}
 
-  /**
-   * Check if game is loading.
-   */
+/**
+ * Game session load, error, and terminal-state helpers.
+ */
+export class GameSessionStatusPage extends BasePage {
   async isLoading(): Promise<boolean> {
     return this.isVisibleByTestId('game-loading');
   }
 
-  /**
-   * Check if game has error.
-   */
   async hasError(): Promise<boolean> {
     return this.isVisibleByTestId('game-error');
   }
 
-  /**
-   * Click retry button on error.
-   */
   async clickRetry(): Promise<void> {
     await this.clickByTestId('game-retry-btn');
   }
 
-  /**
-   * Check if game is completed.
-   */
   async isCompleted(): Promise<boolean> {
     return this.isVisibleByTestId('game-completed');
   }
+}
 
-  /**
-   * Click replay button on completed game.
-   */
-  async clickReplayButton(): Promise<void> {
-    await this.clickAndWaitForNavigation(this.getByTestId('replay-game-btn'));
-  }
-
-  /**
-   * Get the current phase name.
-   */
+/**
+ * Game session turn rail readers.
+ */
+export class GameSessionTurnPage extends BasePage {
   async getPhaseName(): Promise<string> {
     return this.getTextByTestId('phase-name');
   }
 
-  /**
-   * Get the current turn number.
-   */
   async getTurnNumber(): Promise<string> {
     return this.getTextByTestId('turn-number');
   }
 
-  /**
-   * Get the turn indicator (Your Turn / Opponent's Turn).
-   */
   async getTurnIndicator(): Promise<string> {
     return this.getTextByTestId('turn-indicator');
   }
+}
 
-  /**
-   * Check if hex map is visible.
-   */
+/**
+ * Tactical map and camera controls for a game session.
+ */
+export class GameSessionMapPage extends BasePage {
   async isHexMapVisible(): Promise<boolean> {
     const map = this.page.locator(
       [
@@ -150,75 +124,48 @@ export class GameSessionPage extends BasePage {
       .catch(() => false);
   }
 
-  /**
-   * Check if the tactical action dock (the primary command surface) is
-   * visible. The legacy `action-bar` only exists inside a `hidden` mount
-   * (GameplayLayout's legacy-action-bar-mount) — `tactical-action-dock`
-   * is the live surface (Wave 7.2).
-   */
-  async isActionBarVisible(): Promise<boolean> {
-    return this.isVisibleByTestId('tactical-action-dock');
-  }
-
-  /**
-   * Click a command button in the tactical action dock.
-   * @param commandId - Registry command ID (e.g. 'weapon.clear-attacks',
-   *   'heat-end.end-phase', 'heat.continue', 'heat-end.next-turn')
-   */
-  async clickAction(commandId: string): Promise<void> {
-    await this.clickByTestId(`command-btn-${commandId}`);
-  }
-
-  /**
-   * Check if a specific dock command button is visible. Disabled commands
-   * stay rendered with a reason tooltip, so visibility asserts the command
-   * is REGISTERED for the current phase, not that it is currently enabled.
-   * @param commandId - Registry command ID
-   */
-  async isActionVisible(commandId: string): Promise<boolean> {
-    return this.isVisibleByTestId(`command-btn-${commandId}`);
-  }
-
-  /**
-   * Click a unit token on the map.
-   * @param unitId - Unit ID
-   */
-  async clickUnitToken(unitId: string): Promise<void> {
-    await this.clickByTestId(`unit-token-${unitId}`);
-  }
-
-  /**
-   * Check if a unit token is visible.
-   * @param unitId - Unit ID
-   */
-  async isUnitTokenVisible(unitId: string): Promise<boolean> {
-    return this.isVisibleByTestId(`unit-token-${unitId}`);
-  }
-
-  /**
-   * Click zoom in button.
-   */
   async clickZoomIn(): Promise<void> {
     await this.clickByTestId('zoom-in-btn');
   }
 
-  /**
-   * Click zoom out button.
-   */
   async clickZoomOut(): Promise<void> {
     await this.clickByTestId('zoom-out-btn');
   }
 
-  /**
-   * Click reset view button.
-   */
   async clickResetView(): Promise<void> {
     await this.clickByTestId('reset-view-btn');
   }
+}
 
-  /**
-   * Check if record sheet panel shows "no unit selected" message.
-   */
+/**
+ * Tactical action dock helpers.
+ */
+export class GameSessionCommandPage extends BasePage {
+  async isActionBarVisible(): Promise<boolean> {
+    return this.isVisibleByTestId('tactical-action-dock');
+  }
+
+  async clickAction(commandId: string): Promise<void> {
+    await this.clickByTestId(`command-btn-${commandId}`);
+  }
+
+  async isActionVisible(commandId: string): Promise<boolean> {
+    return this.isVisibleByTestId(`command-btn-${commandId}`);
+  }
+}
+
+/**
+ * Unit token and record-sheet selection helpers.
+ */
+export class GameSessionUnitPage extends BasePage {
+  async clickUnitToken(unitId: string): Promise<void> {
+    await this.clickByTestId(`unit-token-${unitId}`);
+  }
+
+  async isUnitTokenVisible(unitId: string): Promise<boolean> {
+    return this.isVisibleByTestId(`unit-token-${unitId}`);
+  }
+
   async isNoUnitSelectedVisible(): Promise<boolean> {
     return this.isVisibleByTestId('no-unit-selected');
   }
@@ -226,86 +173,77 @@ export class GameSessionPage extends BasePage {
 
 /**
  * Page object for the game replay page (/gameplay/games/[id]/replay).
- * Provides methods to interact with game replay controls.
  */
 export class GameReplayPage extends BasePage {
-  /**
-   * Navigate to a specific game's replay.
-   * @param id - The game ID
-   */
+  readonly read: GameReplayReadPage;
+  readonly controls: GameReplayControlsPage;
+  readonly timeline: GameReplayTimelinePage;
+
+  constructor(page: Page) {
+    super(page);
+    this.read = new GameReplayReadPage(page);
+    this.controls = new GameReplayControlsPage(page);
+    this.timeline = new GameReplayTimelinePage(page);
+  }
+
   async navigate(id: string): Promise<void> {
     await this.page.goto(`/gameplay/games/${id}/replay`);
     await this.waitForReady();
   }
 
-  /**
-   * Wait for replay page to load.
-   */
   async waitForReplayLoaded(): Promise<void> {
     await this.page.waitForSelector('[data-testid="replay-page"]', {
       timeout: 15000,
     });
   }
+}
 
-  /**
-   * Get replay title text.
-   */
+/**
+ * Read-only replay page helpers.
+ */
+export class GameReplayReadPage extends BasePage {
   async getTitle(): Promise<string> {
     return this.getTextByTestId('replay-title');
   }
 
-  /**
-   * Get event count text.
-   */
   async getEventCount(): Promise<string> {
     return this.getTextByTestId('replay-event-count');
   }
 
-  /**
-   * Check if replay controls are visible.
-   */
   async areControlsVisible(): Promise<boolean> {
     return this.isVisibleByTestId('replay-controls');
   }
+}
 
-  /**
-   * Click play/pause button.
-   */
+/**
+ * Replay transport controls.
+ */
+export class GameReplayControlsPage extends BasePage {
   async clickPlayPause(): Promise<void> {
     await this.clickByTestId('replay-btn-play-pause');
   }
 
-  /**
-   * Click stop button.
-   */
   async clickStop(): Promise<void> {
     await this.clickByTestId('replay-btn-stop');
   }
 
-  /**
-   * Click step forward button.
-   */
   async clickStepForward(): Promise<void> {
     await this.clickByTestId('replay-btn-step-forward');
   }
 
-  /**
-   * Click step backward button.
-   */
   async clickStepBackward(): Promise<void> {
     await this.clickByTestId('replay-btn-step-back');
   }
+}
 
-  /**
-   * Click skip to start button.
-   */
+/**
+ * Replay timeline jump controls.
+ */
+export class GameReplayTimelinePage extends BasePage {
   async clickSkipToStart(): Promise<void> {
     await this.clickByTestId('replay-btn-skip-back');
   }
 
-  /**
-   * Click skip to end button.
-   */
   async clickSkipToEnd(): Promise<void> {
     await this.clickByTestId('replay-btn-skip-forward');
   }

--- a/e2e/pages/index.ts
+++ b/e2e/pages/index.ts
@@ -50,6 +50,22 @@ export {
   EncounterCreateSubmitPage,
 } from './encounter.page';
 
+// Game pages
+export {
+  GameListPage,
+  GameListReadPage,
+  GameReplayControlsPage,
+  GameReplayPage,
+  GameReplayReadPage,
+  GameReplayTimelinePage,
+  GameSessionCommandPage,
+  GameSessionMapPage,
+  GameSessionPage,
+  GameSessionStatusPage,
+  GameSessionTurnPage,
+  GameSessionUnitPage,
+} from './game.page';
+
 // Customizer pages
 export { CustomizerPage, AerospaceCustomizerPage } from './customizer.page';
 
@@ -63,4 +79,19 @@ export {
 } from './compendium.page';
 
 // Repair pages
-export { RepairBayPage } from './repair.page';
+export {
+  RepairActionPage,
+  RepairAssessmentPage,
+  RepairBayPage,
+  RepairCostBreakdownPage,
+  RepairCostSummaryPage,
+  RepairErrorPage,
+  RepairFilterPage,
+  RepairHeaderPage,
+  RepairItemSelectionPage,
+  RepairQueueActionsPage,
+  RepairQueuePage,
+  RepairStatsReadPage,
+  RepairUnitListPage,
+  RepairUnitListStatePage,
+} from './repair.page';

--- a/e2e/pages/repair.page.ts
+++ b/e2e/pages/repair.page.ts
@@ -1,79 +1,86 @@
+import type { Page } from '@playwright/test';
+
 import { BasePage } from './base.page';
 
 /**
  * Page object for the repair bay page (/gameplay/repair).
- * Provides methods to interact with the repair management interface.
+ * Provides navigation plus role-specific helper groups.
  */
 export class RepairBayPage extends BasePage {
   readonly url = '/gameplay/repair';
+  readonly stats: RepairStatsReadPage;
+  readonly filters: RepairFilterPage;
+  readonly list: RepairUnitListPage;
+  readonly listState: RepairUnitListStatePage;
+  readonly assessment: RepairAssessmentPage;
+  readonly selection: RepairItemSelectionPage;
+  readonly costSummary: RepairCostSummaryPage;
+  readonly actions: RepairActionPage;
+  readonly costBreakdown: RepairCostBreakdownPage;
+  readonly queue: RepairQueuePage;
+  readonly queueActions: RepairQueueActionsPage;
+  readonly header: RepairHeaderPage;
+  readonly errors: RepairErrorPage;
 
-  /**
-   * Navigate to the repair bay page.
-   * @param campaignId - Optional campaign ID to pass as query param
-   */
+  constructor(page: Page) {
+    super(page);
+    this.stats = new RepairStatsReadPage(page);
+    this.filters = new RepairFilterPage(page);
+    this.list = new RepairUnitListPage(page);
+    this.listState = new RepairUnitListStatePage(page);
+    this.assessment = new RepairAssessmentPage(page);
+    this.selection = new RepairItemSelectionPage(page);
+    this.costSummary = new RepairCostSummaryPage(page);
+    this.actions = new RepairActionPage(page);
+    this.costBreakdown = new RepairCostBreakdownPage(page);
+    this.queue = new RepairQueuePage(page);
+    this.queueActions = new RepairQueueActionsPage(page);
+    this.header = new RepairHeaderPage(page);
+    this.errors = new RepairErrorPage(page);
+  }
+
   async navigate(campaignId?: string): Promise<void> {
     const url = campaignId ? `${this.url}?campaignId=${campaignId}` : this.url;
     await this.page.goto(url);
     await this.waitForReady();
   }
+}
 
-  // =============================================================================
-  // Stats Cards
-  // =============================================================================
-
-  /**
-   * Get the active jobs count from stats.
-   */
+/**
+ * Repair overview stats readers.
+ */
+export class RepairStatsReadPage extends BasePage {
   async getActiveCount(): Promise<string> {
     return this.getTextByTestId('repair-stats-active');
   }
 
-  /**
-   * Get the pending jobs count from stats.
-   */
   async getPendingCount(): Promise<string> {
     return this.getTextByTestId('repair-stats-pending');
   }
 
-  /**
-   * Get the completed jobs count from stats.
-   */
   async getCompletedCount(): Promise<string> {
     return this.getTextByTestId('repair-stats-completed');
   }
 
-  /**
-   * Get the estimated cost from stats.
-   */
   async getEstimatedCost(): Promise<string> {
     return this.getTextByTestId('repair-stats-cost');
   }
+}
 
-  // =============================================================================
-  // Search & Filtering
-  // =============================================================================
-
-  /**
-   * Search for units by query string.
-   * @param query - The search query
-   */
+/**
+ * Search and status-filter helpers.
+ */
+export class RepairFilterPage extends BasePage {
   async searchUnits(query: string): Promise<void> {
     await this.fillByTestId('repair-search-input', query);
-    await this.page.waitForTimeout(300); // Debounce
+    await this.page.waitForTimeout(300);
   }
 
-  /**
-   * Clear the search input.
-   */
   async clearSearch(): Promise<void> {
     await this.fillByTestId('repair-search-input', '');
     await this.page.waitForTimeout(300);
   }
 
-  /**
-   * Filter by status.
-   * @param status - 'all' | 'pending' | 'in-progress' | 'complete'
-   */
   async filterByStatus(
     status: 'all' | 'pending' | 'in-progress' | 'complete',
   ): Promise<void> {
@@ -81,297 +88,212 @@ export class RepairBayPage extends BasePage {
     await this.page.waitForTimeout(200);
   }
 
-  /**
-   * Get current filter results count text.
-   */
   async getResultsCount(): Promise<string> {
     return this.getTextByTestId('repair-results-count');
   }
+}
 
-  // =============================================================================
-  // Unit Cards
-  // =============================================================================
-
-  /**
-   * Get the count of unit repair cards displayed.
-   */
+/**
+ * Unit-card list helpers.
+ */
+export class RepairUnitListPage extends BasePage {
   async getUnitCardCount(): Promise<number> {
     const cards = this.getByTestId('repair-unit-card');
     return cards.count();
   }
 
-  /**
-   * Click a specific unit repair card.
-   * @param unitId - The unit ID
-   */
   async selectUnit(unitId: string): Promise<void> {
     await this.clickByTestId(`repair-unit-card-${unitId}`);
     await this.page.waitForTimeout(200);
   }
 
-  /**
-   * Check if a unit card is selected.
-   * @param unitId - The unit ID
-   */
   async isUnitSelected(unitId: string): Promise<boolean> {
     const card = this.getByTestId(`repair-unit-card-${unitId}`);
     const classList = await card.getAttribute('class');
     return classList?.includes('border-accent') ?? false;
   }
 
-  /**
-   * Get unit names from all visible unit cards.
-   */
   async getUnitNames(): Promise<string[]> {
     const names = this.getByTestId('repair-unit-name');
     return names.allTextContents();
   }
+}
 
-  /**
-   * Check if the unit list is empty.
-   */
+/**
+ * Empty and all-operational unit-list states.
+ */
+export class RepairUnitListStatePage extends BasePage {
   async isUnitListEmpty(): Promise<boolean> {
     return this.isVisibleByTestId('repair-empty-state');
   }
 
-  /**
-   * Check if "All Units Operational" empty state is shown.
-   */
   async isAllOperational(): Promise<boolean> {
     return this.isVisibleByTestId('repair-all-operational');
   }
+}
 
-  // =============================================================================
-  // Damage Assessment Panel
-  // =============================================================================
-
-  /**
-   * Check if the damage assessment panel is visible.
-   */
+/**
+ * Damage assessment panel helpers.
+ */
+export class RepairAssessmentPage extends BasePage {
   async isDamageAssessmentVisible(): Promise<boolean> {
     return this.isVisibleByTestId('damage-assessment-panel');
   }
 
-  /**
-   * Get the unit name from the damage assessment panel.
-   */
   async getDamageAssessmentUnitName(): Promise<string> {
     return this.getTextByTestId('damage-assessment-unit-name');
   }
 
-  /**
-   * Toggle a specific repair item selection.
-   * @param itemId - The repair item ID
-   */
   async toggleRepairItem(itemId: string): Promise<void> {
     await this.clickByTestId(`repair-item-checkbox-${itemId}`);
   }
+}
 
-  /**
-   * Click "Select All" items button.
-   */
+/**
+ * Repair-item selection helpers.
+ */
+export class RepairItemSelectionPage extends BasePage {
   async selectAllItems(): Promise<void> {
     await this.clickByTestId('repair-select-all-btn');
   }
 
-  /**
-   * Click "Deselect All" items button.
-   */
   async deselectAllItems(): Promise<void> {
     await this.clickByTestId('repair-deselect-all-btn');
   }
 
-  /**
-   * Get the selected items count text.
-   */
   async getSelectedItemsCount(): Promise<string> {
     return this.getTextByTestId('repair-selected-count');
   }
+}
 
-  /**
-   * Get the estimated repair time.
-   */
+/**
+ * Cost summary and repair action state helpers.
+ */
+export class RepairCostSummaryPage extends BasePage {
   async getEstimatedTime(): Promise<string> {
     return this.getTextByTestId('repair-estimated-time');
   }
 
-  /**
-   * Get the total repair cost from the panel.
-   */
   async getTotalCost(): Promise<string> {
     return this.getTextByTestId('repair-total-cost');
   }
 
-  /**
-   * Click the "Start Full Repair" button.
-   */
-  async startFullRepair(): Promise<void> {
-    await this.clickByTestId('repair-start-full-btn');
-    await this.page.waitForTimeout(300);
-  }
-
-  /**
-   * Click the "Partial Repair" button.
-   */
-  async startPartialRepair(): Promise<void> {
-    await this.clickByTestId('repair-partial-btn');
-    await this.page.waitForTimeout(300);
-  }
-
-  /**
-   * Check if the start repair button is disabled.
-   */
   async isStartRepairDisabled(): Promise<boolean> {
     const btn = this.getByTestId('repair-start-full-btn');
     return btn.isDisabled();
   }
 
-  /**
-   * Check if insufficient funds warning is shown.
-   */
   async hasInsufficientFundsWarning(): Promise<boolean> {
     return this.isVisibleByTestId('repair-insufficient-funds');
   }
+}
 
-  // =============================================================================
-  // Cost Breakdown
-  // =============================================================================
+/**
+ * Repair execution actions.
+ */
+export class RepairActionPage extends BasePage {
+  async startFullRepair(): Promise<void> {
+    await this.clickByTestId('repair-start-full-btn');
+    await this.page.waitForTimeout(300);
+  }
 
-  /**
-   * Check if cost breakdown panel is visible.
-   */
+  async startPartialRepair(): Promise<void> {
+    await this.clickByTestId('repair-partial-btn');
+    await this.page.waitForTimeout(300);
+  }
+}
+
+/**
+ * Cost breakdown helpers.
+ */
+export class RepairCostBreakdownPage extends BasePage {
   async isCostBreakdownVisible(): Promise<boolean> {
     return this.isVisibleByTestId('repair-cost-breakdown');
   }
 
-  /**
-   * Get the armor repair cost.
-   */
   async getArmorRepairCost(): Promise<string> {
     return this.getTextByTestId('repair-cost-armor');
   }
 
-  /**
-   * Get the structure repair cost.
-   */
   async getStructureRepairCost(): Promise<string> {
     return this.getTextByTestId('repair-cost-structure');
   }
+}
 
-  // =============================================================================
-  // Repair Queue
-  // =============================================================================
-
-  /**
-   * Check if repair queue section is visible.
-   */
+/**
+ * Repair queue readers and selection helpers.
+ */
+export class RepairQueuePage extends BasePage {
   async isRepairQueueVisible(): Promise<boolean> {
     return this.isVisibleByTestId('repair-queue');
   }
 
-  /**
-   * Get count of jobs in the queue.
-   */
   async getQueueJobCount(): Promise<number> {
     const items = this.getByTestId('repair-queue-item');
     return items.count();
   }
 
-  /**
-   * Get queue job details by job ID.
-   * @param jobId - The job ID
-   */
   async getQueueJobStatus(jobId: string): Promise<string> {
     return this.getTextByTestId(`repair-queue-status-${jobId}`);
   }
 
-  /**
-   * Click a job in the queue.
-   * @param jobId - The job ID
-   */
   async clickQueueJob(jobId: string): Promise<void> {
     await this.clickByTestId(`repair-queue-item-${jobId}`);
   }
+}
 
-  /**
-   * Move a job up in the queue.
-   * @param jobId - The job ID
-   */
+/**
+ * Repair queue mutation helpers.
+ */
+export class RepairQueueActionsPage extends BasePage {
   async moveJobUp(jobId: string): Promise<void> {
     await this.clickByTestId(`repair-queue-up-${jobId}`);
   }
 
-  /**
-   * Move a job down in the queue.
-   * @param jobId - The job ID
-   */
   async moveJobDown(jobId: string): Promise<void> {
     await this.clickByTestId(`repair-queue-down-${jobId}`);
   }
 
-  /**
-   * Cancel a job in the queue.
-   * @param jobId - The job ID
-   */
   async cancelQueueJob(jobId: string): Promise<void> {
     await this.clickByTestId(`repair-queue-cancel-${jobId}`);
   }
 
-  /**
-   * Expand the completed jobs section.
-   */
   async expandCompletedJobs(): Promise<void> {
     await this.clickByTestId('repair-queue-completed-toggle');
   }
+}
 
-  // =============================================================================
-  // Header Actions
-  // =============================================================================
-
-  /**
-   * Click the "Field Repair" button.
-   */
+/**
+ * Header-level repair actions.
+ */
+export class RepairHeaderPage extends BasePage {
   async clickFieldRepair(): Promise<void> {
     await this.clickByTestId('repair-field-btn');
   }
 
-  /**
-   * Click the "Repair All" button.
-   */
   async clickRepairAll(): Promise<void> {
     await this.clickByTestId('repair-all-btn');
     await this.page.waitForTimeout(300);
   }
 
-  /**
-   * Check if the "Repair All" button is disabled.
-   */
   async isRepairAllDisabled(): Promise<boolean> {
     const btn = this.getByTestId('repair-all-btn');
     return btn.isDisabled();
   }
+}
 
-  // =============================================================================
-  // Error State
-  // =============================================================================
-
-  /**
-   * Check if error message is displayed.
-   */
+/**
+ * Repair error state helpers.
+ */
+export class RepairErrorPage extends BasePage {
   async hasError(): Promise<boolean> {
     return this.isVisibleByTestId('repair-error');
   }
 
-  /**
-   * Get the error message text.
-   */
   async getErrorMessage(): Promise<string> {
     return this.getTextByTestId('repair-error');
   }
 
-  /**
-   * Dismiss the error message.
-   */
   async dismissError(): Promise<void> {
     await this.clickByTestId('repair-error-dismiss');
   }

--- a/e2e/repair.spec.ts
+++ b/e2e/repair.spec.ts
@@ -140,7 +140,7 @@ test.describe('Repair Unit List @repair', () => {
   test('shows results count', async ({ page }) => {
     // Results count should show
     await expect(page.getByTestId('repair-results-count')).toBeVisible();
-    const countText = await repairPage.getResultsCount();
+    const countText = await repairPage.filters.getResultsCount();
     expect(countText).toContain('unit');
   });
 
@@ -149,13 +149,14 @@ test.describe('Repair Unit List @repair', () => {
 
     if (jobs.length > 0) {
       // Click first unit card
-      await repairPage.selectUnit(jobs[0].id);
+      await repairPage.list.selectUnit(jobs[0].id);
 
       // Damage assessment panel should appear
       await expect(page.getByTestId('damage-assessment-panel')).toBeVisible();
 
       // Should show unit name
-      const unitName = await repairPage.getDamageAssessmentUnitName();
+      const unitName =
+        await repairPage.assessment.getDamageAssessmentUnitName();
       expect(unitName).toBe(jobs[0].unitName);
     }
   });
@@ -165,11 +166,11 @@ test.describe('Repair Unit List @repair', () => {
 
     if (jobs.length > 0) {
       // Click first unit card
-      await repairPage.selectUnit(jobs[0].id);
+      await repairPage.list.selectUnit(jobs[0].id);
       await expect(page.getByTestId('damage-assessment-panel')).toBeVisible();
 
       // Click same card again to deselect
-      await repairPage.selectUnit(jobs[0].id);
+      await repairPage.list.selectUnit(jobs[0].id);
 
       // Should show select prompt instead
       await expect(page.getByTestId('repair-select-prompt')).toBeVisible();
@@ -199,10 +200,10 @@ test.describe('Repair Search and Filters @repair', () => {
       const firstUnitName = jobs[0].unitName;
 
       // Search for a unit name
-      await repairPage.searchUnits(firstUnitName.substring(0, 3));
+      await repairPage.filters.searchUnits(firstUnitName.substring(0, 3));
 
       // Results should update
-      const countText = await repairPage.getResultsCount();
+      const countText = await repairPage.filters.getResultsCount();
       expect(countText).toContain('filtered');
     }
   });
@@ -212,13 +213,13 @@ test.describe('Repair Search and Filters @repair', () => {
 
     if (jobs.length > 0) {
       // Search first
-      await repairPage.searchUnits('xyz');
+      await repairPage.filters.searchUnits('xyz');
 
       // Clear search
-      await repairPage.clearSearch();
+      await repairPage.filters.clearSearch();
 
       // Should not show filtered indicator
-      const countText = await repairPage.getResultsCount();
+      const countText = await repairPage.filters.getResultsCount();
       // Only shows "(filtered)" when filter is active
       const isFiltered = countText.includes('filtered');
       // After clearing, should not be filtered (unless status filter is active)
@@ -228,16 +229,16 @@ test.describe('Repair Search and Filters @repair', () => {
 
   test('status filter shows pending jobs', async () => {
     // Click pending filter
-    await repairPage.filterByStatus('pending');
+    await repairPage.filters.filterByStatus('pending');
 
     // Results should show filtered
-    const countText = await repairPage.getResultsCount();
+    const countText = await repairPage.filters.getResultsCount();
     expect(countText).toContain('unit');
   });
 
   test('status filter shows in-progress jobs', async ({ page }) => {
     // Click in-progress filter
-    await repairPage.filterByStatus('in-progress');
+    await repairPage.filters.filterByStatus('in-progress');
 
     // Results should update
     await expect(page.getByTestId('repair-results-count')).toBeVisible();
@@ -245,13 +246,13 @@ test.describe('Repair Search and Filters @repair', () => {
 
   test('all filter shows all jobs', async () => {
     // First apply a filter
-    await repairPage.filterByStatus('pending');
+    await repairPage.filters.filterByStatus('pending');
 
     // Then click all
-    await repairPage.filterByStatus('all');
+    await repairPage.filters.filterByStatus('all');
 
     // Should not show filtered indicator (unless search is active)
-    const countText = await repairPage.getResultsCount();
+    const countText = await repairPage.filters.getResultsCount();
     expect(countText).not.toContain('filtered');
   });
 });
@@ -275,7 +276,7 @@ test.describe('Damage Assessment Panel @repair', () => {
     const jobs = await getRepairJobs(page, DEMO_CAMPAIGN_ID);
 
     if (jobs.length > 0) {
-      await repairPage.selectUnit(jobs[0].id);
+      await repairPage.list.selectUnit(jobs[0].id);
 
       // Panel should be visible
       await expect(page.getByTestId('damage-assessment-panel')).toBeVisible();
@@ -290,7 +291,7 @@ test.describe('Damage Assessment Panel @repair', () => {
     const jobs = await getRepairJobs(page, DEMO_CAMPAIGN_ID);
 
     if (jobs.length > 0) {
-      await repairPage.selectUnit(jobs[0].id);
+      await repairPage.list.selectUnit(jobs[0].id);
 
       // Cost summary should be visible
       await expect(page.getByTestId('repair-cost-summary')).toBeVisible();
@@ -304,7 +305,7 @@ test.describe('Damage Assessment Panel @repair', () => {
     const jobs = await getRepairJobs(page, DEMO_CAMPAIGN_ID);
 
     if (jobs.length > 0) {
-      await repairPage.selectUnit(jobs[0].id);
+      await repairPage.list.selectUnit(jobs[0].id);
 
       // Action buttons should be visible for pending jobs
       const job = await getRepairJob(page, DEMO_CAMPAIGN_ID, jobs[0].id);
@@ -319,13 +320,13 @@ test.describe('Damage Assessment Panel @repair', () => {
     const jobs = await getRepairJobs(page, DEMO_CAMPAIGN_ID);
 
     if (jobs.length > 0) {
-      await repairPage.selectUnit(jobs[0].id);
+      await repairPage.list.selectUnit(jobs[0].id);
 
       // Click select all
-      await repairPage.selectAllItems();
+      await repairPage.selection.selectAllItems();
 
       // Selected count should match total items
-      const countText = await repairPage.getSelectedItemsCount();
+      const countText = await repairPage.selection.getSelectedItemsCount();
       // Format is "X / Y"
       const parts = countText.split('/').map((s) => s.trim());
       expect(parts[0]).toBe(parts[1]);
@@ -336,16 +337,16 @@ test.describe('Damage Assessment Panel @repair', () => {
     const jobs = await getRepairJobs(page, DEMO_CAMPAIGN_ID);
 
     if (jobs.length > 0) {
-      await repairPage.selectUnit(jobs[0].id);
+      await repairPage.list.selectUnit(jobs[0].id);
 
       // First select all
-      await repairPage.selectAllItems();
+      await repairPage.selection.selectAllItems();
 
       // Then deselect all
-      await repairPage.deselectAllItems();
+      await repairPage.selection.deselectAllItems();
 
       // Selected count should be 0
-      const countText = await repairPage.getSelectedItemsCount();
+      const countText = await repairPage.selection.getSelectedItemsCount();
       expect(countText.startsWith('0')).toBe(true);
     }
   });
@@ -370,7 +371,7 @@ test.describe('Repair Cost Breakdown @repair', () => {
     const jobs = await getRepairJobs(page, DEMO_CAMPAIGN_ID);
 
     if (jobs.length > 0) {
-      await repairPage.selectUnit(jobs[0].id);
+      await repairPage.list.selectUnit(jobs[0].id);
 
       // Cost breakdown should be visible
       await expect(page.getByTestId('repair-cost-breakdown')).toBeVisible();
@@ -381,7 +382,7 @@ test.describe('Repair Cost Breakdown @repair', () => {
     const jobs = await getRepairJobs(page, DEMO_CAMPAIGN_ID);
 
     if (jobs.length > 0) {
-      await repairPage.selectUnit(jobs[0].id);
+      await repairPage.list.selectUnit(jobs[0].id);
 
       // Cost items section should be visible
       await expect(page.getByTestId('repair-cost-items')).toBeVisible();
@@ -441,7 +442,7 @@ test.describe('Repair Queue @repair', () => {
 
     if (activeOrPending.length > 0) {
       // Click queue item
-      await repairPage.clickQueueJob(activeOrPending[0].id);
+      await repairPage.queue.clickQueueJob(activeOrPending[0].id);
 
       // Should select that job
       const selectedId = await getSelectedJobId(page);
@@ -486,13 +487,13 @@ test.describe('Repair Actions @repair', () => {
 
     if (pendingJobs.length > 0) {
       // Select a pending job
-      await repairPage.selectUnit(pendingJobs[0].id);
+      await repairPage.list.selectUnit(pendingJobs[0].id);
 
       // Deselect all items
-      await repairPage.deselectAllItems();
+      await repairPage.selection.deselectAllItems();
 
       // Start button should be disabled
-      const isDisabled = await repairPage.isStartRepairDisabled();
+      const isDisabled = await repairPage.costSummary.isStartRepairDisabled();
       expect(isDisabled).toBe(true);
     }
   });
@@ -503,13 +504,13 @@ test.describe('Repair Actions @repair', () => {
 
     if (pendingJobs.length > 0) {
       // Select a pending job
-      await repairPage.selectUnit(pendingJobs[0].id);
+      await repairPage.list.selectUnit(pendingJobs[0].id);
 
       // Select all items
-      await repairPage.selectAllItems();
+      await repairPage.selection.selectAllItems();
 
       // Start button should be enabled
-      const isDisabled = await repairPage.isStartRepairDisabled();
+      const isDisabled = await repairPage.costSummary.isStartRepairDisabled();
       expect(isDisabled).toBe(false);
     }
   });
@@ -543,10 +544,10 @@ test.describe('Repair Error States @repair', () => {
     // For now, just verify error dismiss button exists when error is shown
 
     // Check if error is visible (it may not be in normal flow)
-    const hasError = await repairPage.hasError();
+    const hasError = await repairPage.errors.hasError();
 
     if (hasError) {
-      await repairPage.dismissError();
+      await repairPage.errors.dismissError();
 
       // Error should no longer be visible
       await expect(page.getByTestId('repair-error')).not.toBeVisible();


### PR DESCRIPTION
## Summary
- split the remaining broad game/replay and repair E2E page objects into narrow role helpers
- rewired affected game, combat, repair, layout, and tactical action specs to use the scoped helpers
- updated the maintenance ledger/QC map/registry graph to mark the e2e page-object design findings as fixed

## Validation
- npx.cmd tsc --noEmit --pretty false --project tsconfig.json
- npx.cmd playwright test e2e/game.spec.ts e2e/combat.spec.ts e2e/repair.spec.ts e2e/gameplay-layout-slots.spec.ts e2e/tactical-action-menu.spec.ts --project=chromium --workers=1
- node scripts/qc/validate-maintenance-warning-ledger.mjs
- npm.cmd run qc:validate
- npm.cmd run qc:app-completion -- --json
- npm.cmd run verify:qc:maintenance
- npm.cmd run qc:lifecycle:status
- npm.cmd test -- --watchAll=false --runTestsByPath scripts/__tests__/maintenance-warning-ledger.test.ts
- npm.cmd run format:check
- git diff --check
- commit hook: lint-staged, TypeScript, full npm build