### PR TITLE
Enable custom multiplayer roster setup

### DIFF
--- a/docs/qc/mekstation-qc-registry.json
+++ b/docs/qc/mekstation-qc-registry.json
@@ -1336,13 +1336,13 @@
         "2026-06-25 `npm.cmd run validate:multiplayer:packaged-socket` passed after `npm.cmd run build`: packaged server socket upgrade/replay succeeded, the process restarted against the same durable SQLite match store, the same match replayed after reconnect, and the co-op runtime proposal committed.",
         "2026-06-25 `npx.cmd playwright test --project=chromium e2e/multiplayer-live-vault-auth.spec.ts --workers=1` passed: two browser contexts seeded real E2E-locked vault identities, host created a fog-enabled lobby, guest joined by invite, both connected through signed tokens, both readied, host launched, both rendered the networked game surface, and the host advanced the server-owned Initiative phase to Movement over the real WebSocket path.",
         "2026-06-26 `npx.cmd playwright test --project=chromium e2e/multiplayer-live-vault-auth.spec.ts --workers=1` passed: REST-created fog-enabled matches returned real Atlas/Marauder unit bootstrap metadata, both vault-auth browser contexts launched over signed sockets, host and guest rendered side-owned tactical unit tokens, and the host advanced Initiative to Movement over WebSocket.",
-        "2026-06-28 multiplayer create-match UI now exposes unit roster presets and submits explicit unitBootstrap metadata; focused Jest coverage proves the form emits selected Atlas/Marauder presets, the API preserves explicit bootstrap rows, and MatchHostRegistry still boots stored units.",
+        "2026-06-28 multiplayer create-match UI now exposes unit roster presets plus supported custom per-seat unit/pilot/skill overrides and submits explicit unitBootstrap metadata; focused Jest coverage proves the form emits selected Atlas/Marauder presets, custom Awesome/Locust bootstrap rows, the API preserves explicit bootstrap rows, and MatchHostRegistry still boots stored units.",
         "2026-06-25 Wave 4 validator requires multiplayer aggregate scripts plus route, contract, capstone source anchors, and the packaged socket command while keeping live host/guest identity play tracked separately.",
         "Archived OpenSpec change 2026-06-21-reconcile-multiplayer-coop-reality retired from activeChangeRefs on 2026-06-23.",
         "Archived OpenSpec change 2026-06-21-harden-desktop-and-api-security retired from activeChangeRefs on 2026-06-23."
       ],
       "gaps": [
-        "Create-match roster presets are UI-backed; fully custom per-seat unit/pilot roster configuration remains future multiplayer product scope."
+        "Create-match custom roster controls are UI-backed for the supported bootstrap unit set and pilot name/skill overrides; broader compendium search/import and true multi-side FFA ownership semantics remain future multiplayer product scope."
       ]
     },
     {

--- a/docs/qc/mekstation-qc-validation-graph.json
+++ b/docs/qc/mekstation-qc-validation-graph.json
@@ -1396,7 +1396,7 @@
         "2026-06-24 `verify:qc:multiplayer-reliability` groups browser route smoke, mock P2P sync, co-op route mounting, API fog/spectate contracts, server host/reconnect/spectator/fog behavior, turn ownership, and the Phase 4 capstone host/join/reconnect/outcome flow.",
         "2026-06-25 `npm.cmd run validate:multiplayer:packaged-socket` passed after `npm.cmd run build`: packaged server socket upgrade/replay succeeded, the process restarted against the same durable SQLite match store, the same match replayed after reconnect, and the co-op runtime proposal committed.",
         "2026-06-26 `npx.cmd playwright test --project=chromium e2e/multiplayer-live-vault-auth.spec.ts --workers=1` passed: REST-created fog-enabled matches returned real Atlas/Marauder unit bootstrap metadata, both vault-auth browser contexts launched over signed sockets, host and guest rendered side-owned tactical unit tokens, and the host advanced Initiative to Movement over WebSocket.",
-        "2026-06-28 multiplayer create-match UI now exposes unit roster presets and submits explicit unitBootstrap metadata; focused Jest coverage proves the form emits selected Atlas/Marauder presets, the API preserves explicit bootstrap rows, and MatchHostRegistry still boots stored units.",
+        "2026-06-28 multiplayer create-match UI now exposes unit roster presets plus supported custom per-seat unit/pilot/skill overrides and submits explicit unitBootstrap metadata; focused Jest coverage proves the form emits selected Atlas/Marauder presets, custom Awesome/Locust bootstrap rows, the API preserves explicit bootstrap rows, and MatchHostRegistry still boots stored units.",
         "Archived OpenSpec change 2026-06-21-reconcile-multiplayer-coop-reality retired from activeChangeRefs on 2026-06-23.",
         "Archived OpenSpec change 2026-06-21-harden-desktop-and-api-security retired from activeChangeRefs on 2026-06-23."
       ]
