### PR TITLE
Preserve multiplayer roster selection in match bootstrap

### DIFF
--- a/docs/qc/mekstation-qc-registry.json
+++ b/docs/qc/mekstation-qc-registry.json
@@ -1290,6 +1290,7 @@
         "server.js",
         "src/lib/multiplayer",
         "src/pages/api/multiplayer",
+        "src/components/multiplayer",
         "src/components/campaign/coop"
       ],
       "submodules": [
@@ -1306,6 +1307,7 @@
         "e2e/playtest-mp-smoke.spec.ts",
         "e2e/playtest-coop-route-smoke.spec.ts",
         "e2e/multiplayer-live-vault-auth.spec.ts",
+        "src/components/multiplayer/__tests__/CreateMatchForm.test.tsx",
         "src/__tests__/unit/api/multiplayerMatchesFog.test.ts",
         "src/__tests__/unit/api/multiplayerSpectate.test.ts",
         "src/__tests__/integration/phase4Multiplayer.test.ts",
@@ -1331,12 +1333,13 @@
         "2026-06-25 `npm.cmd run validate:multiplayer:packaged-socket` passed after `npm.cmd run build`: packaged server socket upgrade/replay succeeded, the process restarted against the same durable SQLite match store, the same match replayed after reconnect, and the co-op runtime proposal committed.",
         "2026-06-25 `npx.cmd playwright test --project=chromium e2e/multiplayer-live-vault-auth.spec.ts --workers=1` passed: two browser contexts seeded real E2E-locked vault identities, host created a fog-enabled lobby, guest joined by invite, both connected through signed tokens, both readied, host launched, both rendered the networked game surface, and the host advanced the server-owned Initiative phase to Movement over the real WebSocket path.",
         "2026-06-26 `npx.cmd playwright test --project=chromium e2e/multiplayer-live-vault-auth.spec.ts --workers=1` passed: REST-created fog-enabled matches returned real Atlas/Marauder unit bootstrap metadata, both vault-auth browser contexts launched over signed sockets, host and guest rendered side-owned tactical unit tokens, and the host advanced Initiative to Movement over WebSocket.",
+        "2026-06-28 multiplayer create-match UI now exposes unit roster presets and submits explicit unitBootstrap metadata; focused Jest coverage proves the form emits selected Atlas/Marauder presets, the API preserves explicit bootstrap rows, and MatchHostRegistry still boots stored units.",
         "2026-06-25 Wave 4 validator requires multiplayer aggregate scripts plus route, contract, capstone source anchors, and the packaged socket command while keeping live host/guest identity play tracked separately.",
         "Archived OpenSpec change 2026-06-21-reconcile-multiplayer-coop-reality retired from activeChangeRefs on 2026-06-23.",
         "Archived OpenSpec change 2026-06-21-harden-desktop-and-api-security retired from activeChangeRefs on 2026-06-23."
       ],
       "gaps": [
-        "Room-created unit selection is metadata/API-driven; the lobby UI does not yet expose user-selectable roster configuration."
+        "Create-match roster presets are UI-backed; fully custom per-seat unit/pilot roster configuration remains future multiplayer product scope."
       ]
     },
     {

--- a/docs/qc/mekstation-qc-validation-graph.json
+++ b/docs/qc/mekstation-qc-validation-graph.json
@@ -1392,6 +1392,7 @@
         "2026-06-24 `verify:qc:multiplayer-reliability` groups browser route smoke, mock P2P sync, co-op route mounting, API fog/spectate contracts, server host/reconnect/spectator/fog behavior, turn ownership, and the Phase 4 capstone host/join/reconnect/outcome flow.",
         "2026-06-25 `npm.cmd run validate:multiplayer:packaged-socket` passed after `npm.cmd run build`: packaged server socket upgrade/replay succeeded, the process restarted against the same durable SQLite match store, the same match replayed after reconnect, and the co-op runtime proposal committed.",
         "2026-06-26 `npx.cmd playwright test --project=chromium e2e/multiplayer-live-vault-auth.spec.ts --workers=1` passed: REST-created fog-enabled matches returned real Atlas/Marauder unit bootstrap metadata, both vault-auth browser contexts launched over signed sockets, host and guest rendered side-owned tactical unit tokens, and the host advanced Initiative to Movement over WebSocket.",
+        "2026-06-28 multiplayer create-match UI now exposes unit roster presets and submits explicit unitBootstrap metadata; focused Jest coverage proves the form emits selected Atlas/Marauder presets, the API preserves explicit bootstrap rows, and MatchHostRegistry still boots stored units.",
         "Archived OpenSpec change 2026-06-21-reconcile-multiplayer-coop-reality retired from activeChangeRefs on 2026-06-23.",
         "Archived OpenSpec change 2026-06-21-harden-desktop-and-api-security retired from activeChangeRefs on 2026-06-23."
       ]
