### PR TITLE
Prove GM ledger reloads player-safe effects

### DIFF
--- a/e2e/gm-campaign-ledger-control-plane.spec.ts
+++ b/e2e/gm-campaign-ledger-control-plane.spec.ts
@@ -51,6 +51,24 @@ test.describe('GM campaign ledger control plane @gm-ledger', () => {
       await expect(page.getByTestId('gm-ledger-private-log')).toContainText(
         'Hidden campaign merchant reversal',
       );
+
+      await page.reload({ waitUntil: 'domcontentloaded' });
+      await expect(page.getByTestId('page-title')).toContainText('GM Ledger');
+      await expect(page.getByTestId('gm-ledger-balance')).toContainText(
+        '997,500.00 C-bills',
+      );
+      await expect(page.getByTestId('gm-ledger-player-log')).toContainText(
+        'Merchant charge corrected by -2,500.00 C-bills.',
+      );
+      await expect(page.getByTestId('gm-ledger-player-log')).not.toContainText(
+        /Hidden campaign|black-market|GM-only/i,
+      );
+      await expect(page.getByTestId('gm-ledger-private-log')).toContainText(
+        'Merchant charge corrected by -2,500.00 C-bills.',
+      );
+      await expect(page.getByTestId('gm-ledger-private-log')).not.toContainText(
+        /Hidden campaign|black-market|GM-only/i,
+      );
     } finally {
       if (campaignId) {
         await deleteCampaign(page, campaignId);

--- a/src/components/campaign/gm/GmCampaignInterventionControlPlane.helpers.ts
+++ b/src/components/campaign/gm/GmCampaignInterventionControlPlane.helpers.ts
@@ -177,6 +177,40 @@ export function refreshLedgerRows(
   );
 }
 
+export function buildPersistedCampaignEventRows(
+  events: readonly IGmCampaignProjectedEffect[] | undefined,
+  createdAt: string,
+  actorId: string = GM_ACTOR_ID,
+): {
+  readonly playerRows: readonly PlayerLedgerRow[];
+  readonly gmRows: readonly GmLedgerRow[];
+} {
+  const playerRows: PlayerLedgerRow[] = (events ?? []).map((event, index) => ({
+    id: `persisted:${event.interventionId ?? event.type}:${index}`,
+    sequence: index + 1,
+    recordKind: 'gm-intervention',
+    actorId,
+    actorRole: 'gm',
+    domain: event.domain,
+    action: 'fix',
+    status: 'approved',
+    targetRefs: event.changedStateRefs,
+    publicEffect: {
+      summary: event.publicSummary,
+      family: event.family,
+      changedStateRefs: event.changedStateRefs,
+    },
+    interventionRecordId: event.interventionId,
+    createdAt,
+    approvedAt: createdAt,
+  }));
+
+  return {
+    playerRows,
+    gmRows: playerRows.map((row) => ({ ...row })),
+  };
+}
+
 export function findFundsEffect(
   events: readonly unknown[],
 ): Extract<

--- a/src/components/campaign/gm/GmCampaignInterventionControlPlane.tsx
+++ b/src/components/campaign/gm/GmCampaignInterventionControlPlane.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 import type { ICampaign } from '@/types/campaign/Campaign';
 import type {
@@ -28,6 +28,7 @@ import {
   MERCHANT_REVERSAL_ID,
   TIME_CASCADE_ID,
   TIME_CASCADE_MANUAL_ID,
+  buildPersistedCampaignEventRows,
   refreshLedgerRows,
   type GmCampaignPreview,
   type GmCampaignUpdate,
@@ -71,15 +72,34 @@ export function GmCampaignInterventionControlPlane({
     return next;
   }, []);
   const actionLedger = useMemo(() => new ActionLedger(), []);
+  const persistedRows = useMemo(
+    () =>
+      buildPersistedCampaignEventRows(
+        campaign.gmInterventionEvents,
+        campaign.updatedAt,
+        actorId,
+      ),
+    [actorId, campaign.gmInterventionEvents, campaign.updatedAt],
+  );
   const [preview, setPreview] = useState<GmLedgerPreview | null>(null);
   const [approvalStatus, setApprovalStatus] = useState<string>(
     'No approved GM corrections yet.',
   );
   const [approvalReason, setApprovalReason] = useState<string | null>(null);
-  const [playerRows, setPlayerRows] = useState<readonly PlayerLedgerRow[]>([]);
-  const [gmRows, setGmRows] = useState<readonly GmLedgerRow[]>([]);
+  const [playerRows, setPlayerRows] = useState<readonly PlayerLedgerRow[]>(
+    () => persistedRows.playerRows,
+  );
+  const [gmRows, setGmRows] = useState<readonly GmLedgerRow[]>(
+    () => persistedRows.gmRows,
+  );
   const [manualTakeover, setManualTakeover] =
     useState<ManualTakeoverState | null>(null);
+
+  useEffect(() => {
+    if (actionLedger.getRecords().length > 0) return;
+    setPlayerRows(persistedRows.playerRows);
+    setGmRows(persistedRows.gmRows);
+  }, [actionLedger, persistedRows]);
 
   const canApprove = preview?.status === 'ready';
   const canTakeManualControl = preview?.status === 'requires-manual-takeover';

--- a/src/components/campaign/gm/__tests__/GmCampaignInterventionControlPlane.test.tsx
+++ b/src/components/campaign/gm/__tests__/GmCampaignInterventionControlPlane.test.tsx
@@ -1,7 +1,10 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import React from 'react';
 
+import type { IGmCampaignProjectedEffect } from '@/types/interventions';
+
 import { createCampaign } from '@/types/campaign/Campaign';
+import { TransactionType } from '@/types/campaign/Transaction';
 
 import { GmCampaignInterventionControlPlane } from '../GmCampaignInterventionControlPlane';
 
@@ -10,6 +13,62 @@ function fixedNow(): string {
 }
 
 describe('GmCampaignInterventionControlPlane', () => {
+  it('hydrates player-safe rows from persisted campaign intervention events', () => {
+    const campaign = {
+      ...createCampaign('GM Ledger Reload Test', 'mercenary', {
+        startingFunds: 1_000_000,
+      }),
+      id: 'campaign-gm-reload',
+      updatedAt: '3025-01-03T00:00:00.000Z',
+      gmInterventionEvents: [
+        {
+          type: 'gm.campaign.funds_transaction_corrected',
+          domain: 'economy',
+          family: 'funds-transaction',
+          interventionId: 'gm-ledger-merchant-reversal',
+          transactionId: 'gm-ledger-merchant-reversal',
+          changedStateRefs: ['campaign:campaign-gm-reload:finances'],
+          publicSummary: 'Merchant charge corrected by -2,500.00 C-bills.',
+          before: {
+            balanceCents: 100_000_000,
+            transactionIds: [],
+          },
+          after: {
+            balanceCents: 99_750_000,
+            transaction: {
+              id: 'gm-ledger-merchant-reversal',
+              type: TransactionType.PartPurchase,
+              amountCents: -250_000,
+              date: '3025-01-03T00:00:00.000Z',
+              description: 'GM merchant charge reversal',
+            },
+          },
+        } satisfies IGmCampaignProjectedEffect,
+      ],
+    };
+
+    render(
+      <GmCampaignInterventionControlPlane
+        campaign={campaign}
+        onApplyCampaignUpdate={jest.fn()}
+        now={fixedNow}
+      />,
+    );
+
+    expect(screen.getByTestId('gm-ledger-player-log')).toHaveTextContent(
+      'Merchant charge corrected by -2,500.00 C-bills.',
+    );
+    expect(screen.getByTestId('gm-ledger-player-log')).not.toHaveTextContent(
+      /Hidden campaign|black-market|GM-only/i,
+    );
+    expect(screen.getByTestId('gm-ledger-private-log')).toHaveTextContent(
+      'Merchant charge corrected by -2,500.00 C-bills.',
+    );
+    expect(screen.getByTestId('gm-ledger-private-log')).not.toHaveTextContent(
+      /Hidden campaign|black-market|GM-only/i,
+    );
+  });
+
   it('previews and approves a funds correction with player-safe output', () => {
     const campaign = createCampaign('GM Ledger Test', 'mercenary', {
       startingFunds: 1_000_000,


### PR DESCRIPTION
## Summary
- Hydrates GM ledger rows from persisted campaign intervention effects so approved player-safe net effects survive a route reload.
- Extends the GM ledger browser proof to approve a merchant reversal, reload the route, and verify the balance/player log remain visible without hidden GM reasoning.
- Adds a component test for hydrating persisted campaign intervention events into player-safe and GM-visible rows.

## Boundary
This intentionally does not persist full GM-private action records into the campaign aggregate. The campaign aggregate carries public projected effects; a future dedicated ledger-storage change should own durable private GM audit records.

## Validation
- `npx.cmd oxfmt --check src/components/campaign/gm/GmCampaignInterventionControlPlane.tsx src/components/campaign/gm/GmCampaignInterventionControlPlane.helpers.ts src/components/campaign/gm/__tests__/GmCampaignInterventionControlPlane.test.tsx e2e/gm-campaign-ledger-control-plane.spec.ts`
- `npm.cmd run typecheck`
- `npm.cmd test -- --watchAll=false --runTestsByPath src/components/campaign/gm/__tests__/GmCampaignInterventionControlPlane.test.tsx`
- `node scripts/playwright/run-playwright.mjs test --project=chromium e2e/gm-campaign-ledger-control-plane.spec.ts --workers=1` — 4 passed
- `npm.cmd run qc:gm:campaign-ledger:validate` — errors=0 warnings=0