@@ -1414,7 +1414,7 @@
       "kind": "known-gap",
       "label": "Multiplayer, Co-op, P2P Sync known gaps",
       "entries": [
-        "Create-match roster presets are UI-backed; fully custom per-seat unit/pilot roster configuration remains future multiplayer product scope."
+        "Create-match custom roster controls are UI-backed for the supported bootstrap unit set and pilot name/skill overrides; broader compendium search/import and true multi-side FFA ownership semantics remain future multiplayer product scope."
       ]
     },
     {

--- a/scripts/qc/validate-wave4-scope-recovery.mjs
+++ b/scripts/qc/validate-wave4-scope-recovery.mjs
@@ -153,7 +153,11 @@ const requiredSurfaces = [
       'fogOfWar.test.ts',
     ],
     manualIncludes: ['side-owned units', 'hidden GM/private fields'],
-    gapIncludes: ['fully custom per-seat unit/pilot roster configuration'],
+    gapIncludes: [
+      'supported bootstrap unit set',
+      'broader compendium search/import',
+      'true multi-side FFA ownership semantics',
+    ],
   },
   {
     id: 'replay-audit-history',

--- a/src/components/multiplayer/CreateMatchForm.tsx
+++ b/src/components/multiplayer/CreateMatchForm.tsx
@@ -12,14 +12,20 @@
 
 import { useState } from 'react';
 
-import type { MatchRosterPresetId } from '@/lib/multiplayer/matchRosterPresets';
+import type {
+  IMatchCustomRosterSeatInput,
+  MatchRosterPresetId,
+} from '@/lib/multiplayer/matchRosterPresets';
 import type { IMatchUnitBootstrapEntry } from '@/lib/multiplayer/server/IMatchStore';
 import type { TeamLayout } from '@/types/multiplayer/Lobby';
 
 import {
+  buildCustomRosterSeatRows,
+  buildMatchUnitBootstrapForCustomRoster,
   buildMatchUnitBootstrapForPreset,
   DEFAULT_MATCH_ROSTER_PRESET_ID,
   MATCH_ROSTER_PRESETS,
+  MATCH_ROSTER_UNIT_OPTIONS,
 } from '@/lib/multiplayer/matchRosterPresets';
 
 // =============================================================================
@@ -32,6 +38,7 @@ export interface ICreateMatchFormValue {
   readonly mapRadius: number;
   readonly turnLimit: number;
   readonly fogOfWar: boolean;
+  readonly rosterMode: MatchRosterMode;
   readonly rosterPresetId: MatchRosterPresetId;
   readonly unitBootstrap: readonly IMatchUnitBootstrapEntry[];
 }
@@ -64,6 +71,12 @@ const LAYOUT_OPTIONS: ReadonlyArray<{ value: TeamLayout; label: string }> = [
   { value: 'ffa-8', label: 'Free-for-all (8)' },
 ];
 
+type MatchRosterMode = 'preset' | 'custom';
+
+type CustomRosterInputs = Record<string, Partial<IMatchCustomRosterSeatInput>>;
+
+const SKILL_OPTIONS: readonly number[] = [0, 1, 2, 3, 4, 5, 6, 7, 8];
+
 // =============================================================================
 // Component
 // =============================================================================
@@ -76,9 +89,29 @@ export function CreateMatchForm(
   const [mapRadius, setMapRadius] = useState<number>(8);
   const [turnLimit, setTurnLimit] = useState<number>(20);
   const [fogOfWar, setFogOfWar] = useState<boolean>(false);
+  const [rosterMode, setRosterMode] = useState<MatchRosterMode>('preset');
   const [rosterPresetId, setRosterPresetId] = useState<MatchRosterPresetId>(
     DEFAULT_MATCH_ROSTER_PRESET_ID,
   );
+  const [customRosterInputs, setCustomRosterInputs] =
+    useState<CustomRosterInputs>({});
+  const customRosterRows = buildCustomRosterSeatRows(
+    layout,
+    customRosterInputs,
+  );
+
+  const updateCustomRosterSeat = (
+    slotId: string,
+    patch: Partial<IMatchCustomRosterSeatInput>,
+  ): void => {
+    setCustomRosterInputs((current) => ({
+      ...current,
+      [slotId]: {
+        ...current[slotId],
+        ...patch,
+      },
+    }));
+  };
 
   return (
     <form
@@ -90,12 +123,20 @@ export function CreateMatchForm(
           mapRadius,
           turnLimit,
           fogOfWar,
+          rosterMode,
           rosterPresetId,
-          unitBootstrap: buildMatchUnitBootstrapForPreset(
-            layout,
-            rosterPresetId,
-            mapRadius,
-          ),
+          unitBootstrap:
+            rosterMode === 'custom'
+              ? buildMatchUnitBootstrapForCustomRoster(
+                  layout,
+                  customRosterInputs,
+                  mapRadius,
+                )
+              : buildMatchUnitBootstrapForPreset(
+                  layout,
+                  rosterPresetId,
+                  mapRadius,
+                ),
         });
       }}
       className="space-y-4"