@@ -1409,7 +1410,7 @@
       "kind": "known-gap",
       "label": "Multiplayer, Co-op, P2P Sync known gaps",
       "entries": [
-        "Room-created unit selection is metadata/API-driven; the lobby UI does not yet expose user-selectable roster configuration."
+        "Create-match roster presets are UI-backed; fully custom per-seat unit/pilot roster configuration remains future multiplayer product scope."
       ]
     },
     {

--- a/scripts/qc/validate-wave4-scope-recovery.mjs
+++ b/scripts/qc/validate-wave4-scope-recovery.mjs
@@ -153,7 +153,7 @@ const requiredSurfaces = [
       'fogOfWar.test.ts',
     ],
     manualIncludes: ['side-owned units', 'hidden GM/private fields'],
-    gapIncludes: ['user-selectable roster configuration'],
+    gapIncludes: ['fully custom per-seat unit/pilot roster configuration'],
   },
   {
     id: 'replay-audit-history',

--- a/src/__tests__/unit/api/multiplayerMatchesFog.test.ts
+++ b/src/__tests__/unit/api/multiplayerMatchesFog.test.ts
@@ -118,4 +118,49 @@ describe('POST /api/multiplayer/matches fog config', () => {
       fogOfWar: true,
     });
   });
+
+  it('preserves explicit unit bootstrap selected by the create-match UI', async () => {
+    const { req, res, result } = mockReqRes({
+      config: { mapRadius: 8, turnLimit: 20, fogOfWar: true },
+      layout: '1v1',
+      displayName: 'Host',
+      unitBootstrap: [
+        {
+          unitId: 'host-selected-atlas',
+          unitRef: 'atlas-as7-d',
+          side: 'player',
+          name: 'Atlas AS7-D 1',
+          pilotRef: 'host-selected-pilot',
+          gunnery: 3,
+          piloting: 4,
+          startHex: { q: -2, r: 0 },
+        },
+        {
+          unitId: 'guest-selected-marauder',
+          unitRef: 'marauder-mad-3r',
+          side: 'opponent',
+          name: 'Marauder MAD-3R 1',
+          pilotRef: 'guest-selected-pilot',
+          gunnery: 4,
+          piloting: 5,
+          startHex: { q: 2, r: 0 },
+        },
+      ],
+    });
+
+    await handler(req, res);
+
+    expect(createdMeta(result).unitBootstrap).toEqual([
+      expect.objectContaining({
+        unitId: 'host-selected-atlas',
+        unitRef: 'atlas-as7-d',
+        side: 'player',
+      }),
+      expect.objectContaining({
+        unitId: 'guest-selected-marauder',
+        unitRef: 'marauder-mad-3r',
+        side: 'opponent',
+      }),
+    ]);
+  });
 });

--- a/src/components/multiplayer/CreateMatchForm.tsx
+++ b/src/components/multiplayer/CreateMatchForm.tsx
@@ -12,7 +12,15 @@
 
 import { useState } from 'react';
 
