### PR TITLE
Reduce BV analysis duplicate debt

### DIFF
--- a/docs/qc/maintenance-warning-ledger.json
+++ b/docs/qc/maintenance-warning-ledger.json
@@ -23,9 +23,9 @@
       "follow-up": 15
     },
     "near-duplicate": {
-      "fixed": 0,
+      "fixed": 5,
       "accepted": 0,
-      "follow-up": 5
+      "follow-up": 1
     },
     "import-health": {
       "fixed": 0,
@@ -242,9 +242,8 @@
       "severity": "warn",
       "file": "scripts/analyze-2to5-band.ts",
       "message": "8-line block cluster appears in 30 files",
-      "status": "follow-up",
-      "rationale": "The analysis script helper pass reduced this cluster from 32 to 30 copies; remaining TypeScript analysis scripts should be handled in a later focused dedup pass.",
-      "followUps": ["wave-12-analysis-script-dedup"]
+      "status": "fixed",
+      "rationale": "The repeated BV report/index/unit-loading prelude was replaced across the TypeScript analysis and trace scripts with shared bv-analysis-helpers access, clearing this warning while preserving script typecheck coverage."
     },
     {
       "key": "near-duplicate|warn|scripts/check-cockpit-fixes.ts|8-line block cluster appears in 42 files",
@@ -252,9 +251,8 @@
       "severity": "warn",
       "file": "scripts/check-cockpit-fixes.ts",
       "message": "8-line block cluster appears in 42 files",
-      "status": "follow-up",
-      "rationale": "This cockpit-analysis setup cluster became visible after the high-severity BV analysis clusters were removed; it belongs with the remaining analysis script dedup wave.",
-      "followUps": ["wave-12-analysis-script-dedup"]
+      "status": "fixed",
+      "rationale": "The repeated BV report/index/unit-loading prelude was replaced across the TypeScript analysis and trace scripts with shared bv-analysis-helpers access, reducing near-duplicate warnings from three to one without changing analysis outputs."
     },
     {
       "key": "near-duplicate|warn|scripts/analyze-engine-armor.js|8-line block cluster appears in 39 files",

--- a/docs/qc/mekstation-qc-registry.json
+++ b/docs/qc/mekstation-qc-registry.json
@@ -1626,7 +1626,8 @@
         "scripts/qc/validate-maintenance-warning-ledger.mjs",
         "2026-06-27 validate-bv architecture split moved the BattleMech BV calculation engine into focused calculator, crit-scan, ammo-resolution, weapon-resolution, known-unit, normalizer, and type modules; the original validate-bv.ts critical file-bloat finding is fixed, with three high file-bloat follow-ups tracked for the remaining validator submodules.",
         "2026-06-28 maintenance release scope promoted to ready-with-scope after `verify:qc:maintenance` and `qc:app-completion -- --json` proved the src critical/high regression gate, repo-wide warning ledger accounting, and remaining follow-up/accepted warning debt are machine-checkable instead of hidden release blockers.",
-        "2026-06-28 event-log formatter maintenance split moved prefix and summary helpers into tracked `scripts/lib/event_log_format_*.py` modules, added sample NDJSON fixture coverage in `scripts/__tests__/format-event-log.test.ts`, and fixed the `scripts/format-event-log.py` file-bloat warning without adding new actionable Python findings."
+        "2026-06-28 event-log formatter maintenance split moved prefix and summary helpers into tracked `scripts/lib/event_log_format_*.py` modules, added sample NDJSON fixture coverage in `scripts/__tests__/format-event-log.test.ts`, and fixed the `scripts/format-event-log.py` file-bloat warning without adding new actionable Python findings.",
+        "2026-06-28 TypeScript BV analysis scripts now reuse `scripts/bv-analysis-helpers.ts` for report, index, and unit loading; `tsc --noEmit --skipLibCheck --pretty false` passes and the repo-wide near-duplicate warning count drops from three to one."
       ],
       "gaps": [
         "Scanner report is grouped as a regression baseline; avoid broad refactors until findings are selected as validated remediation waves.",

--- a/docs/qc/mekstation-qc-validation-graph.json
+++ b/docs/qc/mekstation-qc-validation-graph.json
@@ -1669,7 +1669,8 @@
         "scripts/qc/validate-maintenance-warning-ledger.mjs",
         "2026-06-27 validate-bv architecture split moved the BattleMech BV calculation engine into focused calculator, crit-scan, ammo-resolution, weapon-resolution, known-unit, normalizer, and type modules; the original validate-bv.ts critical file-bloat finding is fixed, with three high file-bloat follow-ups tracked for the remaining validator submodules.",
         "2026-06-28 maintenance release scope promoted to ready-with-scope after `verify:qc:maintenance` and `qc:app-completion -- --json` proved the src critical/high regression gate, repo-wide warning ledger accounting, and remaining follow-up/accepted warning debt are machine-checkable instead of hidden release blockers.",
-        "2026-06-28 event-log formatter maintenance split moved prefix and summary helpers into tracked `scripts/lib/event_log_format_*.py` modules, added sample NDJSON fixture coverage in `scripts/__tests__/format-event-log.test.ts`, and fixed the `scripts/format-event-log.py` file-bloat warning without adding new actionable Python findings."
+        "2026-06-28 event-log formatter maintenance split moved prefix and summary helpers into tracked `scripts/lib/event_log_format_*.py` modules, added sample NDJSON fixture coverage in `scripts/__tests__/format-event-log.test.ts`, and fixed the `scripts/format-event-log.py` file-bloat warning without adding new actionable Python findings.",
+        "2026-06-28 TypeScript BV analysis scripts now reuse `scripts/bv-analysis-helpers.ts` for report, index, and unit loading; `tsc --noEmit --skipLibCheck --pretty false` passes and the repo-wide near-duplicate warning count drops from three to one."
       ]
     },
     {

--- a/scripts/check-cockpit-fixes.ts
+++ b/scripts/check-cockpit-fixes.ts
@@ -2,19 +2,15 @@
  * Find overcalculated units that would be fixed by 0.95 cockpit modifier.
  * Analyze their HEAD crit layout to find a reliable detection pattern.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
-
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null,
+);
 const outside1 = valid.filter((x: any) => Math.abs(x.percentDiff) > 1);
 
 // Find overcalculated units fixed by 0.95 cockpit
@@ -35,14 +31,25 @@ for (const u of fixableUnits) {
   const unit = loadUnit(u.unitId);
   if (!unit) continue;
   const headSlots = unit.criticalSlots?.HEAD;
-  const lsCount = headSlots?.filter((s: string | null) => s && s.includes('Life Support')).length ?? 0;
-  const sensorCount = headSlots?.filter((s: string | null) => s && s.includes('Sensors')).length ?? 0;
-  const cockpitStr = headSlots?.filter((s: string | null) => s && s.toLowerCase().includes('cockpit')).length ?? 0;
+  const lsCount =
+    headSlots?.filter((s: string | null) => s && s.includes('Life Support'))
+      .length ?? 0;
+  const sensorCount =
+    headSlots?.filter((s: string | null) => s && s.includes('Sensors'))
+      .length ?? 0;
+  const cockpitStr =
+    headSlots?.filter(
+      (s: string | null) => s && s.toLowerCase().includes('cockpit'),
+    ).length ?? 0;
   const slot4 = headSlots?.[3];
 
-  console.log(`  ${u.unitId.padEnd(40)} diff=+${u.difference} (${u.percentDiff.toFixed(1)}%) cockpit=${unit.cockpit || 'STANDARD'}`);
+  console.log(
+    `  ${u.unitId.padEnd(40)} diff=+${u.difference} (${u.percentDiff.toFixed(1)}%) cockpit=${unit.cockpit || 'STANDARD'}`,
+  );
   console.log(`    HEAD: [${headSlots?.join(', ')}]`);
-  console.log(`    LS=${lsCount} Sensors=${sensorCount} CockpitSlots=${cockpitStr} slot4=${slot4}`);
+  console.log(
+    `    LS=${lsCount} Sensors=${sensorCount} CockpitSlots=${cockpitStr} slot4=${slot4}`,
+  );
   console.log(`    Would become: ${u.recalcBV} (${u.recalcPct.toFixed(1)}%)`);
   console.log('');
 }
@@ -55,10 +62,13 @@ for (const u of fixableUnits) {
   const unit = loadUnit(u.unitId);
   if (!unit) continue;
   const headSlots = unit.criticalSlots?.HEAD;
-  const lsCount = headSlots?.filter((s: string | null) => s && s.includes('Life Support')).length ?? 0;
+  const lsCount =
+    headSlots?.filter((s: string | null) => s && s.includes('Life Support'))
+      .length ?? 0;
   const slot4 = headSlots?.[3];
   if (lsCount !== 1) allHaveLsCount1 = false;
-  if (!slot4 || typeof slot4 !== 'string' || !slot4.includes('Sensors')) allHaveSlot4Sensors = false;
+  if (!slot4 || typeof slot4 !== 'string' || !slot4.includes('Sensors'))
+    allHaveSlot4Sensors = false;
 }
 console.log(`  All have lsCount=1: ${allHaveLsCount1}`);
 console.log(`  All have slot4=Sensors: ${allHaveSlot4Sensors}`);
