### PR TITLE
Reduce bundle measurement maintenance debt

### DIFF
--- a/docs/qc/maintenance-warning-ledger.json
+++ b/docs/qc/maintenance-warning-ledger.json
@@ -33,9 +33,9 @@
       "follow-up": 0
     },
     "design-violation": {
-      "fixed": 20,
+      "fixed": 21,
       "accepted": 3,
-      "follow-up": 4
+      "follow-up": 3
     }
   },
   "entries": [
@@ -467,9 +467,12 @@
       "severity": "critical",
       "file": "scripts/performance/measure-bundle-size.js",
       "message": "class has 11 public methods",
-      "status": "follow-up",
-      "rationale": "Bundle measurement utility should be split with performance smoke checks rather than altered in the ledger wave.",
-      "followUps": ["wave-12-script-bloat-follow-up"]
+      "status": "fixed",
+      "rationale": "Bundle measurement utility is now a thin orchestrator over testable module helpers, and the chunk walker no longer double-counts app/pages chunks.",
+      "fixedEvidence": [
+        "2026-06-27 `npm.cmd run maintain:scan -- --scope=scripts/performance/measure-bundle-size.js --json` reported 0 findings.",
+        "2026-06-27 `npm.cmd test -- --watchAll=false --runTestsByPath scripts/__tests__/measure-bundle-size.test.ts --runInBand` passed 4 checks."
+      ]
     },
     {
       "key": "design-violation|high|desktop/electron/main.behavior.ts|switch statement has 9 cases",

--- a/scripts/__tests__/measure-bundle-size.test.ts
+++ b/scripts/__tests__/measure-bundle-size.test.ts
@@ -1,0 +1,177 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+type ChunkAnalysis = {
+  chunks: Record<string, { size: number; category: string; path: string }>;
+  totalSize: number;
+  categories: Record<string, number>;
+};
+
+type BundleSizeTestables = {
+  analyzeChunks: (
+    buildDir: string,
+    logger?: Pick<Console, 'log'>,
+  ) => ChunkAnalysis;
+  calculateImprovements: (analysis: ChunkAnalysis) => {
+    totalSizeReduction: number;
+    totalSizeReductionPercent: number;
+    categoryImprovements: Record<
+      string,
+      {
+        before: number;
+        after: number;
+        reduction: number;
+        reductionPercent: number;
+      }
+    >;
+  };
+  createAnalysis: () => ChunkAnalysis;
+  createDetailedReport: (
+    buildMetrics: { buildTime: number; timestamp: string },
+    chunkAnalysis: ChunkAnalysis,
+    improvements: ReturnType<BundleSizeTestables['calculateImprovements']>,
+  ) => {
+    summary: {
+      recommendedActions: string[];
+      equipmentTreeShakingEfficiency: number;
+      totalSizeReductionPercent: number;
+    };
+  };
+  categorizeChunk: (
+    filename: string,
+    size: number,
+    categories: Record<string, number>,
+  ) => void;
+  formatBytes: (bytes: number) => string;
+  resolveChunkCategory: (filename: string) => string;
+};
+
+const measurementModule = require('../performance/measure-bundle-size.js') as {
+  __testables: BundleSizeTestables;
+};
+
+const {
+  analyzeChunks,
+  calculateImprovements,
+  categorizeChunk,
+  createAnalysis,
+  createDetailedReport,
+  formatBytes,
+  resolveChunkCategory,
+} = measurementModule.__testables;
+
+function makeTempBuild(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'mekstation-bundle-size-'));
+}
+
+function writeChunk(
+  buildDir: string,
+  relativePath: string,
+  bytes: number,
+): void {
+  const chunkPath = path.join(buildDir, 'static', 'chunks', relativePath);
+  fs.mkdirSync(path.dirname(chunkPath), { recursive: true });
+  fs.writeFileSync(chunkPath, 'x'.repeat(bytes));
+}
+
+describe('bundle size measurement helpers', () => {
+  let tempDir: string;
+  const quietLogger = { log: jest.fn() };
+
+  beforeEach(() => {
+    tempDir = makeTempBuild();
+    quietLogger.log.mockClear();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { force: true, recursive: true });
+  });
+
+  it('categorizes known chunk families into stable totals', () => {
+    const analysis = createAnalysis();
+
+    categorizeChunk('weapon-catalog.js', 100, analysis.categories);
+    categorizeChunk('local-service.js', 200, analysis.categories);
+    categorizeChunk('campaign-component.js', 300, analysis.categories);
+    categorizeChunk('math-util.js', 400, analysis.categories);
+    categorizeChunk('vendor-node_modules.js', 500, analysis.categories);
+    categorizeChunk('main-app.js', 600, analysis.categories);
+
+    expect(resolveChunkCategory('weapon-catalog.js')).toBe('equipment');
+    expect(analysis.categories).toEqual({
+      equipment: 100,
+      services: 200,
+      components: 300,
+      utils: 400,
+      vendor: 500,
+      main: 600,
+    });
+  });
+
+  it('discovers top-level and nested js chunks without counting non-js files', () => {
+    writeChunk(tempDir, 'main-app.js', 1024);
+    writeChunk(tempDir, 'app/weapon-panel.js', 2048);
+    writeChunk(tempDir, 'pages/service-worker.js', 512);
+    fs.writeFileSync(
+      path.join(tempDir, 'static', 'chunks', 'ignored.css'),
+      'body{}',
+    );
+
+    const analysis = analyzeChunks(tempDir, quietLogger);
+
+    expect(Object.keys(analysis.chunks).sort()).toEqual([
+      'main-app.js',
+      'service-worker.js',
+      'weapon-panel.js',
+    ]);
+    expect(analysis.totalSize).toBe(3584);
+    expect(analysis.categories.equipment).toBe(2048);
+    expect(analysis.categories.services).toBe(512);
+    expect(analysis.categories.main).toBe(1024);
+  });
+
+  it('builds the same simulated improvement and recommendation summary', () => {
+    const analysis = createAnalysis();
+    analysis.totalSize = 260 * 1024;
+    analysis.categories.vendor = 150 * 1024;
+    analysis.categories.main = 210 * 1024;
+    analysis.chunks = {
+      'main-app.js': {
+        size: 210 * 1024,
+        category: 'static',
+        path: 'main-app.js',
+      },
+      'vendor.js': {
+        size: 150 * 1024,
+        category: 'static',
+        path: 'vendor.js',
+      },
+    };
+
+    const improvements = calculateImprovements(analysis);
+    const report = createDetailedReport(
+      { buildTime: 123, timestamp: '2026-06-27T00:00:00.000Z' },
+      analysis,
+      improvements,
+    );
+
+    expect(improvements.totalSizeReductionPercent).toBeCloseTo(28.57, 2);
+    expect(report.summary.recommendedActions).toEqual(
+      expect.arrayContaining([
+        'Consider vendor chunk splitting for better caching',
+        'Main chunk could be further optimized',
+        'Equipment data could benefit from further splitting',
+        'Consider more aggressive code splitting',
+      ]),
+    );
+    expect(report.summary.equipmentTreeShakingEfficiency).toBe(100);
+  });
+
+  it('formats byte counts for console reports', () => {
+    expect(formatBytes(0)).toBe('0 B');
+    expect(formatBytes(1024)).toBe('1 KB');
+    expect(formatBytes(1536)).toBe('1.5 KB');
+    expect(formatBytes(1024 * 1024)).toBe('1 MB');
+  });
+});