+import type { MatchRosterPresetId } from '@/lib/multiplayer/matchRosterPresets';
+import type { IMatchUnitBootstrapEntry } from '@/lib/multiplayer/server/IMatchStore';
 import type { TeamLayout } from '@/types/multiplayer/Lobby';
+
+import {
+  buildMatchUnitBootstrapForPreset,
+  DEFAULT_MATCH_ROSTER_PRESET_ID,
+  MATCH_ROSTER_PRESETS,
+} from '@/lib/multiplayer/matchRosterPresets';
 
 // =============================================================================
 // Props
@@ -24,6 +32,8 @@ export interface ICreateMatchFormValue {
   readonly mapRadius: number;
   readonly turnLimit: number;
   readonly fogOfWar: boolean;
+  readonly rosterPresetId: MatchRosterPresetId;
+  readonly unitBootstrap: readonly IMatchUnitBootstrapEntry[];
 }
 
 export interface ICreateMatchFormProps {
@@ -66,6 +76,9 @@ export function CreateMatchForm(
   const [mapRadius, setMapRadius] = useState<number>(8);
   const [turnLimit, setTurnLimit] = useState<number>(20);
   const [fogOfWar, setFogOfWar] = useState<boolean>(false);
+  const [rosterPresetId, setRosterPresetId] = useState<MatchRosterPresetId>(
+    DEFAULT_MATCH_ROSTER_PRESET_ID,
+  );
 
   return (
     <form
@@ -77,6 +90,12 @@ export function CreateMatchForm(
           mapRadius,
           turnLimit,
           fogOfWar,
+          rosterPresetId,
+          unitBootstrap: buildMatchUnitBootstrapForPreset(
+            layout,
+            rosterPresetId,
+            mapRadius,
+          ),
         });
       }}
       className="space-y-4"
@@ -114,6 +133,28 @@ export function CreateMatchForm(
           {LAYOUT_OPTIONS.map((opt) => (
             <option key={opt.value} value={opt.value}>
               {opt.label}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label
+          htmlFor="cm-rosterPreset"
+          className="block text-xs font-medium tracking-wide text-slate-300 uppercase"
+        >
+          Unit roster preset
+        </label>
+        <select
+          id="cm-rosterPreset"
+          value={rosterPresetId}
+          onChange={(e) =>
+            setRosterPresetId(e.target.value as MatchRosterPresetId)
+          }
+          className="mt-1 w-full rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-500 focus:outline-none"
+        >
+          {MATCH_ROSTER_PRESETS.map((preset) => (
+            <option key={preset.id} value={preset.id}>
+              {preset.label}
             </option>
           ))}
         </select>

--- a/src/components/multiplayer/__tests__/CreateMatchForm.test.tsx
+++ b/src/components/multiplayer/__tests__/CreateMatchForm.test.tsx
@@ -17,6 +17,19 @@ describe('CreateMatchForm', () => {
       mapRadius: 8,
       turnLimit: 20,
       fogOfWar: false,
+      rosterPresetId: 'assault-vs-heavy',
+      unitBootstrap: expect.arrayContaining([
+        expect.objectContaining({
+          unitId: 'player-1-atlas-as7-d',
+          unitRef: 'atlas-as7-d',
+          side: 'player',
+        }),
+        expect.objectContaining({
+          unitId: 'opponent-1-marauder-mad-3r',
+          unitRef: 'marauder-mad-3r',
+          side: 'opponent',
+        }),
+      ]),
     });
   });
 
@@ -34,6 +47,37 @@ describe('CreateMatchForm', () => {
       mapRadius: 8,
       turnLimit: 20,
       fogOfWar: true,
+      rosterPresetId: 'assault-vs-heavy',
+      unitBootstrap: expect.any(Array),
     });
+  });
+
+  it('submits the selected roster preset as explicit match bootstrap', async () => {
+    const onSubmit = jest.fn();
+    render(<CreateMatchForm onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByLabelText('Unit roster preset'), {
+      target: { value: 'atlas-mirror' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create match' }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rosterPresetId: 'atlas-mirror',
+        unitBootstrap: expect.arrayContaining([
+          expect.objectContaining({
+            unitId: 'player-1-atlas-as7-d',
+            unitRef: 'atlas-as7-d',
+            side: 'player',
+          }),
+          expect.objectContaining({
+            unitId: 'opponent-1-atlas-as7-d',
+            unitRef: 'atlas-as7-d',
+            side: 'opponent',
+          }),
+        ]),
+      }),
+    );
   });
 });