@@ -73,14 +83,17 @@ for (const u of valid) {
   const unit = loadUnit(u.unitId);
   if (!unit) continue;
   const headSlots = unit.criticalSlots?.HEAD;
-  const lsCount = headSlots?.filter((s: string | null) => s && s.includes('Life Support')).length ?? 0;
+  const lsCount =
+    headSlots?.filter((s: string | null) => s && s.includes('Life Support'))
+      .length ?? 0;
   const b = u.breakdown;
   if (!b) continue;
 
   // Currently detected as small?
   const currentlySmall = b.cockpitModifier < 1;
   // Would be detected as small with lsCount=1?
-  const wouldBeSmall = lsCount === 1 && (unit.cockpit || 'STANDARD').toUpperCase() === 'STANDARD';
+  const wouldBeSmall =
+    lsCount === 1 && (unit.cockpit || 'STANDARD').toUpperCase() === 'STANDARD';
 
   if (wouldBeSmall && !currentlySmall) {
     // New detection
@@ -111,14 +124,20 @@ for (const u of valid) {
 
   const currentlySmall = b.cockpitModifier < 1;
   const unitCockpit = (unit.cockpit || 'STANDARD').toUpperCase();
-  const wouldBeSmall = unitCockpit.includes('SMALL') || unitCockpit.includes('TORSO') || unitCockpit.includes('DRONE') || unitCockpit.includes('INTERFACE');
+  const wouldBeSmall =
+    unitCockpit.includes('SMALL') ||
+    unitCockpit.includes('TORSO') ||
+    unitCockpit.includes('DRONE') ||
+    unitCockpit.includes('INTERFACE');
 
   if (currentlySmall && !wouldBeSmall) {
     // Removing heuristic: would set this to 1.0 instead of 0.95
     const recalcBV = Math.round((b.defensiveBV + b.offensiveBV) * 1.0);
     const recalcPct = ((recalcBV - u.indexBV) / u.indexBV) * 100;
-    if (Math.abs(recalcPct) <= 1 && Math.abs(u.percentDiff) > 1) noHeuristicFix++;
-    if (Math.abs(recalcPct) > 1 && Math.abs(u.percentDiff) <= 1) noHeuristicBreak++;
+    if (Math.abs(recalcPct) <= 1 && Math.abs(u.percentDiff) > 1)
+      noHeuristicFix++;
+    if (Math.abs(recalcPct) > 1 && Math.abs(u.percentDiff) <= 1)
+      noHeuristicBreak++;
   }
 }
 console.log(`  Would fix: ${noHeuristicFix}`);

--- a/scripts/check-df18.ts
+++ b/scripts/check-df18.ts
@@ -1,20 +1,20 @@
 /**
  * Check the 8 units with DF=1.8 to understand overcalculation.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
-
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown);
-const df18 = valid.filter((x: any) => x.breakdown?.defensiveFactor >= 1.75 && x.breakdown?.defensiveFactor <= 1.85);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown,
+);
+const df18 = valid.filter(
+  (x: any) =>
+    x.breakdown?.defensiveFactor >= 1.75 &&
+    x.breakdown?.defensiveFactor <= 1.85,
+);
 
 console.log(`=== UNITS WITH DF=1.8 (${df18.length} total) ===\n`);
 
@@ -22,30 +22,50 @@ for (const u of df18) {
   const b = u.breakdown;
   const unit = loadUnit(u.unitId);
   console.log(`${u.unitId}`);
-  console.log(`  ref=${u.indexBV} calc=${u.calculatedBV} diff=${u.difference} (${u.percentDiff.toFixed(1)}%)`);
-  console.log(`  DEF=${b.defensiveBV?.toFixed(0)} OFF=${b.offensiveBV?.toFixed(0)} cockpit=${b.cockpitModifier}`);
+  console.log(
+    `  ref=${u.indexBV} calc=${u.calculatedBV} diff=${u.difference} (${u.percentDiff.toFixed(1)}%)`,
+  );
+  console.log(
+    `  DEF=${b.defensiveBV?.toFixed(0)} OFF=${b.offensiveBV?.toFixed(0)} cockpit=${b.cockpitModifier}`,
+  );
   console.log(`  DF=${b.defensiveFactor} SF=${b.speedFactor}`);
-  console.log(`  run=${b.runMP} jump=${b.jumpMP} walk=${unit?.movement?.walk} jump_mp=${unit?.movement?.jump}`);
+  console.log(
+    `  run=${b.runMP} jump=${b.jumpMP} walk=${unit?.movement?.walk} jump_mp=${unit?.movement?.jump}`,
+  );
   console.log(`  engine=${unit?.engine?.type} tonnage=${unit?.tonnage}`);
   // Check if there are special movement features
   const eqs = (unit?.equipment || []).map((e: any) => e.id.toLowerCase());
-  const hasJJ = eqs.some((e: string) => e.includes('jump-jet') || e.includes('jump jet'));
+  const hasJJ = eqs.some(
+    (e: string) => e.includes('jump-jet') || e.includes('jump jet'),
+  );
   const hasMASC = eqs.some((e: string) => e.includes('masc'));
   const hasSC = eqs.some((e: string) => e.includes('supercharger'));
-  const hasPartialWing = eqs.some((e: string) => e.includes('partial-wing') || e.includes('partialwing'));
+  const hasPartialWing = eqs.some(
+    (e: string) => e.includes('partial-wing') || e.includes('partialwing'),
+  );
   const hasUMU = eqs.some((e: string) => e.includes('umu'));
-  console.log(`  JJ=${hasJJ} MASC=${hasMASC} SC=${hasSC} PW=${hasPartialWing} UMU=${hasUMU}`);
+  console.log(
+    `  JJ=${hasJJ} MASC=${hasMASC} SC=${hasSC} PW=${hasPartialWing} UMU=${hasUMU}`,
+  );
   console.log('');
 }
 
 // Also check DF=1.6 and DF=1.7 for comparison
 for (const targetDF of [1.6, 1.7]) {
-  const group = valid.filter((x: any) => x.breakdown?.defensiveFactor >= targetDF - 0.05 && x.breakdown?.defensiveFactor <= targetDF + 0.05);
+  const group = valid.filter(
+    (x: any) =>
+      x.breakdown?.defensiveFactor >= targetDF - 0.05 &&
+      x.breakdown?.defensiveFactor <= targetDF + 0.05,
+  );
   const over = group.filter((x: any) => x.percentDiff > 1);
-  console.log(`DF=${targetDF}: ${group.length} units, ${over.length} overcalculated`);
+  console.log(
+    `DF=${targetDF}: ${group.length} units, ${over.length} overcalculated`,
+  );
   for (const u of over.slice(0, 3)) {
     const b = u.breakdown;
     const unit = loadUnit(u.unitId);
-    console.log(`  ${u.unitId}: diff=${u.percentDiff.toFixed(1)}% run=${b.runMP} jump=${b.jumpMP} walk=${unit?.movement?.walk}`);
+    console.log(
+      `  ${u.unitId}: diff=${u.percentDiff.toFixed(1)}% run=${b.runMP} jump=${b.jumpMP} walk=${unit?.movement?.walk}`,
+    );
   }
 }

--- a/scripts/check-explosive-penalty.ts
+++ b/scripts/check-explosive-penalty.ts
@@ -2,19 +2,15 @@
  * Check if explosive ammo penalty is being correctly applied.
  * Theory: overcalculated units might be missing explosive ammo penalties.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
-
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown,
+);
 
 // Find units that have ammo but zero explosive penalty AND no CASE protection
 let suspiciousCount = 0;
@@ -37,7 +33,10 @@ for (const u of valid) {
     for (const [, slots] of Object.entries(unit.criticalSlots || {})) {
       if (!Array.isArray(slots)) continue;
       for (const s of slots) {
-        if (typeof s === 'string' && /case/i.test(s.replace(/\(omnipod\)/gi,'').trim())) {
+        if (
+          typeof s === 'string' &&
+          /case/i.test(s.replace(/\(omnipod\)/gi, '').trim())
+        ) {
           hasCASE = true;
         }
       }
@@ -55,33 +54,56 @@ for (const u of valid) {
   }
 }
 
-console.log(`=== IS UNITS WITH AMMO, NO CASE, NO EXPLOSIVE PENALTY: ${suspiciousCount} ===\n`);
-const overSusp = suspicious.filter(u => u.diff > 0).sort((a, b) => b.diff - a.diff);
-const underSusp = suspicious.filter(u => u.diff < 0);
+console.log(
+  `=== IS UNITS WITH AMMO, NO CASE, NO EXPLOSIVE PENALTY: ${suspiciousCount} ===\n`,
+);
+const overSusp = suspicious
+  .filter((u) => u.diff > 0)
+  .sort((a, b) => b.diff - a.diff);
+const underSusp = suspicious.filter((u) => u.diff < 0);
 console.log(`Overcalculated: ${overSusp.length}`);
 for (const u of overSusp.slice(0, 20)) {
-  console.log(`  ${u.unitId.padEnd(45)} diff=${u.diff.toFixed(1).padStart(6)}% ammoBV=${u.ammoBV}`);
+  console.log(
+    `  ${u.unitId.padEnd(45)} diff=${u.diff.toFixed(1).padStart(6)}% ammoBV=${u.ammoBV}`,
+  );
 }
 console.log(`Undercalculated: ${underSusp.length}`);
 
 // Check explosive penalty distribution
 console.log(`\n=== EXPLOSIVE PENALTY DISTRIBUTION (all units) ===`);
-const bands: Record<string, {count: number, avgDiff: number}> = {};
+const bands: Record<string, { count: number; avgDiff: number }> = {};
 for (const u of valid) {
   const pen = u.breakdown?.explosivePenalty || 0;
-  const band = pen === 0 ? '0' : pen <= 15 ? '1-15' : pen <= 30 ? '16-30' : pen <= 60 ? '31-60' : pen <= 120 ? '61-120' : '121+';
-  if (!bands[band]) bands[band] = {count: 0, avgDiff: 0};
+  const band =
+    pen === 0
+      ? '0'
+      : pen <= 15
+        ? '1-15'
+        : pen <= 30
+          ? '16-30'
+          : pen <= 60
+            ? '31-60'
+            : pen <= 120
+              ? '61-120'
+              : '121+';
+  if (!bands[band]) bands[band] = { count: 0, avgDiff: 0 };
   bands[band].count++;
   bands[band].avgDiff += u.percentDiff;
 }
 for (const [band, data] of Object.entries(bands)) {
-  console.log(`  pen=${band.padEnd(8)}: ${String(data.count).padStart(5)} units, avgDiff=${(data.avgDiff/data.count).toFixed(2)}%`);
+  console.log(
+    `  pen=${band.padEnd(8)}: ${String(data.count).padStart(5)} units, avgDiff=${(data.avgDiff / data.count).toFixed(2)}%`,
+  );
 }
 
 // For the most overcalculated units, check explosive situation
 console.log(`\n=== OVERCALCULATED >5% WITH AMMO ===`);
-const bigOver = valid.filter((x: any) => x.percentDiff > 5 && x.breakdown?.ammoBV > 0);
-for (const u of bigOver.sort((a: any, b: any) => b.percentDiff - a.percentDiff).slice(0, 15)) {
+const bigOver = valid.filter(
+  (x: any) => x.percentDiff > 5 && x.breakdown?.ammoBV > 0,
+);
+for (const u of bigOver
+  .sort((a: any, b: any) => b.percentDiff - a.percentDiff)
+  .slice(0, 15)) {
   const b = u.breakdown;
   const unit = loadUnit(u.unitId);
   const hasCASEInCrits = (() => {
@@ -93,5 +115,7 @@ for (const u of bigOver.sort((a: any, b: any) => b.percentDiff - a.percentDiff).
     }
     return 'none';
   })();
-  console.log(`  ${u.unitId.padEnd(45)} diff=${u.percentDiff.toFixed(1)}% ammoBV=${b.ammoBV} expPen=${b.explosivePenalty?.toFixed(0)} CASE=${hasCASEInCrits} tech=${unit?.techBase}`);
+  console.log(
+    `  ${u.unitId.padEnd(45)} diff=${u.percentDiff.toFixed(1)}% ammoBV=${b.ammoBV} expPen=${b.explosivePenalty?.toFixed(0)} CASE=${hasCASEInCrits} tech=${unit?.techBase}`,
+  );
 }

--- a/scripts/check-false-masc.ts
+++ b/scripts/check-false-masc.ts
@@ -2,27 +2,36 @@
  * Check for false MASC/Supercharger detection by comparing
  * equipment list, crit slots, and runMP calculation.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
-
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null,
+);
 const suspectUnits = [
-  'alpha-wolf-a', 'berserker-brz-c3', 'black-knight-bl-6-knt-ian',
-  'black-lanner-f', 'cadaver-cvr-t1', 'celerity-clr-03-ob',
-  'celerity-clr-03-od', 'celerity-clr-03-oe', 'charger-c',
-  'charger-cgr-1x1', 'daedalus-dad-4a', 'doloire-dlr-od',
-  'gladiator-gld-1r-keller', 'hatamoto-chi-htm-27t-lowenbrau',
-  'hitman-hm-2', 'jade-hawk-jhk-03', 'linebacker-i',
-  'mantis-mts-l', 'raptor-ii-rpt-2x2', 'raptor-ii-rpt-3x',
+  'alpha-wolf-a',
+  'berserker-brz-c3',
+  'black-knight-bl-6-knt-ian',
+  'black-lanner-f',
+  'cadaver-cvr-t1',
+  'celerity-clr-03-ob',
+  'celerity-clr-03-od',
+  'celerity-clr-03-oe',
+  'charger-c',
+  'charger-cgr-1x1',
+  'daedalus-dad-4a',
+  'doloire-dlr-od',
+  'gladiator-gld-1r-keller',
+  'hatamoto-chi-htm-27t-lowenbrau',
+  'hitman-hm-2',
+  'jade-hawk-jhk-03',
+  'linebacker-i',
+  'mantis-mts-l',
+  'raptor-ii-rpt-2x2',
+  'raptor-ii-rpt-3x',
 ];
 
 console.log('=== CHECKING MASC/SC IN CRIT SLOTS ===\n');
@@ -31,7 +40,10 @@ let truePositives = 0;
 
 for (const uid of suspectUnits) {
   const unit = loadUnit(uid);
-  if (!unit) { console.log(`${uid}: NOT FOUND`); continue; }
+  if (!unit) {
+    console.log(`${uid}: NOT FOUND`);
+    continue;
+  }
   const r = valid.find((x: any) => x.unitId === uid);
 
   // Check crits for MASC/SC
@@ -65,7 +77,10 @@ for (const uid of suspectUnits) {
       if (!Array.isArray(slots)) continue;
       for (const s of slots) {
         if (!s || typeof s !== 'string') continue;
-        const lo = (s as string).replace(/\s*\(omnipod\)/gi, '').trim().toLowerCase();
+        const lo = (s as string)
+          .replace(/\s*\(omnipod\)/gi, '')
+          .trim()
+          .toLowerCase();
         if (lo.includes('masc') && !lo.includes('ammo')) {
           allCritMatches.push(`[${loc}] ${s}`);
         }
@@ -80,8 +95,11 @@ for (const uid of suspectUnits) {
   if (isFalse) trueFalsePositives++;
   else truePositives++;
 
-  console.log(`${uid}: walk=${walk} normalRun=${normalRun} runMP=${r?.breakdown?.runMP || '?'} MASC_crit=${critMASC} SC_crit=${critSC} ${isFalse ? '*** FALSE POSITIVE ***' : 'CORRECT'}`);
-  if (allCritMatches.length > 0) console.log(`  MASC matches: ${allCritMatches.join(', ')}`);
+  console.log(
+    `${uid}: walk=${walk} normalRun=${normalRun} runMP=${r?.breakdown?.runMP || '?'} MASC_crit=${critMASC} SC_crit=${critSC} ${isFalse ? '*** FALSE POSITIVE ***' : 'CORRECT'}`,
+  );
+  if (allCritMatches.length > 0)
+    console.log(`  MASC matches: ${allCritMatches.join(', ')}`);
   if (scSlots.length > 0) console.log(`  SC matches: ${scSlots.join(', ')}`);
   if (isFalse) {
     // Find what's causing the inflated runMP
@@ -98,7 +116,10 @@ for (const uid of suspectUnits) {
         if (!Array.isArray(slots)) continue;
         for (const s of slots) {
           if (!s || typeof s !== 'string') continue;
-          const lo = (s as string).replace(/\s*\(omnipod\)/gi, '').trim().toLowerCase();
+          const lo = (s as string)
+            .replace(/\s*\(omnipod\)/gi, '')
+            .trim()
+            .toLowerCase();
           if (lo.includes('supercharger') || lo.includes('super charger')) {
             console.log(`  SC CRIT HIT: [${loc}] ${s}`);
           }
@@ -108,7 +129,9 @@ for (const uid of suspectUnits) {
   }
 }
 
-console.log(`\nSummary: ${trueFalsePositives} true false positives, ${truePositives} correct detections`);
+console.log(
+  `\nSummary: ${trueFalsePositives} true false positives, ${truePositives} correct detections`,
+);
 
 // Now check ALL overcalculated units for false MASC/SC
 console.log('\n=== FULL SCAN: ALL OVERCALCULATED UNITS ===');
@@ -138,9 +161,13 @@ for (const u of over) {
       if (!Array.isArray(slots)) continue;
       for (const s of slots) {
         if (!s || typeof s !== 'string') continue;
-        const lo = (s as string).replace(/\s*\(omnipod\)/gi, '').trim().toLowerCase();
+        const lo = (s as string)
+          .replace(/\s*\(omnipod\)/gi, '')
+          .trim()
+          .toLowerCase();
         if (lo.includes('masc') && !lo.includes('ammo')) critMASC = true;
-        if (lo.includes('supercharger') || lo.includes('super charger')) critSC = true;
+        if (lo.includes('supercharger') || lo.includes('super charger'))
+          critSC = true;
       }
     }
   }
@@ -148,8 +175,12 @@ for (const u of over) {
   if (detectedMASC && !critMASC && !critSC) {
     totalFalseMASC++;
     if (u.percentDiff > 3) {
-      console.log(`  FALSE: ${u.unitId.padEnd(45)} +${u.percentDiff.toFixed(1)}% walk=${walk} normalRun=${normalRun} run=${b.runMP}`);
+      console.log(
+        `  FALSE: ${u.unitId.padEnd(45)} +${u.percentDiff.toFixed(1)}% walk=${walk} normalRun=${normalRun} run=${b.runMP}`,
+      );
     }
   }
 }
-console.log(`\n  Total false MASC/SC detections in overcalculated: ${totalFalseMASC}`);
+console.log(
+  `\n  Total false MASC/SC detections in overcalculated: ${totalFalseMASC}`,
+);

--- a/scripts/check-hag-c3.ts
+++ b/scripts/check-hag-c3.ts
@@ -1,19 +1,15 @@
 /**
  * Investigate HAG undercalculation and C3 slave issues.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
-
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown,
+);
 
 // HAG units
 console.log('=== HAG UNITS ===');
@@ -23,15 +19,26 @@ for (const r of valid) {
   if (!unit?.criticalSlots) continue;
   const critsStr = JSON.stringify(unit.criticalSlots).toLowerCase();
   if (critsStr.includes('hag')) {
-    const weaps = r.breakdown?.weapons?.filter((w: any) => w.id?.toLowerCase().includes('hag') || w.name?.toLowerCase().includes('hag')) || [];
+    const weaps =
+      r.breakdown?.weapons?.filter(
+        (w: any) =>
+          w.id?.toLowerCase().includes('hag') ||
+          w.name?.toLowerCase().includes('hag'),
+      ) || [];
     hagUnits.push({ ...r, hagWeapons: weaps, unit });
   }
 }
 
 console.log(`Total HAG units: ${hagUnits.length}`);
-for (const r of hagUnits.filter((x: any) => Math.abs(x.percentDiff) > 1).sort((a: any, b: any) => a.percentDiff - b.percentDiff)) {
-  const weaps = r.hagWeapons.map((w: any) => `${w.name||w.id}(bv=${w.bv})`).join(', ');
-  console.log(`  ${r.unitId.padEnd(40)} diff=${r.percentDiff.toFixed(1).padStart(5)}% ref=${r.indexBV} calc=${r.calculatedBV} HAG: ${weaps}`);
+for (const r of hagUnits
+  .filter((x: any) => Math.abs(x.percentDiff) > 1)
+  .sort((a: any, b: any) => a.percentDiff - b.percentDiff)) {
+  const weaps = r.hagWeapons
+    .map((w: any) => `${w.name || w.id}(bv=${w.bv})`)
+    .join(', ');
+  console.log(
+    `  ${r.unitId.padEnd(40)} diff=${r.percentDiff.toFixed(1).padStart(5)}% ref=${r.indexBV} calc=${r.calculatedBV} HAG: ${weaps}`,
+  );
 }
 
 // Check HAG weapon BV values
@@ -45,7 +52,9 @@ for (const r of hagUnits) {
   }
 }
 for (const [name, bvs] of hagBVs) {
-  console.log(`  ${name}: BV values = ${[...bvs].sort((a, b) => a - b).join(', ')}`);
+  console.log(
+    `  ${name}: BV values = ${[...bvs].sort((a, b) => a - b).join(', ')}`,
+  );
 }
 
 // C3 slave units
@@ -55,18 +64,28 @@ for (const r of valid) {
   const unit = loadUnit(r.unitId);
   if (!unit?.criticalSlots) continue;
   const critsStr = JSON.stringify(unit.criticalSlots).toLowerCase();
-  const hasC3Slave = critsStr.includes('c3 slave') || critsStr.includes('c3slave') || critsStr.includes('isc3boostedslaveunit');
-  const hasC3Master = critsStr.includes('c3 master') || critsStr.includes('c3master');
+  const hasC3Slave =
+    critsStr.includes('c3 slave') ||
+    critsStr.includes('c3slave') ||
+    critsStr.includes('isc3boostedslaveunit');
+  const hasC3Master =
+    critsStr.includes('c3 master') || critsStr.includes('c3master');
   if (hasC3Slave && !hasC3Master) {
     c3Units.push({ ...r, unit });
   }
 }
 
 const c3Outliers = c3Units.filter((x: any) => Math.abs(x.percentDiff) > 1);
-console.log(`Total C3 slave-only units: ${c3Units.length}, outliers: ${c3Outliers.length}`);
-for (const r of c3Outliers.sort((a: any, b: any) => a.percentDiff - b.percentDiff)) {
+console.log(
+  `Total C3 slave-only units: ${c3Units.length}, outliers: ${c3Outliers.length}`,
+);
+for (const r of c3Outliers.sort(
+  (a: any, b: any) => a.percentDiff - b.percentDiff,
+)) {
   const b = r.breakdown;
-  console.log(`  ${r.unitId.padEnd(40)} diff=${r.percentDiff.toFixed(1).padStart(5)}% ref=${r.indexBV} calc=${r.calculatedBV} DF=${b?.defensiveFactor} SF=${b?.speedFactor}`);
+  console.log(
+    `  ${r.unitId.padEnd(40)} diff=${r.percentDiff.toFixed(1).padStart(5)}% ref=${r.indexBV} calc=${r.calculatedBV} DF=${b?.defensiveFactor} SF=${b?.speedFactor}`,
+  );
 }
 
 // Check: PPC Capacitor units
@@ -77,16 +96,31 @@ for (const r of valid) {
   if (!unit?.criticalSlots) continue;
   const critsStr = JSON.stringify(unit.criticalSlots).toLowerCase();
   if (critsStr.includes('ppc capacitor') || critsStr.includes('ppccapacitor')) {
-    const weaps = r.breakdown?.weapons?.filter((w: any) => w.id?.toLowerCase().includes('ppc') || w.name?.toLowerCase().includes('ppc')) || [];
+    const weaps =
+      r.breakdown?.weapons?.filter(
+        (w: any) =>
+          w.id?.toLowerCase().includes('ppc') ||
+          w.name?.toLowerCase().includes('ppc'),
+      ) || [];
     ppcCapUnits.push({ ...r, ppcWeapons: weaps, unit });
   }
 }
 
-const ppcCapOutliers = ppcCapUnits.filter((x: any) => Math.abs(x.percentDiff) > 1);
-console.log(`Total PPC Capacitor units: ${ppcCapUnits.length}, outliers: ${ppcCapOutliers.length}`);
-for (const r of ppcCapOutliers.sort((a: any, b: any) => a.percentDiff - b.percentDiff)) {
-  const weaps = r.ppcWeapons.map((w: any) => `${w.name||w.id}(bv=${w.bv})`).join(', ');
-  console.log(`  ${r.unitId.padEnd(40)} diff=${r.percentDiff.toFixed(1).padStart(5)}% ref=${r.indexBV} calc=${r.calculatedBV} PPC: ${weaps}`);
+const ppcCapOutliers = ppcCapUnits.filter(
+  (x: any) => Math.abs(x.percentDiff) > 1,
+);
+console.log(
+  `Total PPC Capacitor units: ${ppcCapUnits.length}, outliers: ${ppcCapOutliers.length}`,
+);
+for (const r of ppcCapOutliers.sort(
+  (a: any, b: any) => a.percentDiff - b.percentDiff,
+)) {
+  const weaps = r.ppcWeapons
+    .map((w: any) => `${w.name || w.id}(bv=${w.bv})`)
+    .join(', ');
+  console.log(
+    `  ${r.unitId.padEnd(40)} diff=${r.percentDiff.toFixed(1).padStart(5)}% ref=${r.indexBV} calc=${r.calculatedBV} PPC: ${weaps}`,
+  );
 }
 
 // Check: do we handle PPC Capacitor BV bonus? It adds +5 damage and changes BV
@@ -99,7 +133,8 @@ for (const r of ppcCapOutliers.slice(0, 5)) {
   for (const [loc, slots] of Object.entries(unit.criticalSlots || {})) {
     if (!Array.isArray(slots)) continue;
     for (const s of slots) {
-      if (typeof s === 'string' && s.toLowerCase().includes('ppc capacitor')) capCount++;
+      if (typeof s === 'string' && s.toLowerCase().includes('ppc capacitor'))
+        capCount++;
     }
   }
   console.log(`  ${r.unitId}: ${capCount} PPC Capacitor crit slots`);

--- a/scripts/check-hag-engines.ts
+++ b/scripts/check-hag-engines.ts
@@ -1,26 +1,38 @@
 /**
  * Check engine types and structure BV for HAG undercalculated units.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
-
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown,
+);
 // HAG outliers
-const hagIds = ['amarok-3', 'boreas-a', 'boreas-b', 'boreas-d', 'thunder-stallion-3', 'marauder-iic-4', 'rifleman-iic-6', 'osteon-e', 'battlemaster-c', 'jupiter-3', 'notos-a', 'rifleman-rfl-x3-muse-wind'];
+const hagIds = [
+  'amarok-3',
+  'boreas-a',
+  'boreas-b',
+  'boreas-d',
+  'thunder-stallion-3',
+  'marauder-iic-4',
+  'rifleman-iic-6',
+  'osteon-e',
+  'battlemaster-c',
+  'jupiter-3',
+  'notos-a',
+  'rifleman-rfl-x3-muse-wind',
+];
 
 for (const unitId of hagIds) {
   const unit = loadUnit(unitId);
   const r = valid.find((x: any) => x.unitId === unitId);
-  if (!unit || !r) { console.log(`${unitId}: not found`); continue; }
+  if (!unit || !r) {
+    console.log(`${unitId}: not found`);
+    continue;
+  }
   const b = r.breakdown;
   const engineType = unit.engine?.type || 'STANDARD';
   const structType = unit.structure?.type || 'STANDARD';
@@ -28,7 +40,9 @@ for (const unitId of hagIds) {
   // Compute expected structBV
   const STRUCTURE_POINTS: Record<number, number> = {};
   // Just show the values we have
-  console.log(`${unitId.padEnd(35)} ${unit.tonnage}t engine=${engineType.padEnd(10)} struct=${structType.padEnd(15)} structBV=${b?.structureBV?.toFixed(0)} diff=${r.percentDiff.toFixed(1)}% def=${b?.defensiveBV?.toFixed(0)} off=${b?.offensiveBV?.toFixed(0)}`);
+  console.log(
+    `${unitId.padEnd(35)} ${unit.tonnage}t engine=${engineType.padEnd(10)} struct=${structType.padEnd(15)} structBV=${b?.structureBV?.toFixed(0)} diff=${r.percentDiff.toFixed(1)}% def=${b?.defensiveBV?.toFixed(0)} off=${b?.offensiveBV?.toFixed(0)}`,
+  );
 }
 
 // Check: for ALL undercalculated outliers, what are their engine types?
@@ -41,21 +55,39 @@ for (const r of underOutliers) {
   const et = unit.engine?.type || 'STANDARD';
   engineCounts[et] = (engineCounts[et] || 0) + 1;
 }
-for (const [et, count] of Object.entries(engineCounts).sort((a, b) => b[1] - a[1])) {
+for (const [et, count] of Object.entries(engineCounts).sort(
+  (a, b) => b[1] - a[1],
+)) {
   console.log(`  ${et}: ${count}`);
 }
 
 // Check: for C3 slave undercalculated units, what are their details?
 console.log('\n=== C3 SLAVE UNDERCALCULATED DETAILS ===');
-const c3Ids = ['barghest-bgs-4t', 'revenant-ubm-2r4', 'celerity-clr-03-o', 'raven-rvn-4lc', 'tessen-tsn-c3', 'tessen-tsn-1cr', 'whitworth-wth-3', 'thanatos-tns-6s', 'night-stalker-nsr-kc'];
+const c3Ids = [
+  'barghest-bgs-4t',
+  'revenant-ubm-2r4',
+  'celerity-clr-03-o',
+  'raven-rvn-4lc',
+  'tessen-tsn-c3',
+  'tessen-tsn-1cr',
+  'whitworth-wth-3',
+  'thanatos-tns-6s',
+  'night-stalker-nsr-kc',
+];
 for (const unitId of c3Ids) {
   const unit = loadUnit(unitId);
   const r = valid.find((x: any) => x.unitId === unitId);
   if (!unit || !r) continue;
   const b = r.breakdown;
   // Check for C3 equipment
-  const equip = (unit.equipment || []).filter((e: any) => e.id.toLowerCase().includes('c3'));
-  console.log(`  ${unitId.padEnd(35)} ${r.percentDiff.toFixed(1).padStart(5)}% ${unit.tonnage}t ${unit.techBase} equip=${equip.map((e: any) => e.id).join(',')}`);
+  const equip = (unit.equipment || []).filter((e: any) =>
+    e.id.toLowerCase().includes('c3'),
+  );
+  console.log(
+    `  ${unitId.padEnd(35)} ${r.percentDiff.toFixed(1).padStart(5)}% ${unit.tonnage}t ${unit.techBase} equip=${equip.map((e: any) => e.id).join(',')}`,
+  );
   // Check if C3 slave adds to any BV component
-  console.log(`    defEq=${b?.defEquipBV?.toFixed(0)} offEq=${b?.offEquipBV} wBV=${b?.weaponBV?.toFixed(0)} ammo=${b?.ammoBV}`);
+  console.log(
+    `    defEq=${b?.defEquipBV?.toFixed(0)} offEq=${b?.offEquipBV} wBV=${b?.weaponBV?.toFixed(0)} ammo=${b?.ammoBV}`,
+  );
 }

--- a/scripts/check-head-crit-names.ts
+++ b/scripts/check-head-crit-names.ts
@@ -2,19 +2,15 @@
  * Check HEAD crit slot naming for small cockpit vs standard cockpit.
  * Does the crit slot say "Small Cockpit" vs "Cockpit"?
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
-
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown,
+);
 const with095 = valid.filter((x: any) => x.breakdown?.cockpitModifier === 0.95);
 
 // For all units with cockpit=0.95, check HEAD crit names
@@ -38,17 +34,25 @@ for (const r of with095) {
 }
 
 console.log('=== COCKPIT CRIT SLOT NAMES (in 0.95 modifier units) ===');
-for (const [name, count] of [...cockpitNames.entries()].sort((a, b) => b[1] - a[1])) {
+for (const [name, count] of [...cockpitNames.entries()].sort(
+  (a, b) => b[1] - a[1],
+)) {
   console.log(`  "${name}": ${count}`);
 }
 
 // Check LS=1 false positives — what's in their HEAD?
 console.log('\n=== HEAD LAYOUT OF LS=1 FALSE POSITIVE CANDIDATES ===');
 const falsePosIds = [
-  'barghest-bgs-4t', 'celerity-clr-02-x-d', 'celerity-clr-03-o',
-  'celerity-clr-03-ob', 'celerity-clr-03-oc', 'celerity-clr-05-x',
-  'revenant-ubm-2r4', 'revenant-ubm-2r7', 'thunder-fox-tft-l8',
-  'galahad-glh-3d-laodices'
+  'barghest-bgs-4t',
+  'celerity-clr-02-x-d',
+  'celerity-clr-03-o',
+  'celerity-clr-03-ob',
+  'celerity-clr-03-oc',
+  'celerity-clr-05-x',
+  'revenant-ubm-2r4',
+  'revenant-ubm-2r7',
+  'thunder-fox-tft-l8',
+  'galahad-glh-3d-laodices',
 ];
 
 for (const unitId of falsePosIds) {
@@ -62,7 +66,11 @@ for (const unitId of falsePosIds) {
 
 // And a confirmed small cockpit unit for comparison
 console.log('\n=== CONFIRMED SMALL COCKPIT UNITS HEAD LAYOUT ===');
-const confirmedSmall = ['axman-axm-6t', 'black-knight-blk-nt-2y', 'hierofalcon-d'];
+const confirmedSmall = [
+  'axman-axm-6t',
+  'black-knight-blk-nt-2y',
+  'hierofalcon-d',
+];
 for (const unitId of confirmedSmall) {
   const unit = loadUnit(unitId);
   if (!unit) continue;

--- a/scripts/check-ls1-undercalc.ts
+++ b/scripts/check-ls1-undercalc.ts
@@ -2,71 +2,108 @@
  * Check LS=1 heuristic false positives that are UNDERCALCULATED.
  * These would benefit from removing the 0.95 modifier.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
-
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
 const KNOWN_SMALL_COCKPIT_UNITS = new Set([
-  'archer-arc-4m-ismail', 'atlas-as7-s-hanssen',
-  'axman-axm-6t', 'axman-axm-6x',
-  'black-knight-blk-nt-2y', 'black-knight-blk-nt-3b',
+  'archer-arc-4m-ismail',
+  'atlas-as7-s-hanssen',
+  'axman-axm-6t',
+  'axman-axm-6x',
+  'black-knight-blk-nt-2y',
+  'black-knight-blk-nt-3b',
   'crockett-crk-5003-0-saddleford',
-  'helepolis-hep-2x', 'hermes-ii-her-5c', 'hierofalcon-d',
+  'helepolis-hep-2x',
+  'hermes-ii-her-5c',
+  'hierofalcon-d',
   'pathfinder-pff-2t',
-  'phoenix-hawk-pxh-1bc', 'phoenix-hawk-pxh-7cs',
-  'raven-rvn-3l', 'raven-rvn-3m', 'raven-rvn-4l', 'raven-rvn-4lc',
+  'phoenix-hawk-pxh-1bc',
+  'phoenix-hawk-pxh-7cs',
+  'raven-rvn-3l',
+  'raven-rvn-3m',
+  'raven-rvn-4l',
+  'raven-rvn-4lc',
   'scorpion-scp-12c',
-  'tessen-tsn-1cr', 'tessen-tsn-c3',
+  'tessen-tsn-1cr',
+  'tessen-tsn-c3',
 ]);
 
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown);
-
-// Find units with cockpit=0.95 that are undercalculated, NOT in the known list
-console.log('=== UNDERCALCULATED units with cockpit=0.95, NOT in known list ===');
-const underSmall = valid.filter((x: any) =>
-  x.breakdown?.cockpitModifier === 0.95 && x.percentDiff < -1 &&
-  !KNOWN_SMALL_COCKPIT_UNITS.has(x.unitId)
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown,
 );
 
-for (const r of underSmall.sort((a: any, b: any) => a.percentDiff - b.percentDiff)) {
+// Find units with cockpit=0.95 that are undercalculated, NOT in the known list
+console.log(
+  '=== UNDERCALCULATED units with cockpit=0.95, NOT in known list ===',
+);
+const underSmall = valid.filter(
+  (x: any) =>
+    x.breakdown?.cockpitModifier === 0.95 &&
+    x.percentDiff < -1 &&
+    !KNOWN_SMALL_COCKPIT_UNITS.has(x.unitId),
+);
+
+for (const r of underSmall.sort(
+  (a: any, b: any) => a.percentDiff - b.percentDiff,
+)) {
   const unit = loadUnit(r.unitId);
   const headSlots = unit?.criticalSlots?.HEAD || unit?.criticalSlots?.HD || [];
-  const lsCount = headSlots.filter((s: any) => typeof s === 'string' && s.toLowerCase().includes('life support')).length;
+  const lsCount = headSlots.filter(
+    (s: any) =>
+      typeof s === 'string' && s.toLowerCase().includes('life support'),
+  ).length;
   const with10 = Math.round(r.calculatedBV / 0.95);
-  const newPct = ((with10 - r.indexBV) / r.indexBV * 100);
+  const newPct = ((with10 - r.indexBV) / r.indexBV) * 100;
   const improved = Math.abs(newPct) < Math.abs(r.percentDiff);
-  console.log(`  ${r.unitId.padEnd(40)} ${r.percentDiff.toFixed(1).padStart(6)}% LS=${lsCount} cockpit=${unit?.cockpit||'?'} with1.0→${newPct.toFixed(1).padStart(6)}% ${improved ? '✓BETTER' : '✗WORSE'}`);
+  console.log(
+    `  ${r.unitId.padEnd(40)} ${r.percentDiff.toFixed(1).padStart(6)}% LS=${lsCount} cockpit=${unit?.cockpit || '?'} with1.0→${newPct.toFixed(1).padStart(6)}% ${improved ? '✓BETTER' : '✗WORSE'}`,
+  );
 }
 
 // Count all units with cockpit=0.95
 const all095 = valid.filter((x: any) => x.breakdown?.cockpitModifier === 0.95);
 console.log(`\nTotal units with cockpit=0.95: ${all095.length}`);
-console.log(`  In KNOWN list: ${all095.filter((x: any) => KNOWN_SMALL_COCKPIT_UNITS.has(x.unitId)).length}`);
-console.log(`  LS=1 heuristic: ${all095.filter((x: any) => {
-  const unit = loadUnit(x.unitId);
-  const hs = unit?.criticalSlots?.HEAD || unit?.criticalSlots?.HD || [];
-  return hs.filter((s: any) => typeof s === 'string' && s.toLowerCase().includes('life support')).length === 1;
-}).length}`);
+console.log(
+  `  In KNOWN list: ${all095.filter((x: any) => KNOWN_SMALL_COCKPIT_UNITS.has(x.unitId)).length}`,
+);
+console.log(
+  `  LS=1 heuristic: ${
+    all095.filter((x: any) => {
+      const unit = loadUnit(x.unitId);
+      const hs = unit?.criticalSlots?.HEAD || unit?.criticalSlots?.HD || [];
+      return (
+        hs.filter(
+          (s: any) =>
+            typeof s === 'string' && s.toLowerCase().includes('life support'),
+        ).length === 1
+      );
+    }).length
+  }`,
+);
 
 // Check: what cockpit detection source is each 0.95 unit using?
 // (Drone OS also gives 0.95)
 console.log('\n=== BREAKDOWN BY COCKPIT DETECTION SOURCE ===');
-let droneOS = 0, ls1 = 0, knownList = 0, other = 0;
+let droneOS = 0,
+  ls1 = 0,
+  knownList = 0,
+  other = 0;
 for (const r of all095) {
   const unit = loadUnit(r.unitId);
   if (!unit) continue;
   const headSlots = unit?.criticalSlots?.HEAD || unit?.criticalSlots?.HD || [];
-  const lsCount = headSlots.filter((s: any) => typeof s === 'string' && s.toLowerCase().includes('life support')).length;
-  const isDroneOS = r.breakdown?.cockpitType === 'drone' ||
-    headSlots.some((s: any) => typeof s === 'string' && s.toLowerCase().includes('drone'));
+  const lsCount = headSlots.filter(
+    (s: any) =>
+      typeof s === 'string' && s.toLowerCase().includes('life support'),
+  ).length;
+  const isDroneOS =
+    r.breakdown?.cockpitType === 'drone' ||
+    headSlots.some(
+      (s: any) => typeof s === 'string' && s.toLowerCase().includes('drone'),
+    );
   const inKnown = KNOWN_SMALL_COCKPIT_UNITS.has(r.unitId);
 
   if (isDroneOS) droneOS++;

--- a/scripts/check-masc-heat-impact.ts
+++ b/scripts/check-masc-heat-impact.ts
@@ -2,19 +2,15 @@
  * Check how MASC/SC heat change affects BV accuracy.
  * Compare units with MASC/SC in the validation report.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
-
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null,
+);
 
 // Find all units where the breakdown shows MASC or SC
 let mascCount = 0;
@@ -38,9 +34,13 @@ for (const u of valid) {
       if (!Array.isArray(slots)) continue;
       for (const s of slots) {
         if (!s || typeof s !== 'string') continue;
-        const lo = (s as string).replace(/\s*\(omnipod\)/gi, '').trim().toLowerCase();
+        const lo = (s as string)
+          .replace(/\s*\(omnipod\)/gi, '')
+          .trim()
+          .toLowerCase();
         if (lo.includes('masc') && !lo.includes('ammo')) hasMASC = true;
-        if (lo.includes('supercharger') || lo.includes('super charger')) hasSC = true;
+        if (lo.includes('supercharger') || lo.includes('super charger'))
+          hasSC = true;
       }
     }
   }
@@ -61,7 +61,9 @@ for (const u of valid) {
   if (pct > 1) {
     const walk = unit.movement?.walk || 0;
     const normalRun = Math.ceil(walk * 1.5);
-    console.log(`${u.unitId.padEnd(45)} ${u.percentDiff > 0 ? '+' : ''}${u.percentDiff.toFixed(1)}% walk=${walk} run=${b.runMP} normalRun=${normalRun} MASC=${hasMASC} SC=${hasSC} HE=${b.heatEfficiency} SF=${b.speedFactor}`);
+    console.log(
+      `${u.unitId.padEnd(45)} ${u.percentDiff > 0 ? '+' : ''}${u.percentDiff.toFixed(1)}% walk=${walk} run=${b.runMP} normalRun=${normalRun} MASC=${hasMASC} SC=${hasSC} HE=${b.heatEfficiency} SF=${b.speedFactor}`,
+    );
   }
 }
 

--- a/scripts/check-modular-armor.ts
+++ b/scripts/check-modular-armor.ts
@@ -1,24 +1,25 @@
 /**
  * Count units with Modular Armor and check impact.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
-
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null,
+);
 
 let totalWithModArmor = 0;
 let underWithModArmor = 0;
 let exactWithModArmor = 0;
-const modArmorUnits: Array<{ id: string; count: number; status: string; pctDiff: number }> = [];
+const modArmorUnits: Array<{
+  id: string;
+  count: number;
+  status: string;
+  pctDiff: number;
+}> = [];
 
 for (const u of valid) {
   const unit = loadUnit(u.unitId);
@@ -28,7 +29,10 @@ for (const u of valid) {
     if (!Array.isArray(slots)) continue;
     for (const s of slots as string[]) {
       if (!s || typeof s !== 'string') continue;
-      if (s.toLowerCase().includes('modulararmor') || s.toLowerCase().includes('modular armor')) {
+      if (
+        s.toLowerCase().includes('modulararmor') ||
+        s.toLowerCase().includes('modular armor')
+      ) {
         modCount++;
       }
     }
@@ -37,7 +41,12 @@ for (const u of valid) {
     totalWithModArmor++;
     if (u.status === 'exact') exactWithModArmor++;
     if (u.percentDiff < -1) underWithModArmor++;
-    modArmorUnits.push({ id: u.unitId, count: modCount, status: u.status, pctDiff: u.percentDiff || 0 });
+    modArmorUnits.push({
+      id: u.unitId,
+      count: modCount,
+      status: u.status,
+      pctDiff: u.percentDiff || 0,
+    });
   }
 }
 
@@ -48,5 +57,7 @@ console.log(`Undercalculated >1%: ${underWithModArmor}`);
 console.log('');
 
 for (const u of modArmorUnits.sort((a, b) => a.pctDiff - b.pctDiff)) {
-  console.log(`  ${u.id.padEnd(40)} slots=${u.count} pct=${u.pctDiff.toFixed(1)}% status=${u.status}`);
+  console.log(
+    `  ${u.id.padEnd(40)} slots=${u.count} pct=${u.pctDiff.toFixed(1)}% status=${u.status}`,
+  );
 }

--- a/scripts/check-offeq-tc.ts
+++ b/scripts/check-offeq-tc.ts
@@ -2,19 +2,15 @@
  * Check offensive equipment BV and targeting computer handling.
  * Is offEquipBV overcounted? Is TC bonus applied correctly?
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
-
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown,
+);
 
 // Check: units with offEquipBV > 0
 const withOffEq = valid.filter((x: any) => (x.breakdown?.offEquipBV || 0) > 0);
@@ -22,10 +18,20 @@ console.log(`=== OFFENSIVE EQUIPMENT BV ===`);
 console.log(`Units with offEquipBV > 0: ${withOffEq.length}`);
 const offEqOutlier = withOffEq.filter((x: any) => Math.abs(x.percentDiff) > 1);
 const offEqWithin = withOffEq.filter((x: any) => Math.abs(x.percentDiff) <= 1);
-console.log(`  Outlier rate: ${(offEqOutlier.length/withOffEq.length*100).toFixed(1)}% (${offEqOutlier.length}/${withOffEq.length})`);
-const avgErrOffEq = withOffEq.reduce((s: number, x: any) => s + x.percentDiff, 0) / withOffEq.length;
-const avgErrNoOffEq = valid.filter((x: any) => !(x.breakdown?.offEquipBV > 0)).reduce((s: number, x: any) => s + x.percentDiff, 0) / valid.filter((x: any) => !(x.breakdown?.offEquipBV > 0)).length;
-console.log(`  Avg error with offEquipBV: ${avgErrOffEq.toFixed(3)}%, without: ${avgErrNoOffEq.toFixed(3)}%`);
+console.log(
+  `  Outlier rate: ${((offEqOutlier.length / withOffEq.length) * 100).toFixed(1)}% (${offEqOutlier.length}/${withOffEq.length})`,
+);
+const avgErrOffEq =
+  withOffEq.reduce((s: number, x: any) => s + x.percentDiff, 0) /
+  withOffEq.length;
+const avgErrNoOffEq =
+  valid
+    .filter((x: any) => !(x.breakdown?.offEquipBV > 0))
+    .reduce((s: number, x: any) => s + x.percentDiff, 0) /
+  valid.filter((x: any) => !(x.breakdown?.offEquipBV > 0)).length;
+console.log(
+  `  Avg error with offEquipBV: ${avgErrOffEq.toFixed(3)}%, without: ${avgErrNoOffEq.toFixed(3)}%`,
+);
 
 // What are the offEquipBV values?
 console.log('\n=== OFFEQBV DISTRIBUTION ===');
@@ -34,9 +40,12 @@ for (const r of withOffEq) {
   const v = r.breakdown.offEquipBV;
   offEqValues.set(v, (offEqValues.get(v) || 0) + 1);
 }
-for (const [v, count] of [...offEqValues.entries()].sort((a, b) => b[1] - a[1]).slice(0, 15)) {
+for (const [v, count] of [...offEqValues.entries()]
+  .sort((a, b) => b[1] - a[1])
+  .slice(0, 15)) {
   const subset = withOffEq.filter((x: any) => x.breakdown.offEquipBV === v);
-  const avgErr = subset.reduce((s: number, x: any) => s + x.percentDiff, 0) / subset.length;
+  const avgErr =
+    subset.reduce((s: number, x: any) => s + x.percentDiff, 0) / subset.length;
   console.log(`  offEqBV=${v}: ${count} units, avg err=${avgErr.toFixed(2)}%`);
 }
 
@@ -46,7 +55,9 @@ console.log('\n=== TARGETING COMPUTER ===');
 const withTC = valid.filter((x: any) => {
   const w = x.breakdown?.weapons;
   if (!w || !Array.isArray(w)) return false;
-  return w.some((ww: any) => ww.name?.includes('(TC)') || ww.bvNote?.includes('TC'));
+  return w.some(
+    (ww: any) => ww.name?.includes('(TC)') || ww.bvNote?.includes('TC'),
+  );
 });
 
 // Alternative: check unit crits for TC
@@ -64,7 +75,11 @@ for (const r of valid) {
     for (const s of slots) {
       if (typeof s !== 'string') continue;
       const lo = s.toLowerCase().replace(/\s*\(omnipod\)/gi, '');
-      if (lo.includes('targeting computer') || lo === 'istargetingcomputer' || lo === 'cltargetingcomputer') {
+      if (
+        lo.includes('targeting computer') ||
+        lo === 'istargetingcomputer' ||
+        lo === 'cltargetingcomputer'
+      ) {
         hasTC = true;
         break;
       }
@@ -83,26 +98,39 @@ for (const r of valid) {
 }
 
 console.log(`Units with TC: ${tcCount}`);
-console.log(`TC outlier rate: ${(tcOutlier/tcCount*100).toFixed(1)}% (${tcOutlier} total, over=${tcOverCount}, under=${tcUnderCount})`);
-const avgTCErr = tcUnits.reduce((s: number, x: any) => s + x.percentDiff, 0) / tcUnits.length;
+console.log(
+  `TC outlier rate: ${((tcOutlier / tcCount) * 100).toFixed(1)}% (${tcOutlier} total, over=${tcOverCount}, under=${tcUnderCount})`,
+);
+const avgTCErr =
+  tcUnits.reduce((s: number, x: any) => s + x.percentDiff, 0) / tcUnits.length;
 console.log(`TC avg error: ${avgTCErr.toFixed(3)}%`);
 
 // TC outliers
 console.log('\nTC OUTLIERS:');
-for (const r of tcUnits.filter((x: any) => Math.abs(x.percentDiff) > 1).sort((a: any, b: any) => Math.abs(b.percentDiff) - Math.abs(a.percentDiff)).slice(0, 10)) {
-  console.log(`  ${r.unitId.padEnd(40)} diff=${r.percentDiff.toFixed(1).padStart(6)}% offEqBV=${r.breakdown?.offEquipBV}`);
+for (const r of tcUnits
+  .filter((x: any) => Math.abs(x.percentDiff) > 1)
+  .sort((a: any, b: any) => Math.abs(b.percentDiff) - Math.abs(a.percentDiff))
+  .slice(0, 10)) {
+  console.log(
+    `  ${r.unitId.padEnd(40)} diff=${r.percentDiff.toFixed(1).padStart(6)}% offEqBV=${r.breakdown?.offEquipBV}`,
+  );
 }
 
 // Check: what specific equipment is in offEquipBV?
 // Look at units where offEquipBV is pushing them over
 console.log('\n=== OVERCALCULATED WITH HIGH OFFEQBV ===');
-const overWithOffEq = valid.filter((x: any) => x.percentDiff > 1 && (x.breakdown?.offEquipBV || 0) > 0)
-  .sort((a: any, b: any) => b.percentDiff - a.percentDiff).slice(0, 10);
+const overWithOffEq = valid
+  .filter((x: any) => x.percentDiff > 1 && (x.breakdown?.offEquipBV || 0) > 0)
+  .sort((a: any, b: any) => b.percentDiff - a.percentDiff)
+  .slice(0, 10);
 for (const r of overWithOffEq) {
   const unit = loadUnit(r.unitId);
-  const equip = unit?.equipment?.filter((e: any) => {
-    const lo = e.id.toLowerCase();
-    return lo.includes('tag') || lo.includes('narc') || lo.includes('c3');
-  }) || [];
-  console.log(`  ${r.unitId.padEnd(40)} ${r.percentDiff.toFixed(1).padStart(5)}% offEqBV=${r.breakdown?.offEquipBV} equip=${equip.map((e: any) => e.id).join(',') || 'none'}`);
+  const equip =
+    unit?.equipment?.filter((e: any) => {
+      const lo = e.id.toLowerCase();
+      return lo.includes('tag') || lo.includes('narc') || lo.includes('c3');
+    }) || [];
+  console.log(
+    `  ${r.unitId.padEnd(40)} ${r.percentDiff.toFixed(1).padStart(5)}% offEqBV=${r.breakdown?.offEquipBV} equip=${equip.map((e: any) => e.id).join(',') || 'none'}`,
+  );
 }

--- a/scripts/check-prefix-resolve.ts
+++ b/scripts/check-prefix-resolve.ts
@@ -2,19 +2,15 @@
  * Check if "1-" prefix equipment IDs resolve correctly.
  * Compare accuracy of prefix vs non-prefix units.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
-
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null,
+);
 
 // Split into prefix and non-prefix units
 const prefixUnits: any[] = [];
@@ -28,11 +24,17 @@ for (const u of valid) {
   else nonPrefixUnits.push(u);
 }
 
-function stats(arr: any[]): { within1: number, within2: number, avgDiff: number, avgAbsDiff: number } {
-  const w1 = arr.filter(u => Math.abs(u.percentDiff) <= 1).length;
-  const w2 = arr.filter(u => Math.abs(u.percentDiff) <= 2).length;
+function stats(arr: any[]): {
+  within1: number;
+  within2: number;
+  avgDiff: number;
+  avgAbsDiff: number;
+} {
+  const w1 = arr.filter((u) => Math.abs(u.percentDiff) <= 1).length;
+  const w2 = arr.filter((u) => Math.abs(u.percentDiff) <= 2).length;
   const avg = arr.reduce((s, u) => s + u.percentDiff, 0) / arr.length;
-  const avgAbs = arr.reduce((s, u) => s + Math.abs(u.percentDiff), 0) / arr.length;
+  const avgAbs =
+    arr.reduce((s, u) => s + Math.abs(u.percentDiff), 0) / arr.length;
   return { within1: w1, within2: w2, avgDiff: avg, avgAbsDiff: avgAbs };
 }
 
@@ -41,28 +43,48 @@ const nStats = stats(nonPrefixUnits);
 
 console.log(`=== PREFIX vs NON-PREFIX ACCURACY ===`);
 console.log(`Prefix units: ${prefixUnits.length}`);
-console.log(`  Within 1%: ${pStats.within1} (${(pStats.within1/prefixUnits.length*100).toFixed(1)}%)`);
-console.log(`  Within 2%: ${pStats.within2} (${(pStats.within2/prefixUnits.length*100).toFixed(1)}%)`);
-console.log(`  Avg diff: ${pStats.avgDiff.toFixed(2)}%, avg abs: ${pStats.avgAbsDiff.toFixed(2)}%`);
+console.log(
+  `  Within 1%: ${pStats.within1} (${((pStats.within1 / prefixUnits.length) * 100).toFixed(1)}%)`,
+);
+console.log(
+  `  Within 2%: ${pStats.within2} (${((pStats.within2 / prefixUnits.length) * 100).toFixed(1)}%)`,
+);
+console.log(
+  `  Avg diff: ${pStats.avgDiff.toFixed(2)}%, avg abs: ${pStats.avgAbsDiff.toFixed(2)}%`,
+);
 
 console.log(`Non-prefix units: ${nonPrefixUnits.length}`);
-console.log(`  Within 1%: ${nStats.within1} (${(nStats.within1/nonPrefixUnits.length*100).toFixed(1)}%)`);
-console.log(`  Within 2%: ${nStats.within2} (${(nStats.within2/nonPrefixUnits.length*100).toFixed(1)}%)`);
-console.log(`  Avg diff: ${nStats.avgDiff.toFixed(2)}%, avg abs: ${nStats.avgAbsDiff.toFixed(2)}%`);
+console.log(
+  `  Within 1%: ${nStats.within1} (${((nStats.within1 / nonPrefixUnits.length) * 100).toFixed(1)}%)`,
+);
+console.log(
+  `  Within 2%: ${nStats.within2} (${((nStats.within2 / nonPrefixUnits.length) * 100).toFixed(1)}%)`,
+);
+console.log(
+  `  Avg diff: ${nStats.avgDiff.toFixed(2)}%, avg abs: ${nStats.avgAbsDiff.toFixed(2)}%`,
+);
 
 // Check outlier distribution
-const prefixOutliers = prefixUnits.filter(u => Math.abs(u.percentDiff) > 1);
-console.log(`\nPrefix outliers (>1%): ${prefixOutliers.length} (${(prefixOutliers.length/prefixUnits.length*100).toFixed(1)}%)`);
-const prefixOver = prefixOutliers.filter(u => u.percentDiff > 0);
-const prefixUnder = prefixOutliers.filter(u => u.percentDiff < 0);
+const prefixOutliers = prefixUnits.filter((u) => Math.abs(u.percentDiff) > 1);
+console.log(
+  `\nPrefix outliers (>1%): ${prefixOutliers.length} (${((prefixOutliers.length / prefixUnits.length) * 100).toFixed(1)}%)`,
+);
+const prefixOver = prefixOutliers.filter((u) => u.percentDiff > 0);
+const prefixUnder = prefixOutliers.filter((u) => u.percentDiff < 0);
 console.log(`  Over: ${prefixOver.length}, Under: ${prefixUnder.length}`);
 
 // Show top prefix outliers
 console.log('\nTop prefix outliers:');
-for (const u of prefixOutliers.sort((a: any, b: any) => Math.abs(b.percentDiff) - Math.abs(a.percentDiff)).slice(0, 15)) {
+for (const u of prefixOutliers
+  .sort((a: any, b: any) => Math.abs(b.percentDiff) - Math.abs(a.percentDiff))
+  .slice(0, 15)) {
   const unit = loadUnit(u.unitId);
-  const eqs = (unit?.equipment || []).filter((e: any) => /^\d+-/.test(e.id)).map((e: any) => e.id);
-  console.log(`  ${u.unitId.padEnd(45)} ${u.percentDiff.toFixed(1).padStart(6)}%  prefixed: ${eqs.slice(0,3).join(', ')}${eqs.length > 3 ? '...' : ''}`);
+  const eqs = (unit?.equipment || [])
+    .filter((e: any) => /^\d+-/.test(e.id))
+    .map((e: any) => e.id);
+  console.log(
+    `  ${u.unitId.padEnd(45)} ${u.percentDiff.toFixed(1).padStart(6)}%  prefixed: ${eqs.slice(0, 3).join(', ')}${eqs.length > 3 ? '...' : ''}`,
+  );
 }
 
 // Check: do prefix IDs get the "1-" stripped during normalization?
@@ -71,7 +93,7 @@ console.log('\n--- SAMPLE PREFIX IDS ---');
 const samplePrefixIds = new Set<string>();
 for (const u of prefixUnits.slice(0, 50)) {
   const unit = loadUnit(u.unitId);
-  for (const e of (unit?.equipment || [])) {
+  for (const e of unit?.equipment || []) {
     if (/^\d+-/.test(e.id)) samplePrefixIds.add(e.id);
   }
 }

--- a/scripts/check-prefix-units.ts
+++ b/scripts/check-prefix-units.ts
@@ -2,19 +2,15 @@
  * Find units with "1-" or other numeric prefix in equipment IDs
  * and check if ammo is missing for gauss-type weapons.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
-
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null,
+);
 
 // Check for numeric prefix equipment IDs
 let prefixCount = 0;
@@ -38,7 +34,30 @@ if (prefixUnits.length <= 20) {
 
 // Check for ammo-needing weapons with ammoBV=0
 console.log('\n=== WEAPONS NEEDING AMMO BUT ammoBV=0 ===');
-const ammoWeapons = ['gauss', 'ac/', 'ac-', 'autocannon', 'lrm', 'srm', 'lbx', 'lb-', 'uac', 'ultra', 'rotary', 'rac-', 'atm', 'narc', 'mml', 'streak', 'thunderbolt', 'arrow', 'mortar', 'thumper', 'sniper', 'long-tom'];
+const ammoWeapons = [
+  'gauss',
+  'ac/',
+  'ac-',
+  'autocannon',
+  'lrm',
+  'srm',
+  'lbx',
+  'lb-',
+  'uac',
+  'ultra',
+  'rotary',
+  'rac-',
+  'atm',
+  'narc',
+  'mml',
+  'streak',
+  'thunderbolt',
+  'arrow',
+  'mortar',
+  'thumper',
+  'sniper',
+  'long-tom',
+];
 
 let ammoMissingCount = 0;
 const ammoMissingUnits: any[] = [];
@@ -49,7 +68,9 @@ for (const u of valid) {
   if (!unit) continue;
 
   const eqs = (unit.equipment || []).map((e: any) => e.id.toLowerCase());
-  const hasAmmoWeapon = eqs.some((eq: string) => ammoWeapons.some(aw => eq.includes(aw)));
+  const hasAmmoWeapon = eqs.some((eq: string) =>
+    ammoWeapons.some((aw) => eq.includes(aw)),
+  );
 
   if (hasAmmoWeapon) {
     // Check if there's actually ammo in crits
@@ -67,15 +88,21 @@ for (const u of valid) {
 
     if (hasAmmoInCrits) {
       ammoMissingCount++;
-      const weapons = eqs.filter(eq => ammoWeapons.some(aw => eq.includes(aw)));
+      const weapons = eqs.filter((eq) =>
+        ammoWeapons.some((aw) => eq.includes(aw)),
+      );
       ammoMissingUnits.push({ unitId: u.unitId, diff: u.percentDiff, weapons });
     }
   }
 }
 
-console.log(`Units with ammo weapons + crit ammo but ammoBV=0: ${ammoMissingCount}`);
+console.log(
+  `Units with ammo weapons + crit ammo but ammoBV=0: ${ammoMissingCount}`,
+);
 for (const u of ammoMissingUnits.sort((a, b) => a.diff - b.diff)) {
-  console.log(`  ${u.unitId.padEnd(45)} diff=${u.diff?.toFixed(1).padStart(6)}%  weapons: ${u.weapons.join(', ')}`);
+  console.log(
+    `  ${u.unitId.padEnd(45)} diff=${u.diff?.toFixed(1).padStart(6)}%  weapons: ${u.weapons.join(', ')}`,
+  );
 }
 
 // Check for named variants with potentially wrong reference BV
@@ -83,12 +110,23 @@ console.log('\n=== POSSIBLE NAMED VARIANT BV MISMATCHES ===');
 const namedPatterns = /\(.*\)$|-[a-z]+$/;
 const bigOverNamed: any[] = [];
 for (const u of valid.filter((x: any) => x.percentDiff > 5)) {
-  if (u.unitId.includes('-') && (u.unitId.includes('webster') || u.unitId.includes('lowenbrau') || u.unitId.includes('grace') || u.unitId.includes('stacy') || u.unitId.includes('wendall') || u.unitId.includes('ian') || u.unitId.includes('austin'))) {
+  if (
+    u.unitId.includes('-') &&
+    (u.unitId.includes('webster') ||
+      u.unitId.includes('lowenbrau') ||
+      u.unitId.includes('grace') ||
+      u.unitId.includes('stacy') ||
+      u.unitId.includes('wendall') ||
+      u.unitId.includes('ian') ||
+      u.unitId.includes('austin'))
+  ) {
     bigOverNamed.push(u);
   }
 }
 for (const u of bigOverNamed) {
-  console.log(`  ${u.unitId.padEnd(45)} ref=${u.indexBV} calc=${u.calculatedBV} diff=${u.percentDiff?.toFixed(1)}%`);
+  console.log(
+    `  ${u.unitId.padEnd(45)} ref=${u.indexBV} calc=${u.calculatedBV} diff=${u.percentDiff?.toFixed(1)}%`,
+  );
 }
 
 // Count how many overcalculated >5% units have named-variant patterns in their IDs

--- a/scripts/check-remaining-quick.ts
+++ b/scripts/check-remaining-quick.ts
@@ -1,29 +1,36 @@
 /**
  * Quick check remaining outliers for fixable patterns.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
-
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown,
+);
 const outliers = valid.filter((x: any) => Math.abs(x.percentDiff) > 1);
 
 console.log(`Remaining outliers: ${outliers.length}`);
 
 // Check: units with offEquipBV still > 0
-const withOffEq = outliers.filter((x: any) => (x.breakdown?.offEquipBV || 0) > 0);
+const withOffEq = outliers.filter(
+  (x: any) => (x.breakdown?.offEquipBV || 0) > 0,
+);
 console.log(`\nOutliers with offEquipBV > 0: ${withOffEq.length}`);
 
 // Break down by specific features
-const features: Record<string, { total: number, outlier: number, over: number, under: number, avgDiff: number }> = {};
+const features: Record<
+  string,
+  {
+    total: number;
+    outlier: number;
+    over: number;
+    under: number;
+    avgDiff: number;
+  }
+> = {};
 
 for (const r of valid) {
   const unit = loadUnit(r.unitId);
@@ -37,28 +44,42 @@ for (const r of valid) {
   const critsStr = JSON.stringify(unit.criticalSlots).toLowerCase();
 
   const checks: Record<string, boolean> = {
-    'TSEMP': critsStr.includes('tsemp'),
-    'BlueShield': critsStr.includes('blue shield') || critsStr.includes('blueshield'),
-    'C3i': critsStr.includes('c3i') || critsStr.includes('improved c3') || critsStr.includes('c3 computer'),
-    'C3master': critsStr.includes('c3 master') || critsStr.includes('c3master'),
-    'C3slave': critsStr.includes('c3 slave') || critsStr.includes('c3slave') || critsStr.includes('isc3boostedslaveunit'),
-    'ArtemisIV': b?.weapons?.some?.((w: any) => w.artemisType === 'iv') || critsStr.includes('artemis iv'),
-    'ArtemisV': b?.weapons?.some?.((w: any) => w.artemisType === 'v') || critsStr.includes('artemis v'),
-    'Apollo': critsStr.includes('apollo'),
-    'PPCCapacitor': critsStr.includes('ppc capacitor') || critsStr.includes('ppccapacitor'),
-    'RotaryAC': critsStr.includes('rotary') || critsStr.includes('clrotaryac'),
-    'HAG': critsStr.includes('hag'),
-    'HeavyLaser': critsStr.includes('heavy laser') || critsStr.includes('heavylaser'),
-    'MRM': critsStr.includes('mrm'),
-    'Streak': critsStr.includes('streak'),
-    'UltraAC': critsStr.includes('ultra') || critsStr.includes('ultraac'),
-    'LBX': critsStr.includes('lbx') || critsStr.includes('lb '),
-    'RAC': critsStr.includes('rotaryac') || critsStr.includes('rotary ac'),
+    TSEMP: critsStr.includes('tsemp'),
+    BlueShield:
+      critsStr.includes('blue shield') || critsStr.includes('blueshield'),
+    C3i:
+      critsStr.includes('c3i') ||
+      critsStr.includes('improved c3') ||
+      critsStr.includes('c3 computer'),
+    C3master: critsStr.includes('c3 master') || critsStr.includes('c3master'),
+    C3slave:
+      critsStr.includes('c3 slave') ||
+      critsStr.includes('c3slave') ||
+      critsStr.includes('isc3boostedslaveunit'),
+    ArtemisIV:
+      b?.weapons?.some?.((w: any) => w.artemisType === 'iv') ||
+      critsStr.includes('artemis iv'),
+    ArtemisV:
+      b?.weapons?.some?.((w: any) => w.artemisType === 'v') ||
+      critsStr.includes('artemis v'),
+    Apollo: critsStr.includes('apollo'),
+    PPCCapacitor:
+      critsStr.includes('ppc capacitor') || critsStr.includes('ppccapacitor'),
+    RotaryAC: critsStr.includes('rotary') || critsStr.includes('clrotaryac'),
+    HAG: critsStr.includes('hag'),
+    HeavyLaser:
+      critsStr.includes('heavy laser') || critsStr.includes('heavylaser'),
+    MRM: critsStr.includes('mrm'),
+    Streak: critsStr.includes('streak'),
+    UltraAC: critsStr.includes('ultra') || critsStr.includes('ultraac'),
+    LBX: critsStr.includes('lbx') || critsStr.includes('lb '),
+    RAC: critsStr.includes('rotaryac') || critsStr.includes('rotary ac'),
   };
 
   for (const [feat, has] of Object.entries(checks)) {
     if (!has) continue;
-    if (!features[feat]) features[feat] = { total: 0, outlier: 0, over: 0, under: 0, avgDiff: 0 };
+    if (!features[feat])
+      features[feat] = { total: 0, outlier: 0, over: 0, under: 0, avgDiff: 0 };
     features[feat].total++;
     features[feat].avgDiff += r.percentDiff;
     if (isOutlier) {
@@ -70,18 +91,26 @@ for (const r of valid) {
 }
 
 console.log('\n=== FEATURE OUTLIER RATES ===');
-for (const [feat, data] of Object.entries(features).sort((a, b) => (b[1].outlier/b[1].total) - (a[1].outlier/a[1].total))) {
+for (const [feat, data] of Object.entries(features).sort(
+  (a, b) => b[1].outlier / b[1].total - a[1].outlier / a[1].total,
+)) {
   if (data.total < 5) continue;
-  const rate = (data.outlier / data.total * 100).toFixed(1);
+  const rate = ((data.outlier / data.total) * 100).toFixed(1);
   const avgDiff = (data.avgDiff / data.total).toFixed(2);
-  console.log(`  ${feat.padEnd(15)} total=${data.total.toString().padStart(4)} outlier=${data.outlier.toString().padStart(3)} (${rate.padStart(5)}%) over=${data.over} under=${data.under} avgDiff=${avgDiff}%`);
+  console.log(
+    `  ${feat.padEnd(15)} total=${data.total.toString().padStart(4)} outlier=${data.outlier.toString().padStart(3)} (${rate.padStart(5)}%) over=${data.over} under=${data.under} avgDiff=${avgDiff}%`,
+  );
 }
 
 // Check: are there units near the 1% boundary that might flip?
 console.log('\n=== NEAR-BOUNDARY UNITS (0.9-1.1%) ===');
-const nearBound = valid.filter((x: any) => Math.abs(x.percentDiff) >= 0.9 && Math.abs(x.percentDiff) <= 1.1);
+const nearBound = valid.filter(
+  (x: any) => Math.abs(x.percentDiff) >= 0.9 && Math.abs(x.percentDiff) <= 1.1,
+);
 console.log(`Units at 0.9-1.1%: ${nearBound.length}`);
-const justOver = valid.filter((x: any) => Math.abs(x.percentDiff) > 1 && Math.abs(x.percentDiff) <= 1.2);
+const justOver = valid.filter(
+  (x: any) => Math.abs(x.percentDiff) > 1 && Math.abs(x.percentDiff) <= 1.2,
+);
 console.log(`Just over 1% (1.0-1.2%): ${justOver.length}`);
 
 // Show what a generic 0.5% BV shift would do
@@ -93,12 +122,20 @@ for (const shift of [0.3, 0.5, 0.7, 1.0]) {
     if (Math.abs(r.percentDiff) > 1 && Math.abs(newDiff) <= 1) improved++;
     if (Math.abs(r.percentDiff) <= 1 && Math.abs(newDiff) > 1) improved--;
   }
-  console.log(`  Shifting all BV down by ${shift}%: net ${improved} units gained`);
+  console.log(
+    `  Shifting all BV down by ${shift}%: net ${improved} units gained`,
+  );
 }
 
 // Check: Cockpit modifier = 0.95 remaining outlier impact
-const cock095Outliers = outliers.filter((x: any) => x.breakdown?.cockpitModifier === 0.95);
+const cock095Outliers = outliers.filter(
+  (x: any) => x.breakdown?.cockpitModifier === 0.95,
+);
 console.log(`\nCockpit=0.95 outliers remaining: ${cock095Outliers.length}`);
-const cock095Over = cock095Outliers.filter((x: any) => x.percentDiff > 0).length;
-const cock095Under = cock095Outliers.filter((x: any) => x.percentDiff < 0).length;
+const cock095Over = cock095Outliers.filter(
+  (x: any) => x.percentDiff > 0,
+).length;
+const cock095Under = cock095Outliers.filter(
+  (x: any) => x.percentDiff < 0,
+).length;
 console.log(`  Over: ${cock095Over}, Under: ${cock095Under}`);

--- a/scripts/check-shield-narc-impact.ts
+++ b/scripts/check-shield-narc-impact.ts
@@ -3,19 +3,15 @@
  * 1. Large shield running MP reduction (-1)
  * 2. iNARC/NARC pods not detected as explosive or ammo
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
-
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown,
+);
 
 // 1. Large Shield analysis
 console.log('=== LARGE SHIELD UNITS ===');
@@ -25,15 +21,32 @@ let smallShieldUnits: any[] = [];
 for (const r of valid) {
   const unit = loadUnit(r.unitId);
   if (!unit?.criticalSlots) continue;
-  let hasLarge = false, hasMed = false, hasSmall = false;
+  let hasLarge = false,
+    hasMed = false,
+    hasSmall = false;
   for (const slots of Object.values(unit.criticalSlots)) {
     if (!Array.isArray(slots)) continue;
     for (const s of slots) {
       if (typeof s !== 'string') continue;
       const lo = s.toLowerCase().replace(/\s*\(omnipod\)/gi, '');
-      if (lo.includes('largeshield') || lo.includes('large shield') || lo === 'islargeshield') hasLarge = true;
-      if (lo.includes('mediumshield') || lo.includes('medium shield') || lo === 'ismediumshield') hasMed = true;
-      if (lo.includes('smallshield') || lo.includes('small shield') || lo === 'issmallshield') hasSmall = true;
+      if (
+        lo.includes('largeshield') ||
+        lo.includes('large shield') ||
+        lo === 'islargeshield'
+      )
+        hasLarge = true;
+      if (
+        lo.includes('mediumshield') ||
+        lo.includes('medium shield') ||
+        lo === 'ismediumshield'
+      )
+        hasMed = true;
+      if (
+        lo.includes('smallshield') ||
+        lo.includes('small shield') ||
+        lo === 'issmallshield'
+      )
+        hasSmall = true;
     }
   }
   if (hasLarge) largeShieldUnits.push(r);
@@ -43,15 +56,21 @@ for (const r of valid) {
 
 console.log(`Large Shield: ${largeShieldUnits.length} units`);
 for (const r of largeShieldUnits) {
-  console.log(`  ${r.unitId.padEnd(45)} diff=${r.percentDiff?.toFixed(1).padStart(6)}% ref=${r.indexBV} calc=${r.calculatedBV}`);
+  console.log(
+    `  ${r.unitId.padEnd(45)} diff=${r.percentDiff?.toFixed(1).padStart(6)}% ref=${r.indexBV} calc=${r.calculatedBV}`,
+  );
 }
 console.log(`\nMedium Shield: ${medShieldUnits.length} units`);
 for (const r of medShieldUnits) {
-  console.log(`  ${r.unitId.padEnd(45)} diff=${r.percentDiff?.toFixed(1).padStart(6)}% ref=${r.indexBV} calc=${r.calculatedBV}`);
+  console.log(
+    `  ${r.unitId.padEnd(45)} diff=${r.percentDiff?.toFixed(1).padStart(6)}% ref=${r.indexBV} calc=${r.calculatedBV}`,
+  );
 }
 console.log(`\nSmall Shield: ${smallShieldUnits.length} units`);
 for (const r of smallShieldUnits) {
-  console.log(`  ${r.unitId.padEnd(45)} diff=${r.percentDiff?.toFixed(1).padStart(6)}% ref=${r.indexBV} calc=${r.calculatedBV}`);
+  console.log(
+    `  ${r.unitId.padEnd(45)} diff=${r.percentDiff?.toFixed(1).padStart(6)}% ref=${r.indexBV} calc=${r.calculatedBV}`,
+  );
 }
 
 // 2. iNARC/NARC pods in crits (not containing "ammo")
@@ -67,7 +86,11 @@ for (const r of valid) {
     for (const s of slots) {
       if (typeof s !== 'string') continue;
       const lo = s.toLowerCase();
-      if ((lo.includes('narc') || lo.includes('inarc')) && lo.includes('pod') && !lo.includes('ammo')) {
+      if (
+        (lo.includes('narc') || lo.includes('inarc')) &&
+        lo.includes('pod') &&
+        !lo.includes('ammo')
+      ) {
         hasNarcPods = true;
         podEntries.push(`${loc}:${s}`);
       }
@@ -81,15 +104,28 @@ for (const r of valid) {
 console.log(`Units with NARC/iNARC pods (not "ammo"): ${narcPodUnits.length}`);
 for (const r of narcPodUnits) {
   const hasClan = r.techBase === 'CLAN';
-  console.log(`  ${r.unitId.padEnd(45)} diff=${r.percentDiff?.toFixed(1).padStart(6)}% ${hasClan ? 'CLAN' : 'IS'} pods: ${r.pods.length}`);
+  console.log(
+    `  ${r.unitId.padEnd(45)} diff=${r.percentDiff?.toFixed(1).padStart(6)}% ${hasClan ? 'CLAN' : 'IS'} pods: ${r.pods.length}`,
+  );
 }
 
 // 3. What patterns exist in the 1-2% overcalculated band (no flags)?
 console.log('\n=== OVERCALCULATED 1-5% BAND (no shield/narc) ===');
-const over1_5 = valid.filter((x: any) => x.percentDiff > 1 && x.percentDiff <= 5);
-const shieldNarcIds = new Set([...largeShieldUnits, ...medShieldUnits, ...smallShieldUnits, ...narcPodUnits].map((x: any) => x.unitId));
+const over1_5 = valid.filter(
+  (x: any) => x.percentDiff > 1 && x.percentDiff <= 5,
+);
+const shieldNarcIds = new Set(
+  [
+    ...largeShieldUnits,
+    ...medShieldUnits,
+    ...smallShieldUnits,
+    ...narcPodUnits,
+  ].map((x: any) => x.unitId),
+);
 const cleanOver = over1_5.filter((x: any) => !shieldNarcIds.has(x.unitId));
-console.log(`Total 1-5% overcalculated: ${over1_5.length}, after removing shield/narc: ${cleanOver.length}`);
+console.log(
+  `Total 1-5% overcalculated: ${over1_5.length}, after removing shield/narc: ${cleanOver.length}`,
+);
 
 // Check what these clean overcalculated units have in common
 const patterns: Record<string, number> = {};

--- a/scripts/check-weight-bonus.ts
+++ b/scripts/check-weight-bonus.ts
@@ -1,19 +1,15 @@
 /**
  * Check weight bonus accuracy - detect possible false AES/TSM detection.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
-
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown,
+);
 
 // Check weight bonus values - find non-standard ratios
 let nonStdCount = 0;
@@ -36,20 +32,27 @@ for (const u of valid) {
   if (!isStandard && !isTSM && !isITSM) {
     nonStdCount++;
     nonStdUnits.push({
-      unitId: u.unitId, tonnage: unit.tonnage,
-      weightBonus: b.weightBonus, ratio, diff: u.percentDiff,
+      unitId: u.unitId,
+      tonnage: unit.tonnage,
+      weightBonus: b.weightBonus,
+      ratio,
+      diff: u.percentDiff,
     });
   }
 }
 
 console.log(`=== WEIGHT BONUS RATIO DISTRIBUTION ===`);
-for (const [r, c] of Object.entries(ratioCount).sort((a,b) => b[1]-a[1])) {
+for (const [r, c] of Object.entries(ratioCount).sort((a, b) => b[1] - a[1])) {
   console.log(`  ratio=${r}: ${c} units`);
 }
 
 console.log(`\nNon-standard ratios: ${nonStdCount}`);
-for (const u of nonStdUnits.sort((a, b) => Math.abs(b.diff) - Math.abs(a.diff)).slice(0, 20)) {
-  console.log(`  ${u.unitId.padEnd(45)} tonnage=${u.tonnage} bonus=${u.weightBonus.toFixed(1)} ratio=${u.ratio.toFixed(3)} diff=${u.diff.toFixed(1)}%`);
+for (const u of nonStdUnits
+  .sort((a, b) => Math.abs(b.diff) - Math.abs(a.diff))
+  .slice(0, 20)) {
+  console.log(
+    `  ${u.unitId.padEnd(45)} tonnage=${u.tonnage} bonus=${u.weightBonus.toFixed(1)} ratio=${u.ratio.toFixed(3)} diff=${u.diff.toFixed(1)}%`,
+  );
 }
 
 // Check TSM false positives - weightBonus = tonnage*1.5 but no TSM in crit/equip data
@@ -65,7 +68,10 @@ for (const u of valid) {
     for (const [, slots] of Object.entries(unit.criticalSlots || {})) {
       if (!Array.isArray(slots)) continue;
       for (const s of slots) {
-        if (typeof s === 'string' && /tsm|triple.?strength/i.test(s)) { hasTSM = true; break; }
+        if (typeof s === 'string' && /tsm|triple.?strength/i.test(s)) {
+          hasTSM = true;
+          break;
+        }
       }
     }
     for (const eq of unit.equipment || []) {
@@ -73,7 +79,10 @@ for (const u of valid) {
     }
     if (!hasTSM) {
       tsmFP++;
-      if (tsmFP <= 10) console.log(`  FALSE TSM: ${u.unitId} (diff=${u.percentDiff.toFixed(1)}%)`);
+      if (tsmFP <= 10)
+        console.log(
+          `  FALSE TSM: ${u.unitId} (diff=${u.percentDiff.toFixed(1)}%)`,
+        );
     }
   }
 }
@@ -93,12 +102,18 @@ for (const u of valid) {
     for (const [, slots] of Object.entries(unit.criticalSlots || {})) {
       if (!Array.isArray(slots)) continue;
       for (const s of slots) {
-        if (typeof s === 'string' && /actuator enhancement|aes/i.test(s)) { hasAES = true; break; }
+        if (typeof s === 'string' && /actuator enhancement|aes/i.test(s)) {
+          hasAES = true;
+          break;
+        }
       }
     }
     if (!hasAES) {
       aesFP++;
-      if (aesFP <= 10) console.log(`  FALSE AES: ${u.unitId} ratio=${ratio.toFixed(3)} (diff=${u.percentDiff.toFixed(1)}%)`);
+      if (aesFP <= 10)
+        console.log(
+          `  FALSE AES: ${u.unitId} ratio=${ratio.toFixed(3)} (diff=${u.percentDiff.toFixed(1)}%)`,
+        );
     }
   }
 }

--- a/scripts/deep-trace-nearmiss.ts
+++ b/scripts/deep-trace-nearmiss.ts
@@ -2,22 +2,24 @@
  * Deep trace a few 1-2% overcalculated and undercalculated units
  * to find the systematic source of the BV difference.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
-
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown);
-const near = valid.filter((x: any) => Math.abs(x.percentDiff) > 1 && Math.abs(x.percentDiff) <= 2);
-const over = near.filter((x: any) => x.percentDiff > 1).sort((a: any, b: any) => b.percentDiff - a.percentDiff);
-const under = near.filter((x: any) => x.percentDiff < -1).sort((a: any, b: any) => a.percentDiff - b.percentDiff);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown,
+);
+const near = valid.filter(
+  (x: any) => Math.abs(x.percentDiff) > 1 && Math.abs(x.percentDiff) <= 2,
+);
+const over = near
+  .filter((x: any) => x.percentDiff > 1)
+  .sort((a: any, b: any) => b.percentDiff - a.percentDiff);
+const under = near
+  .filter((x: any) => x.percentDiff < -1)
+  .sort((a: any, b: any) => a.percentDiff - b.percentDiff);
 
 // Pick 5 overcalculated and 5 undercalculated that are IS, no special equipment, to isolate the issue
 function trace(u: any) {
@@ -27,34 +29,59 @@ function trace(u: any) {
 
   console.log(`\n${'='.repeat(70)}`);
   console.log(`${u.unitId} — ${unit.chassis} ${unit.model}`);
-  console.log(`  ref=${u.indexBV} calc=${u.calculatedBV} diff=${u.difference} (${u.percentDiff.toFixed(2)}%)`);
+  console.log(
+    `  ref=${u.indexBV} calc=${u.calculatedBV} diff=${u.difference} (${u.percentDiff.toFixed(2)}%)`,
+  );
   console.log(`  tonnage=${unit.tonnage} techBase=${unit.techBase}`);
   console.log(`  engine=${unit.engine?.type} rating=${unit.engine?.rating}`);
-  console.log(`  armor=${unit.armor?.type} structure=${unit.structure?.type || 'standard'}`);
+  console.log(
+    `  armor=${unit.armor?.type} structure=${unit.structure?.type || 'standard'}`,
+  );
   console.log(`  heatSinks: ${unit.heatSinks?.count}x ${unit.heatSinks?.type}`);
-  console.log(`  movement: walk=${unit.movement?.walk} jump=${unit.movement?.jump || 0}`);
+  console.log(
+    `  movement: walk=${unit.movement?.walk} jump=${unit.movement?.jump || 0}`,
+  );
   console.log(`  cockpit: ${unit.cockpit || 'STANDARD'}`);
 
   console.log(`\n  --- BV Breakdown ---`);
-  console.log(`  armorBV=${b.armorBV?.toFixed(1)} structBV=${b.structureBV?.toFixed(1)} gyroBV=${b.gyroBV?.toFixed(1)}`);
-  console.log(`  defEquipBV=${b.defEquipBV?.toFixed(1)} explosivePenalty=${b.explosivePenalty?.toFixed(1)}`);
-  console.log(`  baseDef=${((b.armorBV||0)+(b.structureBV||0)+(b.gyroBV||0)+(b.defEquipBV||0)-(b.explosivePenalty||0)).toFixed(1)}`);
-  console.log(`  DF=${b.defensiveFactor} → defensiveBV=${b.defensiveBV?.toFixed(1)}`);
-  console.log(`  weaponBV=${b.weaponBV?.toFixed(1)} ammoBV=${b.ammoBV} physBV=${b.physicalWeaponBV?.toFixed(1)}`);
-  console.log(`  weightBonus=${b.weightBonus?.toFixed(1)} offEquipBV=${b.offEquipBV?.toFixed(1)}`);
+  console.log(
+    `  armorBV=${b.armorBV?.toFixed(1)} structBV=${b.structureBV?.toFixed(1)} gyroBV=${b.gyroBV?.toFixed(1)}`,
+  );
+  console.log(
+    `  defEquipBV=${b.defEquipBV?.toFixed(1)} explosivePenalty=${b.explosivePenalty?.toFixed(1)}`,
+  );
+  console.log(
+    `  baseDef=${((b.armorBV || 0) + (b.structureBV || 0) + (b.gyroBV || 0) + (b.defEquipBV || 0) - (b.explosivePenalty || 0)).toFixed(1)}`,
+  );
+  console.log(
+    `  DF=${b.defensiveFactor} → defensiveBV=${b.defensiveBV?.toFixed(1)}`,
+  );
+  console.log(
+    `  weaponBV=${b.weaponBV?.toFixed(1)} ammoBV=${b.ammoBV} physBV=${b.physicalWeaponBV?.toFixed(1)}`,
+  );
+  console.log(
+    `  weightBonus=${b.weightBonus?.toFixed(1)} offEquipBV=${b.offEquipBV?.toFixed(1)}`,
+  );
   console.log(`  HE=${b.heatEfficiency} run=${b.runMP} jump=${b.jumpMP}`);
-  console.log(`  SF=${b.speedFactor} → offensiveBV=${b.offensiveBV?.toFixed(1)}`);
+  console.log(
+    `  SF=${b.speedFactor} → offensiveBV=${b.offensiveBV?.toFixed(1)}`,
+  );
   console.log(`  cockpitMod=${b.cockpitModifier}`);
-  console.log(`  raw total=${((b.defensiveBV||0) + (b.offensiveBV||0)).toFixed(1)} → cockpit → ${u.calculatedBV}`);
+  console.log(
+    `  raw total=${((b.defensiveBV || 0) + (b.offensiveBV || 0)).toFixed(1)} → cockpit → ${u.calculatedBV}`,
+  );
 
   // Calculate what the ref implies
   const refPreCockpit = u.indexBV / (b.cockpitModifier || 1);
-  const defShare = (b.defensiveBV || 0) / ((b.defensiveBV || 0) + (b.offensiveBV || 0));
+  const defShare =
+    (b.defensiveBV || 0) / ((b.defensiveBV || 0) + (b.offensiveBV || 0));
   const refDef = refPreCockpit * defShare;
   const refOff = refPreCockpit * (1 - defShare);
   const defDiff = (b.defensiveBV || 0) - refDef;
   const offDiff = (b.offensiveBV || 0) - refOff;
-  console.log(`  If DEF/OFF ratio matches: refDef≈${refDef.toFixed(0)} refOff≈${refOff.toFixed(0)} defDiff≈${defDiff.toFixed(0)} offDiff≈${offDiff.toFixed(0)}`);
+  console.log(
+    `  If DEF/OFF ratio matches: refDef≈${refDef.toFixed(0)} refOff≈${refOff.toFixed(0)} defDiff≈${defDiff.toFixed(0)} offDiff≈${offDiff.toFixed(0)}`,
+  );
 
   // List equipment
   const eqs = (unit.equipment || []).map((e: any) => `${e.id} (${e.location})`);
@@ -66,7 +93,9 @@ function trace(u: any) {
   if (b.weapons && b.weapons.length > 0) {
     console.log(`  --- Weapons (from breakdown) ---`);
     for (const w of b.weapons) {
-      console.log(`    ${w.name || w.id}: heat=${w.heat} bv=${w.bv} ${w.rear ? '(rear)' : ''}`);
+      console.log(
+        `    ${w.name || w.id}: heat=${w.heat} bv=${w.bv} ${w.rear ? '(rear)' : ''}`,
+      );
     }
   }
 
@@ -74,7 +103,9 @@ function trace(u: any) {
   if (b.ammo && b.ammo.length > 0) {
     console.log(`  --- Ammo (from breakdown) ---`);
     for (const a of b.ammo) {
-      console.log(`    ${a.id || a.name}: bv=${a.bv} weaponType=${a.weaponType}`);
+      console.log(
+        `    ${a.id || a.name}: bv=${a.bv} weaponType=${a.weaponType}`,
+      );
     }
   }
 }
@@ -83,20 +114,33 @@ function trace(u: any) {
 function isSimple(unitId: string): boolean {
   const unit = loadUnit(unitId);
   if (!unit) return false;
-  const eqStr = (unit.equipment || []).map((e: any) => e.id.toLowerCase()).join(' ');
-  return !eqStr.includes('stealth') && !eqStr.includes('null-sig') && !eqStr.includes('chameleon') && !eqStr.includes('novacews');
+  const eqStr = (unit.equipment || [])
+    .map((e: any) => e.id.toLowerCase())
+    .join(' ');
+  return (
+    !eqStr.includes('stealth') &&
+    !eqStr.includes('null-sig') &&
+    !eqStr.includes('chameleon') &&
+    !eqStr.includes('novacews')
+  );
 }
 
 console.log('===== OVERCALCULATED 1-2% (IS, simple) =====');
 let count = 0;
 for (const u of over) {
   if (count >= 5) break;
-  if (isSimple(u.unitId)) { trace(u); count++; }
+  if (isSimple(u.unitId)) {
+    trace(u);
+    count++;
+  }
 }
 
 console.log('\n\n===== UNDERCALCULATED 1-2% (IS, simple) =====');
 count = 0;
 for (const u of under) {
   if (count >= 5) break;
-  if (isSimple(u.unitId)) { trace(u); count++; }
+  if (isSimple(u.unitId)) {
+    trace(u);
+    count++;
+  }
 }

--- a/scripts/deep-trace-overcalc.ts
+++ b/scripts/deep-trace-overcalc.ts
@@ -2,26 +2,29 @@
  * Deep trace specific overcalculated 1-2% units to find the exact component that's wrong.
  * Compare our defensive and offensive sub-components against what they should be.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
-
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
 // Pick simple overcalculated units for tracing
 const targets = [
-  'ostscout-ott-8j', 'dola-dol-1a1', 'kabuto-kbo-7a', 'jackal-ja-kl-1579',
-  'panther-pnt-10alag', 'strider-sr1-oe', 'thunderbolt-tdr-12r', 'archer-arc-6w',
-  'battlemaster-blr-6r', 'turkina-u',
+  'ostscout-ott-8j',
+  'dola-dol-1a1',
+  'kabuto-kbo-7a',
+  'jackal-ja-kl-1579',
+  'panther-pnt-10alag',
+  'strider-sr1-oe',
+  'thunderbolt-tdr-12r',
+  'archer-arc-6w',
+  'battlemaster-blr-6r',
+  'turkina-u',
 ];
 
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null,
+);
 
 for (const uid of targets) {
   const u = valid.find((x: any) => x.unitId === uid);
@@ -36,53 +39,94 @@ for (const uid of targets) {
   const refBase = refBV / cockpit;
 
   console.log(`=== ${uid} (${unit.tonnage}t ${unit.techBase}) ===`);
-  console.log(`  Reference BV: ${refBV}  Calculated: ${calcBV}  Diff: +${u.difference} (+${u.percentDiff.toFixed(2)}%)`);
+  console.log(
+    `  Reference BV: ${refBV}  Calculated: ${calcBV}  Diff: +${u.difference} (+${u.percentDiff.toFixed(2)}%)`,
+  );
   console.log(`  CockpitMod: ${cockpit}  RefBase: ${refBase.toFixed(1)}`);
   console.log('');
 
   // Defensive breakdown
   console.log('  DEFENSIVE:');
-  console.log(`    armorBV=${b.armorBV?.toFixed(1)}  structBV=${b.structureBV?.toFixed(1)}  gyroBV=${b.gyroBV?.toFixed(1)}`);
-  console.log(`    defEquipBV=${b.defEquipBV}  amsAmmoBV=${b.amsAmmoBV || 0}  armoredComp=${b.armoredComponentBV || 0}  harjel=${b.harjelBonus || 0}`);
-  console.log(`    explosivePenalty=${b.explosivePenalty}  defensiveFactor=${b.defensiveFactor}  TMM=${b.maxTMM}`);
+  console.log(
+    `    armorBV=${b.armorBV?.toFixed(1)}  structBV=${b.structureBV?.toFixed(1)}  gyroBV=${b.gyroBV?.toFixed(1)}`,
+  );
+  console.log(
+    `    defEquipBV=${b.defEquipBV}  amsAmmoBV=${b.amsAmmoBV || 0}  armoredComp=${b.armoredComponentBV || 0}  harjel=${b.harjelBonus || 0}`,
+  );
+  console.log(
+    `    explosivePenalty=${b.explosivePenalty}  defensiveFactor=${b.defensiveFactor}  TMM=${b.maxTMM}`,
+  );
   console.log(`    defensiveBV=${b.defensiveBV?.toFixed(1)}`);
 
   // Compute expected defensive base
-  const defBase = (b.armorBV ?? 0) + (b.structureBV ?? 0) + (b.gyroBV ?? 0) +
-    (b.defEquipBV ?? 0) + (b.amsAmmoBV ?? 0) + (b.armoredComponentBV ?? 0) + (b.harjelBonus ?? 0) -
+  const defBase =
+    (b.armorBV ?? 0) +
+    (b.structureBV ?? 0) +
+    (b.gyroBV ?? 0) +
+    (b.defEquipBV ?? 0) +
+    (b.amsAmmoBV ?? 0) +
+    (b.armoredComponentBV ?? 0) +
+    (b.harjelBonus ?? 0) -
     (b.explosivePenalty ?? 0);
-  console.log(`    defBase (computed)=${defBase.toFixed(1)}  defBV/DF=${(b.defensiveBV / b.defensiveFactor).toFixed(1)}`);
+  console.log(
+    `    defBase (computed)=${defBase.toFixed(1)}  defBV/DF=${(b.defensiveBV / b.defensiveFactor).toFixed(1)}`,
+  );
 
   // Offensive breakdown
   console.log('  OFFENSIVE:');
-  console.log(`    weaponBV=${b.weaponBV?.toFixed(1)}  rawWeaponBV=${b.rawWeaponBV?.toFixed(1)}  halvedBV=${b.halvedWeaponBV?.toFixed(1)}`);
-  console.log(`    ammoBV=${b.ammoBV}  weightBonus=${b.weightBonus?.toFixed(1)}  physBV=${b.physicalWeaponBV?.toFixed(1)}  offEquipBV=${b.offEquipBV}`);
-  console.log(`    speedFactor=${b.speedFactor}  HE=${b.heatEfficiency}  halved=${b.halvedWeaponCount}/${b.weaponCount}`);
+  console.log(
+    `    weaponBV=${b.weaponBV?.toFixed(1)}  rawWeaponBV=${b.rawWeaponBV?.toFixed(1)}  halvedBV=${b.halvedWeaponBV?.toFixed(1)}`,
+  );
+  console.log(
+    `    ammoBV=${b.ammoBV}  weightBonus=${b.weightBonus?.toFixed(1)}  physBV=${b.physicalWeaponBV?.toFixed(1)}  offEquipBV=${b.offEquipBV}`,
+  );
+  console.log(
+    `    speedFactor=${b.speedFactor}  HE=${b.heatEfficiency}  halved=${b.halvedWeaponCount}/${b.weaponCount}`,
+  );
   console.log(`    offensiveBV=${b.offensiveBV?.toFixed(1)}`);
 
-  const baseOff = (b.weaponBV ?? 0) + (b.ammoBV ?? 0) + (b.weightBonus ?? 0) + (b.physicalWeaponBV ?? 0) + (b.offEquipBV ?? 0);
-  console.log(`    baseOff (computed)=${baseOff.toFixed(1)}  offBV/SF=${(b.offensiveBV / b.speedFactor).toFixed(1)}`);
+  const baseOff =
+    (b.weaponBV ?? 0) +
+    (b.ammoBV ?? 0) +
+    (b.weightBonus ?? 0) +
+    (b.physicalWeaponBV ?? 0) +
+    (b.offEquipBV ?? 0);
+  console.log(
+    `    baseOff (computed)=${baseOff.toFixed(1)}  offBV/SF=${(b.offensiveBV / b.speedFactor).toFixed(1)}`,
+  );
 
   // What would need to change to match?
   console.log('  NEEDED:');
   const neededDefBV = refBase - b.offensiveBV;
   const neededOffBV = refBase - b.defensiveBV;
-  console.log(`    If off correct, def needed: ${neededDefBV.toFixed(1)} (have ${b.defensiveBV.toFixed(1)}, excess=${(b.defensiveBV - neededDefBV).toFixed(1)})`);
-  console.log(`    If def correct, off needed: ${neededOffBV.toFixed(1)} (have ${b.offensiveBV.toFixed(1)}, excess=${(b.offensiveBV - neededOffBV).toFixed(1)})`);
+  console.log(
+    `    If off correct, def needed: ${neededDefBV.toFixed(1)} (have ${b.defensiveBV.toFixed(1)}, excess=${(b.defensiveBV - neededDefBV).toFixed(1)})`,
+  );
+  console.log(
+    `    If def correct, off needed: ${neededOffBV.toFixed(1)} (have ${b.offensiveBV.toFixed(1)}, excess=${(b.offensiveBV - neededOffBV).toFixed(1)})`,
+  );
 
   // What the base def should be if DF is correct
   const neededBaseDef = neededDefBV / b.defensiveFactor;
-  console.log(`    If off correct + DF correct: baseDef needed=${neededBaseDef.toFixed(1)} (have ${defBase.toFixed(1)}, excess=${(defBase - neededBaseDef).toFixed(1)})`);
+  console.log(
+    `    If off correct + DF correct: baseDef needed=${neededBaseDef.toFixed(1)} (have ${defBase.toFixed(1)}, excess=${(defBase - neededBaseDef).toFixed(1)})`,
+  );
 
   // What the base off should be if SF is correct
   const neededBaseOff = neededOffBV / b.speedFactor;
-  console.log(`    If def correct + SF correct: baseOff needed=${neededBaseOff.toFixed(1)} (have ${baseOff.toFixed(1)}, excess=${(baseOff - neededBaseOff).toFixed(1)})`);
+  console.log(
+    `    If def correct + SF correct: baseOff needed=${neededBaseOff.toFixed(1)} (have ${baseOff.toFixed(1)}, excess=${(baseOff - neededBaseOff).toFixed(1)})`,
+  );
 
   // Unit details
   console.log('  UNIT:');
-  console.log(`    engine=${unit.engine?.type}  armor=${unit.armor?.type}  structure=${unit.structure?.type}`);
+  console.log(
+    `    engine=${unit.engine?.type}  armor=${unit.armor?.type}  structure=${unit.structure?.type}`,
+  );
   console.log(`    cockpit=${unit.cockpit}  gyro=${unit.gyro || 'standard'}`);
-  console.log(`    walk=${unit.movement?.walk}  jump=${unit.movement?.jump || 0}  runMP=${b.runMP}`);
+  console.log(
+    `    walk=${unit.movement?.walk}  jump=${unit.movement?.jump || 0}  runMP=${b.runMP}`,
+  );
   console.log(`    heatSinks=${unit.heatSinks?.count} ${unit.heatSinks?.type}`);
   console.log('');
 }

--- a/scripts/diagnose-ammo-gap.ts
+++ b/scripts/diagnose-ammo-gap.ts
@@ -4,26 +4,45 @@
  * Also check for "data quality" issues: units with ammo-consuming weapons
  * but zero ammo entries.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
-
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null,
+);
 const under = valid.filter((x: any) => x.percentDiff < -1 && x.breakdown);
 
 // Check for units with ballistic/missile weapons that need ammo but have zero ammo
 console.log('=== MISSING AMMO CHECK ===');
-const ammoNeeding = ['ac-', 'uac-', 'lb-', 'lrm-', 'srm-', 'mrm-', 'mml-', 'atm-', 'iatm-', 'streak-', 'hag-',
-  'gauss', 'rac-', 'thunderbolt', 'arrow-iv', 'narc', 'sniper', 'long-tom', 'thumper',
-  'rotary-ac', 'hvac-', 'light-ac-', 'machine-gun', 'mg'];
+const ammoNeeding = [
+  'ac-',
+  'uac-',
+  'lb-',
+  'lrm-',
+  'srm-',
+  'mrm-',
+  'mml-',
+  'atm-',
+  'iatm-',
+  'streak-',
+  'hag-',
+  'gauss',
+  'rac-',
+  'thunderbolt',
+  'arrow-iv',
+  'narc',
+  'sniper',
+  'long-tom',
+  'thumper',
+  'rotary-ac',
+  'hvac-',
+  'light-ac-',
+  'machine-gun',
+  'mg',
+];
 let missingAmmoUnits = 0;
 const missingAmmoExamples: string[] = [];
 
@@ -36,19 +55,30 @@ for (const u of under) {
     const lo = eq.id.toLowerCase().replace(/^\d+-/, '');
     if (lo.includes('ammo')) continue;
     for (const pat of ammoNeeding) {
-      if (lo.includes(pat) || lo.replace(/^(?:is|cl|clan)-?/, '').includes(pat)) {
+      if (
+        lo.includes(pat) ||
+        lo.replace(/^(?:is|cl|clan)-?/, '').includes(pat)
+      ) {
         ammoWeapons.push(eq.id);
         break;
       }
     }
   }
 
-  const hasAmmo = unit.equipment.some((eq: any) => eq.id.toLowerCase().includes('ammo'));
+  const hasAmmo = unit.equipment.some((eq: any) =>
+    eq.id.toLowerCase().includes('ammo'),
+  );
 
   let critAmmo = false;
   if (unit.criticalSlots) {
     for (const [, slots] of Object.entries(unit.criticalSlots)) {
-      if (Array.isArray(slots) && slots.some((s: any) => s && typeof s === 'string' && s.toLowerCase().includes('ammo'))) {
+      if (
+        Array.isArray(slots) &&
+        slots.some(
+          (s: any) =>
+            s && typeof s === 'string' && s.toLowerCase().includes('ammo'),
+        )
+      ) {
         critAmmo = true;
         break;
       }
@@ -62,14 +92,23 @@ for (const u of under) {
     const neededTotal = u.indexBV / cockpit;
     const neededOff = neededTotal - b.defensiveBV;
     const neededBase = neededOff / b.speedFactor;
-    const currentBase = b.weaponBV + b.ammoBV + b.weightBonus + (b.physicalWeaponBV ?? 0) + (b.offEquipBV ?? 0);
+    const currentBase =
+      b.weaponBV +
+      b.ammoBV +
+      b.weightBonus +
+      (b.physicalWeaponBV ?? 0) +
+      (b.offEquipBV ?? 0);
     const baseGap = neededBase - currentBase;
     if (missingAmmoExamples.length < 20) {
-      missingAmmoExamples.push(`${u.unitId}: weapons=[${ammoWeapons.join(', ')}] ammo=NONE gap=${Math.round(baseGap)}`);
+      missingAmmoExamples.push(
+        `${u.unitId}: weapons=[${ammoWeapons.join(', ')}] ammo=NONE gap=${Math.round(baseGap)}`,
+      );
     }
   }
 }
-console.log(`Units with ammo-needing weapons but NO ammo: ${missingAmmoUnits}/${under.length}`);
+console.log(
+  `Units with ammo-needing weapons but NO ammo: ${missingAmmoUnits}/${under.length}`,
+);
 for (const e of missingAmmoExamples) console.log(`  ${e}`);
 
 // Check for units where ammoBV is 0 but they have ammo in crits
@@ -100,14 +139,23 @@ for (const u of under) {
     const neededTotal = u.indexBV / cockpit;
     const neededOff = neededTotal - b.defensiveBV;
     const neededBase = neededOff / b.speedFactor;
-    const currentBase = b.weaponBV + b.ammoBV + b.weightBonus + (b.physicalWeaponBV ?? 0) + (b.offEquipBV ?? 0);
+    const currentBase =
+      b.weaponBV +
+      b.ammoBV +
+      b.weightBonus +
+      (b.physicalWeaponBV ?? 0) +
+      (b.offEquipBV ?? 0);
     const baseGap = neededBase - currentBase;
     if (zeroBVExamples.length < 20) {
-      zeroBVExamples.push(`${u.unitId}: ammoBV=0 critAmmoSlots=${critAmmoCount} types=[${ammoTypes.slice(0, 3).join('; ')}] gap=${Math.round(baseGap)}`);
+      zeroBVExamples.push(
+        `${u.unitId}: ammoBV=0 critAmmoSlots=${critAmmoCount} types=[${ammoTypes.slice(0, 3).join('; ')}] gap=${Math.round(baseGap)}`,
+      );
     }
   }
 }
-console.log(`Units with ammoBV=0 but ammo in crits: ${zeroBVWithAmmo}/${under.length}`);
+console.log(
+  `Units with ammoBV=0 but ammo in crits: ${zeroBVWithAmmo}/${under.length}`,
+);
 for (const e of zeroBVExamples) console.log(`  ${e}`);
 
 // Check ammo BV as fraction of gap
@@ -122,12 +170,23 @@ for (const u of under) {
   const neededTotal = u.indexBV / cockpit;
   const neededOff = neededTotal - b.defensiveBV;
   const neededBase = neededOff / b.speedFactor;
-  const currentBase = b.weaponBV + b.ammoBV + b.weightBonus + (b.physicalWeaponBV ?? 0) + (b.offEquipBV ?? 0);
+  const currentBase =
+    b.weaponBV +
+    b.ammoBV +
+    b.weightBonus +
+    (b.physicalWeaponBV ?? 0) +
+    (b.offEquipBV ?? 0);
   const baseGap = neededBase - currentBase;
 
-  if (baseGap <= 0) { ammoExplainsNone++; continue; }
+  if (baseGap <= 0) {
+    ammoExplainsNone++;
+    continue;
+  }
 
-  if (b.ammoBV === 0) { ammoExplainsNone++; continue; }
+  if (b.ammoBV === 0) {
+    ammoExplainsNone++;
+    continue;
+  }
 
   const ammoPctOfGap = b.ammoBV / baseGap;
   if (ammoPctOfGap >= 1.0) ammoExplainsAll++;
@@ -149,12 +208,19 @@ for (const pctIncrease of [2, 5, 10, 15, 20]) {
     const b = u.breakdown;
     const cockpit = b.cockpitModifier ?? 1.0;
     const newWeaponBV = b.weaponBV * (1 + pctIncrease / 100);
-    const newBase = newWeaponBV + b.ammoBV + b.weightBonus + (b.physicalWeaponBV ?? 0) + (b.offEquipBV ?? 0);
+    const newBase =
+      newWeaponBV +
+      b.ammoBV +
+      b.weightBonus +
+      (b.physicalWeaponBV ?? 0) +
+      (b.offEquipBV ?? 0);
     const newOff = newBase * b.speedFactor;
     const newBV = Math.round((b.defensiveBV + newOff) * cockpit);
-    if (Math.abs(newBV - u.indexBV) / u.indexBV * 100 <= 1) fixed++;
+    if ((Math.abs(newBV - u.indexBV) / u.indexBV) * 100 <= 1) fixed++;
   }
-  console.log(`  +${pctIncrease}% weaponBV: ${fixed}/${under.length} units fixed`);
+  console.log(
+    `  +${pctIncrease}% weaponBV: ${fixed}/${under.length} units fixed`,
+  );
 }
 
 // Check how many units have ammo in crits but NOT in equipment list
@@ -185,9 +251,13 @@ for (const u of under) {
   if (critAmmoTypes.size > 0 && equipAmmoIds.size === 0) {
     critOnlyAmmo++;
     if (critOnlyExamples.length < 15) {
-      critOnlyExamples.push(`${u.unitId}: critAmmo=[${[...critAmmoTypes].slice(0, 3).join(', ')}] equipAmmo=NONE`);
+      critOnlyExamples.push(
+        `${u.unitId}: critAmmo=[${[...critAmmoTypes].slice(0, 3).join(', ')}] equipAmmo=NONE`,
+      );
     }
   }
 }
-console.log(`Units with ammo in crits but NOT in equipment: ${critOnlyAmmo}/${under.length}`);
+console.log(
+  `Units with ammo in crits but NOT in equipment: ${critOnlyAmmo}/${under.length}`,
+);
 for (const e of critOnlyExamples) console.log(`  ${e}`);

--- a/scripts/diagnose-offensive-gap.ts
+++ b/scripts/diagnose-offensive-gap.ts
@@ -13,21 +13,19 @@
  * - physicalWeaponBV
  * - offEquipBV
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
-
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null,
+);
 const under = valid.filter((x: any) => x.percentDiff < -1 && x.breakdown);
-const exact = valid.filter((x: any) => Math.abs(x.percentDiff) <= 0.5 && x.breakdown);
+const exact = valid.filter(
+  (x: any) => Math.abs(x.percentDiff) <= 0.5 && x.breakdown,
+);
 
 // ANALYSIS 1: Weight bonus check — is tonnage * modifier correct?
 console.log('=== WEIGHT BONUS AUDIT ===');
@@ -38,13 +36,23 @@ for (const u of under) {
   if (!unit) continue;
   const expectedWeight = unit.tonnage; // base weight bonus = tonnage
   // TSM adds 1.5x, industrial TSM adds 1.15x
-  const hasTSM = unit.criticalSlots && Object.values(unit.criticalSlots).some((slots: any) =>
-    Array.isArray(slots) && slots.some((s: any) => s && typeof s === 'string' && s.toLowerCase().includes('tsm'))
-  );
+  const hasTSM =
+    unit.criticalSlots &&
+    Object.values(unit.criticalSlots).some(
+      (slots: any) =>
+        Array.isArray(slots) &&
+        slots.some(
+          (s: any) =>
+            s && typeof s === 'string' && s.toLowerCase().includes('tsm'),
+        ),
+    );
   const expectedBonus = hasTSM ? expectedWeight * 1.5 : expectedWeight;
   if (Math.abs(b.weightBonus - expectedBonus) > 1) {
     weightWrong++;
-    if (weightWrong <= 5) console.log(`  ${u.unitId}: expected=${expectedBonus.toFixed(0)} got=${b.weightBonus.toFixed(0)} (TSM=${hasTSM})`);
+    if (weightWrong <= 5)
+      console.log(
+        `  ${u.unitId}: expected=${expectedBonus.toFixed(0)} got=${b.weightBonus.toFixed(0)} (TSM=${hasTSM})`,
+      );
   }
 }
 console.log(`Weight bonus mismatches: ${weightWrong}/${under.length}`);
@@ -55,10 +63,17 @@ let sfWrong = 0;
 for (const u of under) {
   const b = u.breakdown;
   const expectedMP = b.runMP + Math.round(Math.max(b.jumpMP, 0) / 2);
-  const expectedSF = Math.round(Math.pow(1 + ((expectedMP > 5 ? expectedMP : expectedMP) - 5) / 10, 1.2) * 100) / 100;
+  const expectedSF =
+    Math.round(
+      Math.pow(1 + ((expectedMP > 5 ? expectedMP : expectedMP) - 5) / 10, 1.2) *
+        100,
+    ) / 100;
   if (Math.abs(b.speedFactor - expectedSF) > 0.01) {
     sfWrong++;
-    if (sfWrong <= 5) console.log(`  ${u.unitId}: expected=${expectedSF} got=${b.speedFactor} (run=${b.runMP} jump=${b.jumpMP})`);
+    if (sfWrong <= 5)
+      console.log(
+        `  ${u.unitId}: expected=${expectedSF} got=${b.speedFactor} (run=${b.runMP} jump=${b.jumpMP})`,
+      );
   }
 }
 console.log(`Speed factor mismatches: ${sfWrong}/${under.length}`);
@@ -68,8 +83,10 @@ console.log('\n=== HEAT EFFICIENCY COMPARISON ===');
 // Compare undercalculated vs exact units
 const underHE = under.map((u: any) => u.breakdown.heatEfficiency);
 const exactHE = exact.map((u: any) => u.breakdown.heatEfficiency);
-const avgUnderHE = underHE.reduce((a: number, b: number) => a + b, 0) / underHE.length;
-const avgExactHE = exactHE.reduce((a: number, b: number) => a + b, 0) / exactHE.length;
+const avgUnderHE =
+  underHE.reduce((a: number, b: number) => a + b, 0) / underHE.length;
+const avgExactHE =
+  exactHE.reduce((a: number, b: number) => a + b, 0) / exactHE.length;
 console.log(`  Undercalculated avg HE: ${avgUnderHE.toFixed(1)}`);
 console.log(`  Exact match avg HE: ${avgExactHE.toFixed(1)}`);
 
@@ -77,14 +94,18 @@ console.log(`  Exact match avg HE: ${avgExactHE.toFixed(1)}`);
 console.log('\n=== WEAPON HALVING RATE ===');
 const underHalvePct = under.map((u: any) => {
   const b = u.breakdown;
-  return b.rawWeaponBV > 0 ? (b.halvedWeaponBV / b.rawWeaponBV * 100) : 0;
+  return b.rawWeaponBV > 0 ? (b.halvedWeaponBV / b.rawWeaponBV) * 100 : 0;
 });
 const exactHalvePct = exact.map((u: any) => {
   const b = u.breakdown;
-  return b.rawWeaponBV > 0 ? (b.halvedWeaponBV / b.rawWeaponBV * 100) : 0;
+  return b.rawWeaponBV > 0 ? (b.halvedWeaponBV / b.rawWeaponBV) * 100 : 0;
 });
-console.log(`  Undercalculated: ${(underHalvePct.reduce((a: number, b: number) => a + b, 0) / underHalvePct.length).toFixed(1)}% of weapon BV halved`);
-console.log(`  Exact match: ${(exactHalvePct.reduce((a: number, b: number) => a + b, 0) / exactHalvePct.length).toFixed(1)}% of weapon BV halved`);
+console.log(
+  `  Undercalculated: ${(underHalvePct.reduce((a: number, b: number) => a + b, 0) / underHalvePct.length).toFixed(1)}% of weapon BV halved`,
+);
+console.log(
+  `  Exact match: ${(exactHalvePct.reduce((a: number, b: number) => a + b, 0) / exactHalvePct.length).toFixed(1)}% of weapon BV halved`,
+);
 
 // ANALYSIS 5: Ammo BV patterns
 console.log('\n=== AMMO BV ANALYSIS ===');
@@ -94,8 +115,12 @@ const exactWithAmmo = exact.filter((u: any) => u.breakdown.ammoBV > 0);
 const exactNoAmmo = exact.filter((u: any) => u.breakdown.ammoBV === 0);
 
 // For no-ammo units, the gap MUST be in weaponBV, physicalBV, weightBonus, or offEquipBV
-console.log(`  Undercalc with ammo: ${underWithAmmo.length}, without: ${underNoAmmo.length}`);
-console.log(`  Exact with ammo: ${exactWithAmmo.length}, without: ${exactNoAmmo.length}`);
+console.log(
+  `  Undercalc with ammo: ${underWithAmmo.length}, without: ${underNoAmmo.length}`,
+);
+console.log(
+  `  Exact with ammo: ${exactWithAmmo.length}, without: ${exactNoAmmo.length}`,
+);
 
 // ANALYSIS 6: For no-ammo undercalculated units, trace exactly where the gap is
 console.log('\n=== NO-AMMO UNDERCALCULATED UNIT TRACES ===');
@@ -105,11 +130,19 @@ for (const u of underNoAmmo.slice(0, 20)) {
   const neededTotal = u.indexBV / cockpit;
   const neededOff = neededTotal - b.defensiveBV;
   const neededBase = neededOff / b.speedFactor;
-  const currentBase = b.weaponBV + b.ammoBV + b.weightBonus + (b.physicalWeaponBV ?? 0) + (b.offEquipBV ?? 0);
+  const currentBase =
+    b.weaponBV +
+    b.ammoBV +
+    b.weightBonus +
+    (b.physicalWeaponBV ?? 0) +
+    (b.offEquipBV ?? 0);
   const baseGap = neededBase - currentBase;
   // What % of gap is in weaponBV?
-  const weaponGapPct = b.weaponBV > 0 ? (baseGap / b.weaponBV * 100).toFixed(1) : 'N/A';
-  console.log(`  ${u.unitId.padEnd(35)} gap=${Math.round(baseGap)} (${weaponGapPct}% of weaponBV) weapon=${Math.round(b.weaponBV)} wt=${Math.round(b.weightBonus)} phys=${Math.round(b.physicalWeaponBV ?? 0)} sf=${b.speedFactor} HE=${b.heatEfficiency} halved=${b.halvedWeaponCount}/${b.weaponCount}`);
+  const weaponGapPct =
+    b.weaponBV > 0 ? ((baseGap / b.weaponBV) * 100).toFixed(1) : 'N/A';
+  console.log(
+    `  ${u.unitId.padEnd(35)} gap=${Math.round(baseGap)} (${weaponGapPct}% of weaponBV) weapon=${Math.round(b.weaponBV)} wt=${Math.round(b.weightBonus)} phys=${Math.round(b.physicalWeaponBV ?? 0)} sf=${b.speedFactor} HE=${b.heatEfficiency} halved=${b.halvedWeaponCount}/${b.weaponCount}`,
+  );
 }
 
 // ANALYSIS 7: Reverse-check the heat tracking — what if heatEfficiency is off?
@@ -124,12 +157,19 @@ for (const u of under) {
   const neededTotal = u.indexBV / cockpit;
   const neededOff = neededTotal - b.defensiveBV;
   const neededBase = neededOff / b.speedFactor;
-  const currentBase = b.weaponBV + b.ammoBV + b.weightBonus + (b.physicalWeaponBV ?? 0) + (b.offEquipBV ?? 0);
+  const currentBase =
+    b.weaponBV +
+    b.ammoBV +
+    b.weightBonus +
+    (b.physicalWeaponBV ?? 0) +
+    (b.offEquipBV ?? 0);
   const baseGap = neededBase - currentBase;
   // If gap < halvedWeaponBV, then un-halving some weapons could fix it
   if (baseGap > 0 && baseGap <= b.halvedWeaponBV * 1.5) heFixableCount++;
 }
-console.log(`  Units where un-halving some weapons would fix gap: ${heFixableCount}/${under.length}`);
+console.log(
+  `  Units where un-halving some weapons would fix gap: ${heFixableCount}/${under.length}`,
+);
 
 // ANALYSIS 8: Check heatDissipation calculation directly
 console.log('\n=== HEAT DISSIPATION AUDIT ===');
@@ -138,38 +178,54 @@ for (const u of under.slice(0, 100)) {
   const unit = loadUnit(u.unitId);
   if (!unit) continue;
   const b = u.breakdown;
-  const isDHS = unit.heatSinks?.type?.toUpperCase().includes('DOUBLE') || unit.heatSinks?.type?.toUpperCase().includes('LASER');
+  const isDHS =
+    unit.heatSinks?.type?.toUpperCase().includes('DOUBLE') ||
+    unit.heatSinks?.type?.toUpperCase().includes('LASER');
   const engineHS = Math.min(10, Math.floor(unit.engine.rating / 25));
   const baseHD = unit.heatSinks.count * (isDHS ? 2 : 1);
   // Expected: max(unit.heatSinks.count, engineIntegrated + critDHS) * multiplier
   // For now just check the basic calculation
   if (Math.abs(b.heatDissipation - baseHD) > 1 && !unit.criticalSlots) {
     hdWrong++;
-    if (hdWrong <= 5) console.log(`  ${u.unitId}: expected=${baseHD} got=${b.heatDissipation} (hsType=${unit.heatSinks.type} count=${unit.heatSinks.count})`);
+    if (hdWrong <= 5)
+      console.log(
+        `  ${u.unitId}: expected=${baseHD} got=${b.heatDissipation} (hsType=${unit.heatSinks.type} count=${unit.heatSinks.count})`,
+      );
   }
 }
 
 // ANALYSIS 9: Check if the gap correlates with weapon count
 console.log('\n=== GAP vs WEAPON COUNT ===');
-const weapCountBuckets: Record<string, { count: number; avgGap: number; sumGap: number }> = {};
+const weapCountBuckets: Record<
+  string,
+  { count: number; avgGap: number; sumGap: number }
+> = {};
 for (const u of under) {
   const b = u.breakdown;
   const cockpit = b.cockpitModifier ?? 1.0;
   const neededTotal = u.indexBV / cockpit;
   const neededOff = neededTotal - b.defensiveBV;
   const neededBase = neededOff / b.speedFactor;
-  const currentBase = b.weaponBV + b.ammoBV + b.weightBonus + (b.physicalWeaponBV ?? 0) + (b.offEquipBV ?? 0);
+  const currentBase =
+    b.weaponBV +
+    b.ammoBV +
+    b.weightBonus +
+    (b.physicalWeaponBV ?? 0) +
+    (b.offEquipBV ?? 0);
   const baseGap = neededBase - currentBase;
 
   const wc = b.weaponCount;
   const bucket = wc <= 3 ? '1-3' : wc <= 6 ? '4-6' : wc <= 10 ? '7-10' : '11+';
-  if (!weapCountBuckets[bucket]) weapCountBuckets[bucket] = { count: 0, avgGap: 0, sumGap: 0 };
+  if (!weapCountBuckets[bucket])
+    weapCountBuckets[bucket] = { count: 0, avgGap: 0, sumGap: 0 };
   weapCountBuckets[bucket].count++;
   weapCountBuckets[bucket].sumGap += baseGap;
 }
 for (const [b, s] of Object.entries(weapCountBuckets).sort()) {
   s.avgGap = s.sumGap / s.count;
-  console.log(`  Weapons ${b.padEnd(5)}: ${s.count} units, avg baseGap=${s.avgGap.toFixed(1)}`);
+  console.log(
+    `  Weapons ${b.padEnd(5)}: ${s.count} units, avg baseGap=${s.avgGap.toFixed(1)}`,
+  );
 }
 
 // ANALYSIS 10: Check if any "exact" units have the same equipment types as undercalculated ones
@@ -184,9 +240,18 @@ for (const u of under) {
   const seen = new Set<string>();
   for (const eq of unit.equipment) {
     const lo = eq.id.toLowerCase().replace(/^\d+-/, '');
-    if (lo.includes('ammo') || lo.includes('heat') || lo.includes('case') || lo.includes('targeting') || lo.includes('tsm')) continue;
+    if (
+      lo.includes('ammo') ||
+      lo.includes('heat') ||
+      lo.includes('case') ||
+      lo.includes('targeting') ||
+      lo.includes('tsm')
+    )
+      continue;
     // Normalize to weapon family
-    let family = lo.replace(/^(?:is|cl|clan)-?/, '').replace(/-?(?:os|ios)$/, '');
+    let family = lo
+      .replace(/^(?:is|cl|clan)-?/, '')
+      .replace(/-?(?:os|ios)$/, '');
     family = family.replace(/\d+$/, '').replace(/-$/, '');
     if (seen.has(family)) continue;
     seen.add(family);
@@ -199,8 +264,17 @@ for (const u of exact.slice(0, 500)) {
   const seen = new Set<string>();
   for (const eq of unit.equipment) {
     const lo = eq.id.toLowerCase().replace(/^\d+-/, '');
-    if (lo.includes('ammo') || lo.includes('heat') || lo.includes('case') || lo.includes('targeting') || lo.includes('tsm')) continue;
-    let family = lo.replace(/^(?:is|cl|clan)-?/, '').replace(/-?(?:os|ios)$/, '');
+    if (
+      lo.includes('ammo') ||
+      lo.includes('heat') ||
+      lo.includes('case') ||
+      lo.includes('targeting') ||
+      lo.includes('tsm')
+    )
+      continue;
+    let family = lo
+      .replace(/^(?:is|cl|clan)-?/, '')
+      .replace(/-?(?:os|ios)$/, '');
     family = family.replace(/\d+$/, '').replace(/-$/, '');
     if (seen.has(family)) continue;
     seen.add(family);
@@ -208,22 +282,40 @@ for (const u of exact.slice(0, 500)) {
   }
 }
 // Find weapon types that appear much more often in undercalculated than exact
-const allTypes = new Set([...Object.keys(weaponTypeInUnder), ...Object.keys(weaponTypeInExact)]);
-const enrichment: Array<{ type: string; underPct: number; exactPct: number; ratio: number }> = [];
+const allTypes = new Set([
+  ...Object.keys(weaponTypeInUnder),
+  ...Object.keys(weaponTypeInExact),
+]);
+const enrichment: Array<{
+  type: string;
+  underPct: number;
+  exactPct: number;
+  ratio: number;
+}> = [];
 for (const t of allTypes) {
   const underPct = ((weaponTypeInUnder[t] || 0) / under.length) * 100;
-  const exactPct = ((weaponTypeInExact[t] || 0) / Math.min(exact.length, 500)) * 100;
+  const exactPct =
+    ((weaponTypeInExact[t] || 0) / Math.min(exact.length, 500)) * 100;
   if (underPct > 5 || exactPct > 5) {
-    enrichment.push({ type: t, underPct, exactPct, ratio: underPct / Math.max(0.1, exactPct) });
+    enrichment.push({
+      type: t,
+      underPct,
+      exactPct,
+      ratio: underPct / Math.max(0.1, exactPct),
+    });
   }
 }
 enrichment.sort((a, b) => b.ratio - a.ratio);
 console.log('  Weapon types enriched in undercalculated units:');
 for (const e of enrichment.slice(0, 15)) {
   const marker = e.ratio > 2 ? ' ***' : e.ratio > 1.5 ? ' **' : '';
-  console.log(`    ${e.type.padEnd(30)} under=${e.underPct.toFixed(0)}% exact=${e.exactPct.toFixed(0)}% ratio=${e.ratio.toFixed(2)}${marker}`);
+  console.log(
+    `    ${e.type.padEnd(30)} under=${e.underPct.toFixed(0)}% exact=${e.exactPct.toFixed(0)}% ratio=${e.ratio.toFixed(2)}${marker}`,
+  );
 }
 console.log('  Weapon types enriched in exact-match units:');
 for (const e of enrichment.slice(-10)) {
-  console.log(`    ${e.type.padEnd(30)} under=${e.underPct.toFixed(0)}% exact=${e.exactPct.toFixed(0)}% ratio=${e.ratio.toFixed(2)}`);
+  console.log(
+    `    ${e.type.padEnd(30)} under=${e.underPct.toFixed(0)}% exact=${e.exactPct.toFixed(0)}% ratio=${e.ratio.toFixed(2)}`,
+  );
 }

--- a/scripts/diagnose-overcalc.ts
+++ b/scripts/diagnose-overcalc.ts
@@ -2,19 +2,15 @@
  * Diagnose overcalculated units: what component is wrong?
  * Check speed factor, defensive factor, weight bonus, weapon BV.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
-
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null,
+);
 const over = valid.filter((x: any) => x.percentDiff > 1);
 
 // Check for false MASC detection
@@ -34,19 +30,30 @@ for (const u of over) {
   const reportedRunMP = b.runMP;
 
   // Check if runMP > normalRun (suggesting MASC/SC was detected)
-  if (reportedRunMP > normalRun + 1) { // +1 for TSM
+  if (reportedRunMP > normalRun + 1) {
+    // +1 for TSM
     // Check if unit actually has MASC/SC in equipment
-    const hasMASCEquip = (unit.equipment || []).some((eq: any) => eq.id.toLowerCase().includes('masc'));
-    const hasSCEquip = (unit.equipment || []).some((eq: any) => eq.id.toLowerCase().includes('supercharger'));
+    const hasMASCEquip = (unit.equipment || []).some((eq: any) =>
+      eq.id.toLowerCase().includes('masc'),
+    );
+    const hasSCEquip = (unit.equipment || []).some((eq: any) =>
+      eq.id.toLowerCase().includes('supercharger'),
+    );
 
     if (!hasMASCEquip && !hasSCEquip) {
       falseMASC++;
-      mascDetails.push(`  ${u.unitId.padEnd(45)} walk=${walk} normalRun=${normalRun} reportedRun=${reportedRunMP} diff=+${u.difference} (${u.percentDiff.toFixed(1)}%)`);
+      mascDetails.push(
+        `  ${u.unitId.padEnd(45)} walk=${walk} normalRun=${normalRun} reportedRun=${reportedRunMP} diff=+${u.difference} (${u.percentDiff.toFixed(1)}%)`,
+      );
     }
   }
 
   // Check if runMP doesn't match expected calculation
-  if (reportedRunMP !== normalRun && reportedRunMP !== walk * 2 && reportedRunMP !== Math.ceil(walk * 2.5)) {
+  if (
+    reportedRunMP !== normalRun &&
+    reportedRunMP !== walk * 2 &&
+    reportedRunMP !== Math.ceil(walk * 2.5)
+  ) {
     // Check for TSM
     if (reportedRunMP !== Math.ceil((walk + 1) * 1.5)) {
       falseRunMP++;
@@ -66,7 +73,8 @@ for (const u of over) {
   const b = u.breakdown;
   if (!b) continue;
   const mp = b.runMP + Math.round((b.jumpMP || 0) / 2);
-  const expectedSF = Math.round(Math.pow(1 + Math.max(mp - 5, 0) / 10, 1.2) * 100) / 100;
+  const expectedSF =
+    Math.round(Math.pow(1 + Math.max(mp - 5, 0) / 10, 1.2) * 100) / 100;
   if (Math.abs(b.speedFactor - expectedSF) > 0.01) {
     sfHigh++;
   }
@@ -82,7 +90,9 @@ for (const u of over) {
   const df = b.defensiveFactor;
   dfGroups[df] = (dfGroups[df] || 0) + 1;
 }
-for (const [df, count] of Object.entries(dfGroups).sort((a, b) => parseFloat(b[0]) - parseFloat(a[0]))) {
+for (const [df, count] of Object.entries(dfGroups).sort(
+  (a, b) => parseFloat(b[0]) - parseFloat(a[0]),
+)) {
   console.log(`  DF=${df}: ${count} units`);
 }
 
@@ -94,7 +104,9 @@ for (const u of over) {
   if (!b) continue;
   tmmGroups[b.maxTMM] = (tmmGroups[b.maxTMM] || 0) + 1;
 }
-for (const [tmm, count] of Object.entries(tmmGroups).sort((a, b) => parseInt(b[0]) - parseInt(a[0]))) {
+for (const [tmm, count] of Object.entries(tmmGroups).sort(
+  (a, b) => parseInt(b[0]) - parseInt(a[0]),
+)) {
   console.log(`  TMM=${tmm}: ${count} units`);
 }
 
@@ -106,7 +118,9 @@ for (const u of valid) {
   if (!b) continue;
   tmmAll[b.maxTMM] = (tmmAll[b.maxTMM] || 0) + 1;
 }
-for (const [tmm, count] of Object.entries(tmmAll).sort((a, b) => parseInt(b[0]) - parseInt(a[0]))) {
+for (const [tmm, count] of Object.entries(tmmAll).sort(
+  (a, b) => parseInt(b[0]) - parseInt(a[0]),
+)) {
   console.log(`  TMM=${tmm}: ${count} units`);
 }
 
@@ -127,7 +141,11 @@ for (const u of over) {
   const refOffEstimate = refBase * offRatio;
   const refDefEstimate = refBase * (1 - offRatio);
 
-  if (b.defensiveBV > refDefEstimate + 10 && b.offensiveBV > refOffEstimate + 10) bothExcessCount++;
+  if (
+    b.defensiveBV > refDefEstimate + 10 &&
+    b.offensiveBV > refOffEstimate + 10
+  )
+    bothExcessCount++;
   else if (b.defensiveBV > refDefEstimate + 10) defExcessCount++;
   else offExcessCount++;
 }
@@ -137,19 +155,43 @@ console.log(`  Both: ${bothExcessCount}`);
 
 // List overcalculated units by percentage, showing which have MASC
 console.log('\n=== OVERCALCULATED 3-10% BAND WITH DETAILS ===');
-const over3to10 = over.filter((x: any) => x.percentDiff >= 3 && x.percentDiff < 10);
-for (const u of [...over3to10].sort((a: any, b: any) => b.percentDiff - a.percentDiff).slice(0, 20)) {
+const over3to10 = over.filter(
+  (x: any) => x.percentDiff >= 3 && x.percentDiff < 10,
+);
+for (const u of [...over3to10]
+  .sort((a: any, b: any) => b.percentDiff - a.percentDiff)
+  .slice(0, 20)) {
   const unit = loadUnit(u.unitId);
   if (!unit) continue;
   const b = u.breakdown;
   const walk = unit.movement?.walk || 0;
   const normalRun = Math.ceil(walk * 1.5);
-  const hasMASC = (unit.criticalSlots && Object.values(unit.criticalSlots).some((slots: any) =>
-    Array.isArray(slots) && slots.some((s: any) => s && typeof s === 'string' &&
-      (s as string).toLowerCase().includes('masc'))));
-  const hasSC = (unit.criticalSlots && Object.values(unit.criticalSlots).some((slots: any) =>
-    Array.isArray(slots) && slots.some((s: any) => s && typeof s === 'string' &&
-      (s as string).toLowerCase().includes('supercharger'))));
+  const hasMASC =
+    unit.criticalSlots &&
+    Object.values(unit.criticalSlots).some(
+      (slots: any) =>
+        Array.isArray(slots) &&
+        slots.some(
+          (s: any) =>
+            s &&
+            typeof s === 'string' &&
+            (s as string).toLowerCase().includes('masc'),
+        ),
+    );
+  const hasSC =
+    unit.criticalSlots &&
+    Object.values(unit.criticalSlots).some(
+      (slots: any) =>
+        Array.isArray(slots) &&
+        slots.some(
+          (s: any) =>
+            s &&
+            typeof s === 'string' &&
+            (s as string).toLowerCase().includes('supercharger'),
+        ),
+    );
 
-  console.log(`  ${u.unitId.padEnd(45)} +${u.percentDiff.toFixed(1)}% walk=${walk} run=${b?.runMP} normalRun=${normalRun} MASC=${hasMASC} SC=${hasSC} SF=${b?.speedFactor}`);
+  console.log(
+    `  ${u.unitId.padEnd(45)} +${u.percentDiff.toFixed(1)}% walk=${walk} run=${b?.runMP} normalRun=${normalRun} MASC=${hasMASC} SC=${hasSC} SF=${b?.speedFactor}`,
+  );
 }

--- a/scripts/find-ammo-gaps.ts
+++ b/scripts/find-ammo-gaps.ts
@@ -2,19 +2,15 @@
  * Find units that are undercalculated AND have ammoBV=0 in breakdown
  * despite having ammo-using weapons. These are the true ammo gaps.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
-
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown,
+);
 
 // Find undercalculated units with ammoBV=0 that have ammo in crits
 const ammoGaps: any[] = [];
@@ -32,7 +28,11 @@ for (const u of valid) {
   for (const [loc, slots] of Object.entries(unit.criticalSlots)) {
     if (!Array.isArray(slots)) continue;
     for (const s of slots as string[]) {
-      if (s && s.toLowerCase().includes('ammo') && !s.toLowerCase().includes('ammo feed')) {
+      if (
+        s &&
+        s.toLowerCase().includes('ammo') &&
+        !s.toLowerCase().includes('ammo feed')
+      ) {
         ammoEntries.push(`${loc}:${s}`);
       }
     }
@@ -49,16 +49,22 @@ for (const u of valid) {
   });
 }
 
-console.log(`=== UNDERCALCULATED UNITS WITH ammoBV=0 BUT AMMO IN CRITS (${ammoGaps.length}) ===\n`);
+console.log(
+  `=== UNDERCALCULATED UNITS WITH ammoBV=0 BUT AMMO IN CRITS (${ammoGaps.length}) ===\n`,
+);
 ammoGaps.sort((a, b) => a.pctDiff - b.pctDiff);
 for (const g of ammoGaps) {
-  console.log(`${g.id} (${g.pctDiff.toFixed(1)}%, diff=${g.diff}, weapBV=${g.weaponBV?.toFixed(0)})`);
+  console.log(
+    `${g.id} (${g.pctDiff.toFixed(1)}%, diff=${g.diff}, weapBV=${g.weaponBV?.toFixed(0)})`,
+  );
   for (const a of g.ammoEntries) console.log(`    ${a}`);
 }
 
 // Also check: units with ammoBV > 0 but still significantly undercalculated
 // These might have SOME ammo resolving but not all
-console.log('\n\n=== UNDERCALCULATED >2% WITH PARTIAL AMMO (ammoBV > 0 but low) ===\n');
+console.log(
+  '\n\n=== UNDERCALCULATED >2% WITH PARTIAL AMMO (ammoBV > 0 but low) ===\n',
+);
 const partialAmmo: any[] = [];
 for (const u of valid) {
   if (u.percentDiff >= -2) continue;
@@ -72,7 +78,12 @@ for (const u of valid) {
   for (const [, slots] of Object.entries(unit.criticalSlots)) {
     if (!Array.isArray(slots)) continue;
     for (const s of slots as string[]) {
-      if (s && s.toLowerCase().includes('ammo') && !s.toLowerCase().includes('ammo feed')) ammoCount++;
+      if (
+        s &&
+        s.toLowerCase().includes('ammo') &&
+        !s.toLowerCase().includes('ammo feed')
+      )
+        ammoCount++;
     }
   }
 
@@ -89,5 +100,7 @@ for (const u of valid) {
 }
 partialAmmo.sort((a, b) => a.pctDiff - b.pctDiff);
 for (const p of partialAmmo.slice(0, 30)) {
-  console.log(`  ${p.id.padEnd(42)} ${p.pctDiff.toFixed(1)}% ammoBV=${p.ammoBV} ammoSlots=${p.ammoCount} bv/slot=${p.bvPerAmmo}`);
+  console.log(
+    `  ${p.id.padEnd(42)} ${p.pctDiff.toFixed(1)}% ammoBV=${p.ammoBV} ammoSlots=${p.ammoCount} bv/slot=${p.bvPerAmmo}`,
+  );
 }

--- a/scripts/find-gap-sources.ts
+++ b/scripts/find-gap-sources.ts
@@ -2,19 +2,15 @@
  * For boundary outliers, trace the exact source of BV gap.
  * Check: unresolved weapons, unresolved ammo, physical weapon BV, weight bonus.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
-
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown,
+);
 
 // Check for unresolved weapons across ALL outliers
 console.log('=== UNRESOLVED WEAPONS IN OUTLIERS ===');
@@ -23,15 +19,22 @@ let unresolvedCount = 0;
 for (const r of outliers) {
   const b = r.breakdown;
   if (b?.unresolvedWeapons?.length > 0) {
-    console.log(`  ${r.unitId.padEnd(40)} ${r.percentDiff.toFixed(1).padStart(6)}% unresolved: ${b.unresolvedWeapons.join(', ')}`);
+    console.log(
+      `  ${r.unitId.padEnd(40)} ${r.percentDiff.toFixed(1).padStart(6)}% unresolved: ${b.unresolvedWeapons.join(', ')}`,
+    );
     unresolvedCount++;
   }
 }
-console.log(`Total outliers with unresolved weapons: ${unresolvedCount} / ${outliers.length}`);
+console.log(
+  `Total outliers with unresolved weapons: ${unresolvedCount} / ${outliers.length}`,
+);
 
 // Check for unresolved ammo (ammo that matched no weapon)
 console.log('\n=== AMMO BV ANALYSIS FOR LARGEST UNDERCALCULATED ===');
-const underOutliers = valid.filter((x: any) => x.percentDiff < -2).sort((a: any, b: any) => a.percentDiff - b.percentDiff).slice(0, 15);
+const underOutliers = valid
+  .filter((x: any) => x.percentDiff < -2)
+  .sort((a: any, b: any) => a.percentDiff - b.percentDiff)
+  .slice(0, 15);
 for (const r of underOutliers) {
   const b = r.breakdown;
   const unit = loadUnit(r.unitId);
@@ -42,13 +45,19 @@ for (const r of underOutliers) {
   for (const [loc, slots] of Object.entries(unit.criticalSlots || {})) {
     if (!Array.isArray(slots)) continue;
     for (const s of slots) {
-      if (typeof s === 'string' && (s.toLowerCase().includes('ammo') || s.toLowerCase().includes('pods'))) ammoCritSlots++;
+      if (
+        typeof s === 'string' &&
+        (s.toLowerCase().includes('ammo') || s.toLowerCase().includes('pods'))
+      )
+        ammoCritSlots++;
     }
   }
 
   const weaponCount = b?.weapons?.length || 0;
   const ammoCount = b?.ammo?.length || 0;
-  console.log(`  ${r.unitId.padEnd(35)} ${r.percentDiff.toFixed(1).padStart(6)}% gap=${Math.abs(r.difference).toString().padStart(4)} wBV=${b?.weaponBV?.toFixed(0)} ammoBV=${b?.ammoBV} weps=${weaponCount} ammoEntries=${ammoCount} ammoCrits=${ammoCritSlots} physBV=${b?.physicalWeaponBV?.toFixed(0)} wt=${b?.weightBonus?.toFixed(0)}`);
+  console.log(
+    `  ${r.unitId.padEnd(35)} ${r.percentDiff.toFixed(1).padStart(6)}% gap=${Math.abs(r.difference).toString().padStart(4)} wBV=${b?.weaponBV?.toFixed(0)} ammoBV=${b?.ammoBV} weps=${weaponCount} ammoEntries=${ammoCount} ammoCrits=${ammoCritSlots} physBV=${b?.physicalWeaponBV?.toFixed(0)} wt=${b?.weightBonus?.toFixed(0)}`,
+  );
 }
 
 // Check: physical weapon BV for quad mechs
@@ -58,7 +67,9 @@ for (const r of valid) {
   if (!unit || unit.configuration !== 'Quad') continue;
   if (Math.abs(r.percentDiff) > 1) {
     const b = r.breakdown;
-    console.log(`  ${r.unitId.padEnd(35)} ${r.percentDiff.toFixed(1).padStart(6)}% phys=${b?.physicalWeaponBV?.toFixed(0)} wt=${b?.weightBonus?.toFixed(0)} ${unit.tonnage}t`);
+    console.log(
+      `  ${r.unitId.padEnd(35)} ${r.percentDiff.toFixed(1).padStart(6)}% phys=${b?.physicalWeaponBV?.toFixed(0)} wt=${b?.weightBonus?.toFixed(0)} ${unit.tonnage}t`,
+    );
   }
 }
 
@@ -69,8 +80,11 @@ for (const r of outliers) {
   const unit = loadUnit(r.unitId);
   if (!unit) continue;
   const critsStr = JSON.stringify(unit.criticalSlots || {}).toLowerCase();
-  if (!critsStr.includes('tsm') && !critsStr.includes('triple strength')) continue;
-  console.log(`  ${r.unitId.padEnd(35)} ${r.percentDiff.toFixed(1).padStart(6)}% wt=${b?.weightBonus?.toFixed(0)} ${unit.tonnage}t phys=${b?.physicalWeaponBV?.toFixed(0)} hasTSM=${b?.hasTSM}`);
+  if (!critsStr.includes('tsm') && !critsStr.includes('triple strength'))
+    continue;
+  console.log(
+    `  ${r.unitId.padEnd(35)} ${r.percentDiff.toFixed(1).padStart(6)}% wt=${b?.weightBonus?.toFixed(0)} ${unit.tonnage}t phys=${b?.physicalWeaponBV?.toFixed(0)} hasTSM=${b?.hasTSM}`,
+  );
 }
 
 // Check: are there ammo entries that should match HAG but don't?
@@ -90,10 +104,19 @@ for (const r of hagOutliers) {
   for (const [loc, slots] of Object.entries(unit.criticalSlots || {})) {
     if (!Array.isArray(slots)) continue;
     for (const s of slots) {
-      if (typeof s === 'string' && s.toLowerCase().includes('hag') && s.toLowerCase().includes('ammo')) hagAmmoCrits++;
+      if (
+        typeof s === 'string' &&
+        s.toLowerCase().includes('hag') &&
+        s.toLowerCase().includes('ammo')
+      )
+        hagAmmoCrits++;
     }
   }
 
-  const hagAmmo = (b?.ammo || []).filter((a: any) => (a.id||a.weaponType||'').toLowerCase().includes('hag'));
-  console.log(`  ${r.unitId.padEnd(35)} ${r.percentDiff.toFixed(1).padStart(6)}% hagAmmoCrits=${hagAmmoCrits} resolvedHagAmmo=${hagAmmo.length} totalAmmo=${b?.ammoBV}`);
+  const hagAmmo = (b?.ammo || []).filter((a: any) =>
+    (a.id || a.weaponType || '').toLowerCase().includes('hag'),
+  );
+  console.log(
+    `  ${r.unitId.padEnd(35)} ${r.percentDiff.toFixed(1).padStart(6)}% hagAmmoCrits=${hagAmmoCrits} resolvedHagAmmo=${hagAmmo.length} totalAmmo=${b?.ammoBV}`,
+  );
 }

--- a/scripts/trace-1pct-detail.ts
+++ b/scripts/trace-1pct-detail.ts
@@ -2,22 +2,20 @@
  * Detailed trace of 1-2% band units to find the actual BV components causing the gap.
  * For each unit, show the exact BV components and what they'd need to be.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
-
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown,
+);
 
 // Check overcalculated 1-2% first: what's the consistent excess?
-const over1to2 = valid.filter((x: any) => x.percentDiff > 1 && x.percentDiff <= 2);
+const over1to2 = valid.filter(
+  (x: any) => x.percentDiff > 1 && x.percentDiff <= 2,
+);
 console.log(`=== OVERCALCULATED 1-2% (${over1to2.length} units) ===\n`);
 
 // Track excess patterns
@@ -29,7 +27,7 @@ for (const u of over1to2) {
   const b = u.breakdown;
   const cockpit = b.cockpitModifier ?? 1;
   const refBase = u.indexBV / cockpit;
-  const excess = (b.defensiveBV + b.offensiveBV) - refBase;
+  const excess = b.defensiveBV + b.offensiveBV - refBase;
 
   // Try to identify if the excess is in defense or offense
   // Assume both contribute proportionally
@@ -44,27 +42,43 @@ for (const u of over1to2) {
 
 const avgOverExcess = totalOverExcess / over1to2.length;
 console.log(`Average total excess: ${avgOverExcess.toFixed(1)} BV`);
-console.log(`Average def excess: ${(defExcessArr.reduce((a, b) => a + b, 0) / defExcessArr.length).toFixed(1)} BV`);
-console.log(`Average off excess: ${(offExcessArr.reduce((a, b) => a + b, 0) / offExcessArr.length).toFixed(1)} BV`);
+console.log(
+  `Average def excess: ${(defExcessArr.reduce((a, b) => a + b, 0) / defExcessArr.length).toFixed(1)} BV`,
+);
+console.log(
+  `Average off excess: ${(offExcessArr.reduce((a, b) => a + b, 0) / offExcessArr.length).toFixed(1)} BV`,
+);
 
 // Detailed breakdown of first 15 overcalculated units
 console.log('\n=== DETAILED OVERCALCULATED 1-2% ===');
-for (const u of over1to2.sort((a: any, b: any) => b.percentDiff - a.percentDiff).slice(0, 15)) {
+for (const u of over1to2
+  .sort((a: any, b: any) => b.percentDiff - a.percentDiff)
+  .slice(0, 15)) {
   const unit = loadUnit(u.unitId);
   if (!unit) continue;
   const b = u.breakdown;
   const cockpit = b.cockpitModifier ?? 1;
   const refBase = u.indexBV / cockpit;
-  const excess = (b.defensiveBV + b.offensiveBV) - refBase;
+  const excess = b.defensiveBV + b.offensiveBV - refBase;
 
-  console.log(`${u.unitId.padEnd(45)} +${u.percentDiff.toFixed(1)}% excess=${excess.toFixed(0)} cockpit=${cockpit}`);
-  console.log(`  DEF: armor=${b.armorBV?.toFixed(0)} struct=${b.structureBV?.toFixed(0)} gyro=${b.gyroBV?.toFixed(0)} defEq=${b.defEquipBV} expPen=${b.explosivePenalty} DF=${b.defensiveFactor} → ${b.defensiveBV?.toFixed(0)}`);
-  console.log(`  OFF: weap=${b.weaponBV?.toFixed(0)} ammo=${b.ammoBV} wt=${b.weightBonus?.toFixed(0)} phys=${b.physicalWeaponBV?.toFixed(0)} offEq=${b.offEquipBV} SF=${b.speedFactor} HE=${b.heatEfficiency} halved=${b.halvedWeaponCount}/${b.weaponCount} → ${b.offensiveBV?.toFixed(0)}`);
-  console.log(`  run=${b.runMP} jump=${b.jumpMP || 0} TMM=${b.maxTMM} eng=${unit.engine?.type}`);
+  console.log(
+    `${u.unitId.padEnd(45)} +${u.percentDiff.toFixed(1)}% excess=${excess.toFixed(0)} cockpit=${cockpit}`,
+  );
+  console.log(
+    `  DEF: armor=${b.armorBV?.toFixed(0)} struct=${b.structureBV?.toFixed(0)} gyro=${b.gyroBV?.toFixed(0)} defEq=${b.defEquipBV} expPen=${b.explosivePenalty} DF=${b.defensiveFactor} → ${b.defensiveBV?.toFixed(0)}`,
+  );
+  console.log(
+    `  OFF: weap=${b.weaponBV?.toFixed(0)} ammo=${b.ammoBV} wt=${b.weightBonus?.toFixed(0)} phys=${b.physicalWeaponBV?.toFixed(0)} offEq=${b.offEquipBV} SF=${b.speedFactor} HE=${b.heatEfficiency} halved=${b.halvedWeaponCount}/${b.weaponCount} → ${b.offensiveBV?.toFixed(0)}`,
+  );
+  console.log(
+    `  run=${b.runMP} jump=${b.jumpMP || 0} TMM=${b.maxTMM} eng=${unit.engine?.type}`,
+  );
 }
 
 // Now check undercalculated 1-2%
-const under1to2 = valid.filter((x: any) => x.percentDiff < -1 && x.percentDiff >= -2);
+const under1to2 = valid.filter(
+  (x: any) => x.percentDiff < -1 && x.percentDiff >= -2,
+);
 console.log(`\n=== UNDERCALCULATED 1-2% (${under1to2.length} units) ===\n`);
 
 let totalUnderDeficit = 0;
@@ -74,10 +88,14 @@ for (const u of under1to2) {
   const refBase = u.indexBV / cockpit;
   totalUnderDeficit += refBase - (b.defensiveBV + b.offensiveBV);
 }
-console.log(`Average deficit: ${(totalUnderDeficit / under1to2.length).toFixed(1)} BV`);
+console.log(
+  `Average deficit: ${(totalUnderDeficit / under1to2.length).toFixed(1)} BV`,
+);
 
 console.log('\n=== DETAILED UNDERCALCULATED 1-2% ===');
-for (const u of under1to2.sort((a: any, b: any) => a.percentDiff - b.percentDiff).slice(0, 15)) {
+for (const u of under1to2
+  .sort((a: any, b: any) => a.percentDiff - b.percentDiff)
+  .slice(0, 15)) {
   const unit = loadUnit(u.unitId);
   if (!unit) continue;
   const b = u.breakdown;
@@ -85,10 +103,18 @@ for (const u of under1to2.sort((a: any, b: any) => a.percentDiff - b.percentDiff
   const refBase = u.indexBV / cockpit;
   const deficit = refBase - (b.defensiveBV + b.offensiveBV);
 
-  console.log(`${u.unitId.padEnd(45)} ${u.percentDiff.toFixed(1)}% deficit=${deficit.toFixed(0)} cockpit=${cockpit}`);
-  console.log(`  DEF: armor=${b.armorBV?.toFixed(0)} struct=${b.structureBV?.toFixed(0)} gyro=${b.gyroBV?.toFixed(0)} defEq=${b.defEquipBV} expPen=${b.explosivePenalty} DF=${b.defensiveFactor} → ${b.defensiveBV?.toFixed(0)}`);
-  console.log(`  OFF: weap=${b.weaponBV?.toFixed(0)} ammo=${b.ammoBV} wt=${b.weightBonus?.toFixed(0)} phys=${b.physicalWeaponBV?.toFixed(0)} offEq=${b.offEquipBV} SF=${b.speedFactor} HE=${b.heatEfficiency} halved=${b.halvedWeaponCount}/${b.weaponCount} → ${b.offensiveBV?.toFixed(0)}`);
-  console.log(`  run=${b.runMP} jump=${b.jumpMP || 0} TMM=${b.maxTMM} eng=${unit.engine?.type} tech=${unit.techBase}`);
+  console.log(
+    `${u.unitId.padEnd(45)} ${u.percentDiff.toFixed(1)}% deficit=${deficit.toFixed(0)} cockpit=${cockpit}`,
+  );
+  console.log(
+    `  DEF: armor=${b.armorBV?.toFixed(0)} struct=${b.structureBV?.toFixed(0)} gyro=${b.gyroBV?.toFixed(0)} defEq=${b.defEquipBV} expPen=${b.explosivePenalty} DF=${b.defensiveFactor} → ${b.defensiveBV?.toFixed(0)}`,
+  );
+  console.log(
+    `  OFF: weap=${b.weaponBV?.toFixed(0)} ammo=${b.ammoBV} wt=${b.weightBonus?.toFixed(0)} phys=${b.physicalWeaponBV?.toFixed(0)} offEq=${b.offEquipBV} SF=${b.speedFactor} HE=${b.heatEfficiency} halved=${b.halvedWeaponCount}/${b.weaponCount} → ${b.offensiveBV?.toFixed(0)}`,
+  );
+  console.log(
+    `  run=${b.runMP} jump=${b.jumpMP || 0} TMM=${b.maxTMM} eng=${unit.engine?.type} tech=${unit.techBase}`,
+  );
 }
 
 // Summary: what's the average speed factor, defensive factor, heat efficiency for overcalculated vs undercalculated?
@@ -99,9 +125,21 @@ const overDF = over1to2.map((u: any) => u.breakdown.defensiveFactor);
 const underDF = under1to2.map((u: any) => u.breakdown.defensiveFactor);
 const overHE = over1to2.map((u: any) => u.breakdown.heatEfficiency);
 const underHE = under1to2.map((u: any) => u.breakdown.heatEfficiency);
-console.log(`Over SF avg: ${(overSF.reduce((a: number, b: number) => a + b) / overSF.length).toFixed(3)}`);
-console.log(`Under SF avg: ${(underSF.reduce((a: number, b: number) => a + b) / underSF.length).toFixed(3)}`);
-console.log(`Over DF avg: ${(overDF.reduce((a: number, b: number) => a + b) / overDF.length).toFixed(3)}`);
-console.log(`Under DF avg: ${(underDF.reduce((a: number, b: number) => a + b) / underDF.length).toFixed(3)}`);
-console.log(`Over HE avg: ${(overHE.reduce((a: number, b: number) => a + b) / overHE.length).toFixed(1)}`);
-console.log(`Under HE avg: ${(underHE.reduce((a: number, b: number) => a + b) / underHE.length).toFixed(1)}`);
+console.log(
+  `Over SF avg: ${(overSF.reduce((a: number, b: number) => a + b) / overSF.length).toFixed(3)}`,
+);
+console.log(
+  `Under SF avg: ${(underSF.reduce((a: number, b: number) => a + b) / underSF.length).toFixed(3)}`,
+);
+console.log(
+  `Over DF avg: ${(overDF.reduce((a: number, b: number) => a + b) / overDF.length).toFixed(3)}`,
+);
+console.log(
+  `Under DF avg: ${(underDF.reduce((a: number, b: number) => a + b) / underDF.length).toFixed(3)}`,
+);
+console.log(
+  `Over HE avg: ${(overHE.reduce((a: number, b: number) => a + b) / overHE.length).toFixed(1)}`,
+);
+console.log(
+  `Under HE avg: ${(underHE.reduce((a: number, b: number) => a + b) / underHE.length).toFixed(1)}`,
+);

--- a/scripts/trace-big-outliers.ts
+++ b/scripts/trace-big-outliers.ts
@@ -1,37 +1,47 @@
 /**
  * Trace the biggest outliers to find the BV calculation errors.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
-
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
 // Pick specific big outliers to trace
 const ids = [
-  'jackalope-jlp-kb', 'jenner-jr7-d-webster', 'hatamoto-chi-htm-27t-lowenbrau',
-  'thunderbolt-tdr-5l', 'barghest-bgs-3t', 'stag-ii-st-24g', 'great-turtle-gtr-1',
-  'koshi-a', 'uller-c', 'celerity-clr-03-oe',
+  'jackalope-jlp-kb',
+  'jenner-jr7-d-webster',
+  'hatamoto-chi-htm-27t-lowenbrau',
+  'thunderbolt-tdr-5l',
+  'barghest-bgs-3t',
+  'stag-ii-st-24g',
+  'great-turtle-gtr-1',
+  'koshi-a',
+  'uller-c',
+  'celerity-clr-03-oe',
 ];
 
 for (const unitId of ids) {
   const result = report.allResults.find((x: any) => x.unitId === unitId);
   const unit = loadUnit(unitId);
-  if (!result || !unit) { console.log(`${unitId}: not found`); continue; }
+  if (!result || !unit) {
+    console.log(`${unitId}: not found`);
+    continue;
+  }
 
   const b = result.breakdown || {};
   console.log(`\n${'='.repeat(70)}`);
   console.log(`${unitId} — ${unit.chassis} ${unit.model}`);
-  console.log(`  ref=${result.indexBV} calc=${result.calculatedBV} diff=${result.difference} (${result.percentDiff?.toFixed(1)}%)`);
-  console.log(`  tonnage=${unit.tonnage} techBase=${unit.techBase} engine=${unit.engine?.type}`);
+  console.log(
+    `  ref=${result.indexBV} calc=${result.calculatedBV} diff=${result.difference} (${result.percentDiff?.toFixed(1)}%)`,
+  );
+  console.log(
+    `  tonnage=${unit.tonnage} techBase=${unit.techBase} engine=${unit.engine?.type}`,
+  );
   console.log(`  walk=${unit.movement?.walk} jump=${unit.movement?.jump || 0}`);
-  console.log(`  armor=${unit.armor?.type} structure=${unit.structure?.type || 'standard'}`);
+  console.log(
+    `  armor=${unit.armor?.type} structure=${unit.structure?.type || 'standard'}`,
+  );
   console.log(`  heatSinks: ${unit.heatSinks?.count}x ${unit.heatSinks?.type}`);
   console.log(`  cockpit: ${unit.cockpit || '(not set)'}`);
 
@@ -48,16 +58,33 @@ for (const unitId of ids) {
     for (const s of slots) {
       if (!s || typeof s !== 'string') continue;
       const lo = s.toLowerCase();
-      if (lo.includes('c3') || lo.includes('narc') || lo.includes('tag') ||
-          lo.includes('tsm') || lo.includes('null') || lo.includes('stealth') ||
-          lo.includes('chameleon') || lo.includes('nova') || lo.includes('void') ||
-          lo.includes('angel') || lo.includes('artemis') || lo.includes('apollo') ||
-          lo.includes('drone') || lo.includes('boosted') || lo.includes('coolant') ||
-          lo.includes('targeting computer') || lo.includes('targeting-computer') ||
-          lo.includes('partial wing') || lo.includes('partial-wing') ||
-          lo.includes('blue shield') || lo.includes('blue-shield') ||
-          lo.includes('bap') || lo.includes('beagle') || lo.includes('active-probe') ||
-          lo.includes('watchdog')) {
+      if (
+        lo.includes('c3') ||
+        lo.includes('narc') ||
+        lo.includes('tag') ||
+        lo.includes('tsm') ||
+        lo.includes('null') ||
+        lo.includes('stealth') ||
+        lo.includes('chameleon') ||
+        lo.includes('nova') ||
+        lo.includes('void') ||
+        lo.includes('angel') ||
+        lo.includes('artemis') ||
+        lo.includes('apollo') ||
+        lo.includes('drone') ||
+        lo.includes('boosted') ||
+        lo.includes('coolant') ||
+        lo.includes('targeting computer') ||
+        lo.includes('targeting-computer') ||
+        lo.includes('partial wing') ||
+        lo.includes('partial-wing') ||
+        lo.includes('blue shield') ||
+        lo.includes('blue-shield') ||
+        lo.includes('bap') ||
+        lo.includes('beagle') ||
+        lo.includes('active-probe') ||
+        lo.includes('watchdog')
+      ) {
         specialItems.push(`${s} @ ${loc}`);
       }
     }
@@ -69,19 +96,31 @@ for (const unitId of ids) {
 
   // BV breakdown
   console.log(`  --- BV ---`);
-  console.log(`  armorBV=${b.armorBV?.toFixed(1)} structBV=${b.structureBV?.toFixed(1)} gyroBV=${b.gyroBV?.toFixed(1)}`);
-  console.log(`  defEqBV=${b.defEquipBV?.toFixed(1)} expPen=${b.explosivePenalty?.toFixed(1)}`);
+  console.log(
+    `  armorBV=${b.armorBV?.toFixed(1)} structBV=${b.structureBV?.toFixed(1)} gyroBV=${b.gyroBV?.toFixed(1)}`,
+  );
+  console.log(
+    `  defEqBV=${b.defEquipBV?.toFixed(1)} expPen=${b.explosivePenalty?.toFixed(1)}`,
+  );
   console.log(`  DF=${b.defensiveFactor} DEF=${b.defensiveBV?.toFixed(1)}`);
-  console.log(`  weaponBV=${b.weaponBV?.toFixed(1)} ammoBV=${b.ammoBV} physBV=${b.physicalWeaponBV?.toFixed(1)}`);
-  console.log(`  wtBonus=${b.weightBonus?.toFixed(1)} offEqBV=${b.offEquipBV?.toFixed(1)}`);
-  console.log(`  HE=${b.heatEfficiency} SF=${b.speedFactor} OFF=${b.offensiveBV?.toFixed(1)}`);
+  console.log(
+    `  weaponBV=${b.weaponBV?.toFixed(1)} ammoBV=${b.ammoBV} physBV=${b.physicalWeaponBV?.toFixed(1)}`,
+  );
+  console.log(
+    `  wtBonus=${b.weightBonus?.toFixed(1)} offEqBV=${b.offEquipBV?.toFixed(1)}`,
+  );
+  console.log(
+    `  HE=${b.heatEfficiency} SF=${b.speedFactor} OFF=${b.offensiveBV?.toFixed(1)}`,
+  );
   console.log(`  cockpitMod=${b.cockpitModifier}`);
 
   // Show weapon details if available
   if (b.weapons?.length) {
     console.log(`  --- Weapons Detail ---`);
     for (const w of b.weapons) {
-      console.log(`    ${(w.name||w.id).padEnd(35)} heat=${String(w.heat).padStart(2)} bv=${String(w.bv).padStart(4)} ${w.rear?'(R)':''}`);
+      console.log(
+        `    ${(w.name || w.id).padEnd(35)} heat=${String(w.heat).padStart(2)} bv=${String(w.bv).padStart(4)} ${w.rear ? '(R)' : ''}`,
+      );
     }
   }
 }

--- a/scripts/trace-big-over.ts
+++ b/scripts/trace-big-over.ts
@@ -1,20 +1,18 @@
 /**
  * Deep trace of the biggest overcalculated units (5%+) to find fixable bugs.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
-
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown);
-const big = valid.filter((x: any) => x.percentDiff > 5).sort((a: any, b: any) => b.percentDiff - a.percentDiff);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown,
+);
+const big = valid
+  .filter((x: any) => x.percentDiff > 5)
+  .sort((a: any, b: any) => b.percentDiff - a.percentDiff);
 
 console.log(`=== OVERCALCULATED 5%+ (${big.length} units) ===\n`);
 
@@ -24,42 +22,92 @@ for (const u of big) {
   const b = u.breakdown;
   const cockpit = b.cockpitModifier ?? 1;
   const refBase = u.indexBV / cockpit;
-  const excess = (b.defensiveBV + b.offensiveBV) - refBase;
+  const excess = b.defensiveBV + b.offensiveBV - refBase;
 
   // Check for patterns
-  const hasTSM = unit.criticalSlots && Object.values(unit.criticalSlots).some((slots: any) =>
-    Array.isArray(slots) && slots.some((s: any) => s && typeof s === 'string' &&
-      (s.toLowerCase() === 'tsm' || s.toLowerCase().includes('triple strength'))));
-  const hasMASC = unit.criticalSlots && Object.values(unit.criticalSlots).some((slots: any) =>
-    Array.isArray(slots) && slots.some((s: any) => s && typeof s === 'string' && s.toLowerCase().includes('masc')));
+  const hasTSM =
+    unit.criticalSlots &&
+    Object.values(unit.criticalSlots).some(
+      (slots: any) =>
+        Array.isArray(slots) &&
+        slots.some(
+          (s: any) =>
+            s &&
+            typeof s === 'string' &&
+            (s.toLowerCase() === 'tsm' ||
+              s.toLowerCase().includes('triple strength')),
+        ),
+    );
+  const hasMASC =
+    unit.criticalSlots &&
+    Object.values(unit.criticalSlots).some(
+      (slots: any) =>
+        Array.isArray(slots) &&
+        slots.some(
+          (s: any) =>
+            s && typeof s === 'string' && s.toLowerCase().includes('masc'),
+        ),
+    );
 
-  console.log(`${u.unitId.padEnd(42)} +${u.percentDiff.toFixed(1)}% diff=${u.difference} excess=${excess.toFixed(0)} cockpit=${cockpit}`);
-  console.log(`  DEF: armor=${b.armorBV?.toFixed(0)} struct=${b.structureBV?.toFixed(0)} gyro=${b.gyroBV?.toFixed(0)} defEq=${b.defEquipBV} expPen=${b.explosivePenalty} DF=${b.defensiveFactor} → ${b.defensiveBV?.toFixed(0)}`);
-  console.log(`  OFF: weap=${b.weaponBV?.toFixed(0)} ammo=${b.ammoBV} wt=${b.weightBonus?.toFixed(0)} phys=${b.physicalWeaponBV?.toFixed(0)} offEq=${b.offEquipBV} SF=${b.speedFactor} HE=${b.heatEfficiency} halved=${b.halvedWeaponCount}/${b.weaponCount} → ${b.offensiveBV?.toFixed(0)}`);
-  console.log(`  move: run=${b.runMP} jump=${b.jumpMP || 0} TMM=${b.maxTMM} eng=${unit.engine?.type} tech=${unit.techBase} tonnage=${unit.tonnage} tsm=${hasTSM} masc=${hasMASC}`);
-  console.log(`  cockpit=${unit.cockpit || 'standard'} structure=${unit.structure?.type || 'standard'} armor=${unit.armor?.type || 'standard'}`);
+  console.log(
+    `${u.unitId.padEnd(42)} +${u.percentDiff.toFixed(1)}% diff=${u.difference} excess=${excess.toFixed(0)} cockpit=${cockpit}`,
+  );
+  console.log(
+    `  DEF: armor=${b.armorBV?.toFixed(0)} struct=${b.structureBV?.toFixed(0)} gyro=${b.gyroBV?.toFixed(0)} defEq=${b.defEquipBV} expPen=${b.explosivePenalty} DF=${b.defensiveFactor} → ${b.defensiveBV?.toFixed(0)}`,
+  );
+  console.log(
+    `  OFF: weap=${b.weaponBV?.toFixed(0)} ammo=${b.ammoBV} wt=${b.weightBonus?.toFixed(0)} phys=${b.physicalWeaponBV?.toFixed(0)} offEq=${b.offEquipBV} SF=${b.speedFactor} HE=${b.heatEfficiency} halved=${b.halvedWeaponCount}/${b.weaponCount} → ${b.offensiveBV?.toFixed(0)}`,
+  );
+  console.log(
+    `  move: run=${b.runMP} jump=${b.jumpMP || 0} TMM=${b.maxTMM} eng=${unit.engine?.type} tech=${unit.techBase} tonnage=${unit.tonnage} tsm=${hasTSM} masc=${hasMASC}`,
+  );
+  console.log(
+    `  cockpit=${unit.cockpit || 'standard'} structure=${unit.structure?.type || 'standard'} armor=${unit.armor?.type || 'standard'}`,
+  );
   console.log('');
 }
 
 // Also check overcalculated 2-5%
-const over2to5 = valid.filter((x: any) => x.percentDiff > 2 && x.percentDiff <= 5);
+const over2to5 = valid.filter(
+  (x: any) => x.percentDiff > 2 && x.percentDiff <= 5,
+);
 console.log(`\n=== OVERCALCULATED 2-5% (${over2to5.length} units) ===\n`);
 
-for (const u of over2to5.sort((a: any, b: any) => b.percentDiff - a.percentDiff).slice(0, 20)) {
+for (const u of over2to5
+  .sort((a: any, b: any) => b.percentDiff - a.percentDiff)
+  .slice(0, 20)) {
   const unit = loadUnit(u.unitId);
   if (!unit) continue;
   const b = u.breakdown;
   const cockpit = b.cockpitModifier ?? 1;
   const refBase = u.indexBV / cockpit;
-  const excess = (b.defensiveBV + b.offensiveBV) - refBase;
+  const excess = b.defensiveBV + b.offensiveBV - refBase;
 
-  const hasTSM = unit.criticalSlots && Object.values(unit.criticalSlots).some((slots: any) =>
-    Array.isArray(slots) && slots.some((s: any) => s && typeof s === 'string' &&
-      (s.toLowerCase() === 'tsm' || s.toLowerCase().includes('triple strength'))));
+  const hasTSM =
+    unit.criticalSlots &&
+    Object.values(unit.criticalSlots).some(
+      (slots: any) =>
+        Array.isArray(slots) &&
+        slots.some(
+          (s: any) =>
+            s &&
+            typeof s === 'string' &&
+            (s.toLowerCase() === 'tsm' ||
+              s.toLowerCase().includes('triple strength')),
+        ),
+    );
 
-  console.log(`${u.unitId.padEnd(42)} +${u.percentDiff.toFixed(1)}% diff=${u.difference} excess=${excess.toFixed(0)} cockpit=${cockpit}`);
-  console.log(`  DEF: armor=${b.armorBV?.toFixed(0)} struct=${b.structureBV?.toFixed(0)} gyro=${b.gyroBV?.toFixed(0)} defEq=${b.defEquipBV} expPen=${b.explosivePenalty} DF=${b.defensiveFactor} → ${b.defensiveBV?.toFixed(0)}`);
-  console.log(`  OFF: weap=${b.weaponBV?.toFixed(0)} ammo=${b.ammoBV} wt=${b.weightBonus?.toFixed(0)} phys=${b.physicalWeaponBV?.toFixed(0)} offEq=${b.offEquipBV} SF=${b.speedFactor} HE=${b.heatEfficiency} halved=${b.halvedWeaponCount}/${b.weaponCount} → ${b.offensiveBV?.toFixed(0)}`);
-  console.log(`  move: run=${b.runMP} jump=${b.jumpMP || 0} TMM=${b.maxTMM} eng=${unit.engine?.type} tsm=${hasTSM} tonnage=${unit.tonnage}`);
+  console.log(
+    `${u.unitId.padEnd(42)} +${u.percentDiff.toFixed(1)}% diff=${u.difference} excess=${excess.toFixed(0)} cockpit=${cockpit}`,
+  );
+  console.log(
+    `  DEF: armor=${b.armorBV?.toFixed(0)} struct=${b.structureBV?.toFixed(0)} gyro=${b.gyroBV?.toFixed(0)} defEq=${b.defEquipBV} expPen=${b.explosivePenalty} DF=${b.defensiveFactor} → ${b.defensiveBV?.toFixed(0)}`,
+  );
+  console.log(
+    `  OFF: weap=${b.weaponBV?.toFixed(0)} ammo=${b.ammoBV} wt=${b.weightBonus?.toFixed(0)} phys=${b.physicalWeaponBV?.toFixed(0)} offEq=${b.offEquipBV} SF=${b.speedFactor} HE=${b.heatEfficiency} halved=${b.halvedWeaponCount}/${b.weaponCount} → ${b.offensiveBV?.toFixed(0)}`,
+  );
+  console.log(
+    `  move: run=${b.runMP} jump=${b.jumpMP || 0} TMM=${b.maxTMM} eng=${unit.engine?.type} tsm=${hasTSM} tonnage=${unit.tonnage}`,
+  );
   console.log('');
 }

--- a/scripts/trace-boundary.ts
+++ b/scripts/trace-boundary.ts
@@ -2,28 +2,28 @@
  * Trace the 29 units just over the 1% boundary (1.0-1.2%).
  * Find common patterns that a small fix could push within 1%.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
-
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown);
-const boundary = valid.filter((x: any) => Math.abs(x.percentDiff) > 1 && Math.abs(x.percentDiff) <= 1.5);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown,
+);
+const boundary = valid.filter(
+  (x: any) => Math.abs(x.percentDiff) > 1 && Math.abs(x.percentDiff) <= 1.5,
+);
 
 console.log(`Boundary units (1.0-1.5%): ${boundary.length}`);
 const over = boundary.filter((x: any) => x.percentDiff > 0);
 const under = boundary.filter((x: any) => x.percentDiff < 0);
-console.log(`  Overcalculated: ${over.length}, Undercalculated: ${under.length}`);
+console.log(
+  `  Overcalculated: ${over.length}, Undercalculated: ${under.length}`,
+);
 
 // Feature counts in boundary
-const features: Record<string, { over: string[], under: string[] }> = {};
+const features: Record<string, { over: string[]; under: string[] }> = {};
 
 for (const r of boundary) {
   const unit = loadUnit(r.unitId);
@@ -34,25 +34,34 @@ for (const r of boundary) {
 
   const checks: Record<string, boolean> = {
     'cockpit=0.95': b?.cockpitModifier === 0.95,
-    'isQuad': critsStr.includes('"fl_') || critsStr.includes('"rl_') || critsStr.includes('front_left') || critsStr.includes('rear_left'),
+    isQuad:
+      critsStr.includes('"fl_') ||
+      critsStr.includes('"rl_') ||
+      critsStr.includes('front_left') ||
+      critsStr.includes('rear_left'),
     'explosivePenalty>0': (b?.explosivePenalty || 0) > 0,
-    'HAG': critsStr.includes('hag'),
-    'UltraAC': critsStr.includes('ultra'),
-    'LBX': critsStr.includes('lbx') || critsStr.includes('lb '),
-    'Streak': critsStr.includes('streak'),
-    'HeavyLaser': critsStr.includes('heavy laser') || critsStr.includes('heavylaser'),
-    'RotaryAC': critsStr.includes('rotary'),
-    'PPCCap': critsStr.includes('ppc capacitor'),
-    'ArtemisIV': critsStr.includes('artemis iv') || critsStr.includes('artemisiv'),
-    'TC': critsStr.includes('targeting computer') || critsStr.includes('istargcomp') || critsStr.includes('cltargcomp'),
-    'CASE': !critsStr.includes('case ii') && critsStr.includes('case'),
-    'CASEII': critsStr.includes('case ii') || critsStr.includes('caseii'),
-    'XL': unit.engine?.type?.includes('XL') || false,
-    'XXL': unit.engine?.type?.includes('XXL') || false,
-    'Clan': unit.techBase === 'CLAN',
-    'Mixed': unit.techBase === 'MIXED',
-    'EndoSteel': unit.structure?.type?.includes('ENDO') || false,
-    'FerroFibrous': unit.armor?.type?.includes('FERRO') || false,
+    HAG: critsStr.includes('hag'),
+    UltraAC: critsStr.includes('ultra'),
+    LBX: critsStr.includes('lbx') || critsStr.includes('lb '),
+    Streak: critsStr.includes('streak'),
+    HeavyLaser:
+      critsStr.includes('heavy laser') || critsStr.includes('heavylaser'),
+    RotaryAC: critsStr.includes('rotary'),
+    PPCCap: critsStr.includes('ppc capacitor'),
+    ArtemisIV:
+      critsStr.includes('artemis iv') || critsStr.includes('artemisiv'),
+    TC:
+      critsStr.includes('targeting computer') ||
+      critsStr.includes('istargcomp') ||
+      critsStr.includes('cltargcomp'),
+    CASE: !critsStr.includes('case ii') && critsStr.includes('case'),
+    CASEII: critsStr.includes('case ii') || critsStr.includes('caseii'),
+    XL: unit.engine?.type?.includes('XL') || false,
+    XXL: unit.engine?.type?.includes('XXL') || false,
+    Clan: unit.techBase === 'CLAN',
+    Mixed: unit.techBase === 'MIXED',
+    EndoSteel: unit.structure?.type?.includes('ENDO') || false,
+    FerroFibrous: unit.armor?.type?.includes('FERRO') || false,
     'Jump>0': (unit.movement?.jump || 0) > 0,
   };
 
@@ -65,8 +74,15 @@ for (const r of boundary) {
 }
 
 console.log('\n=== FEATURES IN BOUNDARY UNITS ===');
-for (const [feat, data] of Object.entries(features).sort((a, b) => (b[1].over.length + b[1].under.length) - (a[1].over.length + a[1].under.length))) {
-  console.log(`  ${feat.padEnd(20)} over=${data.over.length} under=${data.under.length} total=${data.over.length + data.under.length}`);
+for (const [feat, data] of Object.entries(features).sort(
+  (a, b) =>
+    b[1].over.length +
+    b[1].under.length -
+    (a[1].over.length + a[1].under.length),
+)) {
+  console.log(
+    `  ${feat.padEnd(20)} over=${data.over.length} under=${data.under.length} total=${data.over.length + data.under.length}`,
+  );
 }
 
 // List all boundary units with key stats
@@ -74,7 +90,9 @@ console.log('\n=== OVER-CALCULATED BOUNDARY UNITS (push down to fix) ===');
 for (const r of over.sort((a: any, b: any) => a.percentDiff - b.percentDiff)) {
   const unit = loadUnit(r.unitId);
   const b = r.breakdown;
-  console.log(`  ${r.unitId.padEnd(40)} +${r.percentDiff.toFixed(2)}% ref=${r.indexBV} calc=${r.calculatedBV} diff=+${r.difference} ${unit?.techBase} ${unit?.tonnage}t exp=${b?.explosivePenalty?.toFixed(0)} cp=${b?.cockpitModifier}`);
+  console.log(
+    `  ${r.unitId.padEnd(40)} +${r.percentDiff.toFixed(2)}% ref=${r.indexBV} calc=${r.calculatedBV} diff=+${r.difference} ${unit?.techBase} ${unit?.tonnage}t exp=${b?.explosivePenalty?.toFixed(0)} cp=${b?.cockpitModifier}`,
+  );
 }
 
 console.log('\n=== UNDER-CALCULATED BOUNDARY UNITS (push up to fix) ===');
@@ -82,21 +100,32 @@ for (const r of under.sort((a: any, b: any) => a.percentDiff - b.percentDiff)) {
   const unit = loadUnit(r.unitId);
   const b = r.breakdown;
   const critsStr = JSON.stringify(unit?.criticalSlots || {}).toLowerCase();
-  const hasTC = critsStr.includes('targeting computer') || critsStr.includes('targcomp');
-  console.log(`  ${r.unitId.padEnd(40)} ${r.percentDiff.toFixed(2)}% ref=${r.indexBV} calc=${r.calculatedBV} diff=${r.difference} ${unit?.techBase} ${unit?.tonnage}t exp=${b?.explosivePenalty?.toFixed(0)} TC=${hasTC} cp=${b?.cockpitModifier}`);
+  const hasTC =
+    critsStr.includes('targeting computer') || critsStr.includes('targcomp');
+  console.log(
+    `  ${r.unitId.padEnd(40)} ${r.percentDiff.toFixed(2)}% ref=${r.indexBV} calc=${r.calculatedBV} diff=${r.difference} ${unit?.techBase} ${unit?.tonnage}t exp=${b?.explosivePenalty?.toFixed(0)} TC=${hasTC} cp=${b?.cockpitModifier}`,
+  );
 }
 
 // Specific check: are there units in the 1.0-1.2% band that would flip if we changed ONE component?
 console.log('\n=== WHAT WOULD FIX OVERCALCULATED BOUNDARY? ===');
-for (const r of over.filter((x: any) => x.percentDiff <= 1.2).sort((a: any, b: any) => a.percentDiff - b.percentDiff)) {
+for (const r of over
+  .filter((x: any) => x.percentDiff <= 1.2)
+  .sort((a: any, b: any) => a.percentDiff - b.percentDiff)) {
   const b = r.breakdown;
   const bvGap = r.calculatedBV - r.indexBV;
-  console.log(`  ${r.unitId.padEnd(40)} gap=${bvGap} — need to subtract ${bvGap} BV`);
+  console.log(
+    `  ${r.unitId.padEnd(40)} gap=${bvGap} — need to subtract ${bvGap} BV`,
+  );
 }
 
 console.log('\n=== WHAT WOULD FIX UNDERCALCULATED BOUNDARY? ===');
-for (const r of under.filter((x: any) => x.percentDiff >= -1.2).sort((a: any, b: any) => a.percentDiff - b.percentDiff)) {
+for (const r of under
+  .filter((x: any) => x.percentDiff >= -1.2)
+  .sort((a: any, b: any) => a.percentDiff - b.percentDiff)) {
   const b = r.breakdown;
   const bvGap = r.indexBV - r.calculatedBV;
-  console.log(`  ${r.unitId.padEnd(40)} gap=${bvGap} — need to add ${bvGap} BV`);
+  console.log(
+    `  ${r.unitId.padEnd(40)} gap=${bvGap} — need to add ${bvGap} BV`,
+  );
 }

--- a/scripts/trace-component-diffs.ts
+++ b/scripts/trace-component-diffs.ts
@@ -2,20 +2,18 @@
  * Deep trace component-level BV for units in 1-2% band.
  * Identify whether DEF or OFF side is causing the error.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
-
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown);
-const near = valid.filter((x: any) => Math.abs(x.percentDiff) > 1 && Math.abs(x.percentDiff) <= 2);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown,
+);
+const near = valid.filter(
+  (x: any) => Math.abs(x.percentDiff) > 1 && Math.abs(x.percentDiff) <= 2,
+);
 
 // For overcalculated units: is DEF or OFF consistently too high?
 // For undercalculated units: is DEF or OFF consistently too low?
@@ -25,7 +23,8 @@ console.log('=== DEF vs OFF RATIO ANALYSIS ===');
 const within1 = valid.filter((x: any) => Math.abs(x.percentDiff) <= 1);
 
 function defFrac(arr: any[]): number {
-  let defs = 0, totals = 0;
+  let defs = 0,
+    totals = 0;
   for (const r of arr) {
     const b = r.breakdown;
     if (!b) continue;
@@ -36,22 +35,30 @@ function defFrac(arr: any[]): number {
 }
 
 console.log(`DEF fraction - within1%: ${defFrac(within1).toFixed(3)}`);
-console.log(`DEF fraction - overcalc 1-2%: ${defFrac(near.filter((x: any) => x.percentDiff > 0)).toFixed(3)}`);
-console.log(`DEF fraction - undercalc 1-2%: ${defFrac(near.filter((x: any) => x.percentDiff < 0)).toFixed(3)}`);
+console.log(
+  `DEF fraction - overcalc 1-2%: ${defFrac(near.filter((x: any) => x.percentDiff > 0)).toFixed(3)}`,
+);
+console.log(
+  `DEF fraction - undercalc 1-2%: ${defFrac(near.filter((x: any) => x.percentDiff < 0)).toFixed(3)}`,
+);
 
 // Detailed: check structure and armor types
 console.log('\n=== ARMOR TYPE IN 1-2% UNDERCALCULATED CLAN ===');
-const clanUnder = near.filter((x: any) => x.percentDiff < -1 && x.breakdown?.techBase === 'CLAN');
+const clanUnder = near.filter(
+  (x: any) => x.percentDiff < -1 && x.breakdown?.techBase === 'CLAN',
+);
 for (const r of clanUnder) {
   const unit = loadUnit(r.unitId);
   if (!unit) continue;
   const b = r.breakdown;
-  console.log(`  ${r.unitId.padEnd(35)} armor=${unit.armor?.type.padEnd(20)} struct=${(unit.structure?.type || 'STANDARD').padEnd(15)} gyro=${(unit.gyro?.type || 'STANDARD').padEnd(12)} diff=${r.percentDiff.toFixed(1)}%`);
+  console.log(
+    `  ${r.unitId.padEnd(35)} armor=${unit.armor?.type.padEnd(20)} struct=${(unit.structure?.type || 'STANDARD').padEnd(15)} gyro=${(unit.gyro?.type || 'STANDARD').padEnd(12)} diff=${r.percentDiff.toFixed(1)}%`,
+  );
 }
 
 // Check structure type distribution in outliers vs within1%
 console.log('\n=== STRUCTURE TYPE DISTRIBUTION ===');
-const structTypes: Record<string, { w1: number, out: number }> = {};
+const structTypes: Record<string, { w1: number; out: number }> = {};
 for (const r of [...within1, ...near]) {
   const unit = loadUnit(r.unitId);
   if (!unit) continue;
@@ -60,14 +67,18 @@ for (const r of [...within1, ...near]) {
   if (Math.abs(r.percentDiff) <= 1) structTypes[st].w1++;
   else structTypes[st].out++;
 }
-for (const [type, counts] of Object.entries(structTypes).sort((a, b) => (b[1].w1 + b[1].out) - (a[1].w1 + a[1].out))) {
+for (const [type, counts] of Object.entries(structTypes).sort(
+  (a, b) => b[1].w1 + b[1].out - (a[1].w1 + a[1].out),
+)) {
   const total = counts.w1 + counts.out;
-  console.log(`  ${type.padEnd(25)} w1=${counts.w1} out=${counts.out} total=${total} outRate=${(counts.out/total*100).toFixed(1)}%`);
+  console.log(
+    `  ${type.padEnd(25)} w1=${counts.w1} out=${counts.out} total=${total} outRate=${((counts.out / total) * 100).toFixed(1)}%`,
+  );
 }
 
 // Check gyro type distribution
 console.log('\n=== GYRO TYPE DISTRIBUTION ===');
-const gyroTypes: Record<string, { w1: number, out: number }> = {};
+const gyroTypes: Record<string, { w1: number; out: number }> = {};
 for (const r of [...within1, ...near]) {
   const unit = loadUnit(r.unitId);
   if (!unit) continue;
@@ -76,19 +87,27 @@ for (const r of [...within1, ...near]) {
   if (Math.abs(r.percentDiff) <= 1) gyroTypes[gt].w1++;
   else gyroTypes[gt].out++;
 }
-for (const [type, counts] of Object.entries(gyroTypes).sort((a, b) => (b[1].w1 + b[1].out) - (a[1].w1 + a[1].out))) {
+for (const [type, counts] of Object.entries(gyroTypes).sort(
+  (a, b) => b[1].w1 + b[1].out - (a[1].w1 + a[1].out),
+)) {
   const total = counts.w1 + counts.out;
-  console.log(`  ${type.padEnd(25)} w1=${counts.w1} out=${counts.out} total=${total} outRate=${(counts.out/total*100).toFixed(1)}%`);
+  console.log(
+    `  ${type.padEnd(25)} w1=${counts.w1} out=${counts.out} total=${total} outRate=${((counts.out / total) * 100).toFixed(1)}%`,
+  );
 }
 
 // Check engine type distribution
 console.log('\n=== ENGINE TYPE DISTRIBUTION ===');
-const engineTypes: Record<string, { w1: number, out: number, overCount: number, underCount: number }> = {};
+const engineTypes: Record<
+  string,
+  { w1: number; out: number; overCount: number; underCount: number }
+> = {};
 for (const r of [...within1, ...near]) {
   const unit = loadUnit(r.unitId);
   if (!unit) continue;
   const et = unit.engine?.type || 'STANDARD';
-  if (!engineTypes[et]) engineTypes[et] = { w1: 0, out: 0, overCount: 0, underCount: 0 };
+  if (!engineTypes[et])
+    engineTypes[et] = { w1: 0, out: 0, overCount: 0, underCount: 0 };
   if (Math.abs(r.percentDiff) <= 1) engineTypes[et].w1++;
   else {
     engineTypes[et].out++;
@@ -96,9 +115,13 @@ for (const r of [...within1, ...near]) {
     else engineTypes[et].underCount++;
   }
 }
-for (const [type, counts] of Object.entries(engineTypes).sort((a, b) => (b[1].w1 + b[1].out) - (a[1].w1 + a[1].out))) {
+for (const [type, counts] of Object.entries(engineTypes).sort(
+  (a, b) => b[1].w1 + b[1].out - (a[1].w1 + a[1].out),
+)) {
   const total = counts.w1 + counts.out;
-  console.log(`  ${type.padEnd(25)} w1=${counts.w1} out=${counts.out} (over=${counts.overCount} under=${counts.underCount}) total=${total} outRate=${(counts.out/total*100).toFixed(1)}%`);
+  console.log(
+    `  ${type.padEnd(25)} w1=${counts.w1} out=${counts.out} (over=${counts.overCount} under=${counts.underCount}) total=${total} outRate=${((counts.out / total) * 100).toFixed(1)}%`,
+  );
 }
 
 // Check for units with "special" equipment that might not be BV-counted
@@ -111,17 +134,35 @@ for (const r of near) {
     if (!Array.isArray(slots)) continue;
     for (const s of slots) {
       if (typeof s !== 'string') continue;
-      const lo = s.toLowerCase().replace(/\s*\(omnipod\)/gi, '').trim();
+      const lo = s
+        .toLowerCase()
+        .replace(/\s*\(omnipod\)/gi, '')
+        .trim();
       // Skip common/known items
-      if (lo.includes('-empty-') || lo.includes('fusion engine') || lo.includes('gyro') || lo.includes('life support') ||
-          lo.includes('sensor') || lo.includes('cockpit') || lo.includes('heat sink') || lo.includes('endo') ||
-          lo.includes('ferro') || lo.includes('jump jet') || lo.includes('actuator') || lo.includes('ammo') ||
-          lo.includes('shoulder') || lo.includes('hip')) continue;
+      if (
+        lo.includes('-empty-') ||
+        lo.includes('fusion engine') ||
+        lo.includes('gyro') ||
+        lo.includes('life support') ||
+        lo.includes('sensor') ||
+        lo.includes('cockpit') ||
+        lo.includes('heat sink') ||
+        lo.includes('endo') ||
+        lo.includes('ferro') ||
+        lo.includes('jump jet') ||
+        lo.includes('actuator') ||
+        lo.includes('ammo') ||
+        lo.includes('shoulder') ||
+        lo.includes('hip')
+      )
+        continue;
       equipPatterns[lo] = (equipPatterns[lo] || 0) + 1;
     }
   }
 }
-const sorted = Object.entries(equipPatterns).sort((a, b) => b[1] - a[1]).slice(0, 30);
+const sorted = Object.entries(equipPatterns)
+  .sort((a, b) => b[1] - a[1])
+  .slice(0, 30);
 for (const [name, count] of sorted) {
   console.log(`  "${name}": ${count}`);
 }

--- a/scripts/trace-def-shortfall.ts
+++ b/scripts/trace-def-shortfall.ts
@@ -2,20 +2,17 @@
  * Deep trace of defensive BV components for 1-2% undercalculated units.
  * Goal: find the ~10-15 BV systematic shortfall source.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
-
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
 // Standard structure table from TechManual
-const STANDARD_STRUCTURE: Record<number, { head: number; ct: number; st: number; arm: number; leg: number }> = {
+const STANDARD_STRUCTURE: Record<
+  number,
+  { head: number; ct: number; st: number; arm: number; leg: number }
+> = {
   20: { head: 3, ct: 6, st: 5, arm: 3, leg: 4 },
   25: { head: 3, ct: 8, st: 6, arm: 4, leg: 6 },
   30: { head: 3, ct: 10, st: 7, arm: 5, leg: 7 },
@@ -46,7 +43,8 @@ function getTotalArmor(unit: any): number {
   let total = 0;
   for (const [loc, val] of Object.entries(unit.armor.allocation)) {
     if (typeof val === 'number') total += val;
-    else if (val && typeof val === 'object') total += ((val as any).front || 0) + ((val as any).rear || 0);
+    else if (val && typeof val === 'object')
+      total += ((val as any).front || 0) + ((val as any).rear || 0);
   }
   return total;
 }
@@ -68,10 +66,16 @@ function getGyroMultiplier(gyroType: string): number {
   return 0.5; // STANDARD, XL, COMPACT
 }
 
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null);
-const under1to2 = valid.filter((x: any) => x.percentDiff >= -2 && x.percentDiff < -1 && x.breakdown);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null,
+);
+const under1to2 = valid.filter(
+  (x: any) => x.percentDiff >= -2 && x.percentDiff < -1 && x.breakdown,
+);
 
-console.log(`=== TRACING ${under1to2.length} UNITS AT 1-2% UNDERCALCULATED ===\n`);
+console.log(
+  `=== TRACING ${under1to2.length} UNITS AT 1-2% UNDERCALCULATED ===\n`,
+);
 
 // For each unit, independently compute defensive components and compare
 let armorDiffs: number[] = [];
@@ -82,15 +86,28 @@ let totalBaseDiffs: number[] = [];
 let offGaps: number[] = [];
 
 const detailed: Array<{
-  id: string; tonnage: number; diff: number; pct: number;
-  reportArmorBV: number; calcArmorBV: number; armorDiff: number;
-  reportStructBV: number; calcStructBV: number; structDiff: number;
-  reportGyroBV: number; calcGyroBV: number; gyroDiff: number;
+  id: string;
+  tonnage: number;
+  diff: number;
+  pct: number;
+  reportArmorBV: number;
+  calcArmorBV: number;
+  armorDiff: number;
+  reportStructBV: number;
+  calcStructBV: number;
+  structDiff: number;
+  reportGyroBV: number;
+  calcGyroBV: number;
+  gyroDiff: number;
   reportDefFactor: number;
-  reportDefEquip: number; reportExplosive: number;
+  reportDefEquip: number;
+  reportExplosive: number;
   baseDefDiff: number;
   offGap: number;
-  engineType: string; armorType: string; structType: string; gyroType: string;
+  engineType: string;
+  armorType: string;
+  structType: string;
+  gyroType: string;
 }> = [];
 
 for (const u of under1to2) {
@@ -108,19 +125,31 @@ for (const u of under1to2) {
 
   // Armor BV: totalArmorPoints * 2.5 * armorMultiplier * BAR/10
   // For standard armor (mult=1, BAR=10): armorBV = totalArmor * 2.5
-  const armorMult = armorType.includes('hardened') ? 2.0 :
-    armorType.includes('reactive') ? 1.5 :
-    armorType.includes('reflective') || armorType.includes('laser-reflective') ? 1.5 :
-    armorType.includes('ballistic') ? 1.5 :
-    armorType.includes('ferro-lamellor') ? 1.2 :
-    armorType.includes('anti-penetrative') ? 1.2 :
-    armorType.includes('heat-dissipating') ? 1.1 : 1.0;
+  const armorMult = armorType.includes('hardened')
+    ? 2.0
+    : armorType.includes('reactive')
+      ? 1.5
+      : armorType.includes('reflective') ||
+          armorType.includes('laser-reflective')
+        ? 1.5
+        : armorType.includes('ballistic')
+          ? 1.5
+          : armorType.includes('ferro-lamellor')
+            ? 1.2
+            : armorType.includes('anti-penetrative')
+              ? 1.2
+              : armorType.includes('heat-dissipating')
+                ? 1.1
+                : 1.0;
   // Compute as the code does: round(pts * 2.5 * mult * BAR) / 10 where BAR=10 for normal
   const calcArmorBV = Math.round(totalArmor * 2.5 * armorMult * 10) / 10;
 
   // Structure BV
-  const structMult = structType.includes('reinforced') ? 2.0 :
-    structType.includes('composite') || structType.includes('industrial') ? 0.5 : 1.0;
+  const structMult = structType.includes('reinforced')
+    ? 2.0
+    : structType.includes('composite') || structType.includes('industrial')
+      ? 0.5
+      : 1.0;
   const engMult = getEngineMultiplier(engineType);
   const calcStructBV = totalStruct * 1.5 * structMult * engMult;
 
@@ -148,16 +177,28 @@ for (const u of under1to2) {
   offGaps.push(offGap);
 
   detailed.push({
-    id: u.unitId, tonnage: unit.tonnage, diff: u.difference, pct: u.percentDiff,
-    reportArmorBV: b.armorBV, calcArmorBV, armorDiff,
-    reportStructBV: b.structureBV, calcStructBV, structDiff,
-    reportGyroBV: b.gyroBV, calcGyroBV, gyroDiff,
+    id: u.unitId,
+    tonnage: unit.tonnage,
+    diff: u.difference,
+    pct: u.percentDiff,
+    reportArmorBV: b.armorBV,
+    calcArmorBV,
+    armorDiff,
+    reportStructBV: b.structureBV,
+    calcStructBV,
+    structDiff,
+    reportGyroBV: b.gyroBV,
+    calcGyroBV,
+    gyroDiff,
     reportDefFactor: b.defensiveFactor,
-    reportDefEquip: b.defensiveEquipBV ?? (b.defEquipBV ?? 0),
+    reportDefEquip: b.defensiveEquipBV ?? b.defEquipBV ?? 0,
     reportExplosive: b.explosivePenalty,
     baseDefDiff,
     offGap,
-    engineType, armorType, structType, gyroType,
+    engineType,
+    armorType,
+    structType,
+    gyroType,
   });
 }
 
@@ -166,25 +207,37 @@ detailed.sort((a, b) => Math.abs(b.offGap) - Math.abs(a.offGap));
 
 // Summary stats
 console.log('=== COMPONENT VERIFICATION ===');
-const nonZeroArmorDiff = armorDiffs.filter(d => Math.abs(d) > 0.1);
-const nonZeroStructDiff = structDiffs.filter(d => Math.abs(d) > 0.1);
-const nonZeroGyroDiff = gyroDiffs.filter(d => Math.abs(d) > 0.1);
-console.log(`  Armor BV mismatches (>0.1): ${nonZeroArmorDiff.length}/${detailed.length}`);
-console.log(`  Structure BV mismatches: ${nonZeroStructDiff.length}/${detailed.length}`);
-console.log(`  Gyro BV mismatches: ${nonZeroGyroDiff.length}/${detailed.length}`);
+const nonZeroArmorDiff = armorDiffs.filter((d) => Math.abs(d) > 0.1);
+const nonZeroStructDiff = structDiffs.filter((d) => Math.abs(d) > 0.1);
+const nonZeroGyroDiff = gyroDiffs.filter((d) => Math.abs(d) > 0.1);
+console.log(
+  `  Armor BV mismatches (>0.1): ${nonZeroArmorDiff.length}/${detailed.length}`,
+);
+console.log(
+  `  Structure BV mismatches: ${nonZeroStructDiff.length}/${detailed.length}`,
+);
+console.log(
+  `  Gyro BV mismatches: ${nonZeroGyroDiff.length}/${detailed.length}`,
+);
 
 if (nonZeroArmorDiff.length > 0) {
-  const avg = nonZeroArmorDiff.reduce((s, d) => s + d, 0) / nonZeroArmorDiff.length;
+  const avg =
+    nonZeroArmorDiff.reduce((s, d) => s + d, 0) / nonZeroArmorDiff.length;
   console.log(`    Armor avg diff: ${avg.toFixed(1)}`);
 }
 if (nonZeroStructDiff.length > 0) {
-  const avg = nonZeroStructDiff.reduce((s, d) => s + d, 0) / nonZeroStructDiff.length;
+  const avg =
+    nonZeroStructDiff.reduce((s, d) => s + d, 0) / nonZeroStructDiff.length;
   console.log(`    Structure avg diff: ${avg.toFixed(1)}`);
 }
 
 // Check: is the gap purely on the offensive side?
-const pureOffGap = detailed.filter(d => Math.abs(d.baseDefDiff) < 1 && d.offGap > 0);
-console.log(`\n  Pure offensive gap (def matches, off short): ${pureOffGap.length}/${detailed.length}`);
+const pureOffGap = detailed.filter(
+  (d) => Math.abs(d.baseDefDiff) < 1 && d.offGap > 0,
+);
+console.log(
+  `\n  Pure offensive gap (def matches, off short): ${pureOffGap.length}/${detailed.length}`,
+);
 
 // Offensive gap stats
 const avgOffGap = offGaps.reduce((s, g) => s + g, 0) / offGaps.length;
@@ -193,13 +246,27 @@ console.log(`  Average offensive gap: ${avgOffGap.toFixed(1)} BV`);
 // Distribution of offensive gap sources
 console.log('\n=== TOP 20 UNIT TRACES ===');
 for (const d of detailed.slice(0, 20)) {
-  console.log(`\n  ${d.id} (${d.tonnage}t) diff=${d.diff} (${d.pct.toFixed(1)}%)`);
-  console.log(`    armor:  report=${d.reportArmorBV.toFixed(1)} calc=${d.calcArmorBV.toFixed(1)} diff=${d.armorDiff.toFixed(1)}`);
-  console.log(`    struct: report=${d.reportStructBV.toFixed(1)} calc=${d.calcStructBV.toFixed(1)} diff=${d.structDiff.toFixed(1)}`);
-  console.log(`    gyro:   report=${d.reportGyroBV.toFixed(1)} calc=${d.calcGyroBV.toFixed(1)} diff=${d.gyroDiff.toFixed(1)}`);
-  console.log(`    defEquip=${d.reportDefEquip} explosive=${d.reportExplosive} defFactor=${d.reportDefFactor.toFixed(2)}`);
-  console.log(`    engine=${d.engineType} armor=${d.armorType} struct=${d.structType} gyro=${d.gyroType}`);
-  console.log(`    offGap=${d.offGap.toFixed(1)} (positive means offensive BV too low)`);
+  console.log(
+    `\n  ${d.id} (${d.tonnage}t) diff=${d.diff} (${d.pct.toFixed(1)}%)`,
+  );
+  console.log(
+    `    armor:  report=${d.reportArmorBV.toFixed(1)} calc=${d.calcArmorBV.toFixed(1)} diff=${d.armorDiff.toFixed(1)}`,
+  );
+  console.log(
+    `    struct: report=${d.reportStructBV.toFixed(1)} calc=${d.calcStructBV.toFixed(1)} diff=${d.structDiff.toFixed(1)}`,
+  );
+  console.log(
+    `    gyro:   report=${d.reportGyroBV.toFixed(1)} calc=${d.calcGyroBV.toFixed(1)} diff=${d.gyroDiff.toFixed(1)}`,
+  );
+  console.log(
+    `    defEquip=${d.reportDefEquip} explosive=${d.reportExplosive} defFactor=${d.reportDefFactor.toFixed(2)}`,
+  );
+  console.log(
+    `    engine=${d.engineType} armor=${d.armorType} struct=${d.structType} gyro=${d.gyroType}`,
+  );
+  console.log(
+    `    offGap=${d.offGap.toFixed(1)} (positive means offensive BV too low)`,
+  );
 }
 
 // Check: what's the breakdown of where the shortfall comes from?
@@ -227,11 +294,21 @@ for (const u of under1to2) {
 
   // Another approach: check the speed factor sensitivity
   // If speed factor is off by 0.01, how much does that affect?
-  const baseOff = (b.weaponBV ?? 0) + (b.ammoBV ?? 0) + (b.weightBonus ?? 0) + (b.physicalWeaponBV ?? 0) + (b.offEquipBV ?? 0);
+  const baseOff =
+    (b.weaponBV ?? 0) +
+    (b.ammoBV ?? 0) +
+    (b.weightBonus ?? 0) +
+    (b.physicalWeaponBV ?? 0) +
+    (b.offEquipBV ?? 0);
   const sfSensitivity = baseOff * 0.01; // BV change per 0.01 SF change
 
   // If defensive factor is off by 0.01...
-  const baseDef = (b.armorBV ?? 0) + (b.structureBV ?? 0) + (b.gyroBV ?? 0) + (b.defensiveEquipBV ?? 0) - (b.explosivePenalty ?? 0);
+  const baseDef =
+    (b.armorBV ?? 0) +
+    (b.structureBV ?? 0) +
+    (b.gyroBV ?? 0) +
+    (b.defensiveEquipBV ?? 0) -
+    (b.explosivePenalty ?? 0);
   const dfSensitivity = baseDef * 0.01;
 
   if (sfSensitivity > dfSensitivity) offShortCount++;
@@ -257,7 +334,9 @@ for (const u of under1to2) {
   const sf = u.breakdown?.speedFactor?.toFixed(2) || 'unknown';
   sfCounts[sf] = (sfCounts[sf] || 0) + 1;
 }
-for (const [sf, count] of Object.entries(sfCounts).sort((a, b) => parseFloat(a[0]) - parseFloat(b[0]))) {
+for (const [sf, count] of Object.entries(sfCounts).sort(
+  (a, b) => parseFloat(a[0]) - parseFloat(b[0]),
+)) {
   console.log(`  SF=${sf}: ${count} units`);
 }
 
@@ -266,5 +345,7 @@ console.log('\n=== HEAT EFFICIENCY vs WEAPON BV ===');
 for (const u of under1to2.slice(0, 10)) {
   const b = u.breakdown;
   if (!b) continue;
-  console.log(`  ${u.unitId.substring(0, 35).padEnd(35)} HE=${b.heatEfficiency} weapBV=${b.weaponBV?.toFixed(0)} rawWeapBV=${b.rawWeaponBV?.toFixed(0)} halvedBV=${b.halvedWeaponBV?.toFixed(0)} halvedCt=${b.halvedWeaponCount}/${b.weaponCount}`);
+  console.log(
+    `  ${u.unitId.substring(0, 35).padEnd(35)} HE=${b.heatEfficiency} weapBV=${b.weaponBV?.toFixed(0)} rawWeapBV=${b.rawWeaponBV?.toFixed(0)} halvedBV=${b.halvedWeaponBV?.toFixed(0)} halvedCt=${b.halvedWeaponCount}/${b.weaponCount}`,
+  );
 }

--- a/scripts/trace-exact-weapons.ts
+++ b/scripts/trace-exact-weapons.ts
@@ -2,42 +2,53 @@
  * Exact weapon trace for specific IS units in the 1-2% undercalculated band.
  * Compare raw weapon BV sum vs validation weapBV.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
-
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
 // Check specific IS units
 const targets = [
-  'flashman-fls-c',       // IS, 75t, diff=-31, weapBV=542
-  'goliath-gol-7k',       // IS, 80t, diff=-31, weapBV=508
-  'thanatos-tns-6s',      // IS, 75t, diff=-35, weapBV=578
-  'hachiwara-hca-3t',     // IS, 70t
-  'commando-com-9s',      // IS, 25t
-  'enforcer-iii-enf-7d',  // IS, 50t
+  'flashman-fls-c', // IS, 75t, diff=-31, weapBV=542
+  'goliath-gol-7k', // IS, 80t, diff=-31, weapBV=508
+  'thanatos-tns-6s', // IS, 75t, diff=-35, weapBV=578
+  'hachiwara-hca-3t', // IS, 70t
+  'commando-com-9s', // IS, 25t
+  'enforcer-iii-enf-7d', // IS, 50t
 ];
 
 for (const uid of targets) {
   const r = report.allResults.find((x: any) => x.unitId === uid);
   const unit = loadUnit(uid);
-  if (!r || !unit) { console.log(`${uid}: NOT FOUND`); continue; }
+  if (!r || !unit) {
+    console.log(`${uid}: NOT FOUND`);
+    continue;
+  }
 
   const b = r.breakdown;
   console.log(`\n${'='.repeat(70)}`);
-  console.log(`${uid} (${unit.techBase}, ${unit.tonnage}t) ref=${r.indexBV} calc=${r.calculatedBV} diff=${r.difference}`);
-  console.log(`  weapBV=${b.weaponBV?.toFixed(1)} rawWeapBV=${b.rawWeaponBV?.toFixed(1)} halvedBV=${b.halvedWeaponBV?.toFixed(1)} halvedCt=${b.halvedWeaponCount}/${b.weaponCount}`);
-  console.log(`  ammoBV=${b.ammoBV} weightBonus=${b.weightBonus?.toFixed(1)} physBV=${b.physicalWeaponBV?.toFixed(1)} offEquip=${b.offEquipBV}`);
-  console.log(`  HE=${b.heatEfficiency} heatDiss=${b.heatDissipation} moveHeat=${b.moveHeat}`);
-  console.log(`  SF=${b.speedFactor} defBV=${b.defensiveBV?.toFixed(1)} offBV=${b.offensiveBV?.toFixed(1)}`);
-  console.log(`  HS: count=${unit.heatSinks?.count} type=${unit.heatSinks?.type}`);
-  console.log(`  Movement: walk=${unit.movement?.walk} jump=${unit.movement?.jump || 0}`);
+  console.log(
+    `${uid} (${unit.techBase}, ${unit.tonnage}t) ref=${r.indexBV} calc=${r.calculatedBV} diff=${r.difference}`,
+  );
+  console.log(
+    `  weapBV=${b.weaponBV?.toFixed(1)} rawWeapBV=${b.rawWeaponBV?.toFixed(1)} halvedBV=${b.halvedWeaponBV?.toFixed(1)} halvedCt=${b.halvedWeaponCount}/${b.weaponCount}`,
+  );
+  console.log(
+    `  ammoBV=${b.ammoBV} weightBonus=${b.weightBonus?.toFixed(1)} physBV=${b.physicalWeaponBV?.toFixed(1)} offEquip=${b.offEquipBV}`,
+  );
+  console.log(
+    `  HE=${b.heatEfficiency} heatDiss=${b.heatDissipation} moveHeat=${b.moveHeat}`,
+  );
+  console.log(
+    `  SF=${b.speedFactor} defBV=${b.defensiveBV?.toFixed(1)} offBV=${b.offensiveBV?.toFixed(1)}`,
+  );
+  console.log(
+    `  HS: count=${unit.heatSinks?.count} type=${unit.heatSinks?.type}`,
+  );
+  console.log(
+    `  Movement: walk=${unit.movement?.walk} jump=${unit.movement?.jump || 0}`,
+  );
 
   // List ALL equipment entries
   console.log(`  EQUIPMENT LIST (${unit.equipment?.length || 0} entries):`);
@@ -50,7 +61,7 @@ for (const uid of targets) {
     console.log(`  CRIT SLOTS:`);
     for (const [loc, slots] of Object.entries(unit.criticalSlots)) {
       if (!Array.isArray(slots)) continue;
-      const items = (slots as any[]).filter(s => s && typeof s === 'string');
+      const items = (slots as any[]).filter((s) => s && typeof s === 'string');
       if (items.length > 0) {
         console.log(`    ${loc}: ${items.join(', ')}`);
       }
@@ -58,13 +69,24 @@ for (const uid of targets) {
   }
 
   // Compute expected baseOff = weapBV + ammoBV + weightBonus + physBV + offEquip
-  const baseOff = (b.weaponBV ?? 0) + (b.ammoBV ?? 0) + (b.weightBonus ?? 0) + (b.physicalWeaponBV ?? 0) + (b.offEquipBV ?? 0);
+  const baseOff =
+    (b.weaponBV ?? 0) +
+    (b.ammoBV ?? 0) +
+    (b.weightBonus ?? 0) +
+    (b.physicalWeaponBV ?? 0) +
+    (b.offEquipBV ?? 0);
   const expectedOffBV = baseOff * b.speedFactor;
-  console.log(`  CHECK: baseOff=${baseOff.toFixed(1)} × SF=${b.speedFactor} = ${expectedOffBV.toFixed(1)} (reported offBV=${b.offensiveBV?.toFixed(1)})`);
+  console.log(
+    `  CHECK: baseOff=${baseOff.toFixed(1)} × SF=${b.speedFactor} = ${expectedOffBV.toFixed(1)} (reported offBV=${b.offensiveBV?.toFixed(1)})`,
+  );
 
   // What offBV would be needed?
   const cockpit = b.cockpitModifier ?? 1;
   const neededOffBV = r.indexBV / cockpit - b.defensiveBV;
-  console.log(`  NEEDED offBV=${neededOffBV.toFixed(1)} (gap=${(neededOffBV - b.offensiveBV).toFixed(1)})`);
-  console.log(`  NEEDED baseOff=${(neededOffBV / b.speedFactor).toFixed(1)} (current=${baseOff.toFixed(1)}, gap=${(neededOffBV / b.speedFactor - baseOff).toFixed(1)})`);
+  console.log(
+    `  NEEDED offBV=${neededOffBV.toFixed(1)} (gap=${(neededOffBV - b.offensiveBV).toFixed(1)})`,
+  );
+  console.log(
+    `  NEEDED baseOff=${(neededOffBV / b.speedFactor).toFixed(1)} (current=${baseOff.toFixed(1)}, gap=${(neededOffBV / b.speedFactor - baseOff).toFixed(1)})`,
+  );
 }

--- a/scripts/trace-explo-penalty.ts
+++ b/scripts/trace-explo-penalty.ts
@@ -2,19 +2,15 @@
  * Check units with ammo but zero explosive penalty.
  * These should have penalties unless they have CASE/CASE II.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
-
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown,
+);
 
 // Find units that have ammo but zero explosive penalty AND are overcalculated
 const suspects = valid.filter((x: any) => {
@@ -22,12 +18,18 @@ const suspects = valid.filter((x: any) => {
   return b.explosivePenalty === 0 && b.ammoBV > 5 && x.percentDiff > 1;
 });
 
-console.log(`=== OVERCALCULATED WITH AMMO BUT NO EXPLOSIVE PENALTY (${suspects.length} units) ===\n`);
+console.log(
+  `=== OVERCALCULATED WITH AMMO BUT NO EXPLOSIVE PENALTY (${suspects.length} units) ===\n`,
+);
 
-let isCount = 0, clanCount = 0, mixedCount = 0;
+let isCount = 0,
+  clanCount = 0,
+  mixedCount = 0;
 let totalExcess = 0;
 
-for (const u of suspects.sort((a: any, b: any) => b.percentDiff - a.percentDiff)) {
+for (const u of suspects.sort(
+  (a: any, b: any) => b.percentDiff - a.percentDiff,
+)) {
   const unit = loadUnit(u.unitId);
   if (!unit) continue;
   const b = u.breakdown;
@@ -47,11 +49,26 @@ for (const u of suspects.sort((a: any, b: any) => b.percentDiff - a.percentDiff)
       for (const s of slots as string[]) {
         if (!s) continue;
         const lo = s.toLowerCase();
-        if (lo.includes('case') && !lo.includes('ammo')) { locHasCase = true; caseLocs.push(loc); }
-        if (lo.includes('ammo') && !lo.includes('case') && !lo.includes('ammo feed')) {
+        if (lo.includes('case') && !lo.includes('ammo')) {
+          locHasCase = true;
+          caseLocs.push(loc);
+        }
+        if (
+          lo.includes('ammo') &&
+          !lo.includes('case') &&
+          !lo.includes('ammo feed')
+        ) {
           // Check if ammo is non-explosive (gauss, plasma, etc.)
-          const isNonExplosive = lo.includes('gauss') || lo.includes('plasma') || lo.includes('fluid') || lo.includes('nail') || lo.includes('rivet');
-          if (!isNonExplosive) { locHasAmmo = true; ammoLocs.push(`${loc}:${s.replace(/\s*\(omnipod\)/gi, '').trim()}`); }
+          const isNonExplosive =
+            lo.includes('gauss') ||
+            lo.includes('plasma') ||
+            lo.includes('fluid') ||
+            lo.includes('nail') ||
+            lo.includes('rivet');
+          if (!isNonExplosive) {
+            locHasAmmo = true;
+            ammoLocs.push(`${loc}:${s.replace(/\s*\(omnipod\)/gi, '').trim()}`);
+          }
         }
       }
     }
@@ -63,8 +80,12 @@ for (const u of suspects.sort((a: any, b: any) => b.percentDiff - a.percentDiff)
 
   totalExcess += u.difference;
 
-  console.log(`${u.unitId.padEnd(45)} +${u.percentDiff.toFixed(1)}% diff=${u.difference} tech=${unit.techBase} ammoBV=${b.ammoBV} expPen=${b.explosivePenalty}`);
-  console.log(`  CASE locs: ${caseLocs.length > 0 ? [...new Set(caseLocs)].join(', ') : 'NONE'}`);
+  console.log(
+    `${u.unitId.padEnd(45)} +${u.percentDiff.toFixed(1)}% diff=${u.difference} tech=${unit.techBase} ammoBV=${b.ammoBV} expPen=${b.explosivePenalty}`,
+  );
+  console.log(
+    `  CASE locs: ${caseLocs.length > 0 ? [...new Set(caseLocs)].join(', ') : 'NONE'}`,
+  );
   console.log(`  Ammo locs: ${[...new Set(ammoLocs)].join(', ')}`);
   console.log('');
 }
@@ -73,7 +94,16 @@ console.log(`Total: IS=${isCount} Clan=${clanCount} Mixed=${mixedCount}`);
 console.log(`Total excess BV: ${totalExcess}`);
 
 // Also check: how many overcalculated units have CORRECT explosive penalties?
-const overWithPenalty = valid.filter((x: any) => x.breakdown.explosivePenalty > 0 && x.percentDiff > 1);
-console.log(`\nOvercalculated with explosive penalty > 0: ${overWithPenalty.length}`);
-const overNoPenalty = valid.filter((x: any) => x.breakdown.explosivePenalty === 0 && x.percentDiff > 1 && x.breakdown.ammoBV > 5);
+const overWithPenalty = valid.filter(
+  (x: any) => x.breakdown.explosivePenalty > 0 && x.percentDiff > 1,
+);
+console.log(
+  `\nOvercalculated with explosive penalty > 0: ${overWithPenalty.length}`,
+);
+const overNoPenalty = valid.filter(
+  (x: any) =>
+    x.breakdown.explosivePenalty === 0 &&
+    x.percentDiff > 1 &&
+    x.breakdown.ammoBV > 5,
+);
 console.log(`Overcalculated with ammo but no penalty: ${overNoPenalty.length}`);

--- a/scripts/trace-hag-ammo.ts
+++ b/scripts/trace-hag-ammo.ts
@@ -1,19 +1,15 @@
 /**
  * Trace HAG ammo BV values to find undercalculation source.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
-
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown,
+);
 
 // Find all HAG units
 const hagUnits: any[] = [];
@@ -27,22 +23,34 @@ for (const r of valid) {
 const outliers = hagUnits.filter((x: any) => Math.abs(x.percentDiff) > 1);
 console.log(`HAG units: ${hagUnits.length}, outliers: ${outliers.length}`);
 
-for (const r of outliers.sort((a: any, b: any) => a.percentDiff - b.percentDiff)) {
+for (const r of outliers.sort(
+  (a: any, b: any) => a.percentDiff - b.percentDiff,
+)) {
   const unit = r.unit;
   const b = r.breakdown;
 
   console.log(`\n${'='.repeat(60)}`);
-  console.log(`${r.unitId} — ref=${r.indexBV} calc=${r.calculatedBV} diff=${r.difference} (${r.percentDiff?.toFixed(1)}%)`);
-  console.log(`  ${unit.tonnage}t ${unit.techBase} walk=${unit.movement?.walk} jump=${unit.movement?.jump||0}`);
-  console.log(`  DEF: armor=${b?.armorBV?.toFixed(0)} struct=${b?.structureBV?.toFixed(0)} gyro=${b?.gyroBV?.toFixed(0)} defEq=${b?.defEquipBV?.toFixed(0)} exp=${b?.explosivePenalty?.toFixed(0)} DF=${b?.defensiveFactor} → ${b?.defensiveBV?.toFixed(0)}`);
-  console.log(`  OFF: wBV=${b?.weaponBV?.toFixed(0)} raw=${b?.rawWeaponBV?.toFixed(0)} halved=${b?.halvedWeaponBV?.toFixed(0)} ammo=${b?.ammoBV} phys=${b?.physicalWeaponBV?.toFixed(0)} wt=${b?.weightBonus?.toFixed(0)} offEq=${b?.offEquipBV?.toFixed(0)} HE=${b?.heatEfficiency} SF=${b?.speedFactor} → ${b?.offensiveBV?.toFixed(0)}`);
+  console.log(
+    `${r.unitId} — ref=${r.indexBV} calc=${r.calculatedBV} diff=${r.difference} (${r.percentDiff?.toFixed(1)}%)`,
+  );
+  console.log(
+    `  ${unit.tonnage}t ${unit.techBase} walk=${unit.movement?.walk} jump=${unit.movement?.jump || 0}`,
+  );
+  console.log(
+    `  DEF: armor=${b?.armorBV?.toFixed(0)} struct=${b?.structureBV?.toFixed(0)} gyro=${b?.gyroBV?.toFixed(0)} defEq=${b?.defEquipBV?.toFixed(0)} exp=${b?.explosivePenalty?.toFixed(0)} DF=${b?.defensiveFactor} → ${b?.defensiveBV?.toFixed(0)}`,
+  );
+  console.log(
+    `  OFF: wBV=${b?.weaponBV?.toFixed(0)} raw=${b?.rawWeaponBV?.toFixed(0)} halved=${b?.halvedWeaponBV?.toFixed(0)} ammo=${b?.ammoBV} phys=${b?.physicalWeaponBV?.toFixed(0)} wt=${b?.weightBonus?.toFixed(0)} offEq=${b?.offEquipBV?.toFixed(0)} HE=${b?.heatEfficiency} SF=${b?.speedFactor} → ${b?.offensiveBV?.toFixed(0)}`,
+  );
   console.log(`  cockpit=${b?.cockpitModifier}`);
 
   // Show ammo in breakdown
   if (b?.ammo?.length) {
     console.log('  --- Ammo BV ---');
     for (const a of b.ammo) {
-      console.log(`    ${(a.name||a.id||'?').padEnd(30)} bv=${a.bv} tons=${a.tons || '?'}`);
+      console.log(
+        `    ${(a.name || a.id || '?').padEnd(30)} bv=${a.bv} tons=${a.tons || '?'}`,
+      );
     }
   }
 
@@ -65,19 +73,33 @@ for (const r of outliers.sort((a: any, b: any) => a.percentDiff - b.percentDiff)
 
   // Calculate expected BV gap
   const totalBV = (b?.defensiveBV || 0) + (b?.offensiveBV || 0);
-  console.log(`  Expected total = DEF + OFF = ${b?.defensiveBV?.toFixed(0)} + ${b?.offensiveBV?.toFixed(0)} = ${totalBV.toFixed(0)}`);
-  console.log(`  After cockpit (${b?.cockpitModifier}): ${Math.round(totalBV * (b?.cockpitModifier || 1))}`);
+  console.log(
+    `  Expected total = DEF + OFF = ${b?.defensiveBV?.toFixed(0)} + ${b?.offensiveBV?.toFixed(0)} = ${totalBV.toFixed(0)}`,
+  );
+  console.log(
+    `  After cockpit (${b?.cockpitModifier}): ${Math.round(totalBV * (b?.cockpitModifier || 1))}`,
+  );
 }
 
 // Check HAG ammo BV per ton from catalog
 console.log('\n=== HAG AMMO IN WEAPON CATALOGS ===');
-const balisticCat = JSON.parse(fs.readFileSync('public/data/equipment/official/weapons/ballistic.json', 'utf8'));
+const balisticCat = JSON.parse(
+  fs.readFileSync(
+    'public/data/equipment/official/weapons/ballistic.json',
+    'utf8',
+  ),
+);
 for (const w of balisticCat) {
-  if (w.id?.toLowerCase().includes('hag') || w.name?.toLowerCase().includes('hag')) {
+  if (
+    w.id?.toLowerCase().includes('hag') ||
+    w.name?.toLowerCase().includes('hag')
+  ) {
     console.log(`  ${w.id}: BV=${w.battleValue}, heat=${w.heat}`);
     if (w.ammo) {
       for (const a of w.ammo) {
-        console.log(`    ammo: ${a.id || a.name} BV=${a.battleValue} perTon=${a.shotsPerTon || '?'}`);
+        console.log(
+          `    ammo: ${a.id || a.name} BV=${a.battleValue} perTon=${a.shotsPerTon || '?'}`,
+        );
       }
     }
   }
@@ -85,18 +107,32 @@ for (const w of balisticCat) {
 
 // Also check ammo catalog
 try {
-  const ammoCat = JSON.parse(fs.readFileSync('public/data/equipment/official/ammunition.json', 'utf8'));
+  const ammoCat = JSON.parse(
+    fs.readFileSync('public/data/equipment/official/ammunition.json', 'utf8'),
+  );
   for (const a of ammoCat) {
-    if (a.id?.toLowerCase().includes('hag') || a.name?.toLowerCase().includes('hag')) {
+    if (
+      a.id?.toLowerCase().includes('hag') ||
+      a.name?.toLowerCase().includes('hag')
+    ) {
       console.log(`  Ammo catalog: ${a.id} BV=${a.battleValue}`);
     }
   }
-} catch { /* no ammo catalog */ }
+} catch {
+  /* no ammo catalog */
+}
 
 // Check if the issue is the raw weapon BV (before heat tracking)
 console.log('\n=== RAW vs HEAT-TRACKED WEAPON BV ===');
