### PR TITLE
Reduce board audit maintenance debt

### DIFF
--- a/docs/qc/maintenance-warning-ledger.json
+++ b/docs/qc/maintenance-warning-ledger.json
@@ -33,9 +33,9 @@
       "follow-up": 0
     },
     "design-violation": {
-      "fixed": 21,
+      "fixed": 22,
       "accepted": 3,
-      "follow-up": 3
+      "follow-up": 2
     }
   },
   "entries": [
@@ -536,9 +536,12 @@
       "severity": "high",
       "file": "scripts/audit-megamek-board-import.ts",
       "message": "switch statement has 9 cases",
-      "status": "follow-up",
-      "rationale": "MegaMek board audit dispatch should be table-driven with board parser fixtures preserved.",
-      "followUps": ["wave-12-script-bloat-follow-up"]
+      "status": "fixed",
+      "rationale": "MegaMek board audit option dispatch is now table-driven, while board parser fixture coverage and CLI helper tests preserve corpus-audit behavior.",
+      "fixedEvidence": [
+        "2026-06-27 `npm.cmd run maintain:scan -- --scope=scripts/audit-megamek-board-import.ts --json` reported 0 critical/high findings.",
+        "2026-06-27 `npm.cmd test -- --watchAll=false --runTestsByPath scripts/__tests__/audit-megamek-board-import.test.ts src/__tests__/unit/lib/parsers/megaMekBoard.test-helpers.ts --runInBand` passed focused board audit and parser fixture coverage."
+      ]
     },
     {
       "key": "design-violation|high|scripts/validate-bv.ts|switch statement has 23 cases",

--- a/scripts/__tests__/audit-megamek-board-import.test.ts
+++ b/scripts/__tests__/audit-megamek-board-import.test.ts
@@ -1,0 +1,131 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+  auditBoard,
+  collectBoardFiles,
+  parseArgs,
+  summarize,
+} from '../audit-megamek-board-import';
+
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'mekstation-board-audit-'));
+}
+
+function writeBoard(
+  root: string,
+  relativePath: string,
+  content: string,
+): string {
+  const filePath = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+  return filePath;
+}
+
+describe('MegaMek board import audit script', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { force: true, recursive: true });
+  });
+
+  it('parses CLI options through table-driven handlers', () => {
+    const options = parseArgs([
+      '--megamek',
+      'E:/Games/MegaMek',
+      '--boards',
+      'fixtures/boards',
+      '--filter',
+      'fort',
+      '--limit',
+      '12',
+      '--require-cliff',
+      '--json',
+      '-h',
+    ]);
+
+    expect(options).toEqual({
+      megamekRoot: path.resolve('E:/Games/MegaMek'),
+      boardsRoot: path.resolve('fixtures/boards'),
+      filter: 'fort',
+      limit: 12,
+      requireCliff: true,
+      json: true,
+      help: true,
+    });
+  });
+
+  it('rejects unknown or valueless CLI options', () => {
+    expect(() => parseArgs(['--unknown'])).toThrow(
+      'Unknown argument: --unknown',
+    );
+    expect(() => parseArgs(['--boards'])).toThrow('--boards requires a value');
+  });
+
+  it('collects board files recursively in stable order', () => {
+    writeBoard(tempDir, 'zeta.board', 'size 1 1\nend');
+    writeBoard(tempDir, 'nested/alpha.board', 'size 1 1\nend');
+    fs.writeFileSync(path.join(tempDir, 'ignore.txt'), 'not a board');
+
+    expect(
+      collectBoardFiles(tempDir).map((filePath) =>
+        path.relative(tempDir, filePath),
+      ),
+    ).toEqual([path.join('nested', 'alpha.board'), 'zeta.board']);
+  });
+
+  it('audits boards with large coordinates and cliff metadata', () => {
+    const boardPath = writeBoard(
+      tempDir,
+      'fort.board',
+      `size 170 120
+hex 9916 3 "" ""
+hex 10015 3 "" ""
+hex 10016 4 "cliff_top:1:33;pavement:1" ""
+hex 104120 0 "" ""
+end`,
+    );
+
+    const result = auditBoard(boardPath, tempDir);
+    const summary = summarize(tempDir, [result]);
+
+    expect(result.error).toBeUndefined();
+    expect(result.hexRows).toBe(4);
+    expect(result.parsedHexes).toBe(4);
+    expect(result.largeCoordinateRows).toBe(3);
+    expect(result.cliffTopRows).toBe(1);
+    expect(summary).toEqual(
+      expect.objectContaining({
+        scannedBoards: 1,
+        parsedBoards: 1,
+        failedBoards: 0,
+        largeCoordinateBoards: 1,
+        largeCoordinateRows: 3,
+        cliffTopBoards: 1,
+        cliffTopRows: 1,
+      }),
+    );
+  });
+
+  it('records parser failures in the audit summary', () => {
+    const boardPath = writeBoard(
+      tempDir,
+      'broken.board',
+      `hex 0101 0 "" ""
+end`,
+    );
+
+    const result = auditBoard(boardPath, tempDir);
+    const summary = summarize(tempDir, [result]);
+
+    expect(result.error).toContain('Missing size declaration');
+    expect(summary.failedBoards).toBe(1);
+    expect(summary.failures).toEqual([result]);
+  });
+});