--- a/scripts/performance/measure-bundle-size.js
+++ b/scripts/performance/measure-bundle-size.js
@@ -3,374 +3,347 @@
 /**
  * Bundle Size Measurement Script
  *
- * Measures and compares bundle sizes before and after refactoring
- * Validates performance improvements from the large file breakdown
- *
- * Phase 3: Day 14 - Update Build System
+ * Measures and compares bundle sizes before and after refactoring.
  */
 
 const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
 
-class BundleSizeMeasurement {
-  constructor() {
-    this.buildDir = '.next';
-    this.resultsFile = 'bundle-analysis.json';
-    this.baseline = {
-      // Baseline measurements before refactoring
-      totalSize: 0,
-      chunkSizes: {},
-      loadTime: 0,
+const DEFAULT_BUILD_DIR = '.next';
+const DEFAULT_RESULTS_FILE = 'bundle-analysis.json';
+
+const CATEGORY_RULES = [
+  ['equipment', ['equipment', 'weapon']],
+  ['services', ['service']],
+  ['components', ['component']],
+  ['utils', ['util']],
+  ['vendor', ['vendor', 'node_modules']],
+];
+
+function createCategoryTotals() {
+  return {
+    equipment: 0,
+    services: 0,
+    components: 0,
+    utils: 0,
+    vendor: 0,
+    main: 0,
+  };
+}
+
+function createAnalysis() {
+  return {
+    chunks: {},
+    totalSize: 0,
+    categories: createCategoryTotals(),
+  };
+}
+
+function resolveChunkCategory(filename) {
+  const name = filename.toLowerCase();
+  const match = CATEGORY_RULES.find(([, patterns]) =>
+    patterns.some((pattern) => name.includes(pattern)),
+  );
+
+  return match ? match[0] : 'main';
+}
+
+function categorizeChunk(filename, size, categories) {
+  categories[resolveChunkCategory(filename)] += size;
+}
+
+function analyzeDirectory(dir, analysis, category, options = {}) {
+  const recursive = options.recursive !== false;
+  const files = fs.readdirSync(dir, { withFileTypes: true });
+
+  files.forEach((file) => {
+    const filePath = path.join(dir, file.name);
+
+    if (file.isDirectory() && recursive) {
+      analyzeDirectory(filePath, analysis, category, options);
+      return;
+    }
+
+    if (!file.isFile() || !file.name.endsWith('.js')) {
+      return;
+    }
+
+    const size = fs.statSync(filePath).size;
+
+    analysis.chunks[file.name] = {
+      size,
+      category,
+      path: filePath,
+    };
+    analysis.totalSize += size;
+    categorizeChunk(file.name, size, analysis.categories);
+  });
+}
+
+function analyzeChunks(buildDir = DEFAULT_BUILD_DIR, logger = console) {
+  logger.log('Analyzing chunks...');
+
+  const staticDir = path.join(buildDir, 'static', 'chunks');
+  const appDir = path.join(staticDir, 'app');
+  const pagesDir = path.join(staticDir, 'pages');
+  const analysis = createAnalysis();
+
+  [
+    [staticDir, 'static', { recursive: false }],
+    [appDir, 'app', { recursive: true }],
+    [pagesDir, 'pages', { recursive: true }],
+  ].forEach(([dir, category, options]) => {
+    if (fs.existsSync(dir)) {
+      analyzeDirectory(dir, analysis, category, options);
+    }
+  });
+
+  logger.log(`  - Found ${Object.keys(analysis.chunks).length} chunks`);
+  logger.log(`  - Total size: ${formatBytes(analysis.totalSize)}`);
+
+  return analysis;
+}
+
+function buildWithMetrics(logger = console) {
+  logger.log('Building with metrics...');
+
+  const startTime = Date.now();
+
+  try {
+    execSync('npm run build', {
+      stdio: 'pipe',
+      env: { ...process.env, ANALYZE: 'false' },
+    });
+
+    const buildTime = Date.now() - startTime;
+    logger.log(`  - Build completed in ${buildTime}ms`);
+
+    return {
+      buildTime,
       timestamp: new Date().toISOString(),
     };
+  } catch (error) {
+    throw new Error(`Build failed: ${error.message}`);
   }
+}
 
-  /**
-   * Execute bundle analysis
-   */
-  async analyze() {
-    console.log('🔍 Starting Bundle Size Analysis...');
+function cleanBuild(buildDir = DEFAULT_BUILD_DIR, logger = console) {
+  logger.log('Cleaning previous build...');
+  fs.rmSync(buildDir, { force: true, recursive: true });
+}
 
-    try {
-      // Clean previous build
-      this.cleanBuild();
+function createSimulatedBaseline(current) {
+  return {
+    totalSize: current.totalSize * 1.4,
+    categories: {
+      equipment: current.categories.equipment * 2.1,
+      services: current.categories.services * 3.2,
+      components: current.categories.components * 1.8,
+      utils: current.categories.utils * 1.5,
+      vendor: current.categories.vendor,
+      main: current.categories.main * 2.5,
+    },
+  };
+}
 
-      // Build with analysis
-      const buildMetrics = this.buildWithMetrics();
-
-      // Analyze chunks
-      const chunkAnalysis = this.analyzeChunks();
-
-      // Calculate improvements
-      const improvements = this.calculateImprovements(chunkAnalysis);
-
-      // Generate report
-      this.generateReport(buildMetrics, chunkAnalysis, improvements);
-
-      console.log('✅ Bundle analysis complete!');
-    } catch (error) {
-      console.error('❌ Bundle analysis failed:', error.message);
-      process.exit(1);
-    }
-  }
-
-  /**
-   * Clean previous build artifacts
-   */
-  cleanBuild() {
-    console.log('🧹 Cleaning previous build...');
-
-    if (fs.existsSync(this.buildDir)) {
-      execSync(`rm -rf ${this.buildDir}`, { stdio: 'inherit' });
-    }
-  }
-
-  /**
-   * Build with performance metrics
-   */
-  buildWithMetrics() {
-    console.log('🏗️ Building with metrics...');
-
-    const startTime = Date.now();
-
-    try {
-      // Build for production
-      execSync('npm run build', {
-        stdio: 'pipe',
-        env: { ...process.env, ANALYZE: 'false' },
-      });
-
-      const buildTime = Date.now() - startTime;
-
-      console.log(`  ✓ Build completed in ${buildTime}ms`);
-
-      return {
-        buildTime,
-        timestamp: new Date().toISOString(),
-      };
-    } catch (error) {
-      throw new Error(`Build failed: ${error.message}`);
-    }
-  }
-
-  /**
-   * Analyze chunk sizes and structure
-   */
-  analyzeChunks() {
-    console.log('📊 Analyzing chunks...');
-
-    const staticDir = path.join(this.buildDir, 'static', 'chunks');
-    const appDir = path.join(this.buildDir, 'static', 'chunks', 'app');
-    const pagesDir = path.join(this.buildDir, 'static', 'chunks', 'pages');
-
-    const analysis = {
-      chunks: {},
-      totalSize: 0,
-      categories: {
-        equipment: 0,
-        services: 0,
-        components: 0,
-        utils: 0,
-        vendor: 0,
-        main: 0,
-      },
-    };
-
-    // Analyze static chunks
-    if (fs.existsSync(staticDir)) {
-      this.analyzeDirectory(staticDir, analysis, 'static');
-    }
-
-    // Analyze app chunks
-    if (fs.existsSync(appDir)) {
-      this.analyzeDirectory(appDir, analysis, 'app');
-    }
-
-    // Analyze pages chunks
-    if (fs.existsSync(pagesDir)) {
-      this.analyzeDirectory(pagesDir, analysis, 'pages');
-    }
-
-    console.log(`  ✓ Found ${Object.keys(analysis.chunks).length} chunks`);
-    console.log(`  ✓ Total size: ${this.formatBytes(analysis.totalSize)}`);
-
-    return analysis;
-  }
-
-  /**
-   * Analyze files in a directory
-   */
-  analyzeDirectory(dir, analysis, category) {
-    const files = fs.readdirSync(dir, { withFileTypes: true });
-
-    files.forEach((file) => {
-      if (file.isFile() && file.name.endsWith('.js')) {
-        const filePath = path.join(dir, file.name);
-        const stats = fs.statSync(filePath);
-        const size = stats.size;
-
-        analysis.chunks[file.name] = {
-          size,
-          category,
-          path: filePath,
-        };
-
-        analysis.totalSize += size;
-
-        // Categorize by content
-        this.categorizeChunk(file.name, size, analysis.categories);
-      }
-
-      if (file.isDirectory()) {
-        this.analyzeDirectory(path.join(dir, file.name), analysis, category);
-      }
-    });
-  }
-
-  /**
-   * Categorize chunks by content type
-   */
-  categorizeChunk(filename, size, categories) {
-    const name = filename.toLowerCase();
-
-    if (name.includes('equipment') || name.includes('weapon')) {
-      categories.equipment += size;
-    } else if (name.includes('service')) {
-      categories.services += size;
-    } else if (name.includes('component')) {
-      categories.components += size;
-    } else if (name.includes('util')) {
-      categories.utils += size;
-    } else if (name.includes('vendor') || name.includes('node_modules')) {
-      categories.vendor += size;
-    } else {
-      categories.main += size;
-    }
-  }
-
-  /**
-   * Calculate performance improvements
-   */
-  calculateImprovements(current) {
-    // Simulated baseline from before refactoring
-    const baseline = {
-      totalSize: current.totalSize * 1.4, // Assume 40% larger before
-      categories: {
-        equipment: current.categories.equipment * 2.1, // Equipment was 2x larger
-        services: current.categories.services * 3.2, // Services were in monolithic file
-        components: current.categories.components * 1.8, // Components were larger
-        utils: current.categories.utils * 1.5,
-        vendor: current.categories.vendor, // Vendor unchanged
-        main: current.categories.main * 2.5, // Main was much larger
-      },
-    };
-
-    const improvements = {
-      totalSizeReduction: baseline.totalSize - current.totalSize,
-      totalSizeReductionPercent:
-        ((baseline.totalSize - current.totalSize) / baseline.totalSize) * 100,
-      categoryImprovements: {},
-    };
-
-    Object.keys(baseline.categories).forEach((category) => {
+function calculateCategoryImprovements(baseline, current) {
+  return Object.fromEntries(
+    Object.keys(baseline.categories).map((category) => {
       const before = baseline.categories[category];
       const after = current.categories[category];
       const reduction = before - after;
       const reductionPercent = before > 0 ? (reduction / before) * 100 : 0;
 
-      improvements.categoryImprovements[category] = {
-        before,
-        after,
-        reduction,
-        reductionPercent,
-      };
+      return [
+        category,
+        {
+          before,
+          after,
+          reduction,
+          reductionPercent,
+        },
+      ];
+    }),
+  );
+}
+
+function calculateImprovements(current) {
+  const baseline = createSimulatedBaseline(current);
+  const totalSizeReduction = baseline.totalSize - current.totalSize;
+
+  return {
+    totalSizeReduction,
+    totalSizeReductionPercent: (totalSizeReduction / baseline.totalSize) * 100,
+    categoryImprovements: calculateCategoryImprovements(baseline, current),
+  };
+}
+
+function calculateTreeShakingEfficiency(analysis) {
+  const equipmentChunks = Object.entries(analysis.chunks).filter(
+    ([name]) => resolveChunkCategory(name) === 'equipment',
+  );
+
+  if (equipmentChunks.length === 0) {
+    return 100;
+  }
+
+  const averageSize =
+    equipmentChunks.reduce((sum, [, data]) => sum + data.size, 0) /
+    equipmentChunks.length;
+  const maxExpectedSize = 50 * 1024;
+
+  return Math.min(100, (maxExpectedSize / averageSize) * 100);
+}
+
+function getRecommendations(analysis, improvements) {
+  const recommendations = [];
+
+  if (analysis.categories.vendor > analysis.totalSize * 0.5) {
+    recommendations.push('Consider vendor chunk splitting for better caching');
+  }
+
+  if (analysis.categories.main > 200 * 1024) {
+    recommendations.push('Main chunk could be further optimized');
+  }
+
+  if (improvements.categoryImprovements.equipment.reductionPercent < 50) {
+    recommendations.push('Equipment data could benefit from further splitting');
+  }
+
+  if (Object.keys(analysis.chunks).length < 10) {
+    recommendations.push('Consider more aggressive code splitting');
+  }
+
+  return recommendations;
+}
+
+function formatBytes(bytes) {
+  if (bytes === 0) {
+    return '0 B';
+  }
+
+  const k = 1024;
+  const sizes = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(1))} ${sizes[i]}`;
+}
+
+function printReport(
+  buildMetrics,
+  chunkAnalysis,
+  improvements,
+  logger = console,
+) {
+  logger.log('\nPerformance Report');
+  logger.log('='.repeat(50));
+  logger.log(`Build Time: ${buildMetrics.buildTime}ms`);
+  logger.log(`Total Bundle Size: ${formatBytes(chunkAnalysis.totalSize)}`);
+  logger.log(`Total Chunks: ${Object.keys(chunkAnalysis.chunks).length}`);
+
+  logger.log('\nSize Improvements');
+  logger.log('-'.repeat(30));
+  logger.log(
+    `Total Reduction: ${formatBytes(improvements.totalSizeReduction)} (${improvements.totalSizeReductionPercent.toFixed(1)}%)`,
+  );
+
+  logger.log('\nCategory Breakdown');
+  logger.log('-'.repeat(30));
+  Object.entries(improvements.categoryImprovements).forEach(
+    ([category, data]) => {
+      logger.log(
+        `${category.padEnd(12)}: ${formatBytes(data.after).padStart(8)} (${data.reductionPercent.toFixed(1)}% reduction)`,
+      );
+    },
+  );
+
+  logger.log('\nLargest Chunks');
+  logger.log('-'.repeat(30));
+  Object.entries(chunkAnalysis.chunks)
+    .sort(([, a], [, b]) => b.size - a.size)
+    .slice(0, 10)
+    .forEach(([name, data]) => {
+      logger.log(`${name.padEnd(40)}: ${formatBytes(data.size).padStart(8)}`);
     });
+}
 
-    return improvements;
+function createDetailedReport(buildMetrics, chunkAnalysis, improvements) {
+  const equipmentEfficiency = calculateTreeShakingEfficiency(chunkAnalysis);
+
+  return {
+    timestamp: new Date().toISOString(),
+    buildMetrics,
+    chunkAnalysis,
+    improvements,
+    summary: {
+      totalSizeReduction: improvements.totalSizeReduction,
+      totalSizeReductionPercent: improvements.totalSizeReductionPercent,
+      equipmentTreeShakingEfficiency: equipmentEfficiency,
+      recommendedActions: getRecommendations(chunkAnalysis, improvements),
+    },
+  };
+}
+
+function writeReport(resultsFile, report, logger = console) {
+  fs.writeFileSync(resultsFile, JSON.stringify(report, null, 2));
+  logger.log(`\nDetailed report saved to ${resultsFile}`);
+}
+
+class BundleSizeMeasurement {
+  constructor(options = {}) {
+    this.buildDir = options.buildDir || DEFAULT_BUILD_DIR;
+    this.resultsFile = options.resultsFile || DEFAULT_RESULTS_FILE;
+    this.logger = options.logger || console;
   }
 
-  /**
-   * Generate performance report
-   */
-  generateReport(buildMetrics, chunkAnalysis, improvements) {
-    console.log('\n📈 Performance Report');
-    console.log('='.repeat(50));
+  async analyze() {
+    this.logger.log('Starting Bundle Size Analysis...');
 
-    // Build metrics
-    console.log(`Build Time: ${buildMetrics.buildTime}ms`);
-    console.log(
-      `Total Bundle Size: ${this.formatBytes(chunkAnalysis.totalSize)}`,
-    );
-    console.log(`Total Chunks: ${Object.keys(chunkAnalysis.chunks).length}`);
-
-    // Size improvements
-    console.log('\n🎯 Size Improvements');
-    console.log('-'.repeat(30));
-    console.log(
-      `Total Reduction: ${this.formatBytes(improvements.totalSizeReduction)} (${improvements.totalSizeReductionPercent.toFixed(1)}%)`,
-    );
-
-    // Category breakdown
-    console.log('\n📊 Category Breakdown');
-    console.log('-'.repeat(30));
-    Object.entries(improvements.categoryImprovements).forEach(
-      ([category, data]) => {
-        console.log(
-          `${category.padEnd(12)}: ${this.formatBytes(data.after).padStart(8)} (${data.reductionPercent.toFixed(1)}% reduction)`,
-        );
-      },
-    );
-
-    // Largest chunks
-    console.log('\n🔍 Largest Chunks');
-    console.log('-'.repeat(30));
-    const sortedChunks = Object.entries(chunkAnalysis.chunks)
-      .sort(([, a], [, b]) => b.size - a.size)
-      .slice(0, 10);
-
-    sortedChunks.forEach(([name, data]) => {
-      console.log(
-        `${name.padEnd(40)}: ${this.formatBytes(data.size).padStart(8)}`,
+    try {
+      cleanBuild(this.buildDir, this.logger);
+      const buildMetrics = buildWithMetrics(this.logger);
+      const chunkAnalysis = analyzeChunks(this.buildDir, this.logger);
+      const improvements = calculateImprovements(chunkAnalysis);
+      const report = createDetailedReport(
+        buildMetrics,
+        chunkAnalysis,
+        improvements,
       );
-    });
 
-    // Tree-shaking effectiveness
-    console.log('\n🌳 Tree-shaking Analysis');
-    console.log('-'.repeat(30));
-    const equipmentEfficiency =
-      this.calculateTreeShakingEfficiency(chunkAnalysis);
-    console.log(
-      `Equipment Data Efficiency: ${equipmentEfficiency.toFixed(1)}%`,
-    );
-    console.log('Equipment files are now optimally split for tree-shaking');
-
-    // Save detailed report
-    const detailedReport = {
-      timestamp: new Date().toISOString(),
-      buildMetrics,
-      chunkAnalysis,
-      improvements,
-      summary: {
-        totalSizeReduction: improvements.totalSizeReduction,
-        totalSizeReductionPercent: improvements.totalSizeReductionPercent,
-        equipmentTreeShakingEfficiency: equipmentEfficiency,
-        recommendedActions: this.getRecommendations(
-          chunkAnalysis,
-          improvements,
-        ),
-      },
-    };
-
-    fs.writeFileSync(this.resultsFile, JSON.stringify(detailedReport, null, 2));
-    console.log(`\n💾 Detailed report saved to ${this.resultsFile}`);
-  }
-
-  /**
-   * Calculate tree-shaking effectiveness for equipment data
-   */
-  calculateTreeShakingEfficiency(analysis) {
-    const equipmentChunks = Object.entries(analysis.chunks).filter(
-      ([name]) => name.includes('equipment') || name.includes('weapon'),
-    );
-
-    if (equipmentChunks.length === 0) return 100;
-
-    const averageSize =
-      equipmentChunks.reduce((sum, [, data]) => sum + data.size, 0) /
-      equipmentChunks.length;
-    const maxExpectedSize = 50 * 1024; // 50KB expected max for equipment chunks
-
-    return Math.min(100, (maxExpectedSize / averageSize) * 100);
-  }
-
-  /**
-   * Get optimization recommendations
-   */
-  getRecommendations(analysis, improvements) {
-    const recommendations = [];
-
-    if (analysis.categories.vendor > analysis.totalSize * 0.5) {
-      recommendations.push(
-        'Consider vendor chunk splitting for better caching',
+      printReport(buildMetrics, chunkAnalysis, improvements, this.logger);
+      this.logger.log(
+        `Equipment Data Efficiency: ${report.summary.equipmentTreeShakingEfficiency.toFixed(1)}%`,
       );
-    }
-
-    if (analysis.categories.main > 200 * 1024) {
-      recommendations.push('Main chunk could be further optimized');
-    }
-
-    if (improvements.categoryImprovements.equipment.reductionPercent < 50) {
-      recommendations.push(
-        'Equipment data could benefit from further splitting',
+      this.logger.log(
+        'Equipment files are now optimally split for tree-shaking',
       );
+      writeReport(this.resultsFile, report, this.logger);
+
+      this.logger.log('Bundle analysis complete!');
+    } catch (error) {
+      this.logger.error('Bundle analysis failed:', error.message);
+      process.exit(1);
     }
-
-    if (Object.keys(analysis.chunks).length < 10) {
-      recommendations.push('Consider more aggressive code splitting');
-    }
-
-    return recommendations;
-  }
-
-  /**
-   * Format bytes to human readable format
-   */
-  formatBytes(bytes) {
-    if (bytes === 0) return '0 B';
-
-    const k = 1024;
-    const sizes = ['B', 'KB', 'MB', 'GB'];
-    const i = Math.floor(Math.log(bytes) / Math.log(k));
-
-    return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i];
   }
 }
 
-// Execute if run directly
 if (require.main === module) {
   const analyzer = new BundleSizeMeasurement();
   analyzer.analyze().catch(console.error);
 }
 
 module.exports = BundleSizeMeasurement;
+module.exports.BundleSizeMeasurement = BundleSizeMeasurement;
+module.exports.__testables = {
+  analyzeChunks,
+  analyzeDirectory,
+  calculateImprovements,
+  calculateTreeShakingEfficiency,
+  categorizeChunk,
+  createAnalysis,
+  createDetailedReport,
+  formatBytes,
+  getRecommendations,
+  resolveChunkCategory,
+};


### PR DESCRIPTION
## Summary
- Refactor `scripts/performance/measure-bundle-size.js` into a thin orchestration class plus testable helper functions.
- Fix the bundle chunk walker so app/pages chunks are not double-counted after scanning `static/chunks`.
- Add focused tests for chunk categorization, discovery, improvement summaries, and byte formatting.
- Update the maintenance warning ledger: design-violation fixed count 20 -> 21, follow-up count 4 -> 3; repo-wide design critical is now 0.

## Validation
- `npm.cmd run maintain:scan -- --scope=scripts/performance/measure-bundle-size.js --json` (0 findings)
- `npm.cmd test -- --watchAll=false --runTestsByPath scripts/__tests__/measure-bundle-size.test.ts --runInBand` (4 tests)
- `node scripts/qc/validate-maintenance-warning-ledger.mjs`
- `npm.cmd run maintain:scan:gate`
- `npm.cmd run qc:app-completion -- --json`
- `npm.cmd run verify:qc:maintenance`
- `npm.cmd run format:check`
- `npm.cmd run typecheck -- --pretty false`
- `git diff --check`
- `npm.cmd run lint` (0 errors; existing warnings remain)

## Notes
- `npm.cmd run qc:app-completion:release -- --json` still fails by design on the known `maintenance-code-health` `active-review` release gap.
- `npm.cmd run perf:test` was not run because it performs a full build and writes `bundle-analysis`/build artifacts; the corrected measurement logic is covered by the focused unit test.