### PR TITLE
Restore visible campaign recovery

### DIFF
--- a/e2e/campaign.spec.ts
+++ b/e2e/campaign.spec.ts
@@ -294,20 +294,29 @@ test.describe('Campaign Detail Page @campaign', () => {
     await expect(page.getByTestId('campaign-dashboard')).toBeVisible();
     await expect(page.getByTestId('daily-battle-audit-feed')).toHaveCount(0);
   });
-});
 
-// =============================================================================
-// Campaign Deletion Tests — RETIRED (obsolete surface)
-//
-// The UI deletion flow (delete-campaign-btn + delete-confirm-dialog) lived
-// on CampaignOverviewTab, which is no longer mounted anywhere — the
-// campaign detail route renders CampaignDashboardPage, which has NO
-// delete affordance. There is currently no UI surface for deleting a
-// campaign at all; that product gap is tracked as T2-F3 in
-// docs/audits/2026-06-09-remediation-tracker.md. Store-level deletion
-// behavior stays covered by playtest-campaign-smoke.spec.ts
-// ("deletes a campaign cleanly and leaves the campaign store empty").
-// =============================================================================
+  test('deletes campaign from routed dashboard after confirmation', async ({
+    page,
+  }) => {
+    await listPage.clickCampaignCard(campaignId);
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByTestId('delete-campaign-btn')).toBeVisible();
+    await page.getByTestId('delete-campaign-btn').click();
+    await expect(page.getByTestId('delete-confirm-dialog')).toBeVisible();
+
+    await page.getByTestId('cancel-delete-btn').click();
+    await expect(page.getByTestId('delete-confirm-dialog')).toHaveCount(0);
+
+    await page.getByTestId('delete-campaign-btn').click();
+    await page.getByTestId('confirm-delete-btn').click();
+
+    await expect(page).toHaveURL(/\/gameplay\/campaigns$/);
+    await expect(page.getByTestId(`campaign-card-${campaignId}`)).toHaveCount(
+      0,
+    );
+  });
+});
 
 // =============================================================================
 // Campaign Mission Tests

