### PR TITLE
Reduce MTF converter maintenance bloat

### DIFF
--- a/docs/qc/maintenance-warning-ledger.json
+++ b/docs/qc/maintenance-warning-ledger.json
@@ -83,8 +83,18 @@
       "severity": "high",
       "file": "scripts/megameklab-conversion/mtf_converter.py",
       "message": "546 LOC exceeds python threshold",
+      "status": "fixed",
+      "rationale": "Serialized DTO dataclasses were extracted to mtf_serialized_models.py, dropping mtf_converter.py below the high Python file-bloat threshold while preserving converter behavior.",
+      "followUps": ["wave-12-megameklab-conversion-split"]
+    },
+    {
+      "key": "file-bloat|warn|scripts/megameklab-conversion/mtf_converter.py|487 LOC exceeds python threshold",
+      "category": "file-bloat",
+      "severity": "warn",
+      "file": "scripts/megameklab-conversion/mtf_converter.py",
+      "message": "487 LOC exceeds python threshold",
       "status": "follow-up",
-      "rationale": "MegaMekLab MTF conversion should be split with converter fixture coverage rather than changed inside this ledger wave.",
+      "rationale": "The MTF converter remains above the advisory Python size threshold after DTO extraction; finish the split only with converter fixture parity coverage.",
       "followUps": ["wave-12-megameklab-conversion-split"]
     },
     {

--- a/docs/qc/mekstation-qc-registry.json
+++ b/docs/qc/mekstation-qc-registry.json
@@ -1603,6 +1603,7 @@
         "2026-06-27 force page-object maintenance slice removed unused force detail/list/create helpers, split list/create read and submission helpers from browser actions, and reduced repo-wide design-violation findings from critical=10/high=6 to critical=7/high=6; typecheck and the full Chromium force spec passed.",
         "2026-06-27 encounter page-object maintenance slice removed unused encounter detail scaffolds, split list reads and create-page submission/read helpers from browser actions, and reduced repo-wide design-violation findings from critical=7/high=6 to critical=4/high=6; typecheck and the full Chromium encounter spec passed.",
         "2026-06-27 game/repair page-object maintenance slice split tactical session, replay, and repair bay helpers into narrow role classes, clearing the remaining e2e page-object design findings and reducing repo-wide design-violation findings from critical=4/high=6 to critical=1/high=5; typecheck and 121 affected Chromium checks passed.",
+        "2026-06-27 MegaMekLab MTF converter DTO extraction moved serialized output dataclasses into mtf_serialized_models.py; mtf_converter.py drops from high file-bloat to warn and the new DTO module has no scanner findings.",
         "docs/qc/maintenance-baseline.json",
         "docs/qc/maintenance-warning-ledger.json",
         "scripts/qc/validate-maintenance-warning-ledger.mjs"

--- a/docs/qc/mekstation-qc-validation-graph.json
+++ b/docs/qc/mekstation-qc-validation-graph.json
@@ -1649,6 +1649,7 @@
         "2026-06-27 force page-object maintenance slice removed unused force detail/list/create helpers, split list/create read and submission helpers from browser actions, and reduced repo-wide design-violation findings from critical=10/high=6 to critical=7/high=6; typecheck and the full Chromium force spec passed.",
         "2026-06-27 encounter page-object maintenance slice removed unused encounter detail scaffolds, split list reads and create-page submission/read helpers from browser actions, and reduced repo-wide design-violation findings from critical=7/high=6 to critical=4/high=6; typecheck and the full Chromium encounter spec passed.",
         "2026-06-27 game/repair page-object maintenance slice split tactical session, replay, and repair bay helpers into narrow role classes, clearing the remaining e2e page-object design findings and reducing repo-wide design-violation findings from critical=4/high=6 to critical=1/high=5; typecheck and 121 affected Chromium checks passed.",
+        "2026-06-27 MegaMekLab MTF converter DTO extraction moved serialized output dataclasses into mtf_serialized_models.py; mtf_converter.py drops from high file-bloat to warn and the new DTO module has no scanner findings.",
         "docs/qc/maintenance-baseline.json",
         "docs/qc/maintenance-warning-ledger.json",
         "scripts/qc/validate-maintenance-warning-ledger.mjs"

--- a/scripts/megameklab-conversion/mtf_converter.py
+++ b/scripts/megameklab-conversion/mtf_converter.py
@@ -17,7 +17,6 @@ import re
 import argparse
 from pathlib import Path
 from typing import Dict, List, Optional, Any, Tuple
-from dataclasses import dataclass, asdict
 from enum_mappings import (
     map_tech_base,
     map_rules_level,
@@ -36,102 +35,17 @@ from enum_mappings import (
     get_era_folder_name,
     get_rules_level_folder_name,
 )
-
-
-@dataclass
-class SerializedEngine:
-    """Engine configuration."""
-    type: str
-    rating: int
-
-
-@dataclass
-class SerializedGyro:
-    """Gyro configuration."""
-    type: str
-
-
-@dataclass
-class SerializedStructure:
-    """Internal structure configuration."""
-    type: str
-
-
-@dataclass
-class SerializedArmor:
-    """Armor configuration."""
-    type: str
-    allocation: Dict[str, Any]  # Can be int or {front: int, rear: int}
-
-
-@dataclass
-class SerializedHeatSinks:
-    """Heat sink configuration."""
-    type: str
-    count: int
-
-
-@dataclass
-class SerializedMovement:
-    """Movement configuration."""
-    walk: int
-    jump: int
-    jumpJetType: Optional[str] = None
-    enhancements: Optional[List[str]] = None
-
-
-@dataclass
-class SerializedEquipment:
-    """Mounted equipment item."""
-    id: str
-    location: str
-    slots: Optional[List[int]] = None
-    isRearMounted: Optional[bool] = None
-    linkedAmmo: Optional[str] = None
-
-
-@dataclass
-class SerializedFluff:
-    """Fluff/flavor text."""
-    overview: Optional[str] = None
-    capabilities: Optional[str] = None
-    history: Optional[str] = None
-    deployment: Optional[str] = None
-    variants: Optional[str] = None
-    notableUnits: Optional[str] = None
-    manufacturer: Optional[str] = None
-    primaryFactory: Optional[str] = None
-    systemManufacturer: Optional[Dict[str, str]] = None
-
-
-@dataclass
-class SerializedUnit:
-    """Complete serialized unit matching ISerializedUnit interface."""
-    id: str
-    chassis: str
-    model: str
-    unitType: str
-    configuration: str
-    techBase: str
-    rulesLevel: str
-    era: str
-    year: int
-    tonnage: int
-    engine: SerializedEngine
-    gyro: SerializedGyro
-    cockpit: str
-    structure: SerializedStructure
-    armor: SerializedArmor
-    heatSinks: SerializedHeatSinks
-    movement: SerializedMovement
-    equipment: List[SerializedEquipment]
-    criticalSlots: Dict[str, List[Optional[str]]]
-    variant: Optional[str] = None
-    quirks: Optional[List[str]] = None
-    fluff: Optional[SerializedFluff] = None
-    mulId: Optional[int] = None
-    role: Optional[str] = None
-    source: Optional[str] = None
+from mtf_serialized_models import (
+    SerializedArmor,
+    SerializedEngine,
+    SerializedEquipment,
+    SerializedFluff,
+    SerializedGyro,
+    SerializedHeatSinks,
+    SerializedMovement,
+    SerializedStructure,
+    SerializedUnit,
+)
 
 
 class MTFParser:
@@ -754,4 +668,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/scripts/megameklab-conversion/mtf_serialized_models.py
+++ b/scripts/megameklab-conversion/mtf_serialized_models.py
@@ -1,0 +1,109 @@
+"""Serialized unit DTOs emitted by the MTF converter."""
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class SerializedEngine:
+    """Engine configuration."""
+
+    type: str
+    rating: int
+
+
+@dataclass
+class SerializedGyro:
+    """Gyro configuration."""
+
+    type: str
+
+
+@dataclass
+class SerializedStructure:
+    """Internal structure configuration."""
+
+    type: str
+
+
+@dataclass
+class SerializedArmor:
+    """Armor configuration."""
+
+    type: str
+    allocation: Dict[str, Any]
+
+
+@dataclass
+class SerializedHeatSinks:
+    """Heat sink configuration."""
+
+    type: str
+    count: int
+
+
+@dataclass
+class SerializedMovement:
+    """Movement configuration."""
+
+    walk: int
+    jump: int
+    jumpJetType: Optional[str] = None
+    enhancements: Optional[List[str]] = None
+
+
+@dataclass
+class SerializedEquipment:
+    """Mounted equipment item."""
+
+    id: str
+    location: str
+    slots: Optional[List[int]] = None
+    isRearMounted: Optional[bool] = None
+    linkedAmmo: Optional[str] = None
+
+
+@dataclass
+class SerializedFluff:
+    """Fluff/flavor text."""
+
+    overview: Optional[str] = None
+    capabilities: Optional[str] = None
+    history: Optional[str] = None
+    deployment: Optional[str] = None
+    variants: Optional[str] = None
+    notableUnits: Optional[str] = None
+    manufacturer: Optional[str] = None
+    primaryFactory: Optional[str] = None
+    systemManufacturer: Optional[Dict[str, str]] = None
+
+
+@dataclass
+class SerializedUnit:
+    """Complete serialized unit matching ISerializedUnit interface."""
+
+    id: str
+    chassis: str
+    model: str
+    unitType: str
+    configuration: str
+    techBase: str
+    rulesLevel: str
+    era: str
+    year: int
+    tonnage: int
+    engine: SerializedEngine
+    gyro: SerializedGyro
+    cockpit: str
+    structure: SerializedStructure
+    armor: SerializedArmor
+    heatSinks: SerializedHeatSinks
+    movement: SerializedMovement
+    equipment: List[SerializedEquipment]
+    criticalSlots: Dict[str, List[Optional[str]]]
+    variant: Optional[str] = None
+    quirks: Optional[List[str]] = None
+    fluff: Optional[SerializedFluff] = None
+    mulId: Optional[int] = None
+    role: Optional[str] = None
+    source: Optional[str] = None


### PR DESCRIPTION
## Summary
- Extract serialized MTF output DTO dataclasses into scripts/megameklab-conversion/mtf_serialized_models.py
- Drop scripts/megameklab-conversion/mtf_converter.py from high file-bloat to warn-level file-bloat
- Update the maintenance ledger, QC registry, and validation graph evidence for the Wave 12 maintenance burn-down

## Validation
- python -B scripts/megameklab-conversion/mtf_converter.py --help
- npm.cmd run maintain:scan -- --scope=scripts/megameklab-conversion/mtf_converter.py --json
- npm.cmd run maintain:scan -- --scope=scripts/megameklab-conversion/mtf_serialized_models.py --json
- node scripts/qc/validate-maintenance-warning-ledger.mjs
- npm.cmd run qc:validate
- npm.cmd run verify:qc:maintenance
- npm.cmd run qc:app-completion -- --json
- git diff --check

## Remaining
- qc:app-completion:release still fails only on maintenance-code-health coverageStatus=active-review
- Remaining live ledger wave findings: file-bloat critical=1 high=1 warn=11, near-duplicate high=2 warn=3, design-violation warn=3