### PR TITLE
Reduce BV CLI maintenance debt

### DIFF
--- a/docs/qc/maintenance-warning-ledger.json
+++ b/docs/qc/maintenance-warning-ledger.json
@@ -33,9 +33,9 @@
       "follow-up": 0
     },
     "design-violation": {
-      "fixed": 22,
+      "fixed": 23,
       "accepted": 3,
-      "follow-up": 2
+      "follow-up": 1
     }
   },
   "entries": [
@@ -58,13 +58,13 @@
       "rationale": "Explanatory store-nudge wording was rewritten so the scanner no longer treats it as active TODO-like debt."
     },
     {
-      "key": "file-bloat|critical|scripts/validate-bv.ts|4854 LOC exceeds rendering threshold",
+      "key": "file-bloat|critical|scripts/validate-bv.ts|4825 LOC exceeds rendering threshold",
       "category": "file-bloat",
       "severity": "critical",
       "file": "scripts/validate-bv.ts",
-      "message": "4854 LOC exceeds rendering threshold",
+      "message": "4825 LOC exceeds rendering threshold",
       "status": "follow-up",
-      "rationale": "The BV validator is large but source-of-truth heavy; splitting it is a dedicated validator architecture wave.",
+      "rationale": "The BV validator is large but source-of-truth heavy; CLI parsing has been extracted, and the remaining split is a dedicated validator architecture wave.",
       "followUps": ["wave-12-script-bloat-follow-up"]
     },
     {
@@ -559,9 +559,13 @@
       "severity": "high",
       "file": "scripts/validate-bv.ts",
       "message": "switch statement has 9 cases",
-      "status": "follow-up",
-      "rationale": "BV validator dispatch belongs with the dedicated validator architecture split.",
-      "followUps": ["wave-12-script-bloat-follow-up"]
+      "status": "fixed",
+      "rationale": "BV validator CLI argument dispatch is now table-driven, while process-level fail-loud tests cover help aliases and invalid numeric parsing before heavy validation work starts.",
+      "fixedEvidence": [
+        "2026-06-27 `npm.cmd run maintain:scan -- --scope=scripts/validate-bv.ts --json` reduced validate-bv critical/high findings from 17 to 16 and removed the 9-case CLI switch finding.",
+        "2026-06-27 `npm.cmd test -- --watchAll=false --runTestsByPath scripts/__tests__/validate-bv-fail-loud.test.ts --runInBand` passed focused BV CLI/fail-loud coverage.",
+        "2026-06-27 `npm.cmd run validate:bv` passed 4196/4196 coverage floor and all accuracy gates."
+      ]
     },
     {
       "key": "design-violation|warn|desktop/services/local/LocalStorageService.ts|value object class has 9 public methods",

--- a/scripts/__tests__/validate-bv-fail-loud.test.ts
+++ b/scripts/__tests__/validate-bv-fail-loud.test.ts
@@ -29,6 +29,22 @@ function writeReferenceCache(referenceDir: string, entries: object): void {
 describe('validate-bv fail-loud exits', () => {
   jest.setTimeout(60_000);
 
+  it('exits with usage text for the short help alias', () => {
+    const result = runValidateBv(['-h']);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Usage: npx tsx scripts/validate-bv.ts');
+    expect(result.stdout).not.toContain('Processing:');
+  });
+
+  it('rejects invalid minimum coverage before loading validation data', () => {
+    const result = runValidateBv(['--min-coverage', 'invalid']);
+
+    expect(result.status).toBe(3);
+    expect(result.stderr).toContain('Invalid BV minimum coverage floor: NaN');
+    expect(result.stdout).not.toContain('Processing:');
+  });
+
   it('exits distinctly when the committed reference dataset is missing', () => {
     const referenceDir = makeTempDir('validate-bv-empty-ref-');
     const outputDir = makeTempDir('validate-bv-empty-out-');

--- a/scripts/validate-bv-cli.ts
+++ b/scripts/validate-bv-cli.ts
@@ -1,0 +1,120 @@
+import * as path from 'path';
+
+export const VALIDATE_BV_USAGE =
+  'Usage: npx tsx scripts/validate-bv.ts [--output path] [--filter pat] [--limit n] [--reference-dir path] [--min-coverage n] [--verbose]';
+
+export interface ValidateBvCliOptions {
+  outputPath: string;
+  referenceDir: string;
+  minimumCoverageFloor: number;
+  minimumCoverageFloorWasExplicit: boolean;
+  filter?: string;
+  limit?: number;
+  verbose: boolean;
+  help: boolean;
+}
+
+interface ValidateBvCliConfig {
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  defaultReferenceDir: string;
+  defaultMinimumCoverageFloor: number;
+}
+
+type ValidateBvArgHandler = (
+  options: ValidateBvCliOptions,
+  args: readonly string[],
+  index: number,
+) => number;
+
+function readArgValue(
+  args: readonly string[],
+  index: number,
+  fallback: string,
+): string {
+  return args[index + 1] || fallback;
+}
+
+function createDefaultOptions(
+  config: ValidateBvCliConfig,
+): ValidateBvCliOptions {
+  let minimumCoverageFloor = Number.parseInt(
+    config.env.MEKSTATION_BV_MIN_COVERAGE || '',
+    10,
+  );
+  if (!Number.isFinite(minimumCoverageFloor) || minimumCoverageFloor <= 0) {
+    minimumCoverageFloor = config.defaultMinimumCoverageFloor;
+  }
+
+  return {
+    outputPath: path.resolve(config.cwd, './validation-output'),
+    referenceDir: path.resolve(
+      config.cwd,
+      config.env.MEKSTATION_BV_REFERENCE_DIR || config.defaultReferenceDir,
+    ),
+    minimumCoverageFloor,
+    minimumCoverageFloorWasExplicit: Boolean(
+      config.env.MEKSTATION_BV_MIN_COVERAGE,
+    ),
+    verbose: false,
+    help: false,
+  };
+}
+
+export function parseValidateBvArgs(
+  args: readonly string[],
+  config: ValidateBvCliConfig,
+): ValidateBvCliOptions {
+  const options = createDefaultOptions(config);
+  const aliases: Readonly<Record<string, string>> = {
+    '-h': '--help',
+    '-v': '--verbose',
+  };
+  const handlers: Readonly<Record<string, ValidateBvArgHandler>> = {
+    '--output': (current, values, index) => {
+      current.outputPath = path.resolve(
+        config.cwd,
+        readArgValue(values, index, './validation-output'),
+      );
+      return index + 1;
+    },
+    '--filter': (current, values, index) => {
+      current.filter = values[index + 1];
+      return index + 1;
+    },
+    '--limit': (current, values, index) => {
+      current.limit = Number.parseInt(readArgValue(values, index, '0'), 10);
+      return index + 1;
+    },
+    '--reference-dir': (current, values, index) => {
+      current.referenceDir = path.resolve(
+        config.cwd,
+        readArgValue(values, index, config.defaultReferenceDir),
+      );
+      return index + 1;
+    },
+    '--min-coverage': (current, values, index) => {
+      current.minimumCoverageFloor = Number.parseInt(
+        readArgValue(values, index, '0'),
+        10,
+      );
+      current.minimumCoverageFloorWasExplicit = true;
+      return index + 1;
+    },
+    '--verbose': (current, _values, index) => {
+      current.verbose = true;
+      return index;
+    },
+    '--help': (current, _values, index) => {
+      current.help = true;
+      return index;
+    },
+  };
+
+  for (let index = 0; index < args.length; index++) {
+    const handler = handlers[aliases[args[index]] ?? args[index]];
+    if (handler) index = handler(options, args, index);
+  }
+
+  return options;
+}

--- a/scripts/validate-bv.ts
+++ b/scripts/validate-bv.ts
@@ -25,6 +25,7 @@ import {
   resolveAmmoBV,
   normalizeEquipmentId,
 } from '../src/utils/construction/equipmentBVResolver';
+import { parseValidateBvArgs, VALIDATE_BV_USAGE } from './validate-bv-cli';
 
 interface IndexUnit {
   id: string;
@@ -4617,54 +4618,24 @@ function buildPareto(results: ValidationResult[]): ParetoAnalysis {
 
 // === MAIN ===
 async function main(): Promise<void> {
-  const args = process.argv.slice(2);
-  let outputPath = path.resolve(process.cwd(), './validation-output');
-  let referenceDir = path.resolve(
-    process.cwd(),
-    process.env.MEKSTATION_BV_REFERENCE_DIR || DEFAULT_REFERENCE_DIR,
-  );
-  let minimumCoverageFloor = Number.parseInt(
-    process.env.MEKSTATION_BV_MIN_COVERAGE || '',
-    10,
-  );
-  let minimumCoverageFloorWasExplicit = Boolean(
-    process.env.MEKSTATION_BV_MIN_COVERAGE,
-  );
-  if (!Number.isFinite(minimumCoverageFloor) || minimumCoverageFloor <= 0) {
-    minimumCoverageFloor = MINIMUM_BV_COVERAGE_FLOOR;
-  }
-  let filter: string | undefined,
-    limit: number | undefined,
-    verbose = false;
-  for (let i = 0; i < args.length; i++) {
-    switch (args[i]) {
-      case '--output':
-        outputPath = path.resolve(args[++i] || './validation-output');
-        break;
-      case '--filter':
-        filter = args[++i];
-        break;
-      case '--limit':
-        limit = parseInt(args[++i] || '0', 10);
-        break;
-      case '--reference-dir':
-        referenceDir = path.resolve(args[++i] || DEFAULT_REFERENCE_DIR);
-        break;
-      case '--min-coverage':
-        minimumCoverageFloor = Number.parseInt(args[++i] || '0', 10);
-        minimumCoverageFloorWasExplicit = true;
-        break;
-      case '--verbose':
-      case '-v':
-        verbose = true;
-        break;
-      case '--help':
-      case '-h':
-        console.log(
-          'Usage: npx tsx scripts/validate-bv.ts [--output path] [--filter pat] [--limit n] [--reference-dir path] [--min-coverage n] [--verbose]',
-        );
-        process.exit(0);
-    }
+  const {
+    outputPath,
+    referenceDir,
+    minimumCoverageFloor,
+    minimumCoverageFloorWasExplicit,
+    filter,
+    limit,
+    verbose,
+    help,
+  } = parseValidateBvArgs(process.argv.slice(2), {
+    cwd: process.cwd(),
+    env: process.env,
+    defaultReferenceDir: DEFAULT_REFERENCE_DIR,
+    defaultMinimumCoverageFloor: MINIMUM_BV_COVERAGE_FLOOR,
+  });
+  if (help) {
+    console.log(VALIDATE_BV_USAGE);
+    process.exit(0);
   }
 
   if (!Number.isFinite(minimumCoverageFloor) || minimumCoverageFloor <= 0) {


### PR DESCRIPTION
## Summary
- extracts validate-bv CLI argument parsing into a table-driven helper
- adds fail-loud coverage for help aliases and invalid minimum coverage input
- updates the maintenance warning ledger so the CLI switch finding is fixed while the source-of-truth BV validator architecture split remains tracked

## Validation
- `npm.cmd run maintain:scan -- --scope=scripts/validate-bv.ts --json`
- `npm.cmd test -- --watchAll=false --runTestsByPath scripts/__tests__/validate-bv-fail-loud.test.ts --runInBand`
- `npm.cmd run typecheck -- --pretty false`
- `node scripts/qc/validate-maintenance-warning-ledger.mjs`
- `npm.cmd run qc:app-completion -- --json`
- `npm.cmd run format:check`
- `git diff --check`
- `npm.cmd run verify:qc:maintenance`
- `npm.cmd run lint`
- `npm.cmd run validate:bv`

## Remaining Boundary
- `maintenance-code-health` remains the single app-completion release gap until the tracked BV validator architecture split, converter bloat, and analysis-script duplicate waves are resolved.