### PR TITLE
Preserve service runtime while packaging Electron

### DIFF
--- a/desktop/scripts/rebuild-next-standalone.js
+++ b/desktop/scripts/rebuild-next-standalone.js
@@ -1,32 +1,53 @@
 #!/usr/bin/env node
 /**
- * Rebuild native Node modules inside Next.js standalone output for Electron.
+ * Rebuild native Node modules inside an Electron-only Next.js standalone copy.
  *
  * Why:
  * - Desktop releases run the Next.js server using Electron's Node runtime (ELECTRON_RUN_AS_NODE).
- * - Native modules bundled into `.next/standalone/node_modules` must match Electron's ABI.
+ * - Native modules bundled into the packaged Next standalone payload must match Electron's ABI.
+ * - The normal service path (`npm run start`) runs root `.next/standalone` with plain Node's ABI.
  * - electron-builder rebuilds native deps for the desktop app, but NOT for the copied Next standalone output.
  *
- * This script rebuilds only the native modules we rely on at runtime (currently: better-sqlite3)
- * inside the root `.next/standalone` directory using Electron headers.
+ * This script creates `desktop/.tmp/next-standalone-electron` from the root
+ * standalone output, then rebuilds only the runtime native modules we rely on
+ * (currently: better-sqlite3) in that isolated copy using Electron headers.
  */
 
 const path = require('path');
 const fs = require('fs');
 const { execFileSync } = require('child_process');
+const crypto = require('crypto');
 
 const nativeModules = [
   {
     name: 'better-sqlite3',
     buildSources: ['binding.gyp', 'deps', 'src'],
+    runtimeBinding: path.join('build', 'Release', 'better_sqlite3.node'),
   },
 ];
 