--- a/src/lib/multiplayer/matchRosterPresets.ts
+++ b/src/lib/multiplayer/matchRosterPresets.ts
@@ -1,0 +1,130 @@
+import type { IMatchUnitBootstrapEntry } from '@/lib/multiplayer/server/IMatchStore';
+import type { TeamLayout } from '@/types/multiplayer/Lobby';
+
+import { seatLayoutSpec } from '@/types/multiplayer/Lobby';
+
+export type MatchRosterPresetId =
+  | 'assault-vs-heavy'
+  | 'atlas-mirror'
+  | 'marauder-mirror';
+
+export interface IMatchRosterPreset {
+  readonly id: MatchRosterPresetId;
+  readonly label: string;
+  readonly playerUnitRef: string;
+  readonly playerUnitName: string;
+  readonly opponentUnitRef: string;
+  readonly opponentUnitName: string;
+}
+
+type BootstrapSide = IMatchUnitBootstrapEntry['side'];
+
+export const DEFAULT_MATCH_ROSTER_PRESET_ID: MatchRosterPresetId =
+  'assault-vs-heavy';
+
+export const MATCH_ROSTER_PRESETS: readonly IMatchRosterPreset[] = [
+  {
+    id: 'assault-vs-heavy',
+    label: 'Atlas vs Marauder',
+    playerUnitRef: 'atlas-as7-d',
+    playerUnitName: 'Atlas AS7-D',
+    opponentUnitRef: 'marauder-mad-3r',
+    opponentUnitName: 'Marauder MAD-3R',
+  },
+  {
+    id: 'atlas-mirror',
+    label: 'Atlas mirror',
+    playerUnitRef: 'atlas-as7-d',
+    playerUnitName: 'Atlas AS7-D',
+    opponentUnitRef: 'atlas-as7-d',
+    opponentUnitName: 'Atlas AS7-D',
+  },
+  {
+    id: 'marauder-mirror',
+    label: 'Marauder mirror',
+    playerUnitRef: 'marauder-mad-3r',
+    playerUnitName: 'Marauder MAD-3R',
+    opponentUnitRef: 'marauder-mad-3r',
+    opponentUnitName: 'Marauder MAD-3R',
+  },
+];
+
+export function matchRosterPresetById(
+  id: MatchRosterPresetId,
+): IMatchRosterPreset {
+  return (
+    MATCH_ROSTER_PRESETS.find((preset) => preset.id === id) ??
+    MATCH_ROSTER_PRESETS[0]
+  );
+}
+
+function sideForSeatSide(sideIndex: number): BootstrapSide {
+  return sideIndex === 0 ? 'player' : 'opponent';
+}
+
+function sideSlug(side: BootstrapSide): string {
+  return side === 'player' ? 'player' : 'opponent';
+}
+
+function unitRefForSide(
+  preset: IMatchRosterPreset,
+  side: BootstrapSide,
+): string {
+  return side === 'player' ? preset.playerUnitRef : preset.opponentUnitRef;
+}
+
+function unitNameForSide(
+  preset: IMatchRosterPreset,
+  side: BootstrapSide,
+): string {
+  return side === 'player' ? preset.playerUnitName : preset.opponentUnitName;
+}
+
+function startHexFor(
+  side: BootstrapSide,
+  sideSeatIndex: number,
+  mapRadius: number,
+): { readonly q: number; readonly r: number } {
+  const qOffset = Math.max(0, Math.min(2, mapRadius - 1));
+  const q = side === 'player' ? -qOffset : qOffset;
+  const desiredR = side === 'player' ? sideSeatIndex - 1 : 1 - sideSeatIndex;
+  const minR = Math.max(-mapRadius, -q - mapRadius);
+  const maxR = Math.min(mapRadius, -q + mapRadius);
+  return {
+    q,
+    r: Math.max(minR, Math.min(maxR, desiredR)),
+  };
+}
+
+export function buildMatchUnitBootstrapForPreset(
+  layout: TeamLayout,
+  presetId: MatchRosterPresetId,
+  mapRadius: number,
+): readonly IMatchUnitBootstrapEntry[] {
+  const preset = matchRosterPresetById(presetId);
+  const spec = seatLayoutSpec(layout);
+  const sideCounts = new Map<BootstrapSide, number>();
+  const entries: IMatchUnitBootstrapEntry[] = [];
+
+  spec.sides.forEach((_seatSide, sideIndex) => {
+    const side = sideForSeatSide(sideIndex);
+    for (let seat = 1; seat <= spec.seatsPerSide; seat += 1) {
+      const sideSeatIndex = (sideCounts.get(side) ?? 0) + 1;
+      sideCounts.set(side, sideSeatIndex);
+      const unitRef = unitRefForSide(preset, side);
+      const slug = sideSlug(side);
+      entries.push({
+        unitId: `${slug}-${sideSeatIndex}-${unitRef}`,
+        unitRef,
+        side,
+        name: `${unitNameForSide(preset, side)} ${sideSeatIndex}`,
+        pilotRef: `${slug}-${sideSeatIndex}-pilot`,
+        gunnery: 4,
+        piloting: 5,
+        startHex: startHexFor(side, sideSeatIndex, mapRadius),
+      });
+    }
+  });
+
+  return entries;
+}

