### PR TITLE
Reduce desktop dispatch maintenance debt

### DIFF
--- a/desktop/electron/__tests__/main.behavior.test.ts
+++ b/desktop/electron/__tests__/main.behavior.test.ts
@@ -1,0 +1,154 @@
+const mockQuit = jest.fn();
+const mockOpenExternal = jest.fn();
+const mockSetLoginItemSettings = jest.fn();
+const mockShowMessageBox = jest.fn();
+
+jest.mock('electron', () => ({
+  app: {
+    getVersion: jest.fn(() => '0.0.0-test'),
+    quit: mockQuit,
+    setLoginItemSettings: mockSetLoginItemSettings,
+  },
+  BrowserWindow: jest.fn(),
+  dialog: {
+    showMessageBox: mockShowMessageBox,
+  },
+  shell: {
+    openExternal: mockOpenExternal,
+  },
+}));
+
+import {
+  APP_IPC_CHANNELS,
+  MENU_IPC_CHANNELS,
+  SETTINGS_IPC_CHANNELS,
+} from '../../types/BaseTypes';
+import { handleMenuCommand, handleSettingsChange } from '../main.behavior';
+
+function menuContext(overrides: Record<string, unknown> = {}) {
+  return {
+    args: [],
+    checkForUpdates: jest.fn(async () => undefined),
+    command: 'file:quit',
+    mainWindow: null,
+    menuManager: null,
+    recentFilesService: null,
+    sendToRenderer: jest.fn(),
+    showAboutDialog: jest.fn(),
+    ...overrides,
+  } as never;
+}
+
+describe('desktop main behavior dispatch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('forwards every menu command to the renderer before local handling', () => {
+    const sendToRenderer = jest.fn();
+
+    handleMenuCommand(
+      menuContext({
+        args: ['payload'],
+        command: 'file:preferences',
+        sendToRenderer,
+      }),
+    );
+
+    expect(sendToRenderer).toHaveBeenCalledWith(
+      MENU_IPC_CHANNELS.COMMAND,
+      'file:preferences',
+      'payload',
+    );
+    expect(sendToRenderer).toHaveBeenCalledWith(APP_IPC_CHANNELS.OPEN_SETTINGS);
+  });
+
+  it('runs local side effects for supported menu commands', () => {
+    const menuManager = { updateRecentFiles: jest.fn() };
+    const recentFilesService = { clear: jest.fn() };
+    const mainWindow = {
+      isFullScreen: jest.fn(() => false),
+      setFullScreen: jest.fn(),
+      webContents: { toggleDevTools: jest.fn() },
+    };
+    const checkForUpdates = jest.fn(async () => undefined);
+    const showAboutDialog = jest.fn();
+
+    handleMenuCommand(
+      menuContext({
+        command: 'file:clear-recent',
+        menuManager,
+        recentFilesService,
+      }),
+    );
+    handleMenuCommand(menuContext({ command: 'view:fullscreen', mainWindow }));
+    handleMenuCommand(menuContext({ command: 'view:dev-tools', mainWindow }));
+    handleMenuCommand(
+      menuContext({ command: 'help:check-updates', checkForUpdates }),
+    );
+    handleMenuCommand(menuContext({ command: 'help:about', showAboutDialog }));
+
+    expect(recentFilesService.clear).toHaveBeenCalled();
+    expect(menuManager.updateRecentFiles).toHaveBeenCalledWith([]);
+    expect(mainWindow.setFullScreen).toHaveBeenCalledWith(true);
+    expect(mainWindow.webContents.toggleDevTools).toHaveBeenCalled();
+    expect(checkForUpdates).toHaveBeenCalled();
+    expect(showAboutDialog).toHaveBeenCalled();
+  });
+
+  it('opens known help links externally', () => {
+    handleMenuCommand(menuContext({ command: 'help:documentation' }));
+    handleMenuCommand(menuContext({ command: 'help:report-issue' }));
+
+    expect(mockOpenExternal).toHaveBeenCalledWith(
+      'https://github.com/SwiggitySwerve/MekStation/wiki',
+    );
+    expect(mockOpenExternal).toHaveBeenCalledWith(
+      'https://github.com/SwiggitySwerve/MekStation/issues/new',
+    );
+  });
+
+  it('applies settings side effects and notifies the renderer', () => {
+    const recentFilesService = { setMaxRecentFiles: jest.fn() };
+    const sendToRenderer = jest.fn();
+    const event = {
+      key: 'maxRecentFiles',
+      oldValue: 15,
+      newValue: 25,
+    } as const;
+
+    handleSettingsChange({
+      event,
+      recentFilesService: recentFilesService as never,
+      sendToRenderer,
+      settingsService: null,
+    });
+
+    expect(recentFilesService.setMaxRecentFiles).toHaveBeenCalledWith(25);
+    expect(sendToRenderer).toHaveBeenCalledWith(
+      SETTINGS_IPC_CHANNELS.ON_CHANGE,
+      event,
+    );
+  });
+
+  it('still notifies the renderer for settings without local side effects', () => {
+    const sendToRenderer = jest.fn();
+    const event = {
+      key: 'enableAutoBackup',
+      oldValue: false,
+      newValue: true,
+    } as const;
+
+    handleSettingsChange({
+      event,
+      recentFilesService: null,
+      sendToRenderer,
+      settingsService: null,
+    });
+
+    expect(sendToRenderer).toHaveBeenCalledWith(
+      SETTINGS_IPC_CHANNELS.ON_CHANGE,
+      event,
+    );
+  });
+});

