### PR TITLE
Preserve compare route recovery during refresh

### DIFF
--- a/src/pages/compare/index.tsx
+++ b/src/pages/compare/index.tsx
@@ -15,6 +15,10 @@ import { logger } from '@/utils/logger';
 
 const MAX_COMPARE = 4;
 
+function isAbortError(err: unknown): boolean {
+  return err instanceof Error && err.name === 'AbortError';
+}
+
 export default function ComparePage(): React.ReactElement {
   const [catalog, setCatalog] = useState<IUnitEntry[]>([]);
   const [searchTerm, setSearchTerm] = useState('');
@@ -24,6 +28,15 @@ export default function ComparePage(): React.ReactElement {
 
   useEffect(() => {
     const controller = new AbortController();
+    let disposed = false;
+
+    const abortCatalogFetch = () => {
+      disposed = true;
+      controller.abort();
+    };
+
+    window.addEventListener('beforeunload', abortCatalogFetch);
+    window.addEventListener('pagehide', abortCatalogFetch);
 
     async function fetchCatalog() {
       try {
@@ -38,16 +51,20 @@ export default function ComparePage(): React.ReactElement {
           setCatalog(data.data || []);
         }
       } catch (err) {
-        if (controller.signal.aborted) return;
+        if (disposed || controller.signal.aborted || isAbortError(err)) return;
         logger.error('Failed to fetch catalog:', err);
       } finally {
-        if (controller.signal.aborted) return;
+        if (disposed || controller.signal.aborted) return;
         setCatalogLoading(false);
       }
     }
     fetchCatalog();
 
-    return () => controller.abort();
+    return () => {
+      window.removeEventListener('beforeunload', abortCatalogFetch);
+      window.removeEventListener('pagehide', abortCatalogFetch);
+      abortCatalogFetch();
+    };
   }, []);
 
   const filteredCatalog = catalog


### PR DESCRIPTION
﻿## Summary
- Abort and mark the compare-page catalog fetch disposed during pagehide, beforeunload, and component unmount.
- Ignore only aborted/disposed catalog fetches so refresh/deep-link route recovery does not emit false critical console errors.
- Keep real catalog load failures logged for product/debug visibility.

## Why
`verify:qc:app-shell` exposed that `/compare` could render correctly after route recovery while still logging `Failed to fetch catalog: TypeError: Failed to fetch` during page teardown. The app-shell proof treats critical console output as a route-quality failure, so the page lifecycle needed to distinguish teardown from live API failure.

## Validation
- `npm.cmd run typecheck -- --pretty false`
- `npm.cmd run lint -- src/pages/compare/index.tsx`
- `npx.cmd playwright test --project=chromium e2e/app-shell-route-proof.spec.ts -g "unit comparison" --workers=1`
- `npm.cmd run verify:qc:app-shell`
- `git diff --check`