@@ -137,28 +178,171 @@ export function CreateMatchForm(
           ))}
         </select>
       </div>
-      <div>
-        <label
-          htmlFor="cm-rosterPreset"
-          className="block text-xs font-medium tracking-wide text-slate-300 uppercase"
-        >
-          Unit roster preset
-        </label>
-        <select
-          id="cm-rosterPreset"
-          value={rosterPresetId}
-          onChange={(e) =>
-            setRosterPresetId(e.target.value as MatchRosterPresetId)
-          }
-          className="mt-1 w-full rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-500 focus:outline-none"
-        >
-          {MATCH_ROSTER_PRESETS.map((preset) => (
-            <option key={preset.id} value={preset.id}>
-              {preset.label}
-            </option>
-          ))}
-        </select>
-      </div>
+      <fieldset className="space-y-3 rounded border border-slate-700 bg-slate-950/70 p-3">
+        <legend className="px-1 text-xs font-medium tracking-wide text-slate-300 uppercase">
+          Unit roster
+        </legend>
+        <div className="grid grid-cols-2 gap-2">
+          <label className="flex items-center gap-2 rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100">
+            <input
+              type="radio"
+              name="cm-rosterMode"
+              value="preset"
+              checked={rosterMode === 'preset'}
+              onChange={() => setRosterMode('preset')}
+              className="h-4 w-4 border-slate-600 bg-slate-950 text-emerald-600 focus:ring-emerald-500"
+            />
+            <span>Preset</span>
+          </label>
+          <label className="flex items-center gap-2 rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100">
+            <input
+              type="radio"
+              name="cm-rosterMode"
+              value="custom"
+              checked={rosterMode === 'custom'}
+              onChange={() => setRosterMode('custom')}
+              className="h-4 w-4 border-slate-600 bg-slate-950 text-emerald-600 focus:ring-emerald-500"
+            />
+            <span>Custom</span>
+          </label>
+        </div>
+        {rosterMode === 'preset' ? (
+          <div>
+            <label
+              htmlFor="cm-rosterPreset"
+              className="block text-xs font-medium tracking-wide text-slate-300 uppercase"
+            >
+              Unit roster preset
+            </label>
+            <select
+              id="cm-rosterPreset"
+              value={rosterPresetId}
+              onChange={(e) =>
+                setRosterPresetId(e.target.value as MatchRosterPresetId)
+              }
+              className="mt-1 w-full rounded border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-500 focus:outline-none"
+            >
+              {MATCH_ROSTER_PRESETS.map((preset) => (
+                <option key={preset.id} value={preset.id}>
+                  {preset.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {customRosterRows.map((row) => (
+              <div
+                key={row.slotId}
+                className="rounded border border-slate-800 bg-slate-900/70 p-3"
+              >
+                <div className="mb-2 flex items-center justify-between gap-2">
+                  <div className="text-sm font-medium text-slate-100">
+                    {row.sideLabel} #{row.seatNumber}
+                  </div>
+                  <div className="text-xs text-slate-400">
+                    {row.side === 'player' ? 'Player side' : 'Opponent side'}
+                  </div>
+                </div>
+                <div className="grid gap-3 md:grid-cols-2">
+                  <div>
+                    <label
+                      htmlFor={`cm-custom-${row.slotId}-unit`}
+                      className="block text-xs font-medium tracking-wide text-slate-300 uppercase"
+                    >
+                      {row.sideLabel} #{row.seatNumber} unit
+                    </label>
+                    <select
+                      id={`cm-custom-${row.slotId}-unit`}
+                      value={row.unitRef}
+                      onChange={(e) =>
+                        updateCustomRosterSeat(row.slotId, {
+                          unitRef: e.target.value,
+                        })
+                      }
+                      className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-emerald-500 focus:outline-none"
+                    >
+                      {MATCH_ROSTER_UNIT_OPTIONS.map((option) => (
+                        <option key={option.unitRef} value={option.unitRef}>
+                          {option.unitName}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div>
+                    <label
+                      htmlFor={`cm-custom-${row.slotId}-pilot`}
+                      className="block text-xs font-medium tracking-wide text-slate-300 uppercase"
+                    >
+                      {row.sideLabel} #{row.seatNumber} pilot
+                    </label>
+                    <input
+                      id={`cm-custom-${row.slotId}-pilot`}
+                      type="text"
+                      value={row.pilotName}
+                      onChange={(e) =>
+                        updateCustomRosterSeat(row.slotId, {
+                          pilotName: e.target.value,
+                        })
+                      }
+                      maxLength={64}
+                      className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-emerald-500 focus:outline-none"
+                    />
+                  </div>
+                  <div>
+                    <label
+                      htmlFor={`cm-custom-${row.slotId}-gunnery`}
+                      className="block text-xs font-medium tracking-wide text-slate-300 uppercase"
+                    >
+                      {row.sideLabel} #{row.seatNumber} gunnery
+                    </label>
+                    <select
+                      id={`cm-custom-${row.slotId}-gunnery`}
+                      value={row.gunnery}
+                      onChange={(e) =>
+                        updateCustomRosterSeat(row.slotId, {
+                          gunnery: Number(e.target.value),
+                        })
+                      }
+                      className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-emerald-500 focus:outline-none"
+                    >
+                      {SKILL_OPTIONS.map((skill) => (
+                        <option key={skill} value={skill}>
+                          {skill}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div>
+                    <label
+                      htmlFor={`cm-custom-${row.slotId}-piloting`}
+                      className="block text-xs font-medium tracking-wide text-slate-300 uppercase"
+                    >
+                      {row.sideLabel} #{row.seatNumber} piloting
+                    </label>
+                    <select
+                      id={`cm-custom-${row.slotId}-piloting`}
+                      value={row.piloting}
+                      onChange={(e) =>
+                        updateCustomRosterSeat(row.slotId, {
+                          piloting: Number(e.target.value),
+                        })
+                      }
+                      className="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-emerald-500 focus:outline-none"
+                    >
+                      {SKILL_OPTIONS.map((skill) => (
+                        <option key={skill} value={skill}>
+                          {skill}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </fieldset>
       <div className="grid grid-cols-2 gap-3">
         <div>
           <label

--- a/src/components/multiplayer/__tests__/CreateMatchForm.test.tsx
+++ b/src/components/multiplayer/__tests__/CreateMatchForm.test.tsx
@@ -17,6 +17,7 @@ describe('CreateMatchForm', () => {
       mapRadius: 8,
       turnLimit: 20,
       fogOfWar: false,
+      rosterMode: 'preset',
       rosterPresetId: 'assault-vs-heavy',
       unitBootstrap: expect.arrayContaining([
         expect.objectContaining({
@@ -47,6 +48,7 @@ describe('CreateMatchForm', () => {
       mapRadius: 8,
       turnLimit: 20,
       fogOfWar: true,
+      rosterMode: 'preset',
       rosterPresetId: 'assault-vs-heavy',
       unitBootstrap: expect.any(Array),
     });
@@ -64,6 +66,7 @@ describe('CreateMatchForm', () => {
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
     expect(onSubmit).toHaveBeenCalledWith(
       expect.objectContaining({
+        rosterMode: 'preset',
         rosterPresetId: 'atlas-mirror',
         unitBootstrap: expect.arrayContaining([
           expect.objectContaining({
@@ -75,6 +78,64 @@ describe('CreateMatchForm', () => {
             unitId: 'opponent-1-atlas-as7-d',
             unitRef: 'atlas-as7-d',
             side: 'opponent',
+          }),
+        ]),
+      }),
+    );
+  });
+
+  it('submits custom per-seat unit and pilot bootstrap', async () => {
+    const onSubmit = jest.fn();
+    render(<CreateMatchForm onSubmit={onSubmit} />);
+
+    fireEvent.click(screen.getByLabelText('Custom'));
+    fireEvent.change(screen.getByLabelText('Alpha #1 unit'), {
+      target: { value: 'awesome-aws-8q' },
+    });
+    fireEvent.change(screen.getByLabelText('Alpha #1 pilot'), {
+      target: { value: 'Morgan Kell' },
+    });
+    fireEvent.change(screen.getByLabelText('Alpha #1 gunnery'), {
+      target: { value: '3' },
+    });
+    fireEvent.change(screen.getByLabelText('Alpha #1 piloting'), {
+      target: { value: '4' },
+    });
+    fireEvent.change(screen.getByLabelText('Bravo #1 unit'), {
+      target: { value: 'locust-lct-1v' },
+    });
+    fireEvent.change(screen.getByLabelText('Bravo #1 pilot'), {
+      target: { value: 'Natasha Kerensky' },
+    });
+    fireEvent.change(screen.getByLabelText('Bravo #1 gunnery'), {
+      target: { value: '2' },
+    });
+    fireEvent.change(screen.getByLabelText('Bravo #1 piloting'), {
+      target: { value: '3' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create match' }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rosterMode: 'custom',
+        rosterPresetId: 'assault-vs-heavy',
+        unitBootstrap: expect.arrayContaining([
+          expect.objectContaining({
+            unitId: 'alpha-1-awesome-aws-8q',
+            unitRef: 'awesome-aws-8q',
+            side: 'player',
+            pilotRef: 'Morgan Kell',
+            gunnery: 3,
+            piloting: 4,
+          }),
+          expect.objectContaining({
+            unitId: 'bravo-1-locust-lct-1v',
+            unitRef: 'locust-lct-1v',
+            side: 'opponent',
+            pilotRef: 'Natasha Kerensky',
+            gunnery: 2,
+            piloting: 3,
           }),
         ]),
       }),

--- a/src/lib/multiplayer/matchRosterPresets.ts
+++ b/src/lib/multiplayer/matchRosterPresets.ts
@@ -1,7 +1,7 @@
 import type { IMatchUnitBootstrapEntry } from '@/lib/multiplayer/server/IMatchStore';
 import type { TeamLayout } from '@/types/multiplayer/Lobby';
 
-import { seatLayoutSpec } from '@/types/multiplayer/Lobby';
+import { buildSlotId, seatLayoutSpec } from '@/types/multiplayer/Lobby';
 
 export type MatchRosterPresetId =
   | 'assault-vs-heavy'
@@ -49,6 +49,36 @@ export const MATCH_ROSTER_PRESETS: readonly IMatchRosterPreset[] = [
   },
 ];
 
+export interface IMatchRosterUnitOption {
+  readonly unitRef: string;
+  readonly unitName: string;
+}
+
+export const MATCH_ROSTER_UNIT_OPTIONS: readonly IMatchRosterUnitOption[] = [
+  { unitRef: 'atlas-as7-d', unitName: 'Atlas AS7-D' },
+  { unitRef: 'marauder-mad-3r', unitName: 'Marauder MAD-3R' },
+  { unitRef: 'awesome-aws-8q', unitName: 'Awesome AWS-8Q' },
+  { unitRef: 'catapult-cplt-c1', unitName: 'Catapult CPLT-C1' },
+  { unitRef: 'hunchback-hbk-4g', unitName: 'Hunchback HBK-4G' },
+  { unitRef: 'locust-lct-1v', unitName: 'Locust LCT-1V' },
+];
+
+export interface IMatchCustomRosterSeatInput {
+  readonly slotId: string;
+  readonly unitRef: string;
+  readonly pilotName: string;
+  readonly gunnery: number;
+  readonly piloting: number;
+}
+
+export interface IMatchCustomRosterSeatRow extends IMatchCustomRosterSeatInput {
+  readonly side: BootstrapSide;
+  readonly sideLabel: string;
+  readonly seatNumber: number;
+  readonly sideSeatIndex: number;
+  readonly unitName: string;
+}
+
 export function matchRosterPresetById(
   id: MatchRosterPresetId,
 ): IMatchRosterPreset {
@@ -78,6 +108,17 @@ function unitNameForSide(
   side: BootstrapSide,
 ): string {
   return side === 'player' ? preset.playerUnitName : preset.opponentUnitName;
+}
+
+function defaultUnitRefForSide(side: BootstrapSide): string {
+  return side === 'player' ? 'atlas-as7-d' : 'marauder-mad-3r';
+}
+
+function unitOptionByRef(unitRef: string): IMatchRosterUnitOption {
+  return (
+    MATCH_ROSTER_UNIT_OPTIONS.find((option) => option.unitRef === unitRef) ??
+    MATCH_ROSTER_UNIT_OPTIONS[0]
+  );
 }
 
 function startHexFor(
@@ -127,4 +168,58 @@ export function buildMatchUnitBootstrapForPreset(
   });
 
   return entries;
+}
+
+export function buildCustomRosterSeatRows(
+  layout: TeamLayout,
+  inputs: Readonly<Record<string, Partial<IMatchCustomRosterSeatInput>>> = {},
+): readonly IMatchCustomRosterSeatRow[] {
+  const spec = seatLayoutSpec(layout);
+  const sideCounts = new Map<BootstrapSide, number>();
+  const rows: IMatchCustomRosterSeatRow[] = [];
+
+  spec.sides.forEach((sideLabel, sideIndex) => {
+    const side = sideForSeatSide(sideIndex);
+    for (let seatNumber = 1; seatNumber <= spec.seatsPerSide; seatNumber += 1) {
+      const sideSeatIndex = (sideCounts.get(side) ?? 0) + 1;
+      sideCounts.set(side, sideSeatIndex);
+      const slotId = buildSlotId(sideLabel, seatNumber);
+      const input = inputs[slotId] ?? {};
+      const unitRef = input.unitRef ?? defaultUnitRefForSide(side);
+      const unitOption = unitOptionByRef(unitRef);
+      rows.push({
+        slotId,
+        side,
+        sideLabel,
+        seatNumber,
+        sideSeatIndex,
+        unitRef: unitOption.unitRef,
+        unitName: unitOption.unitName,
+        pilotName:
+          input.pilotName ??
+          `${sideLabel} ${seatNumber} ${side === 'player' ? 'Pilot' : 'OPFOR'}`,
+        gunnery: input.gunnery ?? 4,
+        piloting: input.piloting ?? 5,
+      });
+    }
+  });
+
+  return rows;
+}
+
+export function buildMatchUnitBootstrapForCustomRoster(
+  layout: TeamLayout,
+  inputs: Readonly<Record<string, Partial<IMatchCustomRosterSeatInput>>>,
+  mapRadius: number,
+): readonly IMatchUnitBootstrapEntry[] {
+  return buildCustomRosterSeatRows(layout, inputs).map((row) => ({
+    unitId: `${row.slotId}-${row.unitRef}`,
+    unitRef: row.unitRef,
+    side: row.side,
+    name: `${row.unitName} ${row.sideSeatIndex}`,
+    pilotRef: row.pilotName.trim() || `${row.slotId}-pilot`,
+    gunnery: row.gunnery,
+    piloting: row.piloting,
+    startHex: startHexFor(row.side, row.sideSeatIndex, mapRadius),
+  }));
 }


### PR DESCRIPTION
## Summary
- add preset/custom roster mode to the multiplayer create-match form
- support per-seat unit, pilot name, gunnery, and piloting overrides through the existing unitBootstrap contract
- update Wave 4 QC gap language and validator tokens to keep custom bootstrap support separate from future compendium search/import and true FFA ownership work

## Validation
- npm.cmd test -- --watchAll=false --runTestsByPath src/components/multiplayer/__tests__/CreateMatchForm.test.tsx src/lib/multiplayer/server/__tests__/MatchHostRegistry.unitBootstrap.test.ts --runInBand
- npm.cmd run verify:qc:multiplayer:contracts
- npm.cmd run verify:qc:multiplayer:browser
- npm.cmd run qc:wave4:validate
- npm.cmd run qc:validate
- npm.cmd run qc:app-completion:release -- --json
- npm.cmd run typecheck -- --pretty false
- npm.cmd run format:check
- git diff --check

## Notes
- `npm.cmd run lint` completed with 0 errors and existing repo-wide warnings; not introduced by this slice.
- Full `verify:app-completion:release` was not rerun locally for this bounded multiplayer UI slice.