### PR TITLE
Reduce physical weapon BV maintenance debt

### DIFF
--- a/docs/qc/maintenance-warning-ledger.json
+++ b/docs/qc/maintenance-warning-ledger.json
@@ -33,9 +33,9 @@
       "follow-up": 0
     },
     "design-violation": {
-      "fixed": 23,
+      "fixed": 24,
       "accepted": 3,
-      "follow-up": 1
+      "follow-up": 0
     }
   },
   "entries": [
@@ -58,13 +58,13 @@
       "rationale": "Explanatory store-nudge wording was rewritten so the scanner no longer treats it as active TODO-like debt."
     },
     {
-      "key": "file-bloat|critical|scripts/validate-bv.ts|4825 LOC exceeds rendering threshold",
+      "key": "file-bloat|critical|scripts/validate-bv.ts|4727 LOC exceeds rendering threshold",
       "category": "file-bloat",
       "severity": "critical",
       "file": "scripts/validate-bv.ts",
-      "message": "4825 LOC exceeds rendering threshold",
+      "message": "4727 LOC exceeds rendering threshold",
       "status": "follow-up",
-      "rationale": "The BV validator is large but source-of-truth heavy; CLI parsing has been extracted, and the remaining split is a dedicated validator architecture wave.",
+      "rationale": "The BV validator is large but source-of-truth heavy; CLI parsing and physical weapon BV tables have been extracted, and the remaining split is a dedicated validator architecture wave.",
       "followUps": ["wave-12-script-bloat-follow-up"]
     },
     {
@@ -549,9 +549,13 @@
       "severity": "high",
       "file": "scripts/validate-bv.ts",
       "message": "switch statement has 23 cases",
-      "status": "follow-up",
-      "rationale": "BV validator dispatch belongs with the dedicated validator architecture split.",
-      "followUps": ["wave-12-script-bloat-follow-up"]
+      "status": "fixed",
+      "rationale": "Physical weapon BV dispatch is now a table-driven helper with focused formula coverage, while broader validate-bv architecture work remains tracked by file-bloat and complexity findings.",
+      "fixedEvidence": [
+        "2026-06-27 `npm.cmd run maintain:scan -- --scope=scripts/validate-bv.ts --json` reduced validate-bv critical/high findings from 16 to 13 and removed the 23-case physical weapon switch finding.",
+        "2026-06-27 `npm.cmd run maintain:scan -- --scope=scripts/validate-bv-physical-weapons.ts --json` reported 0 critical/high findings for the extracted helper.",
+        "2026-06-27 `npm.cmd test -- --watchAll=false --runTestsByPath scripts/__tests__/validate-bv-physical-weapons.test.ts scripts/__tests__/validate-bv-fail-loud.test.ts --runInBand` passed focused physical BV and CLI fail-loud coverage."
+      ]
     },
     {
       "key": "design-violation|high|scripts/validate-bv.ts|switch statement has 9 cases",

--- a/scripts/__tests__/validate-bv-physical-weapons.test.ts
+++ b/scripts/__tests__/validate-bv-physical-weapons.test.ts
@@ -1,0 +1,40 @@
+import {
+  calculatePhysicalWeaponBV,
+  classifyPhysicalWeapon,
+} from '../validate-bv-physical-weapons';
+
+describe('validate-bv physical weapon helpers', () => {
+  it('classifies official physical weapon aliases used by catalog slots', () => {
+    expect(classifyPhysicalWeapon('Hatchet'.toLowerCase())).toBe('hatchet');
+    expect(classifyPhysicalWeapon('IS Lance'.toLowerCase())).toBe('lance');
+    expect(
+      classifyPhysicalWeapon('Retractable Blade (OmniPod)'.toLowerCase()),
+    ).toBe('retractable-blade');
+    expect(classifyPhysicalWeapon('CLBuzzsaw'.toLowerCase())).toBe('buzzsaw');
+    expect(classifyPhysicalWeapon('Heavy Duty Pile Driver'.toLowerCase())).toBe(
+      'pile-driver',
+    );
+    expect(classifyPhysicalWeapon('ISLargeVibroblade'.toLowerCase())).toBe(
+      'vibroblade-large',
+    );
+    expect(classifyPhysicalWeapon('unknown equipment')).toBeNull();
+  });
+
+  it('keeps tonnage and TSM-sensitive BV formulas stable', () => {
+    expect(calculatePhysicalWeaponBV('hatchet', 55, false)).toBe(16.5);
+    expect(calculatePhysicalWeaponBV('hatchet', 55, true)).toBe(33);
+    expect(calculatePhysicalWeaponBV('sword', 50, false)).toBeCloseTo(10.35);
+    expect(calculatePhysicalWeaponBV('mace', 70, true)).toBe(36);
+    expect(calculatePhysicalWeaponBV('claw', 55, false)).toBe(10.2);
+    expect(calculatePhysicalWeaponBV('talon', 55, true)).toBe(12);
+  });
+
+  it('keeps flat MegaMek physical weapon BV values stable', () => {
+    expect(calculatePhysicalWeaponBV('flail', 100, true)).toBe(11);
+    expect(calculatePhysicalWeaponBV('wrecking-ball', 100, true)).toBe(8);
+    expect(calculatePhysicalWeaponBV('chain-whip', 100, true)).toBe(5.175);
+    expect(calculatePhysicalWeaponBV('buzzsaw', 100, true)).toBe(67);
+    expect(calculatePhysicalWeaponBV('vibroblade-large', 100, true)).toBe(24);
+    expect(calculatePhysicalWeaponBV('unknown', 100, true)).toBe(0);
+  });
+});

--- a/scripts/validate-bv-physical-weapons.ts
+++ b/scripts/validate-bv-physical-weapons.ts
@@ -1,0 +1,133 @@
+export type PhysicalWeaponType =
+  | 'backhoe'
+  | 'buzzsaw'
+  | 'chain-whip'
+  | 'chainsaw'
+  | 'claw'
+  | 'combine'
+  | 'dual-saw'
+  | 'flail'
+  | 'hatchet'
+  | 'lance'
+  | 'mace'
+  | 'mining-drill'
+  | 'pile-driver'
+  | 'retractable-blade'
+  | 'rock-cutter'
+  | 'spot-welder'
+  | 'sword'
+  | 'talon'
+  | 'vibroblade-large'
+  | 'vibroblade-medium'
+  | 'vibroblade-small'
+  | 'wrecking-ball';
+
+type PhysicalWeaponBvRule = (tonnage: number, tsmMod: number) => number;
+
+const EXACT_PHYSICAL_WEAPON_ALIASES = new Map<string, PhysicalWeaponType>([
+  ['hatchet', 'hatchet'],
+  ['sword', 'sword'],
+  ['mace', 'mace'],
+  ['is lance', 'lance'],
+  ['lance', 'lance'],
+  ['isclaw', 'claw'],
+  ['clclaw', 'claw'],
+  ['claw', 'claw'],
+  ['claws', 'claw'],
+  ['talons', 'talon'],
+  ['is flail', 'flail'],
+  ['flail', 'flail'],
+  ['is wrecking ball', 'wrecking-ball'],
+  ['wrecking ball', 'wrecking-ball'],
+  ['chain whip', 'chain-whip'],
+  ['buzzsaw', 'buzzsaw'],
+  ['is buzzsaw', 'buzzsaw'],
+  ['clan buzzsaw', 'buzzsaw'],
+  ['clbuzzsaw', 'buzzsaw'],
+  ['dual saw', 'dual-saw'],
+  ['is dual saw', 'dual-saw'],
+  ['miningdrill', 'mining-drill'],
+  ['mining drill', 'mining-drill'],
+  ['is mining drill', 'mining-drill'],
+  ['chainsaw', 'chainsaw'],
+  ['is chainsaw', 'chainsaw'],
+  ['backhoe', 'backhoe'],
+  ['is backhoe', 'backhoe'],
+  ['combine', 'combine'],
+  ['spot welder', 'spot-welder'],
+  ['is spot welder', 'spot-welder'],
+  ['rock cutter', 'rock-cutter'],
+  ['is rock cutter', 'rock-cutter'],
+  ['pile driver', 'pile-driver'],
+  ['is pile driver', 'pile-driver'],
+  ['heavy-duty pile driver', 'pile-driver'],
+  ['heavy duty pile driver', 'pile-driver'],
+]);
+
+const PHYSICAL_WEAPON_BV_RULES: Record<
+  PhysicalWeaponType,
+  PhysicalWeaponBvRule
+> = {
+  hatchet: (tonnage, tsmMod) => Math.ceil(tonnage / 5.0) * 1.5 * tsmMod,
+  sword: (tonnage, tsmMod) => Math.ceil(tonnage / 10.0 + 1) * 1.725 * tsmMod,
+  lance: (tonnage, tsmMod) => Math.ceil(tonnage / 5.0) * tsmMod,
+  mace: (tonnage, tsmMod) => Math.ceil(tonnage / 4.0) * tsmMod,
+  'retractable-blade': (tonnage, tsmMod) =>
+    Math.ceil(tonnage / 10.0) * 1.725 * tsmMod,
+  claw: (tonnage, tsmMod) => Math.ceil(tonnage / 7.0) * 1.275 * tsmMod,
+  talon: (tonnage, tsmMod) =>
+    Math.round(Math.floor(tonnage / 5.0) * 0.5) * tsmMod,
+  flail: () => 11,
+  'wrecking-ball': () => 8,
+  'chain-whip': () => 5.175,
+  buzzsaw: () => 67,
+  'dual-saw': () => 9,
+  'mining-drill': () => 6,
+  chainsaw: () => 7,
+  backhoe: () => 8,
+  combine: () => 5,
+  'spot-welder': () => 5,
+  'rock-cutter': () => 6,
+  'pile-driver': () => 5,
+  'vibroblade-large': () => 24,
+  'vibroblade-medium': () => 17,
+  'vibroblade-small': () => 12,
+};
+
+function normalizePhysicalWeaponSlot(slotLower: string): string {
+  return slotLower.replace(/\s*\(omnipod\)/gi, '').trim();
+}
+
+function classifyVibroblade(slot: string): PhysicalWeaponType | null {
+  if (
+    !slot.includes('vibroblade') &&
+    slot !== 'islargevibroblade' &&
+    slot !== 'ismediumvibroblade' &&
+    slot !== 'issmallvibroblade'
+  ) {
+    return null;
+  }
+
+  if (slot.includes('large')) return 'vibroblade-large';
+  if (slot.includes('small')) return 'vibroblade-small';
+  return 'vibroblade-medium';
+}
+
+export function classifyPhysicalWeapon(
+  slotLower: string,
+): PhysicalWeaponType | null {
+  const slot = normalizePhysicalWeaponSlot(slotLower);
+  const exactMatch = EXACT_PHYSICAL_WEAPON_ALIASES.get(slot);
+  if (exactMatch) return exactMatch;
+  if (slot.startsWith('retractable blade')) return 'retractable-blade';
+  return classifyVibroblade(slot);
+}
+
+export function calculatePhysicalWeaponBV(
+  type: string,
+  tonnage: number,
+  hasTSM: boolean,
+): number {
+  const rule = PHYSICAL_WEAPON_BV_RULES[type as PhysicalWeaponType];
+  return rule ? rule(tonnage, hasTSM ? 2 : 1) : 0;
+}

--- a/scripts/validate-bv.ts
+++ b/scripts/validate-bv.ts
@@ -26,6 +26,10 @@ import {
   normalizeEquipmentId,
 } from '../src/utils/construction/equipmentBVResolver';
 import { parseValidateBvArgs, VALIDATE_BV_USAGE } from './validate-bv-cli';
+import {
+  calculatePhysicalWeaponBV,
+  classifyPhysicalWeapon,
+} from './validate-bv-physical-weapons';
 
 interface IndexUnit {
   id: string;
@@ -989,112 +993,6 @@ interface CritScan {
   hasSCM: boolean;
   /** RISC Laser Pulse Module locations: linked lasers get BV × 1.15 and heat + 2 */
   riscLPMLocs: string[];
-}
-
-function classifyPhysicalWeapon(slotLower: string): string | null {
-  const s = slotLower.replace(/\s*\(omnipod\)/gi, '').trim();
-  if (s === 'hatchet') return 'hatchet';
-  if (s === 'sword') return 'sword';
-  if (s === 'mace') return 'mace';
-  if (s === 'is lance' || s === 'lance') return 'lance';
-  if (s.startsWith('retractable blade')) return 'retractable-blade';
-  if (s === 'isclaw' || s === 'clclaw' || s === 'claw' || s === 'claws')
-    return 'claw';
-  if (s === 'talons') return 'talon';
-  if (s === 'is flail' || s === 'flail') return 'flail';
-  if (s === 'is wrecking ball' || s === 'wrecking ball') return 'wrecking-ball';
-  if (s === 'chain whip') return 'chain-whip';
-  if (
-    s === 'buzzsaw' ||
-    s === 'is buzzsaw' ||
-    s === 'clan buzzsaw' ||
-    s === 'clbuzzsaw'
-  )
-    return 'buzzsaw';
-  if (s === 'dual saw' || s === 'is dual saw') return 'dual-saw';
-  if (s === 'miningdrill' || s === 'mining drill' || s === 'is mining drill')
-    return 'mining-drill';
-  // Industrial physical weapons — flat BV per MegaMek MiscType.java
-  if (s === 'chainsaw' || s === 'is chainsaw') return 'chainsaw';
-  if (s === 'backhoe' || s === 'is backhoe') return 'backhoe';
-  if (s === 'combine') return 'combine';
-  if (s === 'spot welder' || s === 'is spot welder') return 'spot-welder';
-  if (s === 'rock cutter' || s === 'is rock cutter') return 'rock-cutter';
-  if (
-    s === 'pile driver' ||
-    s === 'is pile driver' ||
-    s === 'heavy-duty pile driver' ||
-    s === 'heavy duty pile driver'
-  )
-    return 'pile-driver';
-  if (
-    s.includes('vibroblade') ||
-    s === 'islargevibroblade' ||
-    s === 'ismediumvibroblade' ||
-    s === 'issmallvibroblade'
-  ) {
-    if (s.includes('large')) return 'vibroblade-large';
-    if (s.includes('small')) return 'vibroblade-small';
-    return 'vibroblade-medium';
-  }
-  return null;
-}
-
-function calculatePhysicalWeaponBV(
-  type: string,
-  tonnage: number,
-  hasTSM: boolean,
-): number {
-  const tsmMod = hasTSM ? 2 : 1;
-  switch (type) {
-    case 'hatchet':
-      return Math.ceil(tonnage / 5.0) * 1.5 * tsmMod;
-    case 'sword':
-      return Math.ceil(tonnage / 10.0 + 1) * 1.725 * tsmMod;
-    case 'lance':
-      return Math.ceil(tonnage / 5.0) * tsmMod;
-    case 'mace':
-      return Math.ceil(tonnage / 4.0) * tsmMod;
-    case 'retractable-blade':
-      return Math.ceil(tonnage / 10.0) * 1.725 * tsmMod;
-    case 'claw':
-      return Math.ceil(tonnage / 7.0) * 1.275 * tsmMod;
-    case 'talon':
-      return Math.round(Math.floor(tonnage / 5.0) * 0.5) * tsmMod;
-    case 'flail':
-      return 11;
-    case 'wrecking-ball':
-      return 8;
-    case 'chain-whip':
-      return 5.175;
-    case 'buzzsaw':
-      return 67;
-    case 'dual-saw':
-      return 9; // Flat BV per MegaMek MiscType.java
-    case 'mining-drill':
-      return 6; // Flat BV per MegaMek MiscType.java
-    // Industrial physical weapons — flat BV per MegaMek MiscType.java
-    case 'chainsaw':
-      return 7;
-    case 'backhoe':
-      return 8;
-    case 'combine':
-      return 5;
-    case 'spot-welder':
-      return 5;
-    case 'rock-cutter':
-      return 6;
-    case 'pile-driver':
-      return 5;
-    case 'vibroblade-large':
-      return 24; // Flat BV per MegaMek MiscType.java (not tonnage-based)
-    case 'vibroblade-medium':
-      return 17; // Flat BV per MegaMek MiscType.java
-    case 'vibroblade-small':
-      return 12; // Flat BV per MegaMek MiscType.java
-    default:
-      return 0;
-  }
 }
 
 let _weaponSlotCache: Map<string, number> | null = null;


### PR DESCRIPTION
## Summary
- extracts validate-bv physical weapon classification and BV formulas into a table-driven helper
- adds focused tests for official aliases, TSM-sensitive formulas, and flat MegaMek values
- updates the maintenance ledger so the last high design-violation follow-up is fixed while broader validate-bv architecture debt remains tracked separately

## Validation
- `npm.cmd test -- --watchAll=false --runTestsByPath scripts/__tests__/validate-bv-physical-weapons.test.ts scripts/__tests__/validate-bv-fail-loud.test.ts --runInBand`
- `npm.cmd run maintain:scan -- --scope=scripts/validate-bv.ts --json`
- `npm.cmd run maintain:scan -- --scope=scripts/validate-bv-physical-weapons.ts --json`
- `node scripts/qc/validate-maintenance-warning-ledger.mjs`
- `npm.cmd run typecheck -- --pretty false`
- `npm.cmd run validate:bv`
- `npm.cmd run format:check`
- `npm.cmd run lint`
- `git diff --check`
- `npm.cmd run verify:qc:maintenance`
- `npm.cmd run qc:app-completion -- --json`
- pre-commit hook full `npm run build`

## Remaining Boundary
- `maintenance-code-health` is still active-review because file-bloat and near-duplicate follow-up waves remain. Design-violation high is now zero in the maintenance ledger.