--- a/scripts/audit-megamek-board-import.ts
+++ b/scripts/audit-megamek-board-import.ts
@@ -43,7 +43,93 @@ interface AuditSummary {
   readonly failures: readonly BoardAuditResult[];
 }
 
-function parseArgs(argv: readonly string[]): AuditOptions {
+type ArgParseResult = {
+  readonly options: AuditOptions;
+  readonly nextIndex: number;
+};
+
+type ArgHandler = (
+  options: AuditOptions,
+  argv: readonly string[],
+  index: number,
+) => ArgParseResult;
+
+function readArgValue(
+  argv: readonly string[],
+  index: number,
+  optionName: string,
+): string {
+  const value = argv[index + 1];
+  if (!value) {
+    throw new Error(`${optionName} requires a value`);
+  }
+
+  return value;
+}
+
+function pathOptionHandler(field: 'megamekRoot' | 'boardsRoot'): ArgHandler {
+  return (options, argv, index) => ({
+    options: {
+      ...options,
+      [field]: path.resolve(readArgValue(argv, index, argv[index])),
+    },
+    nextIndex: index + 1,
+  });
+}
+
+function valueOptionHandler(field: 'filter'): ArgHandler {
+  return (options, argv, index) => ({
+    options: { ...options, [field]: readArgValue(argv, index, argv[index]) },
+    nextIndex: index + 1,
+  });
+}
+
+function limitOptionHandler(
+  options: AuditOptions,
+  argv: readonly string[],
+  index: number,
+): ArgParseResult {
+  return {
+    options: {
+      ...options,
+      limit: Number(readArgValue(argv, index, argv[index])),
+    },
+    nextIndex: index + 1,
+  };
+}
+
+function booleanOptionHandler(field: 'requireCliff' | 'json' | 'help') {
+  return (options: AuditOptions, _argv: readonly string[], index: number) => ({
+    options: { ...options, [field]: true },
+    nextIndex: index,
+  });
+}
+
+const ARG_ALIASES: Readonly<Record<string, string>> = {
+  '-h': '--help',
+};
+
+const ARG_HANDLERS: Readonly<Record<string, ArgHandler>> = {
+  '--megamek': pathOptionHandler('megamekRoot'),
+  '--boards': pathOptionHandler('boardsRoot'),
+  '--filter': valueOptionHandler('filter'),
+  '--limit': limitOptionHandler,
+  '--require-cliff': booleanOptionHandler('requireCliff'),
+  '--json': booleanOptionHandler('json'),
+  '--help': booleanOptionHandler('help'),
+};
+
+function resolveArgHandler(arg: string): ArgHandler {
+  const canonicalArg = ARG_ALIASES[arg] ?? arg;
+  const handler = ARG_HANDLERS[canonicalArg];
+  if (!handler) {
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return handler;
+}
+
+export function parseArgs(argv: readonly string[]): AuditOptions {
   const options: AuditOptions = {
     megamekRoot: process.env.MEGAMEK_ROOT ?? DEFAULT_MEGAMEK_ROOT,
     requireCliff: false,
@@ -54,39 +140,9 @@ function parseArgs(argv: readonly string[]): AuditOptions {
   let current: AuditOptions = options;
 
   for (let index = 0; index < argv.length; index++) {
-    const arg = argv[index];
-    switch (arg) {
-      case '--megamek':
-        current = {
-          ...current,
-          megamekRoot: path.resolve(argv[++index] ?? ''),
-        };
-        break;
-      case '--boards':
-        current = {
-          ...current,
-          boardsRoot: path.resolve(argv[++index] ?? ''),
-        };
-        break;
-      case '--filter':
-        current = { ...current, filter: argv[++index] ?? '' };
-        break;
-      case '--limit':
-        current = { ...current, limit: Number(argv[++index] ?? '') };
-        break;
-      case '--require-cliff':
-        current = { ...current, requireCliff: true };
-        break;
-      case '--json':
-        current = { ...current, json: true };
-        break;
-      case '--help':
-      case '-h':
-        current = { ...current, help: true };
-        break;
-      default:
-        throw new Error(`Unknown argument: ${arg}`);
-    }
+    const result = resolveArgHandler(argv[index])(current, argv, index);
+    current = result.options;
+    index = result.nextIndex;
   }
 
   return current;
@@ -110,7 +166,7 @@ Options:
 `);
 }
 
-function collectBoardFiles(root: string): string[] {
+export function collectBoardFiles(root: string): string[] {
   const files: string[] = [];
   const entries = fs
     .readdirSync(root, { withFileTypes: true })
@@ -135,7 +191,10 @@ function countMatches(content: string, pattern: RegExp): number {
   return content.match(pattern)?.length ?? 0;
 }
 
-function auditBoard(filePath: string, boardsRoot: string): BoardAuditResult {
+export function auditBoard(
+  filePath: string,
+  boardsRoot: string,
+): BoardAuditResult {
   const relativePath = path.relative(boardsRoot, filePath);
   const content = fs.readFileSync(filePath, 'utf-8');
   const hexRows = countMatches(content, /^hex\s+\S+/gm);
@@ -184,7 +243,7 @@ function auditBoard(filePath: string, boardsRoot: string): BoardAuditResult {
   }
 }
 
-function summarize(
+export function summarize(
   boardsRoot: string,
   results: readonly BoardAuditResult[],
 ): AuditSummary {
@@ -236,7 +295,7 @@ function printSummary(summary: AuditSummary): void {
   }
 }
 
-function main(): void {
+export function main(): void {
   const options = parseArgs(process.argv.slice(2));
   if (options.help) {
     showHelp();
@@ -303,9 +362,11 @@ function main(): void {
   }
 }
 
-try {
-  main();
-} catch (error) {
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exitCode = 1;
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
 }


### PR DESCRIPTION
## Summary
- Refactors `scripts/audit-megamek-board-import.ts` from switch-based CLI parsing to table-driven option handlers while keeping the CLI behavior importable and testable.
- Adds focused Jest coverage for option parsing, stable board discovery, large-coordinate/cliff metadata accounting, and parser failure summaries.
- Marks the board-audit design-violation ledger item fixed, reducing maintenance design follow-ups while leaving the remaining `validate-bv` and converter debt tracked.

## Validation
- `npm.cmd run maintain:scan -- --scope=scripts/audit-megamek-board-import.ts --json`
- `npm.cmd test -- --watchAll=false --runTestsByPath scripts/__tests__/audit-megamek-board-import.test.ts src/__tests__/unit/lib/parsers/megaMekBoard.test-helpers.ts --runInBand`
- `node scripts/qc/validate-maintenance-warning-ledger.mjs`
- `npm.cmd run typecheck -- --pretty false`
- `npm.cmd run format:check`
- `npm.cmd run verify:qc:maintenance`
- `npm.cmd run qc:app-completion -- --json`
- `npm.cmd run lint`
- `git diff --check`
- `npm.cmd run verify:qc`
- `npm.cmd run verify:rules`
- `npm.cmd run electron:test:build`

## Remaining Boundary
- `qc:app-completion:release` still intentionally fails while `maintenance-code-health` remains `active-review`; this PR burns down one tracked high design follow-up but does not close the whole maintenance surface.