-for (const r of outliers.sort((a: any, b: any) => a.percentDiff - b.percentDiff).slice(0, 5)) {
+for (const r of outliers
+  .sort((a: any, b: any) => a.percentDiff - b.percentDiff)
+  .slice(0, 5)) {
   const b = r.breakdown;
-  const halvedPct = b?.halvedWeaponBV > 0 ? (b.halvedWeaponBV / b.rawWeaponBV * 100).toFixed(1) : '0';
-  console.log(`  ${r.unitId.padEnd(35)} raw=${b?.rawWeaponBV?.toFixed(0)} after=${b?.weaponBV?.toFixed(0)} halved=${b?.halvedWeaponBV?.toFixed(0)} (${halvedPct}%)`);
+  const halvedPct =
+    b?.halvedWeaponBV > 0
+      ? ((b.halvedWeaponBV / b.rawWeaponBV) * 100).toFixed(1)
+      : '0';
+  console.log(
+    `  ${r.unitId.padEnd(35)} raw=${b?.rawWeaponBV?.toFixed(0)} after=${b?.weaponBV?.toFixed(0)} halved=${b?.halvedWeaponBV?.toFixed(0)} (${halvedPct}%)`,
+  );
 }

--- a/scripts/trace-hag-unit.ts
+++ b/scripts/trace-hag-unit.ts
@@ -1,34 +1,43 @@
 /**
  * Trace a HAG unit's weapon breakdown.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
-
-const units = ['amarok-3', 'boreas-a', 'thunder-stallion-3', 'marauder-iic-4', 'rifleman-iic-6'];
+const units = [
+  'amarok-3',
+  'boreas-a',
+  'thunder-stallion-3',
+  'marauder-iic-4',
+  'rifleman-iic-6',
+];
 for (const unitId of units) {
   const r = report.allResults.find((x: any) => x.unitId === unitId);
   const unit = loadUnit(unitId);
-  if (!r || !unit) { console.log(`${unitId}: not found`); continue; }
+  if (!r || !unit) {
+    console.log(`${unitId}: not found`);
+    continue;
+  }
   const b = r.breakdown;
 
   console.log(`\n${'='.repeat(60)}`);
-  console.log(`${unitId} — ref=${r.indexBV} calc=${r.calculatedBV} diff=${r.difference} (${r.percentDiff?.toFixed(1)}%)`);
-  console.log(`  ${unit.tonnage}t ${unit.techBase} walk=${unit.movement?.walk} jump=${unit.movement?.jump||0}`);
+  console.log(
+    `${unitId} — ref=${r.indexBV} calc=${r.calculatedBV} diff=${r.difference} (${r.percentDiff?.toFixed(1)}%)`,
+  );
+  console.log(
+    `  ${unit.tonnage}t ${unit.techBase} walk=${unit.movement?.walk} jump=${unit.movement?.jump || 0}`,
+  );
 
   // All weapons from breakdown
   if (b?.weapons?.length) {
     console.log('  --- Weapons ---');
     for (const w of b.weapons) {
-      console.log(`    ${(w.name||w.id).padEnd(35)} h=${String(w.heat).padStart(2)} bv=${String(w.bv).padStart(4)}${w.rear?' (R)':''}`);
+      console.log(
+        `    ${(w.name || w.id).padEnd(35)} h=${String(w.heat).padStart(2)} bv=${String(w.bv).padStart(4)}${w.rear ? ' (R)' : ''}`,
+      );
     }
   }
 
@@ -38,8 +47,12 @@ for (const unitId of units) {
   }
 
   // BV components
-  console.log(`  DEF: armor=${b?.armorBV?.toFixed(0)} struct=${b?.structureBV?.toFixed(0)} gyro=${b?.gyroBV?.toFixed(0)} defEq=${b?.defEquipBV?.toFixed(0)} exp=${b?.explosivePenalty?.toFixed(0)} DF=${b?.defensiveFactor} → ${b?.defensiveBV?.toFixed(0)}`);
-  console.log(`  OFF: wBV=${b?.weaponBV?.toFixed(0)} raw=${b?.rawWeaponBV?.toFixed(0)} halved=${b?.halvedWeaponBV?.toFixed(0)} ammo=${b?.ammoBV} phys=${b?.physicalWeaponBV?.toFixed(0)} wt=${b?.weightBonus?.toFixed(0)} offEq=${b?.offEquipBV?.toFixed(0)} HE=${b?.heatEfficiency} SF=${b?.speedFactor} → ${b?.offensiveBV?.toFixed(0)}`);
+  console.log(
+    `  DEF: armor=${b?.armorBV?.toFixed(0)} struct=${b?.structureBV?.toFixed(0)} gyro=${b?.gyroBV?.toFixed(0)} defEq=${b?.defEquipBV?.toFixed(0)} exp=${b?.explosivePenalty?.toFixed(0)} DF=${b?.defensiveFactor} → ${b?.defensiveBV?.toFixed(0)}`,
+  );
+  console.log(
+    `  OFF: wBV=${b?.weaponBV?.toFixed(0)} raw=${b?.rawWeaponBV?.toFixed(0)} halved=${b?.halvedWeaponBV?.toFixed(0)} ammo=${b?.ammoBV} phys=${b?.physicalWeaponBV?.toFixed(0)} wt=${b?.weightBonus?.toFixed(0)} offEq=${b?.offEquipBV?.toFixed(0)} HE=${b?.heatEfficiency} SF=${b?.speedFactor} → ${b?.offensiveBV?.toFixed(0)}`,
+  );
   console.log(`  cockpit=${b?.cockpitModifier}`);
 
   // Crit slots with HAG or hag
@@ -56,7 +69,7 @@ for (const unitId of units) {
 
   // Equipment entries
   console.log('  --- Equipment ---');
-  for (const eq of (unit.equipment || [])) {
+  for (const eq of unit.equipment || []) {
     console.log(`    id="${eq.id}" loc="${eq.location}"`);
   }
 }

--- a/scripts/trace-missing-penalty.ts
+++ b/scripts/trace-missing-penalty.ts
@@ -2,19 +2,15 @@
  * Trace the 20 overcalculated units that should have explosive penalties but don't.
  * Compare what our code detects vs what the unit data shows.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
-
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null,
+);
 const over = valid.filter((x: any) => x.percentDiff > 1 && x.breakdown);
 
 console.log('=== OVERCALCULATED WITH MISSING EXPLOSIVE PENALTY ===\n');
@@ -35,18 +31,33 @@ for (const u of over) {
       if (!Array.isArray(slots)) continue;
       for (const s of slots) {
         if (!s || typeof s !== 'string') continue;
-        const lo = (s as string).replace(/\s*\(omnipod\)/gi, '').trim().toLowerCase();
+        const lo = (s as string)
+          .replace(/\s*\(omnipod\)/gi, '')
+          .trim()
+          .toLowerCase();
 
         if (lo.includes('ammo') && !lo.includes('ams')) {
           // Check if it's "non-explosive" ammo
-          const isNonExplosive = lo.includes('gauss') || lo.includes('plasma') || lo.includes('fluid') ||
-            lo.includes('nail') || lo.includes('rivet') || lo.includes('c3') || lo.includes('sensor') || lo.includes('rail gun');
+          const isNonExplosive =
+            lo.includes('gauss') ||
+            lo.includes('plasma') ||
+            lo.includes('fluid') ||
+            lo.includes('nail') ||
+            lo.includes('rivet') ||
+            lo.includes('c3') ||
+            lo.includes('sensor') ||
+            lo.includes('rail gun');
           if (!isNonExplosive) {
             if (!ammoByLoc[loc]) ammoByLoc[loc] = [];
             ammoByLoc[loc].push(s as string);
           }
         }
-        if (lo.includes('case ii') || lo.includes('caseii') || lo.includes('iscaseii') || lo.includes('clcaseii')) {
+        if (
+          lo.includes('case ii') ||
+          lo.includes('caseii') ||
+          lo.includes('iscaseii') ||
+          lo.includes('clcaseii')
+        ) {
           if (!caseIILocs.includes(loc)) caseIILocs.push(loc);
         } else if (lo.includes('case') && !lo.includes('case ii')) {
           if (!caseLocs.includes(loc)) caseLocs.push(loc);
@@ -56,10 +67,21 @@ for (const u of over) {
   }
 
   // Clan built-in CASE
-  const hasClanCASE = unit.techBase === 'CLAN' ||
-    (unit.techBase === 'MIXED' && (unit.engine?.type || '').toUpperCase().includes('CLAN'));
+  const hasClanCASE =
+    unit.techBase === 'CLAN' ||
+    (unit.techBase === 'MIXED' &&
+      (unit.engine?.type || '').toUpperCase().includes('CLAN'));
   if (hasClanCASE) {
-    for (const loc of ['LEFT_TORSO', 'RIGHT_TORSO', 'LEFT_ARM', 'RIGHT_ARM', 'LT', 'RT', 'LA', 'RA']) {
+    for (const loc of [
+      'LEFT_TORSO',
+      'RIGHT_TORSO',
+      'LEFT_ARM',
+      'RIGHT_ARM',
+      'LT',
+      'RT',
+      'LA',
+      'RA',
+    ]) {
       if (!caseLocs.includes(loc)) caseLocs.push(loc);
     }
   }
@@ -67,8 +89,12 @@ for (const u of over) {
   // Find unprotected ammo locations
   const unprotectedLocs: string[] = [];
   for (const loc of Object.keys(ammoByLoc)) {
-    const isTorsoLike = loc.toUpperCase().includes('TORSO') || ['LT', 'RT', 'CT'].includes(loc.toUpperCase());
-    const isArmLike = loc.toUpperCase().includes('ARM') || ['LA', 'RA'].includes(loc.toUpperCase());
+    const isTorsoLike =
+      loc.toUpperCase().includes('TORSO') ||
+      ['LT', 'RT', 'CT'].includes(loc.toUpperCase());
+    const isArmLike =
+      loc.toUpperCase().includes('ARM') ||
+      ['LA', 'RA'].includes(loc.toUpperCase());
     const hasCaseII = caseIILocs.includes(loc);
     const hasCase = caseLocs.includes(loc);
 
@@ -78,7 +104,8 @@ for (const u of over) {
     } else if (isTorsoLike) {
       // CASE in torso only works if engine ST slots < 3
       const engineType = (unit.engine?.type || '').toUpperCase();
-      const isLargeEngine = engineType.includes('XL') || engineType.includes('XXL');
+      const isLargeEngine =
+        engineType.includes('XL') || engineType.includes('XXL');
       const isClanEngine = engineType.includes('CLAN');
       if (isLargeEngine && !isClanEngine) {
         // IS XL/XXL: CASE doesn't protect side torso
@@ -96,15 +123,25 @@ for (const u of over) {
     totalAmmoSlots += ammoByLoc[loc].length;
   }
 
-  console.log(`${u.unitId.padEnd(45)} +${u.percentDiff.toFixed(1)}% diff=+${u.difference}`);
-  console.log(`  tech=${unit.techBase} engine=${unit.engine?.type || '?'} expl=${b.explosivePenalty}`);
+  console.log(
+    `${u.unitId.padEnd(45)} +${u.percentDiff.toFixed(1)}% diff=+${u.difference}`,
+  );
+  console.log(
+    `  tech=${unit.techBase} engine=${unit.engine?.type || '?'} expl=${b.explosivePenalty}`,
+  );
   console.log(`  CASE locs: ${JSON.stringify(caseLocs)}`);
   console.log(`  CASE II locs: ${JSON.stringify(caseIILocs)}`);
-  console.log(`  Breakdown expl details: ${JSON.stringify(b.explosiveDetails || 'none')}`);
+  console.log(
+    `  Breakdown expl details: ${JSON.stringify(b.explosiveDetails || 'none')}`,
+  );
   for (const loc of unprotectedLocs) {
-    console.log(`  UNPROTECTED [${loc}] (${ammoByLoc[loc].length} slots): ${ammoByLoc[loc].join(', ')}`);
+    console.log(
+      `  UNPROTECTED [${loc}] (${ammoByLoc[loc].length} slots): ${ammoByLoc[loc].join(', ')}`,
+    );
   }
-  console.log(`  Expected penalty if fixed: ~${totalAmmoSlots * 15} BV (${totalAmmoSlots} ammo slots * 15)`);
+  console.log(
+    `  Expected penalty if fixed: ~${totalAmmoSlots * 15} BV (${totalAmmoSlots} ammo slots * 15)`,
+  );
   console.log('');
 }
 

--- a/scripts/trace-nearmiss-detail.ts
+++ b/scripts/trace-nearmiss-detail.ts
@@ -1,61 +1,99 @@
 /**
  * Detailed breakdown of specific near-miss units to find systematic offset sources.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
-
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown,
+);
 
 // Sample units from different bands
 const sampleIds = [
   // Undercalculated 1-2%
-  'vandal-li-o', 'hoplite-hop-4a', 'thunderbolt-tdr-5ls', 'scorpion-scp-1n', 'goliath-gol-7k',
+  'vandal-li-o',
+  'hoplite-hop-4a',
+  'thunderbolt-tdr-5ls',
+  'scorpion-scp-1n',
+  'goliath-gol-7k',
   // Overcalculated 1-2%
-  'puma-tc', 'wolfhound-wlf-2x', 'berserker-brz-c3', 'panther-pnt-10alag', 'mantis-mts-l',
+  'puma-tc',
+  'wolfhound-wlf-2x',
+  'berserker-brz-c3',
+  'panther-pnt-10alag',
+  'mantis-mts-l',
   // Undercalculated 2-5%
-  'osteon-a', 'night-stalker-nsr-ka',
+  'osteon-a',
+  'night-stalker-nsr-ka',
 ];
 
 for (const sid of sampleIds) {
   const u = valid.find((x: any) => x.unitId === sid);
-  if (!u) { console.log(`${sid}: NOT IN REPORT`); continue; }
+  if (!u) {
+    console.log(`${sid}: NOT IN REPORT`);
+    continue;
+  }
   const unit = loadUnit(sid);
-  if (!unit) { console.log(`${sid}: UNIT NOT FOUND`); continue; }
+  if (!unit) {
+    console.log(`${sid}: UNIT NOT FOUND`);
+    continue;
+  }
   const b = u.breakdown;
 
   console.log(`\n${'='.repeat(80)}`);
   console.log(`${sid} | ${unit.techBase} | ${unit.tonnage}t`);
-  console.log(`  REF=${u.indexBV} CALC=${u.calculatedBV} DIFF=${u.difference} (${u.percentDiff.toFixed(2)}%)`);
+  console.log(
+    `  REF=${u.indexBV} CALC=${u.calculatedBV} DIFF=${u.difference} (${u.percentDiff.toFixed(2)}%)`,
+  );
   console.log(`  --- Defensive ---`);
-  console.log(`    armorBV=${b.armorBV?.toFixed(1)} structBV=${b.structureBV?.toFixed(1)} gyroBV=${b.gyroBV?.toFixed(1)}`);
-  console.log(`    defEquipBV=${b.defEquipBV?.toFixed(1)} explosivePenalty=${b.explosivePenalty?.toFixed(1)}`);
-  console.log(`    defensiveFactor=${b.defensiveFactor} defensiveBV=${b.defensiveBV?.toFixed(1)}`);
+  console.log(
+    `    armorBV=${b.armorBV?.toFixed(1)} structBV=${b.structureBV?.toFixed(1)} gyroBV=${b.gyroBV?.toFixed(1)}`,
+  );
+  console.log(
+    `    defEquipBV=${b.defEquipBV?.toFixed(1)} explosivePenalty=${b.explosivePenalty?.toFixed(1)}`,
+  );
+  console.log(
+    `    defensiveFactor=${b.defensiveFactor} defensiveBV=${b.defensiveBV?.toFixed(1)}`,
+  );
   console.log(`  --- Offensive ---`);
-  console.log(`    weaponBV=${b.weaponBV?.toFixed(1)} rawWeaponBV=${b.rawWeaponBV?.toFixed(1)} ammoBV=${b.ammoBV}`);
-  console.log(`    physicalWeaponBV=${b.physicalWeaponBV?.toFixed(1)} weightBonus=${b.weightBonus?.toFixed(1)} offEquipBV=${b.offEquipBV?.toFixed(1)}`);
-  console.log(`    speedFactor=${b.speedFactor} offensiveBV=${b.offensiveBV?.toFixed(1)}`);
+  console.log(
+    `    weaponBV=${b.weaponBV?.toFixed(1)} rawWeaponBV=${b.rawWeaponBV?.toFixed(1)} ammoBV=${b.ammoBV}`,
+  );
+  console.log(
+    `    physicalWeaponBV=${b.physicalWeaponBV?.toFixed(1)} weightBonus=${b.weightBonus?.toFixed(1)} offEquipBV=${b.offEquipBV?.toFixed(1)}`,
+  );
+  console.log(
+    `    speedFactor=${b.speedFactor} offensiveBV=${b.offensiveBV?.toFixed(1)}`,
+  );
   console.log(`  --- Other ---`);
-  console.log(`    heatEfficiency=${b.heatEfficiency} heatDissipation=${b.heatDissipation} moveHeat=${b.moveHeat}`);
-  console.log(`    cockpitMod=${b.cockpitModifier} runMP=${b.runMP} jumpMP=${b.jumpMP}`);
+  console.log(
+    `    heatEfficiency=${b.heatEfficiency} heatDissipation=${b.heatDissipation} moveHeat=${b.moveHeat}`,
+  );
+  console.log(
+    `    cockpitMod=${b.cockpitModifier} runMP=${b.runMP} jumpMP=${b.jumpMP}`,
+  );
 
   // Check TSM
   if (unit.criticalSlots) {
     const allCrits: string[] = [];
     for (const [, slots] of Object.entries(unit.criticalSlots)) {
-      if (Array.isArray(slots)) for (const s of slots as string[]) if (s) allCrits.push(s);
+      if (Array.isArray(slots))
+        for (const s of slots as string[]) if (s) allCrits.push(s);
     }
-    const tsmCount = allCrits.filter(c => c.toLowerCase().includes('tsm') || c.toLowerCase().includes('triple strength')).length;
-    const mascCount = allCrits.filter(c => c.toLowerCase().includes('masc')).length;
-    const superCount = allCrits.filter(c => c.toLowerCase().includes('supercharger')).length;
+    const tsmCount = allCrits.filter(
+      (c) =>
+        c.toLowerCase().includes('tsm') ||
+        c.toLowerCase().includes('triple strength'),
+    ).length;
+    const mascCount = allCrits.filter((c) =>
+      c.toLowerCase().includes('masc'),
+    ).length;
+    const superCount = allCrits.filter((c) =>
+      c.toLowerCase().includes('supercharger'),
+    ).length;
     if (tsmCount > 0) console.log(`    TSM slots: ${tsmCount}`);
     if (mascCount > 0) console.log(`    MASC slots: ${mascCount}`);
     if (superCount > 0) console.log(`    Supercharger slots: ${superCount}`);

--- a/scripts/trace-over-offense.ts
+++ b/scripts/trace-over-offense.ts
@@ -2,20 +2,18 @@
  * Deep trace of overcalculated 1-2% units to find systematic offensive excess.
  * Check weight bonus, weapon BV, ammo BV individually.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
-
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null);
-const over1to2 = valid.filter((x: any) => x.percentDiff > 1 && x.percentDiff <= 2 && x.breakdown);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null,
+);
+const over1to2 = valid.filter(
+  (x: any) => x.percentDiff > 1 && x.percentDiff <= 2 && x.breakdown,
+);
 
 // Check if the defensive BV or offensive BV is the primary cause
 console.log(`=== OVERCALCULATED 1-2% (${over1to2.length} units) ===\n`);
@@ -31,27 +29,57 @@ for (const u of over1to2) {
   const unit = loadUnit(u.unitId);
   if (!unit) continue;
 
-  const hasTSM = unit.criticalSlots && Object.values(unit.criticalSlots).some((slots: any) =>
-    Array.isArray(slots) && slots.some((s: any) => s && typeof s === 'string' &&
-      (s.toLowerCase() === 'tsm' || s.toLowerCase().includes('triple strength') || s.toLowerCase().includes('triple-strength'))));
+  const hasTSM =
+    unit.criticalSlots &&
+    Object.values(unit.criticalSlots).some(
+      (slots: any) =>
+        Array.isArray(slots) &&
+        slots.some(
+          (s: any) =>
+            s &&
+            typeof s === 'string' &&
+            (s.toLowerCase() === 'tsm' ||
+              s.toLowerCase().includes('triple strength') ||
+              s.toLowerCase().includes('triple-strength')),
+        ),
+    );
 
   const cockpit = b.cockpitModifier ?? 1;
   const refBase = u.indexBV / cockpit;
-  const baseOff = (b.weaponBV ?? 0) + (b.ammoBV ?? 0) + (b.weightBonus ?? 0) + (b.physicalWeaponBV ?? 0) + (b.offEquipBV ?? 0);
+  const baseOff =
+    (b.weaponBV ?? 0) +
+    (b.ammoBV ?? 0) +
+    (b.weightBonus ?? 0) +
+    (b.physicalWeaponBV ?? 0) +
+    (b.offEquipBV ?? 0);
   const neededBaseOff = (refBase - b.defensiveBV) / b.speedFactor;
   const excess = baseOff - neededBaseOff;
 
   const detail = {
-    unitId: u.unitId, pct: u.percentDiff, diff: u.difference, hasTSM,
-    weaponBV: b.weaponBV, ammoBV: b.ammoBV, weightBonus: b.weightBonus,
-    physBV: b.physicalWeaponBV, offEquipBV: b.offEquipBV,
-    speedFactor: b.speedFactor, tonnage: unit.tonnage, tech: unit.techBase,
-    halvedCount: b.halvedWeaponCount, weaponCount: b.weaponCount,
+    unitId: u.unitId,
+    pct: u.percentDiff,
+    diff: u.difference,
+    hasTSM,
+    weaponBV: b.weaponBV,
+    ammoBV: b.ammoBV,
+    weightBonus: b.weightBonus,
+    physBV: b.physicalWeaponBV,
+    offEquipBV: b.offEquipBV,
+    speedFactor: b.speedFactor,
+    tonnage: unit.tonnage,
+    tech: unit.techBase,
+    halvedCount: b.halvedWeaponCount,
+    weaponCount: b.weaponCount,
     baseExcess: excess,
   };
 
-  if (hasTSM) { tsmOver++; tsmDetails.push(detail); }
-  else { nonTsmOver++; nonTsmDetails.push(detail); }
+  if (hasTSM) {
+    tsmOver++;
+    tsmDetails.push(detail);
+  } else {
+    nonTsmOver++;
+    nonTsmDetails.push(detail);
+  }
 }
 
 console.log(`TSM: ${tsmOver}, Non-TSM: ${nonTsmOver}\n`);
@@ -63,24 +91,34 @@ let excessInWeapon = 0;
 let excessInAmmo = 0;
 let excessInWeight = 0;
 
-for (const d of nonTsmDetails.sort((a: any, b: any) => b.baseExcess - a.baseExcess)) {
+for (const d of nonTsmDetails.sort(
+  (a: any, b: any) => b.baseExcess - a.baseExcess,
+)) {
   // Weight bonus = tonnage (for standard mech)
   // Check if weight bonus matches expected
   const expectedWeight = d.tonnage; // no TSM, no AES
   const weightDiff = d.weightBonus - expectedWeight;
 
-  console.log(`  ${d.unitId.padEnd(42)} +${d.pct.toFixed(1)}% excess=${d.baseExcess.toFixed(0)} weapBV=${d.weaponBV?.toFixed(0)} ammoBV=${d.ammoBV} wt=${d.weightBonus?.toFixed(0)}(exp=${expectedWeight}) SF=${d.speedFactor} halved=${d.halvedCount}/${d.weaponCount}`);
+  console.log(
+    `  ${d.unitId.padEnd(42)} +${d.pct.toFixed(1)}% excess=${d.baseExcess.toFixed(0)} weapBV=${d.weaponBV?.toFixed(0)} ammoBV=${d.ammoBV} wt=${d.weightBonus?.toFixed(0)}(exp=${expectedWeight}) SF=${d.speedFactor} halved=${d.halvedCount}/${d.weaponCount}`,
+  );
 
   if (Math.abs(weightDiff) > 1) {
-    console.log(`    *** WEIGHT DIFF: ${weightDiff.toFixed(1)} (got ${d.weightBonus?.toFixed(1)}, expected ${expectedWeight})`);
+    console.log(
+      `    *** WEIGHT DIFF: ${weightDiff.toFixed(1)} (got ${d.weightBonus?.toFixed(1)}, expected ${expectedWeight})`,
+    );
   }
 }
 
 console.log('\n=== TSM OVERCALCULATED 1-2% ===');
-for (const d of tsmDetails.sort((a: any, b: any) => b.baseExcess - a.baseExcess)) {
+for (const d of tsmDetails.sort(
+  (a: any, b: any) => b.baseExcess - a.baseExcess,
+)) {
   const expectedWeight = d.tonnage * 1.5; // TSM = 1.5x
   const weightDiff = (d.weightBonus ?? 0) - expectedWeight;
-  console.log(`  ${d.unitId.padEnd(42)} +${d.pct.toFixed(1)}% excess=${d.baseExcess.toFixed(0)} weapBV=${d.weaponBV?.toFixed(0)} ammoBV=${d.ammoBV} wt=${d.weightBonus?.toFixed(0)}(exp=${expectedWeight}) SF=${d.speedFactor} halved=${d.halvedCount}/${d.weaponCount}`);
+  console.log(
+    `  ${d.unitId.padEnd(42)} +${d.pct.toFixed(1)}% excess=${d.baseExcess.toFixed(0)} weapBV=${d.weaponBV?.toFixed(0)} ammoBV=${d.ammoBV} wt=${d.weightBonus?.toFixed(0)}(exp=${expectedWeight}) SF=${d.speedFactor} halved=${d.halvedCount}/${d.weaponCount}`,
+  );
   if (Math.abs(weightDiff) > 1) {
     console.log(`    *** WEIGHT DIFF: ${weightDiff.toFixed(1)}`);
   }
@@ -88,10 +126,18 @@ for (const d of tsmDetails.sort((a: any, b: any) => b.baseExcess - a.baseExcess)
 
 // Check if halved weapon count correlates with overcalculation
 console.log('\n=== HALVING ANALYSIS ===');
-const halvedOvercalc = over1to2.filter((x: any) => x.breakdown.halvedWeaponCount > 0);
-const noHalvedOvercalc = over1to2.filter((x: any) => x.breakdown.halvedWeaponCount === 0);
-console.log(`  With halved weapons: ${halvedOvercalc.length} (avg +${(halvedOvercalc.reduce((s: number, x: any) => s + x.percentDiff, 0) / Math.max(halvedOvercalc.length, 1)).toFixed(2)}%)`);
-console.log(`  No halved weapons: ${noHalvedOvercalc.length} (avg +${(noHalvedOvercalc.reduce((s: number, x: any) => s + x.percentDiff, 0) / Math.max(noHalvedOvercalc.length, 1)).toFixed(2)}%)`);
+const halvedOvercalc = over1to2.filter(
+  (x: any) => x.breakdown.halvedWeaponCount > 0,
+);
+const noHalvedOvercalc = over1to2.filter(
+  (x: any) => x.breakdown.halvedWeaponCount === 0,
+);
+console.log(
+  `  With halved weapons: ${halvedOvercalc.length} (avg +${(halvedOvercalc.reduce((s: number, x: any) => s + x.percentDiff, 0) / Math.max(halvedOvercalc.length, 1)).toFixed(2)}%)`,
+);
+console.log(
+  `  No halved weapons: ${noHalvedOvercalc.length} (avg +${(noHalvedOvercalc.reduce((s: number, x: any) => s + x.percentDiff, 0) / Math.max(noHalvedOvercalc.length, 1)).toFixed(2)}%)`,
+);
 
 // Check: for overcalculated units, is the defensive BV too high or too low?
 console.log('\n=== DEFENSIVE BV CHECK ===');

--- a/scripts/trace-over1to2.ts
+++ b/scripts/trace-over1to2.ts
@@ -2,20 +2,18 @@
  * Trace overcalculated 1-2% units to find systematic patterns.
  * Focus on what makes us calculate too high.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
-
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null);
-const over1to2 = valid.filter((x: any) => x.percentDiff > 1 && x.percentDiff <= 2 && x.breakdown);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null,
+);
+const over1to2 = valid.filter(
+  (x: any) => x.percentDiff > 1 && x.percentDiff <= 2 && x.breakdown,
+);
 
 console.log(`=== OVERCALCULATED 1-2%: ${over1to2.length} units ===\n`);
 
@@ -44,13 +42,37 @@ for (const u of over1to2) {
 
   if (offExcessBV > 5) {
     offExcess++;
-    excessDetails.push({ unitId: u.unitId, type: 'off', excess: offExcessBV, diff: u.difference, pct: u.percentDiff, b, unit });
+    excessDetails.push({
+      unitId: u.unitId,
+      type: 'off',
+      excess: offExcessBV,
+      diff: u.difference,
+      pct: u.percentDiff,
+      b,
+      unit,
+    });
   } else if (defExcessBV > 5) {
     defExcess++;
-    excessDetails.push({ unitId: u.unitId, type: 'def', excess: defExcessBV, diff: u.difference, pct: u.percentDiff, b, unit });
+    excessDetails.push({
+      unitId: u.unitId,
+      type: 'def',
+      excess: defExcessBV,
+      diff: u.difference,
+      pct: u.percentDiff,
+      b,
+      unit,
+    });
   } else {
     mixedExcess++;
-    excessDetails.push({ unitId: u.unitId, type: 'mixed', excess: offExcessBV + defExcessBV, diff: u.difference, pct: u.percentDiff, b, unit });
+    excessDetails.push({
+      unitId: u.unitId,
+      type: 'mixed',
+      excess: offExcessBV + defExcessBV,
+      diff: u.difference,
+      pct: u.percentDiff,
+      b,
+      unit,
+    });
   }
 }
 
@@ -81,8 +103,12 @@ for (const u of over1to2) {
       for (const [loc, slots] of Object.entries(unit.criticalSlots)) {
         if (!Array.isArray(slots)) continue;
         for (const s of slots) {
-          if (s && typeof s === 'string' && (s as string).toLowerCase().includes('ammo') &&
-              !(s as string).toLowerCase().includes('ams')) {
+          if (
+            s &&
+            typeof s === 'string' &&
+            (s as string).toLowerCase().includes('ammo') &&
+            !(s as string).toLowerCase().includes('ams')
+          ) {
             ammoLocs.add(loc.toUpperCase());
           }
         }
@@ -90,10 +116,20 @@ for (const u of over1to2) {
     }
     // For each ammo location, check if it has CASE
     for (const loc of ammoLocs) {
-      const hasCaseII = unit.criticalSlots?.[loc]?.some?.((s: any) =>
-        s && typeof s === 'string' && (s.toLowerCase().includes('case ii') || s.toLowerCase().includes('caseii')));
-      const hasCase = unit.criticalSlots?.[loc]?.some?.((s: any) =>
-        s && typeof s === 'string' && s.toLowerCase().includes('case') && !s.toLowerCase().includes('case ii'));
+      const hasCaseII = unit.criticalSlots?.[loc]?.some?.(
+        (s: any) =>
+          s &&
+          typeof s === 'string' &&
+          (s.toLowerCase().includes('case ii') ||
+            s.toLowerCase().includes('caseii')),
+      );
+      const hasCase = unit.criticalSlots?.[loc]?.some?.(
+        (s: any) =>
+          s &&
+          typeof s === 'string' &&
+          s.toLowerCase().includes('case') &&
+          !s.toLowerCase().includes('case ii'),
+      );
       if (!hasCaseII && !hasCase) {
         allProtected = false;
       }
@@ -124,8 +160,16 @@ console.log('\n=== TOP 20 OVERCALCULATED 1-2% ===');
 const sorted = [...excessDetails].sort((a: any, b: any) => b.diff - a.diff);
 for (const u of sorted.slice(0, 20)) {
   const b = u.b;
-  console.log(`${u.unitId.padEnd(45)} +${u.diff} (+${u.pct.toFixed(1)}%) ${u.type} excess=${u.excess.toFixed(0)} tech=${u.unit?.techBase}`);
-  console.log(`  defBV=${b.defensiveBV?.toFixed(0)} offBV=${b.offensiveBV?.toFixed(0)} SF=${b.speedFactor} cockpit=${b.cockpitModifier}`);
-  console.log(`  weapBV=${b.weaponBV?.toFixed(0)} ammoBV=${b.ammoBV} wt=${b.weightBonus?.toFixed(0)} halved=${b.halvedWeaponCount}/${b.weaponCount}`);
-  console.log(`  expl=${b.explosivePenalty} armorBV=${b.armorBV?.toFixed(0)} structBV=${b.structureBV?.toFixed(0)} gyroBV=${b.gyroBV?.toFixed(0)} DF=${b.defensiveFactor} TMM=${b.maxTMM}`);
+  console.log(
+    `${u.unitId.padEnd(45)} +${u.diff} (+${u.pct.toFixed(1)}%) ${u.type} excess=${u.excess.toFixed(0)} tech=${u.unit?.techBase}`,
+  );
+  console.log(
+    `  defBV=${b.defensiveBV?.toFixed(0)} offBV=${b.offensiveBV?.toFixed(0)} SF=${b.speedFactor} cockpit=${b.cockpitModifier}`,
+  );
+  console.log(
+    `  weapBV=${b.weaponBV?.toFixed(0)} ammoBV=${b.ammoBV} wt=${b.weightBonus?.toFixed(0)} halved=${b.halvedWeaponCount}/${b.weaponCount}`,
+  );
+  console.log(
+    `  expl=${b.explosivePenalty} armorBV=${b.armorBV?.toFixed(0)} structBV=${b.structureBV?.toFixed(0)} gyroBV=${b.gyroBV?.toFixed(0)} DF=${b.defensiveFactor} TMM=${b.maxTMM}`,
+  );
 }

--- a/scripts/trace-overcalc-2to5.ts
+++ b/scripts/trace-overcalc-2to5.ts
@@ -1,28 +1,29 @@
 /**
  * Detailed trace of overcalculated 2-5% units to find systematic patterns.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
-
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown);
-const overBand = valid.filter((x: any) => x.percentDiff > 2 && x.percentDiff <= 5);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown,
+);
+const overBand = valid.filter(
+  (x: any) => x.percentDiff > 2 && x.percentDiff <= 5,
+);
 
 // For each overcalculated unit, calculate what the error source might be
 // by computing how much each component would need to change to match reference
 console.log('=== OVERCALCULATED 2-5% DETAILED TRACE ===\n');
 
-const excessPatterns: { defExcess: number; offExcess: number; count: number } = { defExcess: 0, offExcess: 0, count: 0 };
+const excessPatterns: { defExcess: number; offExcess: number; count: number } =
+  { defExcess: 0, offExcess: 0, count: 0 };
 
-for (const u of overBand.sort((a: any, b: any) => b.percentDiff - a.percentDiff).slice(0, 15)) {
+for (const u of overBand
+  .sort((a: any, b: any) => b.percentDiff - a.percentDiff)
+  .slice(0, 15)) {
   const b = u.breakdown;
   const defBV = b.defensiveBV || 0;
   const offBV = b.offensiveBV || 0;
@@ -35,10 +36,18 @@ for (const u of overBand.sort((a: any, b: any) => b.percentDiff - a.percentDiff)
   const offFraction = offBV / (defBV + offBV);
 
   console.log(`${u.unitId}`);
-  console.log(`  REF=${refBV} CALC=${u.calculatedBV} excess=${excess} (${u.percentDiff.toFixed(1)}%)`);
-  console.log(`  DEF=${defBV.toFixed(0)} (${(defFraction*100).toFixed(0)}%) OFF=${offBV.toFixed(0)} (${(offFraction*100).toFixed(0)}%) cockpit=${b.cockpitModifier}`);
-  console.log(`  armorBV=${b.armorBV?.toFixed(0)} struct=${b.structureBV?.toFixed(0)} gyro=${b.gyroBV?.toFixed(0)} defEq=${b.defEquipBV?.toFixed(0)} expPenalty=${b.explosivePenalty?.toFixed(0)} defFactor=${b.defensiveFactor}`);
-  console.log(`  wepBV=${b.weaponBV?.toFixed(0)} ammo=${b.ammoBV} phys=${b.physicalWeaponBV?.toFixed(0)} weight=${b.weightBonus?.toFixed(0)} offEq=${b.offEquipBV?.toFixed(0)} SF=${b.speedFactor}`);
+  console.log(
+    `  REF=${refBV} CALC=${u.calculatedBV} excess=${excess} (${u.percentDiff.toFixed(1)}%)`,
+  );
+  console.log(
+    `  DEF=${defBV.toFixed(0)} (${(defFraction * 100).toFixed(0)}%) OFF=${offBV.toFixed(0)} (${(offFraction * 100).toFixed(0)}%) cockpit=${b.cockpitModifier}`,
+  );
+  console.log(
+    `  armorBV=${b.armorBV?.toFixed(0)} struct=${b.structureBV?.toFixed(0)} gyro=${b.gyroBV?.toFixed(0)} defEq=${b.defEquipBV?.toFixed(0)} expPenalty=${b.explosivePenalty?.toFixed(0)} defFactor=${b.defensiveFactor}`,
+  );
+  console.log(
+    `  wepBV=${b.weaponBV?.toFixed(0)} ammo=${b.ammoBV} phys=${b.physicalWeaponBV?.toFixed(0)} weight=${b.weightBonus?.toFixed(0)} offEq=${b.offEquipBV?.toFixed(0)} SF=${b.speedFactor}`,
+  );
   console.log(`  HE=${b.heatEfficiency} run=${b.runMP} jump=${b.jumpMP}`);
   console.log('');
 
@@ -48,8 +57,12 @@ for (const u of overBand.sort((a: any, b: any) => b.percentDiff - a.percentDiff)
 }
 
 console.log(`\n=== AVERAGE EXCESS DISTRIBUTION ===`);
-console.log(`  Defensive excess: ${(excessPatterns.defExcess / excessPatterns.count).toFixed(1)} BV`);
-console.log(`  Offensive excess: ${(excessPatterns.offExcess / excessPatterns.count).toFixed(1)} BV`);
+console.log(
+  `  Defensive excess: ${(excessPatterns.defExcess / excessPatterns.count).toFixed(1)} BV`,
+);
+console.log(
+  `  Offensive excess: ${(excessPatterns.offExcess / excessPatterns.count).toFixed(1)} BV`,
+);
 
 // Check: do overcalculated units have high defEquipBV?
 console.log('\n=== defEquipBV in overcalculated 2-5% ===');
@@ -59,8 +72,12 @@ for (const u of overBand) {
   defEquipValues.push(b.defEquipBV || 0);
 }
 defEquipValues.sort((a, b) => b - a);
-console.log(`  Max: ${defEquipValues[0]}, Median: ${defEquipValues[Math.floor(defEquipValues.length/2)]}, Min: ${defEquipValues[defEquipValues.length-1]}`);
-console.log(`  With defEquipBV > 0: ${defEquipValues.filter(v => v > 0).length}/${defEquipValues.length}`);
+console.log(
+  `  Max: ${defEquipValues[0]}, Median: ${defEquipValues[Math.floor(defEquipValues.length / 2)]}, Min: ${defEquipValues[defEquipValues.length - 1]}`,
+);
+console.log(
+  `  With defEquipBV > 0: ${defEquipValues.filter((v) => v > 0).length}/${defEquipValues.length}`,
+);
 
 // Check: breakdown of exact-match units for comparison
 const exactUnits = valid.filter((x: any) => x.status === 'exact');
@@ -69,4 +86,6 @@ for (const u of exactUnits.slice(0, 500)) {
   const b = u.breakdown;
   exactDefEquip.push(b.defEquipBV || 0);
 }
-console.log(`\n  Exact units defEquipBV: max=${Math.max(...exactDefEquip)}, median=${exactDefEquip.sort((a,b) => a-b)[Math.floor(exactDefEquip.length/2)]}`);
+console.log(
+  `\n  Exact units defEquipBV: max=${Math.max(...exactDefEquip)}, median=${exactDefEquip.sort((a, b) => a - b)[Math.floor(exactDefEquip.length / 2)]}`,
+);

--- a/scripts/trace-ppc-cap.ts
+++ b/scripts/trace-ppc-cap.ts
@@ -1,63 +1,85 @@
 /**
  * Trace PPC Capacitor outlier units — check weapon name matching and BV values.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
-
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown,
+);
 
 // PPC Capacitor outlier IDs
 const ppcCapIds = [
-  'great-turtle-gtr-2', 'galahad-glh-3d-laodices', 'minsk-2',
-  'vandal-li-oa', 'scorpion-c', 'gladiator-gld-9sf', 'goliath-gol-7k',
-  'anzu-zu-g60', 'blackjack-bj2-ox', 'wolfhound-wlf-2x', 'gladiator-gld-1r-keller'
+  'great-turtle-gtr-2',
+  'galahad-glh-3d-laodices',
+  'minsk-2',
+  'vandal-li-oa',
+  'scorpion-c',
+  'gladiator-gld-9sf',
+  'goliath-gol-7k',
+  'anzu-zu-g60',
+  'blackjack-bj2-ox',
+  'wolfhound-wlf-2x',
+  'gladiator-gld-1r-keller',
 ];
 
 for (const unitId of ppcCapIds) {
   const r = valid.find((x: any) => x.unitId === unitId);
   const unit = loadUnit(unitId);
-  if (!r || !unit) { console.log(`${unitId}: NOT FOUND`); continue; }
+  if (!r || !unit) {
+    console.log(`${unitId}: NOT FOUND`);
+    continue;
+  }
   const b = r.breakdown;
 
   console.log(`\n${'='.repeat(60)}`);
-  console.log(`${unitId} — ref=${r.indexBV} calc=${r.calculatedBV} diff=${r.difference} (${r.percentDiff?.toFixed(1)}%)`);
-  console.log(`  ${unit.tonnage}t ${unit.techBase} walk=${unit.movement?.walk} jump=${unit.movement?.jump||0}`);
+  console.log(
+    `${unitId} — ref=${r.indexBV} calc=${r.calculatedBV} diff=${r.difference} (${r.percentDiff?.toFixed(1)}%)`,
+  );
+  console.log(
+    `  ${unit.tonnage}t ${unit.techBase} walk=${unit.movement?.walk} jump=${unit.movement?.jump || 0}`,
+  );
 
   // Count PPC capacitors in crits
   let capCount = 0;
   for (const [loc, slots] of Object.entries(unit.criticalSlots || {})) {
     if (!Array.isArray(slots)) continue;
     for (const s of slots) {
-      if (typeof s === 'string' && s.toLowerCase().includes('ppc capacitor')) capCount++;
+      if (typeof s === 'string' && s.toLowerCase().includes('ppc capacitor'))
+        capCount++;
     }
   }
 
   // Show PPC weapons in equipment
-  const ppcEquip = (unit.equipment || []).filter((e: any) => e.id.toLowerCase().includes('ppc'));
+  const ppcEquip = (unit.equipment || []).filter((e: any) =>
+    e.id.toLowerCase().includes('ppc'),
+  );
   console.log(`  PPC Capacitor crits: ${capCount}`);
-  console.log(`  PPC Equipment: ${ppcEquip.map((e: any) => `${e.id}@${e.location}`).join(', ')}`);
+  console.log(
+    `  PPC Equipment: ${ppcEquip.map((e: any) => `${e.id}@${e.location}`).join(', ')}`,
+  );
 
   // Show weapon breakdown
   if (b?.weapons?.length) {
     console.log('  --- Weapons ---');
     for (const w of b.weapons) {
       const isPPC = (w.name || w.id || '').toLowerCase().includes('ppc');
-      console.log(`    ${(w.name||w.id).padEnd(35)} h=${String(w.heat).padStart(2)} bv=${String(w.bv).padStart(4)}${isPPC ? ' ← PPC' : ''}${w.rear?' (R)':''}`);
+      console.log(
+        `    ${(w.name || w.id).padEnd(35)} h=${String(w.heat).padStart(2)} bv=${String(w.bv).padStart(4)}${isPPC ? ' ← PPC' : ''}${w.rear ? ' (R)' : ''}`,
+      );
     }
   }
 
   // BV components
-  console.log(`  DEF: armor=${b?.armorBV?.toFixed(0)} struct=${b?.structureBV?.toFixed(0)} gyro=${b?.gyroBV?.toFixed(0)} exp=${b?.explosivePenalty?.toFixed(0)} DF=${b?.defensiveFactor} → ${b?.defensiveBV?.toFixed(0)}`);
-  console.log(`  OFF: wBV=${b?.weaponBV?.toFixed(0)} ammo=${b?.ammoBV} phys=${b?.physicalWeaponBV?.toFixed(0)} wt=${b?.weightBonus?.toFixed(0)} HE=${b?.heatEfficiency} SF=${b?.speedFactor} → ${b?.offensiveBV?.toFixed(0)}`);
+  console.log(
+    `  DEF: armor=${b?.armorBV?.toFixed(0)} struct=${b?.structureBV?.toFixed(0)} gyro=${b?.gyroBV?.toFixed(0)} exp=${b?.explosivePenalty?.toFixed(0)} DF=${b?.defensiveFactor} → ${b?.defensiveBV?.toFixed(0)}`,
+  );
+  console.log(
+    `  OFF: wBV=${b?.weaponBV?.toFixed(0)} ammo=${b?.ammoBV} phys=${b?.physicalWeaponBV?.toFixed(0)} wt=${b?.weightBonus?.toFixed(0)} HE=${b?.heatEfficiency} SF=${b?.speedFactor} → ${b?.offensiveBV?.toFixed(0)}`,
+  );
   console.log(`  cockpit=${b?.cockpitModifier}`);
 
   // Show PPC-related crit slots

--- a/scripts/trace-simple-energy.ts
+++ b/scripts/trace-simple-energy.ts
@@ -2,20 +2,18 @@
  * Find simple energy-only units in the 1-2% band (no ammo, no special equipment)
  * to isolate what component of BV calculation is off.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
-
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown);
-const near = valid.filter((x: any) => Math.abs(x.percentDiff) > 1 && Math.abs(x.percentDiff) <= 5);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown,
+);
+const near = valid.filter(
+  (x: any) => Math.abs(x.percentDiff) > 1 && Math.abs(x.percentDiff) <= 5,
+);
 
 // Find "simple" units: energy only, no ammo, standard everything
 const simple: any[] = [];
@@ -30,13 +28,26 @@ for (const u of near) {
   const unit = loadUnit(u.unitId);
   if (!unit) continue;
   if (unit.techBase !== 'INNER_SPHERE') continue; // IS only for simplicity
-  if (unit.engine?.type !== 'FUSION' && unit.engine?.type !== 'XL' && unit.engine?.type !== 'LIGHT') continue;
+  if (
+    unit.engine?.type !== 'FUSION' &&
+    unit.engine?.type !== 'XL' &&
+    unit.engine?.type !== 'LIGHT'
+  )
+    continue;
 
   const eqs = (unit.equipment || []).map((e: any) => e.id.toLowerCase());
-  const hasSpecial = eqs.some((e: string) =>
-    e.includes('tsm') || e.includes('masc') || e.includes('supercharger') ||
-    e.includes('c3') || e.includes('ecm') || e.includes('bap') || e.includes('stealth') ||
-    e.includes('targeting') || e.includes('artemis') || e.includes('narc')
+  const hasSpecial = eqs.some(
+    (e: string) =>
+      e.includes('tsm') ||
+      e.includes('masc') ||
+      e.includes('supercharger') ||
+      e.includes('c3') ||
+      e.includes('ecm') ||
+      e.includes('bap') ||
+      e.includes('stealth') ||
+      e.includes('targeting') ||
+      e.includes('artemis') ||
+      e.includes('narc'),
   );
   if (hasSpecial) continue;
 
@@ -76,16 +87,33 @@ for (const u of simple.slice(0, 20)) {
   const offNeeded = needed / sf; // base off adjustment needed
 
   console.log(`${u.unitId}`);
-  console.log(`  ref=${ref} calc=${u.calculatedBV} diff=${u.difference} (${u.percentDiff.toFixed(1)}%)`);
-  console.log(`  ${unit.tonnage}t ${unit.engine.type} walk=${unit.movement.walk} jump=${unit.movement.jump||0}`);
-  console.log(`  armor=${unit.armor.type} struct=${unit.structure?.type||'STANDARD'} HS=${unit.heatSinks.count}x${unit.heatSinks.type}`);
-  console.log(`  DEF: armor=${armorBV.toFixed(0)} struct=${structBV.toFixed(0)} gyro=${gyroBV.toFixed(0)} exp=${expPen} base=${baseDef.toFixed(0)} DF=${df} → ${defBV.toFixed(0)}`);
-  console.log(`  OFF: weap=${weapBV.toFixed(0)} wt=${wtBonus.toFixed(0)} HE=${b.heatEfficiency} base=${baseOff.toFixed(0)} SF=${sf} → ${offBV.toFixed(0)}`);
-  console.log(`  Need ${needed>=0?'+':''}${needed.toFixed(0)} BV. If DEF: ${defNeeded>=0?'+':''}${defNeeded.toFixed(0)} base. If OFF: ${offNeeded>=0?'+':''}${offNeeded.toFixed(0)} base.`);
+  console.log(
+    `  ref=${ref} calc=${u.calculatedBV} diff=${u.difference} (${u.percentDiff.toFixed(1)}%)`,
+  );
+  console.log(
+    `  ${unit.tonnage}t ${unit.engine.type} walk=${unit.movement.walk} jump=${unit.movement.jump || 0}`,
+  );
+  console.log(
+    `  armor=${unit.armor.type} struct=${unit.structure?.type || 'STANDARD'} HS=${unit.heatSinks.count}x${unit.heatSinks.type}`,
+  );
+  console.log(
+    `  DEF: armor=${armorBV.toFixed(0)} struct=${structBV.toFixed(0)} gyro=${gyroBV.toFixed(0)} exp=${expPen} base=${baseDef.toFixed(0)} DF=${df} → ${defBV.toFixed(0)}`,
+  );
+  console.log(
+    `  OFF: weap=${weapBV.toFixed(0)} wt=${wtBonus.toFixed(0)} HE=${b.heatEfficiency} base=${baseOff.toFixed(0)} SF=${sf} → ${offBV.toFixed(0)}`,
+  );
+  console.log(
+    `  Need ${needed >= 0 ? '+' : ''}${needed.toFixed(0)} BV. If DEF: ${defNeeded >= 0 ? '+' : ''}${defNeeded.toFixed(0)} base. If OFF: ${offNeeded >= 0 ? '+' : ''}${offNeeded.toFixed(0)} base.`,
+  );
 
   // Show weapons
   if (b.weapons?.length) {
-    const weapList = b.weapons.map((w: any) => `${w.name||w.id}(h=${w.heat},bv=${w.bv}${w.rear?' R':''})`).join(', ');
+    const weapList = b.weapons
+      .map(
+        (w: any) =>
+          `${w.name || w.id}(h=${w.heat},bv=${w.bv}${w.rear ? ' R' : ''})`,
+      )
+      .join(', ');
     console.log(`  weapons: ${weapList}`);
   }
   console.log('');

--- a/scripts/verify-known-small-cockpit.ts
+++ b/scripts/verify-known-small-cockpit.ts
@@ -2,35 +2,43 @@
  * Verify every unit in KNOWN_SMALL_COCKPIT_UNITS — check if 0.95 modifier
  * is correct by comparing calc/0.95 vs reference BV.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
-
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
 const KNOWN_SMALL_COCKPIT_UNITS = [
-  'archer-arc-4m-ismail', 'atlas-as7-s-hanssen',
-  'axman-axm-6t', 'axman-axm-6x',
-  'black-knight-blk-nt-2y', 'black-knight-blk-nt-3b',
+  'archer-arc-4m-ismail',
+  'atlas-as7-s-hanssen',
+  'axman-axm-6t',
+  'axman-axm-6x',
+  'black-knight-blk-nt-2y',
+  'black-knight-blk-nt-3b',
   'crockett-crk-5003-0-saddleford',
-  'helepolis-hep-2x', 'hermes-ii-her-5c', 'hierofalcon-d',
+  'helepolis-hep-2x',
+  'hermes-ii-her-5c',
+  'hierofalcon-d',
   'pathfinder-pff-2t',
-  'phoenix-hawk-pxh-1bc', 'phoenix-hawk-pxh-7cs',
-  'raven-rvn-3l', 'raven-rvn-3m', 'raven-rvn-4l', 'raven-rvn-4lc',
+  'phoenix-hawk-pxh-1bc',
+  'phoenix-hawk-pxh-7cs',
+  'raven-rvn-3l',
+  'raven-rvn-3m',
+  'raven-rvn-4l',
+  'raven-rvn-4lc',
   'scorpion-scp-12c',
-  'tessen-tsn-1cr', 'tessen-tsn-c3',
+  'tessen-tsn-1cr',
+  'tessen-tsn-c3',
 ];
 
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null,
+);
 
 console.log('=== VERIFICATION OF KNOWN_SMALL_COCKPIT_UNITS ===');
-console.log('For each: check if BV/0.95 matches reference better than BV as-is.\n');
+console.log(
+  'For each: check if BV/0.95 matches reference better than BV as-is.\n',
+);
 
 let wrongCount = 0;
 const wrongUnits: string[] = [];
@@ -38,7 +46,10 @@ const wrongUnits: string[] = [];
 for (const unitId of KNOWN_SMALL_COCKPIT_UNITS) {
   const r = valid.find((x: any) => x.unitId === unitId);
   const unit = loadUnit(unitId);
-  if (!r || !unit) { console.log(`${unitId}: NOT FOUND`); continue; }
+  if (!r || !unit) {
+    console.log(`${unitId}: NOT FOUND`);
+    continue;
+  }
 
   const calc = r.calculatedBV;
   const ref = r.indexBV;
@@ -46,43 +57,66 @@ for (const unitId of KNOWN_SMALL_COCKPIT_UNITS) {
 
   // Current diff with 0.95
   const currentDiff = calc - ref;
-  const currentPct = (currentDiff / ref * 100);
+  const currentPct = (currentDiff / ref) * 100;
 
   // What would BV be with 1.0 instead of 0.95?
   // BV = round((def + off) * cockpitMod)
   // If cockpitMod is 0.95, then base = calc / 0.95, newCalc = round(base * 1.0) = round(calc / 0.95)
   const withStandard = Math.round(calc / 0.95);
   const stdDiff = withStandard - ref;
-  const stdPct = (stdDiff / ref * 100);
+  const stdPct = (stdDiff / ref) * 100;
 
   // Check HEAD Life Support count
   const headSlots = unit.criticalSlots?.HEAD || unit.criticalSlots?.HD || [];
-  const lsCount = headSlots.filter((s: any) => typeof s === 'string' && s.toLowerCase().includes('life support')).length;
+  const lsCount = headSlots.filter(
+    (s: any) =>
+      typeof s === 'string' && s.toLowerCase().includes('life support'),
+  ).length;
 
   const correct = Math.abs(currentPct) < Math.abs(stdPct);
-  const verdict = correct ? 'CORRECT (0.95)' : `WRONG → should be 1.0 (diff ${stdPct.toFixed(1)}% vs ${currentPct.toFixed(1)}%)`;
+  const verdict = correct
+    ? 'CORRECT (0.95)'
+    : `WRONG → should be 1.0 (diff ${stdPct.toFixed(1)}% vs ${currentPct.toFixed(1)}%)`;
 
-  if (!correct) { wrongCount++; wrongUnits.push(unitId); }
+  if (!correct) {
+    wrongCount++;
+    wrongUnits.push(unitId);
+  }
 
-  console.log(`${unitId.padEnd(40)} ref=${ref} calc=${calc} with1.0=${withStandard} LS=${lsCount} cockpit=${unit.cockpit||'?'} ${verdict}`);
+  console.log(
+    `${unitId.padEnd(40)} ref=${ref} calc=${calc} with1.0=${withStandard} LS=${lsCount} cockpit=${unit.cockpit || '?'} ${verdict}`,
+  );
 }
 
-console.log(`\nWrong entries: ${wrongCount} / ${KNOWN_SMALL_COCKPIT_UNITS.length}`);
+console.log(
+  `\nWrong entries: ${wrongCount} / ${KNOWN_SMALL_COCKPIT_UNITS.length}`,
+);
 if (wrongUnits.length > 0) console.log(`  Remove: ${wrongUnits.join(', ')}`);
 
 // Also check: are there units detected as small cockpit by LS heuristic that are NOT in this list?
 // and are overcalculated (suggesting false positive)?
-console.log('\n=== LS=1 HEURISTIC FALSE POSITIVES (overcalculated, cockpit=0.95) ===');
-const overCalcSmall = valid.filter((x: any) =>
-  x.breakdown?.cockpitModifier === 0.95 && x.percentDiff > 1 &&
-  !KNOWN_SMALL_COCKPIT_UNITS.includes(x.unitId)
+console.log(
+  '\n=== LS=1 HEURISTIC FALSE POSITIVES (overcalculated, cockpit=0.95) ===',
 );
-for (const r of overCalcSmall.sort((a: any, b: any) => b.percentDiff - a.percentDiff).slice(0, 20)) {
+const overCalcSmall = valid.filter(
+  (x: any) =>
+    x.breakdown?.cockpitModifier === 0.95 &&
+    x.percentDiff > 1 &&
+    !KNOWN_SMALL_COCKPIT_UNITS.includes(x.unitId),
+);
+for (const r of overCalcSmall
+  .sort((a: any, b: any) => b.percentDiff - a.percentDiff)
+  .slice(0, 20)) {
   const unit = loadUnit(r.unitId);
   const headSlots = unit?.criticalSlots?.HEAD || unit?.criticalSlots?.HD || [];
-  const lsCount = headSlots.filter((s: any) => typeof s === 'string' && s.toLowerCase().includes('life support')).length;
+  const lsCount = headSlots.filter(
+    (s: any) =>
+      typeof s === 'string' && s.toLowerCase().includes('life support'),
+  ).length;
   // What would BV be with 1.0?
   const with10 = Math.round(r.calculatedBV / 0.95);
-  const newDiff = ((with10 - r.indexBV) / r.indexBV * 100);
-  console.log(`  ${r.unitId.padEnd(40)} ${r.percentDiff.toFixed(1).padStart(5)}% LS=${lsCount} cockpit=${unit?.cockpit||'?'} with1.0→${newDiff.toFixed(1)}%`);
+  const newDiff = ((with10 - r.indexBV) / r.indexBV) * 100;
+  console.log(
+    `  ${r.unitId.padEnd(40)} ${r.percentDiff.toFixed(1).padStart(5)}% LS=${lsCount} cockpit=${unit?.cockpit || '?'} with1.0→${newDiff.toFixed(1)}%`,
+  );
 }

--- a/scripts/verify-pos3-heuristic.ts
+++ b/scripts/verify-pos3-heuristic.ts
@@ -3,27 +3,32 @@
  * Standard cockpit: HEAD[3] = "Sensors"
  * Small cockpit: HEAD[3] = something else
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as bvAnalysis from './bv-analysis-helpers';
 
-const report = JSON.parse(fs.readFileSync('validation-output/bv-validation-report.json', 'utf8'));
-const idx = JSON.parse(fs.readFileSync('public/data/units/battlemechs/index.json', 'utf8'));
+const report = bvAnalysis.loadBvValidationReport();
+const idx = bvAnalysis.loadBattleMechIndex();
+const loadUnit = bvAnalysis.createBattleMechUnitLoader(idx);
 
-function loadUnit(unitId: string): any {
-  const ie = idx.units.find((e: any) => e.id === unitId);
-  if (!ie?.path) return null;
-  try { return JSON.parse(fs.readFileSync(path.join('public/data/units/battlemechs', ie.path), 'utf8')); } catch { return null; }
-}
-
-const valid = report.allResults.filter((x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown);
+const valid = report.allResults.filter(
+  (x: any) => x.status !== 'error' && x.percentDiff !== null && x.breakdown,
+);
 
 // For ALL units (not just 0.95), check the position 3 heuristic
-let pos3Small = 0, pos3Standard = 0;
-let pos3SmallCorrect = 0, pos3StandardCorrect = 0;
-let pos3SmallWrong = 0, pos3StandardWrong = 0;
+let pos3Small = 0,
+  pos3Standard = 0;
+let pos3SmallCorrect = 0,
+  pos3StandardCorrect = 0;
+let pos3SmallWrong = 0,
+  pos3StandardWrong = 0;
 
 // Group by: current cockpit modifier and new heuristic result
-const changes: { unitId: string, from: number, to: number, pctDiff: number, newPctDiff: number }[] = [];
+const changes: {
+  unitId: string;
+  from: number;
+  to: number;
+  pctDiff: number;
+  newPctDiff: number;
+}[] = [];
 
 for (const r of valid) {
   const unit = loadUnit(r.unitId);
@@ -34,10 +39,13 @@ for (const r of valid) {
   const currentMod = r.breakdown?.cockpitModifier;
   // New heuristic: position 3 in HEAD
   const pos3 = headSlots[3];
-  const pos3IsSensors = typeof pos3 === 'string' && pos3.toLowerCase().includes('sensors');
+  const pos3IsSensors =
+    typeof pos3 === 'string' && pos3.toLowerCase().includes('sensors');
 
   // Drone OS check (drone OS also gets 0.95, separate from cockpit)
-  const isDroneOS = headSlots.some((s: any) => typeof s === 'string' && s.toLowerCase().includes('drone'));
+  const isDroneOS = headSlots.some(
+    (s: any) => typeof s === 'string' && s.toLowerCase().includes('drone'),
+  );
 
   // Interface cockpit check
   const isInterface = r.breakdown?.cockpitType === 'interface';
@@ -61,9 +69,15 @@ for (const r of valid) {
   }
 
   if (newMod !== currentMod) {
-    const newCalc = Math.round(r.calculatedBV / currentMod * newMod);
-    const newPctDiff = (newCalc - r.indexBV) / r.indexBV * 100;
-    changes.push({ unitId: r.unitId, from: currentMod, to: newMod, pctDiff: r.percentDiff, newPctDiff });
+    const newCalc = Math.round((r.calculatedBV / currentMod) * newMod);
+    const newPctDiff = ((newCalc - r.indexBV) / r.indexBV) * 100;
+    changes.push({
+      unitId: r.unitId,
+      from: currentMod,
+      to: newMod,
+      pctDiff: r.percentDiff,
+      newPctDiff,
+    });
   }
 
   // Tracking
@@ -79,7 +93,10 @@ console.log(`\n=== CHANGES FROM POS3 HEURISTIC ===`);
 console.log(`  Total units that would change: ${changes.length}`);
 
 // How many would improve vs worsen?
-let improved = 0, worsened = 0, flippedIn = 0, flippedOut = 0;
+let improved = 0,
+  worsened = 0,
+  flippedIn = 0,
+  flippedOut = 0;
 for (const c of changes) {
   const oldAbs = Math.abs(c.pctDiff);
   const newAbs = Math.abs(c.newPctDiff);
@@ -96,5 +113,7 @@ console.log(`  Net gain: ${flippedIn - flippedOut}`);
 console.log('\n=== DETAILS OF CHANGES ===');
 for (const c of changes.sort((a, b) => a.pctDiff - b.pctDiff)) {
   const mark = Math.abs(c.newPctDiff) < Math.abs(c.pctDiff) ? '✓' : '✗';
-  console.log(`  ${mark} ${c.unitId.padEnd(40)} ${c.from}→${c.to} was=${c.pctDiff.toFixed(1).padStart(6)}% now=${c.newPctDiff.toFixed(1).padStart(6)}%`);
+  console.log(
+    `  ${mark} ${c.unitId.padEnd(40)} ${c.from}→${c.to} was=${c.pctDiff.toFixed(1).padStart(6)}% now=${c.newPctDiff.toFixed(1).padStart(6)}%`,
+  );
 }


### PR DESCRIPTION
## Summary
- Routed 42 TypeScript BV analysis/trace scripts through the shared bv-analysis helper for report, index, and unit loading.
- Marked the cleared analyze-2to5/check-cockpit duplicate warnings fixed in the maintenance ledger.
- Updated QC registry/graph evidence for the near-duplicate warning reduction.

## Outcome
- Repo-wide near-duplicate warnings: 3 -> 1.
- App completion remains at 0 release gaps.
- Maintenance ledger remains tracked with 0 untracked actionable findings.

## Validation
- npm.cmd run typecheck -- --pretty false
- npm.cmd run format:check
- npm.cmd run qc:validate
- node scripts/qc/validate-maintenance-warning-ledger.mjs
- npm.cmd run qc:app-completion -- --json
- npm.cmd run verify:qc:maintenance
- npm.cmd test -- --watchAll=false --runTestsByPath scripts/__tests__/maintenance-warning-ledger.test.ts --runInBand
- npx.cmd tsx scripts/check-cockpit-fixes.ts
- npx.cmd tsx scripts/trace-overcalc-2to5.ts
- node scripts/maintenance/scan-maintenance.mjs --json near-duplicate summary
- git diff --check