--- a/e2e/mobile-navigation.spec.ts
+++ b/e2e/mobile-navigation.spec.ts
@@ -41,11 +41,7 @@ test.describe('Mobile Navigation Header', () => {
 
   test('should display mobile header on units page', async ({ page }) => {
     await page.goto('/units');
-    // NO hydration wait here: this test's contract is header PRESENCE
-    // (server-rendered), and /units currently never finishes hydrating —
-    // a client-bundled better-sqlite3 module crashes at module eval
-    // (`promisify(fs.access)` against the emptyModule fs stub). Tracked
-    // as T2-F2 in docs/audits/2026-06-09-remediation-tracker.md.
+    await waitForHydration(page);
 
     // Should have hamburger menu button
     const menuButton = page.getByRole('button', {

--- a/src/components/gameplay/pages/campaigns/dashboard/CampaignDashboardPage.tsx
+++ b/src/components/gameplay/pages/campaigns/dashboard/CampaignDashboardPage.tsx
@@ -5,10 +5,11 @@ import { useStore } from 'zustand';
 import type { ICampaign } from '@/types/campaign/Campaign';
 
 import { CampaignNavigation } from '@/components/campaign/CampaignNavigation';
+import { DeleteCampaignDialog } from '@/components/campaign/CampaignOverviewTab.sections';
 import { CampaignCoopRouteSurfaceConnected } from '@/components/campaign/coop';
 import { CampaignDashboard } from '@/components/campaign/dashboard/CampaignDashboard';
 import { DayReportPanel } from '@/components/campaign/DayReportPanel';
-import { PageLayout } from '@/components/ui';
+import { Button, PageLayout } from '@/components/ui';
 import { SeededRandom } from '@/simulation/core/SeededRandom';
 import {
   ScenarioGenerator,
@@ -16,6 +17,7 @@ import {
   createDefaultTerrainWeights,
 } from '@/simulation/generator';
 import { installCampaignPersistenceWiring } from '@/stores/campaign/campaignPersistenceWiring';
+import { useCampaignPersistenceStore } from '@/stores/campaign/useCampaignPersistenceStore';
 import { useCampaignRosterStore } from '@/stores/campaign/useCampaignRosterStore';
 import { useCampaignStore } from '@/stores/campaign/useCampaignStore';
 
@@ -81,6 +83,8 @@ export default function CampaignDashboardPage(): React.ReactElement {
   const auditEntries = useDailyBattleAudit();
   const applyErrors = useOutcomeApplyErrors();
   const [isGenerating, setIsGenerating] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const {
     dayReports,
@@ -163,6 +167,41 @@ export default function CampaignDashboardPage(): React.ReactElement {
     },
     [router],
   );
+
+  const handleDeleteCampaign = useCallback(async () => {
+    if (!campaign) {
+      return;
+    }
+
+    setDeleteError(null);
+    try {
+      const response = await fetch(
+        `/api/campaigns/${encodeURIComponent(campaign.id)}`,
+        { method: 'DELETE' },
+      );
+      if (!response.ok) {
+        throw new Error(`server responded ${response.status}`);
+      }
+
+      store.setState({
+        campaign: null,
+        forcesStore: null,
+        missionsStore: null,
+        pendingBattleOutcomes: [],
+        processedBattleIds: [],
+        reviewedBattleIds: {},
+        outcomeApplyErrors: {},
+        activityLog: [],
+      });
+      useCampaignPersistenceStore.getState().reset();
+      setShowDeleteConfirm(false);
+      await router.push('/gameplay/campaigns');
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'failed to delete campaign';
+      setDeleteError(`Campaign could not be deleted: ${message}`);
+    }
+  }, [campaign, router, store]);
 
   if (!isClient) {
     return <CampaignLoadingState />;
@@ -256,6 +295,31 @@ export default function CampaignDashboardPage(): React.ReactElement {
         onNavigate={handleNavigate}
       />
       <CampaignInformationCard campaign={campaign} />
+
+      {deleteError && (
+        <p
+          className="mt-4 rounded-lg border border-red-700 bg-red-950/40 p-3 text-sm text-red-200"
+          data-testid="delete-campaign-error"
+        >
+          {deleteError}
+        </p>
+      )}
+
+      <div className="border-border-theme-subtle mt-6 flex justify-end border-t pt-6">
+        <Button
+          variant="danger"
+          onClick={() => setShowDeleteConfirm(true)}
+          data-testid="delete-campaign-btn"
+        >
+          Delete Campaign
+        </Button>
+      </div>
+      <DeleteCampaignDialog
+        open={showDeleteConfirm}
+        campaignName={campaign.name}
+        onCancel={() => setShowDeleteConfirm(false)}
+        onConfirm={handleDeleteCampaign}
+      />
     </PageLayout>
   );
 }


### PR DESCRIPTION
## Summary
- Restores a routed campaign dashboard delete affordance using the existing confirmation dialog.
- Clears active campaign/persistence state after successful DELETE and returns to the campaign list.
- Updates mobile navigation proof so `/units` must hydrate instead of only proving SSR header presence.

## Validation
- `npm.cmd run format:check`
- `npm.cmd run typecheck -- --pretty false`
- `git diff --check`
- `node scripts/playwright/run-playwright.mjs test --project=chromium e2e/campaign.spec.ts --grep "deletes campaign from routed dashboard" --workers=1`
- `node scripts/playwright/run-playwright.mjs test --project=chromium e2e/mobile-navigation.spec.ts --workers=1`
- `npm.cmd run verify:qc:app-shell`
- `npm.cmd run qc:validate`
- `npm.cmd run qc:app-completion:release -- --json`

## Notes
- Full `verify:qc` and Electron packaged build were not rerun for this narrow UI/browser recovery slice.