### PR TITLE
Prove campaign economy reload state

### DIFF
--- a/e2e/campaign-economy-browser.spec.ts
+++ b/e2e/campaign-economy-browser.spec.ts
@@ -17,6 +17,16 @@ interface SeededCampaign {
   currentDate: string;
 }
 
+interface CampaignEconomySnapshot {
+  acceptedSalvageValue: number;
+  balance: number;
+  currentDate: string;
+  ledgerDescriptions: string[];
+  loanCount: number;
+  repairPriorities: Array<[string, number | null]>;
+  salvageStatuses: Array<[string, string]>;
+}
+
 async function waitForCampaignStoresReady(page: Page): Promise<void> {
   await page.waitForFunction(
     () => {
@@ -30,6 +40,95 @@ async function waitForCampaignStoresReady(page: Page): Promise<void> {
     },
     { timeout: 15_000 },
   );
+}
+
+async function waitForLoadedCampaign(
+  page: Page,
+  campaignId: string,
+): Promise<void> {
+  await waitForCampaignStoresReady(page);
+  await page.waitForFunction(
+    (id) => {
+      type StoreApi = { getState: () => Record<string, any> };
+      type ExposedStore = StoreApi | (() => StoreApi);
+      const resolveStore = (store: ExposedStore): StoreApi =>
+        typeof (store as StoreApi).getState === 'function'
+          ? (store as StoreApi)
+          : (store as () => StoreApi)();
+      const stores = (
+        window as unknown as {
+          __ZUSTAND_STORES__?: { campaign?: ExposedStore };
+        }
+      ).__ZUSTAND_STORES__;
+      const campaign = stores?.campaign
+        ? resolveStore(stores.campaign).getState().getCampaign()
+        : null;
+      return campaign?.id === id;
+    },
+    campaignId,
+    { timeout: 15_000 },
+  );
+}
+
+async function readCampaignEconomySnapshot(
+  page: Page,
+): Promise<CampaignEconomySnapshot> {
+  await waitForCampaignStoresReady(page);
+  return page.evaluate(() => {
+    type StoreApi = { getState: () => Record<string, any> };
+    type ExposedStore = StoreApi | (() => StoreApi);
+    const resolveStore = (store: ExposedStore): StoreApi =>
+      typeof (store as StoreApi).getState === 'function'
+        ? (store as StoreApi)
+        : (store as () => StoreApi)();
+    const stores = (
+      window as unknown as {
+        __ZUSTAND_STORES__?: { campaign?: ExposedStore };
+      }
+    ).__ZUSTAND_STORES__;
+    if (!stores?.campaign) {
+      throw new Error('Campaign E2E store is not exposed');
+    }
+    const campaign = resolveStore(stores.campaign).getState().getCampaign();
+    if (!campaign) {
+      throw new Error('Campaign is not loaded');
+    }
+    const salvageCandidates = Object.values(
+      campaign.salvageAllocations ?? {},
+    ).flatMap((allocation: any) => allocation.mercenaryAward?.candidates ?? []);
+    const normalizeSalvageStatus = (status: string): string =>
+      status === 'awarded' ? 'accepted' : status;
+    return {
+      acceptedSalvageValue: salvageCandidates
+        .filter(
+          (item: { status: string }) =>
+            normalizeSalvageStatus(item.status) === 'accepted',
+        )
+        .reduce(
+          (sum: number, item: { recoveredValue: number }) =>
+            sum + item.recoveredValue,
+          0,
+        ),
+      balance: campaign.finances.balance.amount,
+      currentDate: campaign.currentDate.toISOString().slice(0, 10),
+      ledgerDescriptions: campaign.finances.transactions.map(
+        (transaction: { description: string }) => transaction.description,
+      ),
+      loanCount: (campaign.loans ?? []).length,
+      repairPriorities: (campaign.repairQueue ?? []).map(
+        (ticket: { ticketId: string; priority?: number }) => [
+          ticket.ticketId,
+          ticket.priority ?? null,
+        ],
+      ),
+      salvageStatuses: salvageCandidates.map(
+        (item: { partId?: string; status: string; unitId: string }) => [
+          item.partId ?? item.unitId,
+          normalizeSalvageStatus(item.status),
+        ],
+      ),
+    };
+  });
 }
 
 async function seedPostBattleCampaign(page: Page): Promise<SeededCampaign> {
@@ -284,6 +383,7 @@ test.describe('Campaign economy browser proof', () => {
       const seeded = await seedPostBattleCampaign(page);
 
       await page.goto(`/gameplay/campaigns/${seeded.campaignId}`);
+      await waitForLoadedCampaign(page, seeded.campaignId);
       await expect(page.getByTestId('dashboard-card-finances')).toBeVisible();
       await expect(
         page.getByTestId('dashboard-card-day-advance'),
@@ -297,6 +397,7 @@ test.describe('Campaign economy browser proof', () => {
       expect(dateBefore).toBe('3025-01-01');
 
       await page.goto(`/gameplay/campaigns/${seeded.campaignId}/repair-bay`);
+      await waitForLoadedCampaign(page, seeded.campaignId);
       await expect(page.getByTestId('repair-bay-queue')).toBeVisible();
       await expect(
         page.getByTestId('repair-ticket-ticket-armor-ct'),
@@ -329,8 +430,18 @@ test.describe('Campaign economy browser proof', () => {
         ['ticket-armor-ct', 1],
         ['ticket-structure-lt', 0],
       ]);
+      const repairSnapshot = await readCampaignEconomySnapshot(page);
+      expect(repairSnapshot.repairPriorities).toEqual(repairPriorities);
+
+      await page.reload({ waitUntil: 'networkidle' });
+      await waitForLoadedCampaign(page, seeded.campaignId);
+      await expect(page.getByTestId('repair-bay-queue')).toBeVisible();
+      await expect(readCampaignEconomySnapshot(page)).resolves.toMatchObject({
+        repairPriorities,
+      });
 
       await page.goto(`/gameplay/campaigns/${seeded.campaignId}/salvage`);
+      await waitForLoadedCampaign(page, seeded.campaignId);
       await expect(page.getByTestId('salvage-panel')).toBeVisible();
       await expect(page.getByTestId('salvage-row-salvage-atlas')).toContainText(
         'Atlas AS7-D',
@@ -342,21 +453,86 @@ test.describe('Campaign economy browser proof', () => {
       await expect(page.getByTestId('salvage-value-total')).toContainText(
         '2,000,000 C-Bills',
       );
+      const salvageSnapshot = await readCampaignEconomySnapshot(page);
+      expect(salvageSnapshot).toMatchObject({
+        acceptedSalvageValue: 2_000_000,
+        salvageStatuses: [['salvage-atlas', 'accepted']],
+      });
+
+      await page.reload({ waitUntil: 'networkidle' });
+      await waitForLoadedCampaign(page, seeded.campaignId);
+      await expect(page.getByTestId('salvage-panel')).toBeVisible();
+      await expect(page.getByTestId('salvage-value-total')).toContainText(
+        '2,000,000 C-Bills',
+      );
+      await expect(readCampaignEconomySnapshot(page)).resolves.toMatchObject({
+        acceptedSalvageValue: 2_000_000,
+        salvageStatuses: [['salvage-atlas', 'accepted']],
+      });
 
       await page.goto(`/gameplay/campaigns/${seeded.campaignId}/finances`);
+      await waitForLoadedCampaign(page, seeded.campaignId);
       await expect(page.getByTestId('finances-panel')).toBeVisible();
       await expect(page.getByTestId('finances-balance')).toContainText(
         '2,500,000.00 C-bills',
       );
       await page.getByTestId('loan-submit').click();
+      await expect(page.getByTestId('finances-balance')).toContainText(
+        '3,500,000.00 C-bills',
+      );
       await expect(page.getByTestId('finances-ledger')).toBeVisible();
       await expect(page.getByTestId('finances-loan-list')).toBeVisible();
+      const financeSnapshot = await readCampaignEconomySnapshot(page);
+      expect(financeSnapshot).toMatchObject({
+        balance: 3_500_000,
+        loanCount: 1,
+      });
+      expect(financeSnapshot.ledgerDescriptions).toContain(
+        'Loan disbursement: 1,000,000.00 C-bills',
+      );
+
+      await page.reload({ waitUntil: 'networkidle' });
+      await waitForLoadedCampaign(page, seeded.campaignId);
+      await expect(page.getByTestId('finances-panel')).toBeVisible();
+      await expect(page.getByTestId('finances-balance')).toContainText(
+        '3,500,000.00 C-bills',
+      );
+      await expect(page.getByTestId('finances-loan-list')).toBeVisible();
+      const reloadedFinanceSnapshot = await readCampaignEconomySnapshot(page);
+      expect(reloadedFinanceSnapshot).toMatchObject({
+        balance: 3_500_000,
+        loanCount: 1,
+      });
+      expect(reloadedFinanceSnapshot.ledgerDescriptions).toContain(
+        'Loan disbursement: 1,000,000.00 C-bills',
+      );
 
       await page.goto(`/gameplay/campaigns/${seeded.campaignId}`);
+      await waitForLoadedCampaign(page, seeded.campaignId);
       await page.getByTestId('day-advance-one-day').click();
       await expect(page.getByTestId('day-advance-current-date')).not.toHaveText(
         '3025-01-01',
       );
+      await expect(page.getByTestId('day-advance-current-date')).toHaveText(
+        '3025-01-02',
+      );
+      const advancedSnapshot = await readCampaignEconomySnapshot(page);
+      expect(advancedSnapshot.currentDate).toBe('3025-01-02');
+      expect(advancedSnapshot.balance).toBeLessThan(financeSnapshot.balance);
+
+      await page.reload({ waitUntil: 'networkidle' });
+      await waitForLoadedCampaign(page, seeded.campaignId);
+      await expect(page.getByTestId('day-advance-current-date')).toHaveText(
+        '3025-01-02',
+      );
+      await expect(readCampaignEconomySnapshot(page)).resolves.toMatchObject({
+        acceptedSalvageValue: 2_000_000,
+        balance: advancedSnapshot.balance,
+        currentDate: '3025-01-02',
+        loanCount: 1,
+        repairPriorities,
+        salvageStatuses: [['salvage-atlas', 'accepted']],
+      });
 
       expect(pageErrors).toEqual([]);
     },


### PR DESCRIPTION
## Summary
- strengthens the strict campaign economy browser proof with canonical campaign-store snapshots
- verifies repair priority, salvage acceptance, loan creation, and day-advance cascade survive browser reloads
- keeps the slice test-only while moving Wave 2 campaign save/load confidence forward

## Validation
- node scripts/playwright/run-playwright.mjs test --project=chromium e2e/campaign-economy-browser.spec.ts --workers=1
- npm.cmd run verify:qc:campaign-economy:browser
- npm.cmd run verify:qc:campaign-economy
- npm.cmd run format:check
- npm.cmd run typecheck -- --pretty false
- git diff --check
- npm.cmd run qc:validate
- npm.cmd run qc:app-completion:release -- --json

## Notes
- erify:qc:campaign-economy emits a non-blocking aseline-browser-mapping freshness warning; the command exits successfully and the release gate still reports 0 release gaps.