-function hydrateStandaloneBuildSources(rootDir, nextStandaloneDir) {
+function resolveElectronStandaloneDir(desktopDir) {
+  const override = process.env.MEKSTATION_ELECTRON_STANDALONE_DIR;
+  if (override && override.trim().length > 0) {
+    return path.isAbsolute(override)
+      ? override
+      : path.resolve(desktopDir, override);
+  }
+
+  return path.join(desktopDir, '.tmp', 'next-standalone-electron');
+}
+
+function copyStandaloneForElectron(sourceDir, targetDir) {
+  fs.rmSync(targetDir, { recursive: true, force: true });
+  fs.mkdirSync(path.dirname(targetDir), { recursive: true });
+  fs.cpSync(sourceDir, targetDir, { recursive: true, force: true });
+}
+
+function hydrateStandaloneBuildSources(rootDir, electronStandaloneDir) {
   for (const nativeModule of nativeModules) {
     const rootModuleDir = path.join(rootDir, 'node_modules', nativeModule.name);
-    const standaloneModuleDir = path.join(
-      nextStandaloneDir,
+    const electronStandaloneModuleDir = path.join(
+      electronStandaloneDir,
       'node_modules',
       nativeModule.name,
     );
@@ -34,15 +55,15 @@ function hydrateStandaloneBuildSources(rootDir, nextStandaloneDir) {
     if (!fs.existsSync(rootModuleDir)) {
       throw new Error(`Missing root native module: ${rootModuleDir}`);
     }
-    if (!fs.existsSync(standaloneModuleDir)) {
+    if (!fs.existsSync(electronStandaloneModuleDir)) {
       throw new Error(
-        `Missing standalone native module: ${standaloneModuleDir}`,
+        `Missing Electron standalone native module: ${electronStandaloneModuleDir}`,
       );
     }
 
     for (const sourceName of nativeModule.buildSources) {
       const sourcePath = path.join(rootModuleDir, sourceName);
-      const targetPath = path.join(standaloneModuleDir, sourceName);
+      const targetPath = path.join(electronStandaloneModuleDir, sourceName);
 
       if (!fs.existsSync(sourcePath)) {
         throw new Error(
@@ -55,9 +76,84 @@ function hydrateStandaloneBuildSources(rootDir, nextStandaloneDir) {
   }
 }
 
+function hashFile(filePath) {
+  return crypto
+    .createHash('sha256')
+    .update(fs.readFileSync(filePath))
+    .digest('hex');
+}
+
+function snapshotRootNativeBindings(nextStandaloneDir) {
+  return nativeModules.map((nativeModule) => {
+    const bindingPath = path.join(
+      nextStandaloneDir,
+      'node_modules',
+      nativeModule.name,
+      nativeModule.runtimeBinding,
+    );
+    if (!fs.existsSync(bindingPath)) {
+      throw new Error(`Missing root standalone native binding: ${bindingPath}`);
+    }
+    return {
+      bindingPath,
+      hash: hashFile(bindingPath),
+      name: nativeModule.name,
+    };
+  });
+}
+
+function assertRootNativeBindingsUnchanged(snapshots) {
+  for (const snapshot of snapshots) {
+    const currentHash = hashFile(snapshot.bindingPath);
+    if (currentHash !== snapshot.hash) {
+      throw new Error(
+        `Root standalone native binding changed during Electron rebuild: ${snapshot.bindingPath}`,
+      );
+    }
+  }
+  console.log(
+    '[rebuild-next-standalone] root native binding integrity check: OK',
+  );
+}
+
+function verifyRootNodeRuntime(nextStandaloneDir) {
+  try {
+    execFileSync(
+      process.execPath,
+      [
+        '-e',
+        [
+          "const Database = require('better-sqlite3');",
+          "const db = new Database(':memory:');",
+          "const row = db.prepare('select 1 as x').get();",
+          "if (row.x !== 1) throw new Error('Unexpected sqlite result');",
+          'db.close();',
+          "console.log('[rebuild-next-standalone] root Node better-sqlite3 runtime check: OK');",
+        ].join(' '),
+      ],
+      {
+        cwd: nextStandaloneDir,
+        stdio: 'inherit',
+      },
+    );
+  } catch (error) {
+    const strict =
+      process.env.MEKSTATION_STRICT_ROOT_STANDALONE_NODE_CHECK === '1' ||
+      !process.env.GITHUB_ACTIONS;
+    if (strict) {
+      throw error;
+    }
+    console.warn(
+      '[rebuild-next-standalone] root Node runtime check skipped: root standalone artifact is not executable on this CI runner. Integrity hash still proves the Electron rebuild did not mutate it.',
+    );
+  }
+}
+
 async function main() {
+  const desktopDir = path.join(__dirname, '..');
   const rootDir = path.join(__dirname, '..', '..');
   const nextStandaloneDir = path.join(rootDir, '.next', 'standalone');
+  const electronStandaloneDir = resolveElectronStandaloneDir(desktopDir);
 
   if (!fs.existsSync(nextStandaloneDir)) {
     console.error(
@@ -82,17 +178,26 @@ async function main() {
     },
   );
 
+  console.log(
+    `[rebuild-next-standalone] Preparing isolated Electron standalone copy\n` +
+      `  source=${nextStandaloneDir}\n` +
+      `  target=${electronStandaloneDir}`,
+  );
+  const rootNativeBindingSnapshots =
+    snapshotRootNativeBindings(nextStandaloneDir);
+  copyStandaloneForElectron(nextStandaloneDir, electronStandaloneDir);
+
   // Resolve Electron version from the installed desktop devDependency.
   // This ensures we rebuild against the exact Electron version used for packaging.
   const electronVersion = require('electron/package.json').version;
   const electronBinaryPath = require('electron');
 
   console.log(
-    `[rebuild-next-standalone] Rebuilding native modules in ${nextStandaloneDir}\n` +
+    `[rebuild-next-standalone] Rebuilding native modules in ${electronStandaloneDir}\n` +
       `  electronVersion=${electronVersion} arch=${process.arch}`,
   );
 
-  hydrateStandaloneBuildSources(rootDir, nextStandaloneDir);
+  hydrateStandaloneBuildSources(rootDir, electronStandaloneDir);
 
   // Rebuild native modules for Electron with the same rebuilder electron-builder uses.
   // `npm rebuild` can silently leave host-Node ABI bindings in the standalone tree.
@@ -104,7 +209,7 @@ async function main() {
       '--version',
       electronVersion,
       '--module-dir',
-      nextStandaloneDir,
+      electronStandaloneDir,
       '--only',
       'better-sqlite3',
       '--force',
@@ -118,6 +223,12 @@ async function main() {
       stdio: 'inherit',
     },
   );
+
+  // Sanity check: the root standalone output must remain usable by plain Node.
+  // Electron rebuilds are isolated to the desktop/.tmp copy so service runs and
+  // Docker packaging don't inherit Electron ABI native modules.
+  assertRootNativeBindingsUnchanged(rootNativeBindingSnapshots);
+  verifyRootNodeRuntime(nextStandaloneDir);
 
   // Sanity check: ensure the rebuilt native binding actually loads under Electron's ABI.
   execFileSync(
@@ -134,7 +245,7 @@ async function main() {
       ].join(' '),
     ],
     {
-      cwd: nextStandaloneDir,
+      cwd: electronStandaloneDir,
       env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
       stdio: 'inherit',
     },

--- a/desktop/scripts/test-build.js
+++ b/desktop/scripts/test-build.js
@@ -44,6 +44,109 @@ const packagedSecurityScript = path.join(
   'scripts',
   'validate-packaged-security.js',
 );
+const packagedSocketScript = path.join(
+  rootDir,
+  'scripts',
+  'validate-multiplayer-packaged-socket.mjs',
+);
+
+function resolvePackagedRuntime(platform, releaseDir) {
+  const candidates =
+    platform === 'win'
+      ? [path.join(releaseDir, 'win-unpacked', 'MekStation.exe')]
+      : platform === 'mac'
+        ? [
+            path.join(
+              releaseDir,
+              'mac',
+              'MekStation.app',
+              'Contents',
+              'MacOS',
+              'MekStation',
+            ),
+            path.join(
+              releaseDir,
+              'mac-arm64',
+              'MekStation.app',
+              'Contents',
+              'MacOS',
+              'MekStation',
+            ),
+            path.join(
+              releaseDir,
+              'mac-universal',
+              'MekStation.app',
+              'Contents',
+              'MacOS',
+              'MekStation',
+            ),
+          ]
+        : [
+            path.join(releaseDir, 'linux-unpacked', 'mekstation'),
+            path.join(releaseDir, 'linux-unpacked', 'MekStation'),
+          ];
+
+  const runtimePath = candidates.find((candidate) => fs.existsSync(candidate));
+  if (!runtimePath) {
+    throw new Error(
+      `Packaged Electron runtime not found. Checked: ${candidates.join(', ')}`,
+    );
+  }
+  return runtimePath;
+}
+
+function resolvePackagedStandaloneDir(platform, releaseDir) {
+  const candidates =
+    platform === 'win'
+      ? [path.join(releaseDir, 'win-unpacked', 'resources', 'next-standalone')]
+      : platform === 'mac'
+        ? [
+            path.join(
+              releaseDir,
+              'mac',
+              'MekStation.app',
+              'Contents',
+              'Resources',
+              'next-standalone',
+            ),
+            path.join(
+              releaseDir,
+              'mac-arm64',
+              'MekStation.app',
+              'Contents',
+              'Resources',
+              'next-standalone',
+            ),
+            path.join(
+              releaseDir,
+              'mac-universal',
+              'MekStation.app',
+              'Contents',
+              'Resources',
+              'next-standalone',
+            ),
+          ]
+        : [
+            path.join(
+              releaseDir,
+              'linux-unpacked',
+              'resources',
+              'next-standalone',
+            ),
+          ];
+
+  const standaloneDir = candidates.find((candidate) =>
+    fs.existsSync(candidate),
+  );
+  if (!standaloneDir) {
+    throw new Error(
+      `Packaged Next standalone resources not found. Checked: ${candidates.join(
+        ', ',
+      )}`,
+    );
+  }
+  return standaloneDir;
+}
 
 // Step 1: Build Next.js application
 console.log('📦 Step 1: Building Next.js application...');
@@ -72,19 +175,19 @@ try {
   process.exit(1);
 }
 
-// Step 3: Rebuild native modules in Next.js standalone output for Electron
-// (The packaged desktop app runs Next server under Electron's Node runtime)
+// Step 3: Prepare an Electron-only Next.js standalone copy and rebuild native modules
+// there. Root `.next/standalone` must stay plain-Node compatible for `npm run start`.
 console.log(
-  '🧩 Step 3: Rebuilding Next.js standalone native modules (Electron ABI)...',
+  '🧩 Step 3: Preparing Electron standalone native modules (isolated ABI copy)...',
 );
 try {
   execSync('npm run rebuild:next-standalone', {
     cwd: desktopDir,
     stdio: 'inherit',
   });
-  console.log('✅ Next.js standalone native rebuild complete\n');
+  console.log('✅ Electron standalone native rebuild complete\n');
 } catch (error) {
-  console.error('❌ Next.js standalone native rebuild failed');
+  console.error('❌ Electron standalone native rebuild failed');
   process.exit(1);
 }
 
@@ -188,6 +291,25 @@ for (const platform of PLATFORMS) {
           [packagedSecurityScript, `--output-dir=${OUTPUT_DIR}`],
           {
             cwd: desktopDir,
+            stdio: 'inherit',
+          },
+        );
+        console.log('\nRunning packaged multiplayer socket smoke...');
+        const packagedRuntime = resolvePackagedRuntime(platform, releaseDir);
+        const packagedStandaloneDir = resolvePackagedStandaloneDir(
+          platform,
+          releaseDir,
+        );
+        execFileSync(
+          process.execPath,
+          [
+            packagedSocketScript,
+            `--repo-root=${rootDir}`,
+            `--standalone-dir=${packagedStandaloneDir}`,
+            `--electron-node-exe=${packagedRuntime}`,
+          ],
+          {
+            cwd: rootDir,
             stdio: 'inherit',
           },
         );

--- a/docs/qc/mekstation-qc-map.md
+++ b/docs/qc/mekstation-qc-map.md
@@ -367,11 +367,18 @@ flowchart TD
 1. `desktop-api-security`
    - The 2026-06-23 desktop lane now proves the packaged runtime path with
      `npm.cmd run electron:test:build`: Next production build, Electron
-     TypeScript, standalone native rebuild, Electron `better-sqlite3` runtime
-     load, output verification, and Windows electron-builder packaging all pass.
-   - The standalone rebuild uses `@electron/rebuild` for the copied
-     `.next/standalone` native modules so the package no longer ships a
-     host-Node ABI binding into Electron's Node runtime.
+     TypeScript, isolated Electron-ABI standalone rebuild, Electron
+     `better-sqlite3` runtime load, root Node standalone runtime load, output
+     verification, Windows electron-builder packaging, packaged security audit,
+     and packaged-resource multiplayer socket/replay/reconnect smoke all pass.
+   - The standalone rebuild uses `@electron/rebuild` in
+     `desktop/.tmp/next-standalone-electron` so the package no longer ships a
+     host-Node ABI binding into Electron's Node runtime and root
+     `.next/standalone` remains usable by `npm run start`.
+   - `scripts/validate-multiplayer-packaged-socket.mjs` can now target either
+     the root service standalone output or the unpacked Electron
+     `resources/next-standalone` payload, preventing the desktop package proof
+     from accidentally testing only the root service path.
 
 1. `maintenance-code-health`
    - Full maintenance scanner pass is active with a reviewed `src` regression

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -24,8 +24,9 @@ files:
 
 # Extra resources to include (outside of app.asar)
 extraResources:
-  # Next.js standalone output (self-contained server + deps)
-  - from: '../.next/standalone'
+  # Electron-ABI standalone output (prepared by desktop/scripts/rebuild-next-standalone.js).
+  # Keep this separate from ../.next/standalone so `npm run start` remains plain-Node compatible.
+  - from: '.tmp/next-standalone-electron'
     to: 'next-standalone'
   # Next.js static assets (CSS/JS) for standalone server
   - from: '../.next/static'

--- a/scripts/hydrate-next-standalone-multiplayer-server.mjs
+++ b/scripts/hydrate-next-standalone-multiplayer-server.mjs
@@ -58,11 +58,27 @@ function copyRuntimeLoaders() {
   }
 }
 
+function copyPublicAssets() {
+  copyDir(path.join(root, 'public'), path.join(standaloneDir, 'public'));
+  assertExists(
+    path.join(
+      standaloneDir,
+      'public',
+      'data',
+      'units',
+      'battlemechs',
+      'index.json',
+    ),
+    'standalone BattleMech unit catalog',
+  );
+}
+
 function main() {
   assertExists(standaloneDir, 'Next standalone output');
   assertExists(generatedServerPath, 'generated Next standalone server');
   assertExists(path.join(root, 'server.js'), 'custom multiplayer server');
   assertExists(path.join(root, 'tsconfig.json'), 'TypeScript config');
+  assertExists(path.join(root, 'public'), 'public assets');
   assertExists(path.join(root, 'src'), 'source tree');
   assertExists(path.join(root, 'node_modules', 'tsx'), 'tsx runtime loader');
   assertExists(path.join(root, 'node_modules', 'esbuild'), 'esbuild runtime');
@@ -76,10 +92,10 @@ function main() {
   const nextConfigJson =
     generatedServer.includes('const nextConfig =') &&
     generatedServer.includes('startServer')
-    ? extractNextConfig(generatedServer)
-    : fs.existsSync(standaloneConfigPath)
-      ? fs.readFileSync(standaloneConfigPath, 'utf8').trim()
-      : null;
+      ? extractNextConfig(generatedServer)
+      : fs.existsSync(standaloneConfigPath)
+        ? fs.readFileSync(standaloneConfigPath, 'utf8').trim()
+        : null;
   if (!nextConfigJson) {
     throw new Error(
       'Unable to extract or reuse the resolved Next standalone config.',
@@ -97,6 +113,7 @@ function main() {
   );
   copyDir(path.join(root, 'src'), path.join(standaloneDir, 'src'));
   copyRuntimeLoaders();
+  copyPublicAssets();
 
   const hydratedServer = fs.readFileSync(generatedServerPath, 'utf8');
   if (
@@ -115,6 +132,7 @@ function main() {
         hydratedStandaloneServer: rel(generatedServerPath),
         nextConfig: rel(standaloneConfigPath),
         runtimeLoaders: [...runtimeModuleDirs, ...runtimeScopedDirs],
+        publicAssets: rel(path.join(standaloneDir, 'public')),
         sourceTree: rel(path.join(standaloneDir, 'src')),
       },
       null,

--- a/scripts/validate-multiplayer-packaged-socket.mjs
+++ b/scripts/validate-multiplayer-packaged-socket.mjs
@@ -13,6 +13,12 @@ const BASE58_ALPHABET =
 const PLAYER_ID_PREFIX = 'pid_';
 const PLAYER_ID_BYTES = 20;
 
+function getArg(name) {
+  const prefix = `--${name}=`;
+  const arg = process.argv.find((value) => value.startsWith(prefix));
+  return arg ? arg.slice(prefix.length) : null;
+}
+
 const defaultPort = 3700 + (process.pid % 1000);
 const port = Number.parseInt(process.env.PORT ?? String(defaultPort), 10);
 const host =
@@ -20,6 +26,21 @@ const host =
     ? process.env.HOSTNAME
     : '127.0.0.1';
 const baseUrl = `http://${host}:${port}`;
+const repoRoot = path.resolve(
+  getArg('repo-root') ?? process.env.MEKSTATION_REPO_ROOT ?? process.cwd(),
+);
+const standaloneDirArg =
+  getArg('standalone-dir') ?? process.env.MEKSTATION_STANDALONE_DIR ?? null;
+const standaloneDir = standaloneDirArg
+  ? path.resolve(standaloneDirArg)
+  : path.join(repoRoot, '.next', 'standalone');
+const electronNodeExe =
+  getArg('electron-node-exe') ?? process.env.MEKSTATION_ELECTRON_NODE_EXE ?? '';
+const startMode = standaloneDirArg
+  ? electronNodeExe
+    ? 'electron-node-standalone'
+    : 'node-standalone'
+  : 'npm-run-start';
 const dbPath =
   process.env.MULTIPLAYER_DB_PATH ??
   path.join(os.tmpdir(), `mekstation-mp-packaged-${process.pid}.db`);
@@ -93,41 +114,25 @@ async function issueWireToken() {
 }
 
 function assertHydratedStandaloneServer() {
-  const serverPath = path.join(
-    process.cwd(),
-    '.next',
-    'standalone',
-    'server.js',
-  );
-  const configPath = path.join(
-    process.cwd(),
-    '.next',
-    'standalone',
-    'server.next-config.json',
-  );
-  const tsxPath = path.join(
-    process.cwd(),
-    '.next',
-    'standalone',
-    'node_modules',
-    'tsx',
-  );
-  const wsPath = path.join(
-    process.cwd(),
-    '.next',
-    'standalone',
-    'node_modules',
-    'ws',
-  );
+  const serverPath = path.join(standaloneDir, 'server.js');
+  const configPath = path.join(standaloneDir, 'server.next-config.json');
+  const tsxPath = path.join(standaloneDir, 'node_modules', 'tsx');
+  const wsPath = path.join(standaloneDir, 'node_modules', 'ws');
   const sourcePath = path.join(
-    process.cwd(),
-    '.next',
-    'standalone',
+    standaloneDir,
     'src',
     'lib',
     'multiplayer',
     'server',
     'bindMultiplayerSocketConnection.ts',
+  );
+  const battleMechCatalogPath = path.join(
+    standaloneDir,
+    'public',
+    'data',
+    'units',
+    'battlemechs',
+    'index.json',
   );
 
   for (const filePath of [
@@ -136,13 +141,14 @@ function assertHydratedStandaloneServer() {
     tsxPath,
     wsPath,
     sourcePath,
+    battleMechCatalogPath,
   ]) {
     if (!fs.existsSync(filePath)) {
       throw new Error(
         `Packaged multiplayer server is not hydrated; missing ${path.relative(
-          process.cwd(),
+          repoRoot,
           filePath,
-        )}. Run npm run build first.`,
+        )}. Run npm run build first or package the Electron app before validating unpacked resources.`,
       );
     }
   }
@@ -159,7 +165,7 @@ function assertHydratedStandaloneServer() {
   }
 }
 
-function captureServerOutput(child) {
+function captureServerOutput(child, label) {
   let output = '';
   const onData = (chunk) => {
     output += chunk.toString();
@@ -167,7 +173,7 @@ function captureServerOutput(child) {
   child.stdout.on('data', onData);
   child.stderr.on('data', onData);
   child.on('exit', (code, signal) => {
-    output += `\n[validate] npm run start exited code=${code} signal=${signal}\n`;
+    output += `\n[validate] ${label} exited code=${code} signal=${signal}\n`;
   });
   return () => output;
 }
@@ -225,7 +231,18 @@ async function createMatch(wireToken, playerId, getOutput) {
       }\nServer output:\n${getOutput()}`,
     );
   }
-  const body = await response.json();
+  const responseText = await response.text();
+  let body;
+  try {
+    body = JSON.parse(responseText);
+  } catch (error) {
+    throw new Error(
+      `Match create returned malformed JSON (${response.status}): ${responseText.slice(
+        0,
+        500,
+      )}\nServer output:\n${getOutput()}`,
+    );
+  }
   if (!response.ok) {
     throw new Error(
       `Match create failed (${response.status}): ${JSON.stringify(body)}`,
@@ -386,22 +403,56 @@ async function openAndJoin(wsUrl, wireToken, playerId, matchId, getOutput) {
   return kinds;
 }
 
+function resolveServerStart(npmExecutable) {
+  if (!standaloneDirArg) {
+    return {
+      command: npmExecutable,
+      args: ['run', 'start'],
+      cwd: repoRoot,
+      label: 'npm run start',
+      shell: process.platform === 'win32',
+    };
+  }
+
+  const serverPath = path.join(standaloneDir, 'server.js');
+  if (electronNodeExe) {
+    return {
+      command: electronNodeExe,
+      args: [serverPath],
+      cwd: standaloneDir,
+      label: `Electron Node standalone ${serverPath}`,
+      shell: false,
+    };
+  }
+
+  return {
+    command: process.execPath,
+    args: [serverPath],
+    cwd: standaloneDir,
+    label: `Node standalone ${serverPath}`,
+    shell: false,
+  };
+}
+
 async function startPackagedServer(npmExecutable) {
-  const child = spawn(npmExecutable, ['run', 'start'], {
-    cwd: process.cwd(),
+  const start = resolveServerStart(npmExecutable);
+  const child = spawn(start.command, start.args, {
+    cwd: start.cwd,
     env: {
       ...process.env,
       PORT: String(port),
       HOSTNAME: host,
       NODE_ENV: 'production',
+      ...(electronNodeExe ? { ELECTRON_RUN_AS_NODE: '1' } : {}),
       MULTIPLAYER_SOCKET_TRACE: '1',
       MULTIPLAYER_STORE: process.env.MULTIPLAYER_STORE ?? 'durable',
       MULTIPLAYER_DB_PATH: dbPath,
+      DATABASE_PATH: dbPath,
     },
-    shell: process.platform === 'win32',
+    shell: start.shell,
     stdio: ['ignore', 'pipe', 'pipe'],
   });
-  const getOutput = captureServerOutput(child);
+  const getOutput = captureServerOutput(child, start.label);
   await waitForServer(child, getOutput);
   return { child, getOutput };
 }
@@ -419,7 +470,7 @@ function runCoopRuntimeSmoke(match) {
       match.roomCode,
     ],
     {
-      cwd: process.cwd(),
+      cwd: repoRoot,
       encoding: 'utf8',
       maxBuffer: 10 * 1024 * 1024,
       shell: process.platform === 'win32',
@@ -485,7 +536,13 @@ async function main() {
           packagedMultiplayerReachability: 'socket-upgrade-and-replay-ok',
           packagedRestartReconnect:
             'same-match-replay-after-process-restart-ok',
-          startScript: 'npm run start',
+          startMode,
+          startScript: standaloneDirArg
+            ? electronNodeExe
+              ? `${electronNodeExe} ${path.join(standaloneDir, 'server.js')}`
+              : `${process.execPath} ${path.join(standaloneDir, 'server.js')}`
+            : 'npm run start',
+          standaloneDir,
           baseUrl,
           dbPath,
           matchId: match.matchId,


### PR DESCRIPTION
## Summary
- isolate Electron's Next standalone copy before rebuilding native modules for Electron ABI
- package the isolated desktop standalone resources instead of mutating root .next/standalone
- hydrate standalone public assets and promote unpacked Electron resource multiplayer socket/replay/reconnect smoke into the desktop package gate

## Validation
- npx.cmd oxfmt --check scripts\\hydrate-next-standalone-multiplayer-server.mjs scripts\\validate-multiplayer-packaged-socket.mjs desktop\\scripts\\rebuild-next-standalone.js desktop\\scripts\\test-build.js electron-builder.yml docs\\qc\\mekstation-qc-map.md
- node -c affected scripts
- git diff --check
- npm.cmd run validate:multiplayer:packaged-socket
- node scripts\\validate-multiplayer-packaged-socket.mjs --repo-root=E:\\Projects\\MekStation --standalone-dir=E:\\Projects\\MekStation\\desktop\\release-test\\win-unpacked\\resources\\next-standalone --electron-node-exe=E:\\Projects\\MekStation\\desktop\\release-test\\win-unpacked\\MekStation.exe
- npm.cmd run electron:test:build
- npm.cmd run qc:lifecycle:status
- npm.cmd run qc:app-completion -- --json
- npm.cmd run qc:app-completion:release -- --json
- cmd /c openspec validate --all --strict

## Notes
- macOS and Linux Electron package execution were not run locally on Windows; the test-build script keeps those as CI-platform validations.