--- a/src/pages/multiplayer/index.tsx
+++ b/src/pages/multiplayer/index.tsx
@@ -19,7 +19,10 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 
-import type { IMatchConfig } from '@/lib/multiplayer/server/IMatchStore';
+import type {
+  IMatchConfig,
+  IMatchUnitBootstrapEntry,
+} from '@/lib/multiplayer/server/IMatchStore';
 import type { IPlayerToken } from '@/types/multiplayer/Player';
 
 import { CreateMatchForm } from '@/components/multiplayer/CreateMatchForm';
@@ -136,6 +139,7 @@ export default function MultiplayerHubPage(): React.ReactElement {
     mapRadius: number;
     turnLimit: number;
     fogOfWar: boolean;
+    unitBootstrap: readonly IMatchUnitBootstrapEntry[];
   }): Promise<void> {
     await withAuth('create', async (auth) => {
       const config: IMatchConfig = {
@@ -153,6 +157,7 @@ export default function MultiplayerHubPage(): React.ReactElement {
           config,
           layout: value.layout,
           displayName: value.displayName,
+          unitBootstrap: value.unitBootstrap,
         }),
       });
       if (!res.ok) {


### PR DESCRIPTION
## Summary
- add multiplayer create-match roster presets that build explicit unitBootstrap rows
- forward selected bootstrap metadata through the multiplayer hub create-match request
- update Wave 4 QC honesty wording so custom per-seat unit/pilot configuration remains tracked as future scope

## Validation
- npm.cmd run verify:qc
- npm.cmd run verify:rules
- npm.cmd run electron:test:build
- npm.cmd run format:check
- npm.cmd run typecheck -- --pretty false
- npm.cmd test -- --watchAll=false --runTestsByPath scripts/__tests__/wave4-scope-recovery-qc.test.ts src/components/multiplayer/__tests__/CreateMatchForm.test.tsx src/__tests__/unit/api/multiplayerMatchesFog.test.ts src/lib/multiplayer/server/__tests__/MatchHostRegistry.unitBootstrap.test.ts --runInBand

## Notes
- Browser E2E for selecting the roster preset dropdown remains a follow-up before claiming fully custom multiplayer roster UI.
- Packaged multiplayer socket validation remains build-order dependent and is covered by electron:test:build here.