--- a/desktop/electron/main.behavior.ts
+++ b/desktop/electron/main.behavior.ts
@@ -25,6 +25,41 @@ interface IMenuCommandContext {
   readonly showAboutDialog: () => void;
 }
 
+type MenuCommandAction = (context: IMenuCommandContext) => void;
+
+const menuCommandActions: Partial<Record<MenuCommand, MenuCommandAction>> = {
+  'file:quit': () => app.quit(),
+  'file:preferences': ({ sendToRenderer }) => {
+    sendToRenderer(APP_IPC_CHANNELS.OPEN_SETTINGS);
+  },
+  'file:clear-recent': ({ menuManager, recentFilesService }) => {
+    recentFilesService?.clear();
+    menuManager?.updateRecentFiles([]);
+  },
+  'view:fullscreen': ({ mainWindow }) => {
+    mainWindow?.setFullScreen(!mainWindow.isFullScreen());
+  },
+  'view:dev-tools': ({ mainWindow }) => {
+    mainWindow?.webContents.toggleDevTools();
+  },
+  'help:documentation': () => {
+    void shell.openExternal(
+      'https://github.com/SwiggitySwerve/MekStation/wiki',
+    );
+  },
+  'help:report-issue': () => {
+    void shell.openExternal(
+      'https://github.com/SwiggitySwerve/MekStation/issues/new',
+    );
+  },
+  'help:check-updates': ({ checkForUpdates }) => {
+    void checkForUpdates();
+  },
+  'help:about': ({ showAboutDialog }) => {
+    showAboutDialog();
+  },
+};
+
 export function handleMenuCommand({
   args,
   checkForUpdates,
@@ -37,39 +72,16 @@ export function handleMenuCommand({
 }: IMenuCommandContext): void {
   console.log(`Menu command: ${command}`);
   sendToRenderer(MENU_IPC_CHANNELS.COMMAND, command, ...args);
-
-  switch (command) {
-    case 'file:quit':
-      app.quit();
-      break;
-    case 'file:preferences':
-      sendToRenderer(APP_IPC_CHANNELS.OPEN_SETTINGS);
-      break;
-    case 'file:clear-recent':
-      recentFilesService?.clear();
-      menuManager?.updateRecentFiles([]);
-      break;
-    case 'view:fullscreen':
-      mainWindow?.setFullScreen(!mainWindow.isFullScreen());
-      break;
-    case 'view:dev-tools':
-      mainWindow?.webContents.toggleDevTools();
-      break;
-    case 'help:documentation':
-      shell.openExternal('https://github.com/SwiggitySwerve/MekStation/wiki');
-      break;
-    case 'help:report-issue':
-      shell.openExternal(
-        'https://github.com/SwiggitySwerve/MekStation/issues/new',
-      );
-      break;
-    case 'help:check-updates':
-      void checkForUpdates();
-      break;
-    case 'help:about':
-      showAboutDialog();
-      break;
-  }
+  menuCommandActions[command]?.({
+    args,
+    checkForUpdates,
+    command,
+    mainWindow,
+    menuManager,
+    recentFilesService,
+    sendToRenderer,
+    showAboutDialog,
+  });
 }
 
 interface ISettingsChangeContext {
@@ -83,6 +95,19 @@ interface ISettingsChangeContext {
   readonly settingsService: SettingsService | null;
 }
 
+type SettingsChangeAction = (context: ISettingsChangeContext) => void;
+
+const settingsChangeActions: Partial<
+  Record<keyof IDesktopSettings, SettingsChangeAction>
+> = {
+  launchAtLogin: ({ event, settingsService }) => {
+    updateLaunchAtLogin(event.newValue as boolean, settingsService);
+  },
+  maxRecentFiles: ({ event, recentFilesService }) => {
+    recentFilesService?.setMaxRecentFiles(event.newValue as number);
+  },
+};
+
 export function handleSettingsChange({
   event,
   recentFilesService,
@@ -90,19 +115,12 @@ export function handleSettingsChange({
   settingsService,
 }: ISettingsChangeContext): void {
   console.log(`Setting changed: ${event.key}`);
-
-  switch (event.key) {
-    case 'launchAtLogin':
-      updateLaunchAtLogin(event.newValue as boolean, settingsService);
-      break;
-    case 'maxRecentFiles':
-      recentFilesService?.setMaxRecentFiles(event.newValue as number);
-      break;
-    case 'enableAutoBackup':
-    case 'backupIntervalMinutes':
-      break;
-  }
-
+  settingsChangeActions[event.key]?.({
+    event,
+    recentFilesService,
+    sendToRenderer,
+    settingsService,
+  });
   sendToRenderer(SETTINGS_IPC_CHANNELS.ON_CHANGE, event);
 }
 

--- a/desktop/services/local/SettingsService.ts
+++ b/desktop/services/local/SettingsService.ts
@@ -40,6 +40,56 @@ interface ISettingsServiceConfig {
   readonly localStorage: LocalStorageService;
 }
 
+type SettingValidator = (value: unknown) => ResultType<void, string>;
+type SettingsValidatorMap = {
+  readonly [K in keyof IDesktopSettings]: SettingValidator;
+};
+
+function validatePositiveVersion(value: unknown): ResultType<void, string> {
+  if (typeof value !== 'number' || value < 1) {
+    return Result.error('Version must be a positive number');
+  }
+  return Result.success(undefined);
+}
+
+function validateBooleanSetting(key: keyof IDesktopSettings): SettingValidator {
+  return (value) => {
+    if (typeof value !== 'boolean') {
+      return Result.error(`${key} must be a boolean`);
+    }
+    return Result.success(undefined);
+  };
+}
+
+function validateStringSetting(key: keyof IDesktopSettings): SettingValidator {
+  return (value) => {
+    if (typeof value !== 'string') {
+      return Result.error(`${key} must be a string`);
+    }
+    return Result.success(undefined);
+  };
+}
+
+function validateNumberRange(
+  message: string,
+  min: number,
+  max: number,
+): SettingValidator {
+  return (value) => {
+    if (typeof value !== 'number' || value < min || value > max) {
+      return Result.error(message);
+    }
+    return Result.success(undefined);
+  };
+}
+
+function validateUpdateChannel(value: unknown): ResultType<void, string> {
+  if (!['stable', 'beta'].includes(value as string)) {
+    return Result.error('Update channel must be "stable" or "beta"');
+  }
+  return Result.success(undefined);
+}
+
 /**
  * Settings service implementation
  *
@@ -48,6 +98,42 @@ interface ISettingsServiceConfig {
  */
 export class SettingsService extends EventEmitter implements IService {
   private readonly localStorage: LocalStorageService;
+  private readonly settingValidators: SettingsValidatorMap = {
+    version: validatePositiveVersion,
+    launchAtLogin: validateBooleanSetting('launchAtLogin'),
+    startMinimized: validateBooleanSetting('startMinimized'),
+    reopenLastUnit: validateBooleanSetting('reopenLastUnit'),
+    defaultSaveDirectory: validateStringSetting('defaultSaveDirectory'),
+    rememberWindowState: validateBooleanSetting('rememberWindowState'),
+    windowBounds: (value) =>
+      this.isValidWindowBounds(value)
+        ? Result.success(undefined)
+        : Result.error('Invalid window bounds structure'),
+    enableAutoBackup: validateBooleanSetting('enableAutoBackup'),
+    backupIntervalMinutes: validateNumberRange(
+      'Backup interval must be between 1 and 1440 minutes',
+      1,
+      1440,
+    ),
+    maxBackupCount: validateNumberRange(
+      'Max backup count must be between 1 and 100',
+      1,
+      100,
+    ),
+    backupDirectory: validateStringSetting('backupDirectory'),
+    checkForUpdatesAutomatically: validateBooleanSetting(
+      'checkForUpdatesAutomatically',
+    ),
+    updateChannel: validateUpdateChannel,
+    maxRecentFiles: validateNumberRange(
+      'Max recent files must be between 5 and 50',
+      5,
+      50,
+    ),
+    dataDirectory: validateStringSetting('dataDirectory'),
+    enableDevTools: validateBooleanSetting('enableDevTools'),
+  };
+
   private settings: IDesktopSettings;
   private initialized = false;
 
@@ -302,67 +388,7 @@ export class SettingsService extends EventEmitter implements IService {
     key: K,
     value: unknown,
   ): ResultType<void, string> {
-    switch (key) {
-      case 'version':
-        if (typeof value !== 'number' || value < 1) {
-          return Result.error('Version must be a positive number');
-        }
-        break;
-
-      case 'launchAtLogin':
-      case 'startMinimized':
-      case 'reopenLastUnit':
-      case 'rememberWindowState':
-      case 'enableAutoBackup':
-      case 'checkForUpdatesAutomatically':
-      case 'enableDevTools':
-        if (typeof value !== 'boolean') {
-          return Result.error(`${key} must be a boolean`);
-        }
-        break;
-
-      case 'defaultSaveDirectory':
-      case 'backupDirectory':
-      case 'dataDirectory':
-        if (typeof value !== 'string') {
-          return Result.error(`${key} must be a string`);
-        }
-        break;
-
-      case 'backupIntervalMinutes':
-        if (typeof value !== 'number' || value < 1 || value > 1440) {
-          return Result.error(
-            'Backup interval must be between 1 and 1440 minutes',
-          );
-        }
-        break;
-
-      case 'maxBackupCount':
-        if (typeof value !== 'number' || value < 1 || value > 100) {
-          return Result.error('Max backup count must be between 1 and 100');
-        }
-        break;
-
-      case 'maxRecentFiles':
-        if (typeof value !== 'number' || value < 5 || value > 50) {
-          return Result.error('Max recent files must be between 5 and 50');
-        }
-        break;
-
-      case 'updateChannel':
-        if (!['stable', 'beta'].includes(value as string)) {
-          return Result.error('Update channel must be "stable" or "beta"');
-        }
-        break;
-
-      case 'windowBounds':
-        if (!this.isValidWindowBounds(value)) {
-          return Result.error('Invalid window bounds structure');
-        }
-        break;
-    }
-
-    return Result.success(undefined);
+    return this.settingValidators[key](value);
   }
 
   /**

--- a/docs/qc/maintenance-warning-ledger.json
+++ b/docs/qc/maintenance-warning-ledger.json
@@ -33,9 +33,9 @@
       "follow-up": 0
     },
     "design-violation": {
-      "fixed": 18,
+      "fixed": 20,
       "accepted": 3,
-      "follow-up": 6
+      "follow-up": 4
     }
   },
   "entries": [
@@ -477,9 +477,13 @@
       "severity": "high",
       "file": "desktop/electron/main.behavior.ts",
       "message": "switch statement has 9 cases",
-      "status": "follow-up",
-      "rationale": "Electron main behavior dispatch should be table-driven in a desktop-focused cleanup wave.",
-      "followUps": ["wave-12-desktop-dispatch-cleanup"]
+      "status": "fixed",
+      "rationale": "Electron main behavior dispatch is now table-driven while preserving renderer forwarding and local menu side effects.",
+      "fixedEvidence": [
+        "2026-06-27 `npm.cmd run maintain:scan -- --scope=desktop/electron/main.behavior.ts,desktop/services/local/SettingsService.ts --json` reported 0 critical/high findings for the desktop dispatch slice.",
+        "2026-06-27 `npm.cmd --prefix desktop test -- --runInBand --runTestsByPath electron/__tests__/main.behavior.test.ts services/local/__tests__/SettingsService.test.ts` passed 22 checks.",
+        "2026-06-27 `npm.cmd --prefix desktop run type-check` passed."
+      ]
     },
     {
       "key": "design-violation|high|desktop/services/local/SettingsService.ts|switch statement has 16 cases",
@@ -487,9 +491,13 @@
       "severity": "high",
       "file": "desktop/services/local/SettingsService.ts",
       "message": "switch statement has 16 cases",
-      "status": "follow-up",
-      "rationale": "SettingsService switch dispatch should be table-driven with desktop local service tests preserved.",
-      "followUps": ["wave-12-desktop-dispatch-cleanup"]
+      "status": "fixed",
+      "rationale": "Settings validation now uses a typed validator map instead of switch dispatch, which also clears the validateSetting complexity finding.",
+      "fixedEvidence": [
+        "2026-06-27 `npm.cmd run maintain:scan -- --scope=desktop/electron/main.behavior.ts,desktop/services/local/SettingsService.ts --json` reported 0 critical/high findings for the desktop dispatch slice.",
+        "2026-06-27 `npm.cmd --prefix desktop test -- --runInBand --runTestsByPath electron/__tests__/main.behavior.test.ts services/local/__tests__/SettingsService.test.ts` passed 22 checks.",
+        "2026-06-27 `npm.cmd --prefix desktop run type-check` passed."
+      ]
     },
     {
       "key": "design-violation|high|e2e/pages/campaign.page.ts|class has 7 public methods",


### PR DESCRIPTION
## Summary
- Replace Electron menu/settings switch dispatch with table-driven action maps while preserving renderer notifications and local side effects.
- Replace SettingsService validation switch with typed validators, clearing the validation complexity finding.
- Add focused desktop behavior tests for menu dispatch and settings-change dispatch.
- Update the maintenance warning ledger: design-violation fixed count 18 -> 20, follow-up count 6 -> 4.

## Validation
- `npm.cmd run maintain:scan -- --scope=desktop/electron/main.behavior.ts,desktop/services/local/SettingsService.ts --json` (0 critical/high for targeted slice)
- `npm.cmd --prefix desktop test -- --runInBand --runTestsByPath electron/__tests__/main.behavior.test.ts services/local/__tests__/SettingsService.test.ts` (22 tests)
- `npm.cmd --prefix desktop test -- --runInBand` (56 tests)
- `npm.cmd --prefix desktop run type-check`
- `npm.cmd run typecheck -- --pretty false`
- `npm.cmd run format:check`
- `node scripts/qc/validate-maintenance-warning-ledger.mjs`
- `npm.cmd run verify:qc:maintenance`
- `npm.cmd run qc:app-completion -- --json`
- `npm.cmd run maintain:scan:gate`
- `git diff --check`

## Notes
- `qc:app-completion -- --json` still reports the known release signoff gap: `maintenance-code-health` remains `active-review` until the rest of the maintenance ledger is burned down or accepted.