### PR TITLE
Scope maintenance release gate to ledger-backed debt

### DIFF
--- a/docs/qc/mekstation-major-capability-scenarios.json
+++ b/docs/qc/mekstation-major-capability-scenarios.json
@@ -574,12 +574,12 @@
       "id": "MC-12-maintenance-code-health",
       "surfaceId": "maintenance-code-health",
       "title": "Maintenance code-health gates stay triageable on demand",
-      "realisticFlow": "A maintainer validates that the maintenance scanner has not regressed past baseline, that Wave 12 repo-wide findings are ledger-accounted, and that partial QC lanes remain available for the next cleanup wave.",
+      "realisticFlow": "A maintainer validates that the maintenance scanner has not regressed past baseline, that Wave 12 repo-wide findings are ledger-accounted, and that the maintenance QC lane remains available for the next cleanup wave.",
       "qualityLenses": ["maintainability", "test-quality", "functionality"],
       "successCriteria": [
         "Maintenance scan gate passes against docs/qc/maintenance-baseline.json.",
         "The maintenance warning ledger accounts for every actionable repo-wide Wave 12 finding as fixed, accepted, or follow-up.",
-        "QC partial-lane selection remains available for planning the next remediation wave.",
+        "Maintenance QC lane selection remains available for planning the next remediation wave.",
         "Raw maintenance inventory can be captured as diagnostic evidence without being mistaken for a pass/fail release gate."
       ],
       "checks": [
@@ -605,10 +605,10 @@
           ]
         },
         {
-          "id": "active-review-qc-lane-selection",
+          "id": "maintenance-qc-lane-selection",
           "tier": "standard",
           "required": true,
-          "command": "npm.cmd run qc:select -- --status=active-review",
+          "command": "npm.cmd run qc:select -- --surface=maintenance-code-health",
           "evidence": [
             "docs/qc/mekstation-qc-registry.json",
             "scripts/qc/select-qc-lanes.mjs"

--- a/docs/qc/mekstation-qc-map.md
+++ b/docs/qc/mekstation-qc-map.md
@@ -29,7 +29,7 @@ Next.js page template or required journey sequence.
 npm.cmd run qc:validate
 npm.cmd run qc:app-completion
 npm.cmd run qc:app-completion:release
-npm.cmd run qc:select -- --status=active-review
+npm.cmd run qc:select -- --surface=maintenance-code-health
 npm.cmd run qc:select -- --risk=rules-parity
 npm.cmd run qc:select -- --lens=ux
 npm.cmd run qc:select -- --claim=ui.tactical.movement-preview

--- a/docs/qc/mekstation-qc-registry.json
+++ b/docs/qc/mekstation-qc-registry.json
@@ -1496,7 +1496,7 @@
       "parentId": null,
       "riskTags": ["maintainability", "velocity", "regression"],
       "qualityLenses": ["maintainability", "test-quality", "functionality"],
-      "coverageStatus": "active-review",
+      "coverageStatus": "ready-with-scope",
       "routes": [],
       "apis": [],
       "desktopSurfaces": [],
@@ -1523,7 +1523,7 @@
       ],
       "commands": [
         "npm.cmd run qc:validate",
-        "npm.cmd run qc:select -- --status=active-review",
+        "npm.cmd run qc:select -- --surface=maintenance-code-health",
         "npm.cmd run maintain:scan:gate",
         "node scripts/qc/validate-maintenance-warning-ledger.mjs",
         "npm.cmd run maintain:scan -- --scope=src --limit=80"
@@ -1618,7 +1618,8 @@
         "docs/qc/maintenance-baseline.json",
         "docs/qc/maintenance-warning-ledger.json",
         "scripts/qc/validate-maintenance-warning-ledger.mjs",
-        "2026-06-27 validate-bv architecture split moved the BattleMech BV calculation engine into focused calculator, crit-scan, ammo-resolution, weapon-resolution, known-unit, normalizer, and type modules; the original validate-bv.ts critical file-bloat finding is fixed, with three high file-bloat follow-ups tracked for the remaining validator submodules."
+        "2026-06-27 validate-bv architecture split moved the BattleMech BV calculation engine into focused calculator, crit-scan, ammo-resolution, weapon-resolution, known-unit, normalizer, and type modules; the original validate-bv.ts critical file-bloat finding is fixed, with three high file-bloat follow-ups tracked for the remaining validator submodules.",
+        "2026-06-28 maintenance release scope promoted to ready-with-scope after `verify:qc:maintenance` and `qc:app-completion -- --json` proved the src critical/high regression gate, repo-wide warning ledger accounting, and remaining follow-up/accepted warning debt are machine-checkable instead of hidden release blockers."
       ],
       "gaps": [
         "Scanner report is grouped as a regression baseline; avoid broad refactors until findings are selected as validated remediation waves.",

--- a/docs/qc/mekstation-qc-validation-graph.json
+++ b/docs/qc/mekstation-qc-validation-graph.json
@@ -1568,7 +1568,7 @@
       "id": "surface:maintenance-code-health",
       "kind": "surface",
       "label": "Maintenance Code Health",
-      "coverageStatus": "active-review"
+      "coverageStatus": "ready-with-scope"
     },
     {
       "id": "state:maintenance-code-health:lifecycle",
@@ -1665,7 +1665,8 @@
         "docs/qc/maintenance-baseline.json",
         "docs/qc/maintenance-warning-ledger.json",
         "scripts/qc/validate-maintenance-warning-ledger.mjs",
-        "2026-06-27 validate-bv architecture split moved the BattleMech BV calculation engine into focused calculator, crit-scan, ammo-resolution, weapon-resolution, known-unit, normalizer, and type modules; the original validate-bv.ts critical file-bloat finding is fixed, with three high file-bloat follow-ups tracked for the remaining validator submodules."
+        "2026-06-27 validate-bv architecture split moved the BattleMech BV calculation engine into focused calculator, crit-scan, ammo-resolution, weapon-resolution, known-unit, normalizer, and type modules; the original validate-bv.ts critical file-bloat finding is fixed, with three high file-bloat follow-ups tracked for the remaining validator submodules.",
+        "2026-06-28 maintenance release scope promoted to ready-with-scope after `verify:qc:maintenance` and `qc:app-completion -- --json` proved the src critical/high regression gate, repo-wide warning ledger accounting, and remaining follow-up/accepted warning debt are machine-checkable instead of hidden release blockers."
       ]
     },
     {
@@ -1693,9 +1694,9 @@
       "label": "npm.cmd run qc:validate"
     },
     {
-      "id": "command:npm-cmd-run-qc-select-status-partial",
+      "id": "command:npm-cmd-run-qc-select-maintenance-surface",
       "kind": "command",
-      "label": "npm.cmd run qc:select -- --status=active-review"
+      "label": "npm.cmd run qc:select -- --surface=maintenance-code-health"
     },
     {
       "id": "command:npm-cmd-run-maintain-scan-scope-src-limit-80",
@@ -3872,11 +3873,11 @@
     },
     {
       "from": "state:maintenance-code-health:lifecycle",
-      "to": "command:npm-cmd-run-qc-select-status-partial",
+      "to": "command:npm-cmd-run-qc-select-maintenance-surface",
       "relation": "validated-by"
     },
     {
-      "from": "command:npm-cmd-run-qc-select-status-partial",
+      "from": "command:npm-cmd-run-qc-select-maintenance-surface",
       "to": "evidence:maintenance-code-health:registry",
       "relation": "produces"
     },


### PR DESCRIPTION
## Summary
- Promote maintenance-code-health from active-review to ready-with-scope now that the src critical/high regression gate and repo-wide warning ledger are both machine-checkable.
- Keep remaining warning debt explicit as follow-up/accepted maintenance scope instead of a hidden release blocker.
- Update QC selection docs/graph to target the maintenance surface directly.

## Validation
- npm.cmd run qc:journeys:validate
- npm.cmd run qc:app-completion:release
- npm.cmd run verify:qc:maintenance
- npm.cmd run format:check
- git diff --check
- npm.cmd run qc:known-gaps:validate
- npm.cmd run validate:combat:gaps -- --format=summary --expect-total=0
- npx.cmd openspec validate --all --strict

## Remaining scoped debt
- 16 file-bloat warn follow-ups
- 3 near-duplicate warn follow-ups
- 3 accepted desktop design-violation warnings