### PR TITLE
Preserve GM time-cascade state through ledger QC

### DIFF
--- a/docs/qc/mekstation-qc-map.md
+++ b/docs/qc/mekstation-qc-map.md
@@ -273,6 +273,10 @@ flowchart TD
    - 2026-06-24 Wave 2 added the browser GM Ledger route and focused
      Playwright/component proof for merchant reversal approval, player-safe
      action-log projection, GM-private details, and conflicted manual takeover.
+   - 2026-06-28 `verify:qc:gm:campaign-ledger` passed with validator
+     anchors=14, 5 Jest suites / 32 tests, and 4 Chromium GM ledger checks
+     proving merchant reversal reload, manual-control blocking, approved
+     time-cascade reload, and external-effect manual-control flow.
 
 1. `time-cascade-gm-ledger`
    - Wave 9 lives under `campaign-economy-progression` and proves the
@@ -290,6 +294,10 @@ flowchart TD
      tests after manual review of travel, repair, market/upkeep,
      public/private redaction, external-effect projection, and manual-takeover
      cases.
+   - 2026-06-28 `verify:qc:gm:time-cascade` passed with validator
+     roots=12/12 and anchors=14, 7 Jest suites / 56 tests, repeated-cascade
+     bounded audit-event storage, and 4 Chromium GM ledger checks that poll
+     canonical `timeCascadeEvents` after approval and reload.
 
 1. `long-campaign-stability`
    - `long-campaign-stability` is the Wave 11 guard for deterministic 6-10

--- a/docs/qc/mekstation-qc-registry.json
+++ b/docs/qc/mekstation-qc-registry.json
@@ -1191,7 +1191,8 @@
         "src/lib/interventions/__tests__/GmCampaignInterventionImplementer.test.ts",
         "2026-06-23 `npm.cmd run verify:qc:gm:campaign-ledger` passed: validator reported surfaces=1/1, domains=4/4, families=5/5, anchors=8, errors=0, warnings=0; focused Jest passed 3 suites / 20 tests. Manual review of the covered cases confirmed merchant reversal/funds correction, inventory/base-unit corrections, GM approval, public net-effect projection, private metadata redaction, and manual-takeover blocking for ambiguous merchant cascades.",
         "2026-06-24 Wave 2 browser slice added `/gameplay/campaigns/:id/gm-ledger`, `GmCampaignInterventionControlPlane`, focused component tests, and `e2e/gm-campaign-ledger-control-plane.spec.ts` so merchant reversal preview/approval, player-safe redaction, and manual-control conflict handling are browser-checkable.",
-        "2026-06-24 `npm.cmd run verify:qc:gm:campaign-ledger` keeps the post-combat/economy GM ledger route, component, redaction, and browser checks wired while accumulated time corrections are covered by `time-cascade-gm-ledger`."
+        "2026-06-24 `npm.cmd run verify:qc:gm:campaign-ledger` keeps the post-combat/economy GM ledger route, component, redaction, and browser checks wired while accumulated time corrections are covered by `time-cascade-gm-ledger`.",
+        "2026-06-28 `npm.cmd run verify:qc:gm:campaign-ledger` passed: validator reported surfaces=1/1, domains=4/4, families=5/5, anchors=14, errors=0, warnings=0; focused Jest passed 5 suites / 32 tests, and Chromium passed 4 GM ledger tests for merchant reversal reload, manual-control blocking, approved time-cascade reload, and external-effect manual-control flow."
       ],
       "gaps": [
         "Accumulated time cascades are covered by the separate time-cascade GM ledger lane."
@@ -1268,8 +1269,8 @@
         "e2e/gm-campaign-ledger-control-plane.spec.ts",
         "src/lib/interventions/__tests__/GmTimeCascadeInterventionImplementer.test.ts",
         "src/lib/campaign/processors/__tests__/marketProcessors.test.ts",
-        "2026-06-23 `npm.cmd run verify:qc:gm:time-cascade` passed: validator reported surfaces=1/1, domains=1/1, families=1/1, processors=6/6, roots=11/11, anchors=10, errors=0, warnings=0; focused Jest passed 6 suites / 51 tests. Manual review of the covered cases confirmed travel, repair progression/completion, market/upkeep processors, public/private log redaction, external-effect projection, and GM manual control when external effects are named without projections.",
-        "2026-06-24 `npm.cmd run verify:qc:gm:time-cascade` covers the routed GM ledger page, time-cascade preview/approval, player-safe redaction, private GM context, and unprojected external-effect manual-control handling through component and Chromium checks."
+        "2026-06-24 `npm.cmd run verify:qc:gm:time-cascade` covers the routed GM ledger page, time-cascade preview/approval, player-safe redaction, private GM context, and unprojected external-effect manual-control handling through component and Chromium checks.",
+        "2026-06-28 `npm.cmd run verify:qc:gm:time-cascade` passed: validator reported surfaces=1/1, domains=1/1, families=1/1, processors=6/6, roots=12/12, anchors=14, errors=0, warnings=0; focused Jest passed 7 suites / 56 tests, including repeated-cascade bounded audit-event storage, and Chromium passed 4 GM ledger tests with canonical `timeCascadeEvents` store polling after approval and reload."
       ],
       "gaps": [
         "Pilot recovery, roster progression, and vault-owned effects remain external to campaign-owned time projection; the time-cascade validator requires explicit projected external effects or GM manual-control anchors."

--- a/docs/qc/mekstation-qc-validation-graph.json
+++ b/docs/qc/mekstation-qc-validation-graph.json
@@ -1277,6 +1277,8 @@
         "scripts/qc/validate-gm-campaign-ledger.mjs",
         "scripts/qc/gm-ledger-qc-core.mjs",
         "scripts/__tests__/gm-campaign-ledger-qc.test.ts",
+        "src/components/campaign/gm/GmCampaignInterventionControlPlane.tsx",
+        "e2e/gm-campaign-ledger-control-plane.spec.ts",
         "src/lib/interventions/__tests__/GmCampaignInterventionImplementer.test.ts"
       ]
     },
@@ -1340,6 +1342,8 @@
         "scripts/qc/gm-ledger-qc-core.mjs",
         "scripts/qc/validate-gm-time-cascade-ledger.mjs",
         "scripts/__tests__/gm-time-cascade-qc.test.ts",
+        "src/components/campaign/gm/GmCampaignInterventionControlPlane.tsx",
+        "e2e/gm-campaign-ledger-control-plane.spec.ts",
         "src/lib/interventions/__tests__/GmTimeCascadeInterventionImplementer.test.ts",
         "src/lib/campaign/processors/__tests__/marketProcessors.test.ts"
       ]
@@ -1357,8 +1361,7 @@
       "kind": "known-gap",
       "label": "Time Cascade GM Ledger known gaps",
       "entries": [
-        "Pilot recovery, roster progression, and vault-owned effects remain external to campaign-owned time projection; the time-cascade validator requires explicit projected external effects or manual-takeover anchors.",
-        "Browser UI controls are validated through the broader gameplay UI flow shell rather than this command-only ledger proof."
+        "Pilot recovery, roster progression, and vault-owned effects remain external to campaign-owned time projection; the time-cascade validator requires explicit projected external effects or manual-takeover anchors."
       ]
     },
     {
@@ -1370,6 +1373,11 @@
       "id": "command:npm-cmd-run-verify-qc-gm-time-cascade",
       "kind": "command",
       "label": "npm.cmd run verify:qc:gm:time-cascade"
+    },
+    {
+      "id": "command:npm-cmd-run-verify-qc-gm-campaign-browser",
+      "kind": "command",
+      "label": "npm.cmd run verify:qc:gm:campaign-browser"
     },
     {
       "id": "command:npm-cmd-test-watchall-false-runtestsbypath-scripts-tests-gm-time-cascade-qc-test-ts-src-lib-inte",
@@ -3484,6 +3492,16 @@
     },
     {
       "from": "state:post-combat-base-economy-gm-ledger:lifecycle",
+      "to": "command:npm-cmd-run-verify-qc-gm-campaign-browser",
+      "relation": "validated-by"
+    },
+    {
+      "from": "command:npm-cmd-run-verify-qc-gm-campaign-browser",
+      "to": "evidence:post-combat-base-economy-gm-ledger:registry",
+      "relation": "produces"
+    },
+    {
+      "from": "state:post-combat-base-economy-gm-ledger:lifecycle",
       "to": "command:npm-cmd-test-watchall-false-runtestsbypath-src-lib-interventions-tests-gmcampaigninterventionimp",
       "relation": "validated-by"
     },
@@ -3579,6 +3597,16 @@
     },
     {
       "from": "command:npm-cmd-run-verify-qc-gm-time-cascade",
+      "to": "evidence:time-cascade-gm-ledger:registry",
+      "relation": "produces"
+    },
+    {
+      "from": "state:time-cascade-gm-ledger:lifecycle",
+      "to": "command:npm-cmd-run-verify-qc-gm-campaign-browser",
+      "relation": "validated-by"
+    },
+    {
+      "from": "command:npm-cmd-run-verify-qc-gm-campaign-browser",
       "to": "evidence:time-cascade-gm-ledger:registry",
       "relation": "produces"
     },

--- a/e2e/gm-campaign-ledger-control-plane.spec.ts
+++ b/e2e/gm-campaign-ledger-control-plane.spec.ts
@@ -1,6 +1,44 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 
 import { createTestCampaign, deleteCampaign } from './fixtures/campaign';
+
+type CampaignTimeState = {
+  readonly currentDate: string | null;
+  readonly timeCascadeEventCount: number;
+};
+
+async function readCampaignTimeState(page: Page): Promise<CampaignTimeState> {
+  return page.evaluate(() => {
+    function toIsoDate(value: unknown): string | null {
+      if (value instanceof Date) return value.toISOString();
+      if (typeof value === 'string') {
+        const parsed = new Date(value);
+        return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+      }
+      return null;
+    }
+
+    const stores = (
+      window as unknown as {
+        __ZUSTAND_STORES__?: {
+          campaign?: {
+            getState: () => {
+              getCampaign?: () => {
+                currentDate?: Date | string;
+                timeCascadeEvents?: readonly unknown[];
+              } | null;
+            };
+          };
+        };
+      }
+    ).__ZUSTAND_STORES__;
+    const campaign = stores?.campaign?.getState().getCampaign?.();
+    return {
+      currentDate: toIsoDate(campaign?.currentDate),
+      timeCascadeEventCount: campaign?.timeCascadeEvents?.length ?? 0,
+    };
+  });
+}
 
 test.describe('GM campaign ledger control plane @gm-ledger', () => {
   test('previews, approves, and redacts a merchant reversal', async ({
@@ -134,6 +172,21 @@ test.describe('GM campaign ledger control plane @gm-ledger', () => {
         waitUntil: 'domcontentloaded',
       });
 
+      await expect(page.getByTestId('page-title')).toContainText('GM Ledger');
+      await expect(page.getByTestId('gm-ledger-balance')).toContainText(
+        '1,000,000.00 C-bills',
+      );
+
+      const initialState = await readCampaignTimeState(page);
+      if (!initialState.currentDate) {
+        throw new Error(
+          'Campaign currentDate did not hydrate before time-cascade preview.',
+        );
+      }
+      const expectedDate = new Date(
+        new Date(initialState.currentDate).getTime() + 2 * 24 * 60 * 60 * 1000,
+      ).toISOString();
+
       await page.getByTestId('gm-ledger-time-preview-btn').click();
       await expect(page.getByTestId('gm-ledger-preview-status')).toContainText(
         'ready',
@@ -155,6 +208,34 @@ test.describe('GM campaign ledger control plane @gm-ledger', () => {
       );
       await expect(page.getByTestId('gm-ledger-private-log')).toContainText(
         'Hidden time cascade correction',
+      );
+
+      await expect
+        .poll(async () => readCampaignTimeState(page))
+        .toEqual({
+          currentDate: expectedDate,
+          timeCascadeEventCount: 1,
+        });
+
+      await page.reload({ waitUntil: 'domcontentloaded' });
+      await expect(page.getByTestId('page-title')).toContainText('GM Ledger');
+      await expect
+        .poll(async () => readCampaignTimeState(page))
+        .toEqual({
+          currentDate: expectedDate,
+          timeCascadeEventCount: 1,
+        });
+      await expect(page.getByTestId('gm-ledger-player-log')).toContainText(
+        'Campaign time corrected by 2 days.',
+      );
+      await expect(page.getByTestId('gm-ledger-player-log')).not.toContainText(
+        /Hidden time|Secret employer|GM-only/i,
+      );
+      await expect(page.getByTestId('gm-ledger-private-log')).toContainText(
+        'Campaign time corrected by 2 days.',
+      );
+      await expect(page.getByTestId('gm-ledger-private-log')).not.toContainText(
+        /Hidden time|Secret employer|GM-only/i,
       );
     } finally {
       if (campaignId) {

--- a/scripts/__tests__/gm-time-cascade-qc.test.ts
+++ b/scripts/__tests__/gm-time-cascade-qc.test.ts
@@ -52,7 +52,7 @@ describe('GM time cascade QC validator', () => {
     expect(result.stdout).toContain('domains=1/1');
     expect(result.stdout).toContain('families=1/1');
     expect(result.stdout).toContain('processors=6/6');
-    expect(result.stdout).toContain('roots=11/11');
+    expect(result.stdout).toContain('roots=12/12');
     expect(result.stdout).toContain('errors=0');
   });
 

--- a/scripts/__tests__/maintenance-warning-ledger.test.ts
+++ b/scripts/__tests__/maintenance-warning-ledger.test.ts
@@ -56,6 +56,13 @@ describe('maintenance warning ledger validator', () => {
           line: 1,
           message: '8-line block cluster appears in 2 files',
         },
+        {
+          category: 'near-duplicate',
+          severity: 'warn',
+          file: 'desktop/.tmp/next-standalone-electron/src/components/common/icons/NavigationIcons.tsx',
+          line: 1,
+          message: '12-line block cluster appears in 2 files',
+        },
       ],
     });
   });

--- a/scripts/__tests__/qc-registry.test.ts
+++ b/scripts/__tests__/qc-registry.test.ts
@@ -173,8 +173,9 @@ describe('QC registry validator', () => {
 
     expect(result.status).toBe(1);
     expect(result.stdout).toContain(
-      'Next.js page routes missing from app-shell coverage manifest: /gameplay/campaigns/[id]/finances',
+      'Next.js page routes missing from app-shell coverage manifest:',
     );
+    expect(result.stdout).toContain('/gameplay/campaigns/[id]/finances');
   });
 
   it('rejects stale delegated route patterns in the app-shell coverage manifest', () => {
@@ -217,8 +218,9 @@ describe('QC registry validator', () => {
 
     expect(result.status).toBe(1);
     expect(result.stdout).toContain(
-      'Next.js page routes missing from app-shell coverage manifest: /e2e/sync-test',
+      'Next.js page routes missing from app-shell coverage manifest:',
     );
+    expect(result.stdout).toContain('/e2e/sync-test');
   });
 
   it('rejects test harness route groups without browser proof context', () => {

--- a/scripts/next/run-next.mjs
+++ b/scripts/next/run-next.mjs
@@ -18,6 +18,24 @@ const nextCli = path.join(
   'next',
 );
 const nextArgs = process.argv.slice(2);
+const defaultNextBuildOldSpaceMb = '8192';
+
+function hasExplicitOldSpaceLimit(nodeOptions) {
+  return /(?:^|\s)--max-old-space-size(?:=|\s)\S*/.test(nodeOptions ?? '');
+}
+
+function resolveNodeOptions(env, args) {
+  const nodeOptions = env.NODE_OPTIONS ?? '';
+  if (args[0] !== 'build' || hasExplicitOldSpaceLimit(nodeOptions)) {
+    return nodeOptions;
+  }
+
+  const oldSpaceMb =
+    env.MEKSTATION_NEXT_BUILD_OLD_SPACE_MB ?? defaultNextBuildOldSpaceMb;
+  return [nodeOptions.trim(), `--max-old-space-size=${oldSpaceMb}`]
+    .filter(Boolean)
+    .join(' ');
+}
 
 const child = spawn(process.execPath, [nextCli, ...nextArgs], {
   cwd: repoRoot,
@@ -25,6 +43,7 @@ const child = spawn(process.execPath, [nextCli, ...nextArgs], {
     ...process.env,
     BASELINE_BROWSER_MAPPING_IGNORE_OLD_DATA: 'true',
     BROWSERSLIST_IGNORE_OLD_DATA: 'true',
+    NODE_OPTIONS: resolveNodeOptions(process.env, nextArgs),
   },
   stdio: ['inherit', 'pipe', 'pipe'],
 });

--- a/scripts/qc/validate-gm-time-cascade-ledger.mjs
+++ b/scripts/qc/validate-gm-time-cascade-ledger.mjs
@@ -40,6 +40,7 @@ const requiredProcessors = [
 const requiredCampaignRoots = [
   'currentDate',
   'currentSystemId',
+  'timeCascadeEvents',
   'repairQueue',
   'partsInventory',
   'unitCombatStates',
@@ -127,6 +128,7 @@ const defaultSourceAnchors = [
     tokens: [
       'previews and applies one day without mutating the source campaign',
       'replays stored projected effects for multi-day repair completion',
+      'stores repeated cascades without recursively nesting prior event history',
       'records action-ledger projections while redacting GM-private context',
       'supports optional travel in the same projected cascade',
       'blocks invalid day counts before approval',
@@ -244,6 +246,8 @@ const defaultSourceAnchors = [
       'blocks unprojected external time effects until manual takeover',
       'gm-ledger-time-preview-btn',
       'gm-ledger-time-conflict-preview-btn',
+      'timeCascadeEventCount',
+      'Campaign time corrected by 2 days.',
       'not.toContainText',
     ],
   },

--- a/scripts/qc/validate-maintenance-warning-ledger.mjs
+++ b/scripts/qc/validate-maintenance-warning-ledger.mjs
@@ -28,9 +28,7 @@ const waveCategories = new Set([
 ]);
 const actionableSeverities = new Set(['critical', 'high', 'medium', 'warn']);
 const validStatuses = new Set(['fixed', 'accepted', 'follow-up']);
-const generatedFindingPathPrefixes = [
-  'desktop/.tmp/',
-];
+const generatedFindingPathPrefixes = ['desktop/.tmp/'];
 
 function parseArgs(argv) {
   const options = {

--- a/scripts/qc/validate-maintenance-warning-ledger.mjs
+++ b/scripts/qc/validate-maintenance-warning-ledger.mjs
@@ -28,6 +28,9 @@ const waveCategories = new Set([
 ]);
 const actionableSeverities = new Set(['critical', 'high', 'medium', 'warn']);
 const validStatuses = new Set(['fixed', 'accepted', 'follow-up']);
+const generatedFindingPathPrefixes = [
+  'desktop/.tmp/',
+];
 
 function parseArgs(argv) {
   const options = {
@@ -75,6 +78,11 @@ function findingKey(finding) {
     normalizeFile(finding.file),
     finding.message,
   ].join('|');
+}
+
+function isGeneratedFinding(finding) {
+  const file = normalizeFile(finding.file);
+  return generatedFindingPathPrefixes.some((prefix) => file.startsWith(prefix));
 }
 
 function runScanner() {
@@ -216,7 +224,9 @@ function validate(options) {
   const ledgerPath = path.resolve(repoRoot, options.ledgerPath);
   const ledger = loadJson(ledgerPath);
   const scan = liveScan(options);
-  const findings = Array.isArray(scan.findings) ? scan.findings : [];
+  const findings = Array.isArray(scan.findings)
+    ? scan.findings.filter((finding) => !isGeneratedFinding(finding))
+    : [];
   const liveActionable = findings.filter(isActionableWaveFinding);
   const liveByKey = new Map(
     liveActionable.map((finding) => [findingKey(finding), finding]),

--- a/scripts/qc/validate-qc-registry.mjs
+++ b/scripts/qc/validate-qc-registry.mjs
@@ -49,6 +49,12 @@ const ignoredIndexDirs = new Set([
   'dist',
   'node_modules',
 ]);
+const ignoredIndexPathPrefixes = [
+  'desktop/.electron-cache/',
+  'desktop/.tmp/',
+  'desktop/release/',
+  'desktop/release-test/',
+];
 
 function fail(message) {
   return { severity: 'error', message };
@@ -127,19 +133,41 @@ function isPathLikeEvidence(value) {
   return repoPrefixPattern.test(normalized);
 }
 
-function collectRepoEntries(dir = repoRoot, prefix = '') {
+function shouldIgnoreIndexEntry(dirent, relativePath) {
+  if (dirent.isSymbolicLink()) return true;
+  if (ignoredIndexDirs.has(dirent.name)) return true;
+
+  const normalized = toRepoRelativePath(relativePath);
+  return ignoredIndexPathPrefixes.some(
+    (ignoredPrefix) =>
+      normalized === ignoredPrefix.replace(/\/$/, '') ||
+      normalized.startsWith(ignoredPrefix),
+  );
+}
+
+function collectRepoEntries() {
   const entries = [];
+  const pendingDirs = [{ absolutePath: repoRoot, prefix: '' }];
 
-  for (const dirent of fs.readdirSync(dir, { withFileTypes: true })) {
-    if (ignoredIndexDirs.has(dirent.name)) continue;
+  while (pendingDirs.length > 0) {
+    const currentDir = pendingDirs.pop();
+    const dirents = fs.readdirSync(currentDir.absolutePath, {
+      withFileTypes: true,
+    });
 
-    const absolutePath = path.join(dir, dirent.name);
-    const relativePath = prefix ? `${prefix}/${dirent.name}` : dirent.name;
+    for (const dirent of dirents) {
+      const absolutePath = path.join(currentDir.absolutePath, dirent.name);
+      const relativePath = currentDir.prefix
+        ? `${currentDir.prefix}/${dirent.name}`
+        : dirent.name;
 
-    entries.push(toRepoRelativePath(relativePath));
+      if (shouldIgnoreIndexEntry(dirent, relativePath)) continue;
 
-    if (dirent.isDirectory()) {
-      entries.push(...collectRepoEntries(absolutePath, relativePath));
+      entries.push(toRepoRelativePath(relativePath));
+
+      if (dirent.isDirectory()) {
+        pendingDirs.push({ absolutePath, prefix: relativePath });
+      }
     }
   }
 

--- a/src/components/campaign/gm/GmCampaignInterventionControlPlane.helpers.ts
+++ b/src/components/campaign/gm/GmCampaignInterventionControlPlane.helpers.ts
@@ -179,31 +179,61 @@ export function refreshLedgerRows(
 
 export function buildPersistedCampaignEventRows(
   events: readonly IGmCampaignProjectedEffect[] | undefined,
+  timeEvents: readonly IGmTimeCascadeProjectedEffect[] | undefined,
   createdAt: string,
   actorId: string = GM_ACTOR_ID,
 ): {
   readonly playerRows: readonly PlayerLedgerRow[];
   readonly gmRows: readonly GmLedgerRow[];
 } {
-  const playerRows: PlayerLedgerRow[] = (events ?? []).map((event, index) => ({
-    id: `persisted:${event.interventionId ?? event.type}:${index}`,
-    sequence: index + 1,
-    recordKind: 'gm-intervention',
-    actorId,
-    actorRole: 'gm',
-    domain: event.domain,
-    action: 'fix',
-    status: 'approved',
-    targetRefs: event.changedStateRefs,
-    publicEffect: {
-      summary: event.publicSummary,
-      family: event.family,
-      changedStateRefs: event.changedStateRefs,
-    },
-    interventionRecordId: event.interventionId,
-    createdAt,
-    approvedAt: createdAt,
-  }));
+  const campaignRows: PlayerLedgerRow[] = (events ?? []).map(
+    (event, index) => ({
+      id: `persisted:${event.interventionId ?? event.type}:${index}`,
+      sequence: index + 1,
+      recordKind: 'gm-intervention',
+      actorId,
+      actorRole: 'gm',
+      domain: event.domain,
+      action: 'fix',
+      status: 'approved',
+      targetRefs: event.changedStateRefs,
+      publicEffect: {
+        summary: event.publicSummary,
+        family: event.family,
+        changedStateRefs: event.changedStateRefs,
+      },
+      interventionRecordId: event.interventionId,
+      createdAt,
+      approvedAt: createdAt,
+    }),
+  );
+  const timeRows: PlayerLedgerRow[] = (timeEvents ?? []).map(
+    (event, index) => ({
+      id: `persisted:${event.interventionId ?? event.type}:time:${index}`,
+      sequence: campaignRows.length + index + 1,
+      recordKind: 'gm-intervention',
+      actorId,
+      actorRole: 'gm',
+      domain: event.domain,
+      action: 'fix',
+      status: 'approved',
+      targetRefs: event.changedStateRefs,
+      publicEffect: {
+        summary: event.publicSummary,
+        family: event.family,
+        days: event.days,
+        fromDate: event.before.currentDate,
+        toDate: event.after.currentDate,
+        fromSystemId: event.before.currentSystemId,
+        toSystemId: event.after.currentSystemId,
+        changedStateRefs: event.changedStateRefs,
+      },
+      interventionRecordId: event.interventionId,
+      createdAt,
+      approvedAt: createdAt,
+    }),
+  );
+  const playerRows = [...campaignRows, ...timeRows];
 
   return {
     playerRows,

--- a/src/components/campaign/gm/GmCampaignInterventionControlPlane.tsx
+++ b/src/components/campaign/gm/GmCampaignInterventionControlPlane.tsx
@@ -76,10 +76,16 @@ export function GmCampaignInterventionControlPlane({
     () =>
       buildPersistedCampaignEventRows(
         campaign.gmInterventionEvents,
+        campaign.timeCascadeEvents,
         campaign.updatedAt,
         actorId,
       ),
-    [actorId, campaign.gmInterventionEvents, campaign.updatedAt],
+    [
+      actorId,
+      campaign.gmInterventionEvents,
+      campaign.timeCascadeEvents,
+      campaign.updatedAt,
+    ],
   );
   const [preview, setPreview] = useState<GmLedgerPreview | null>(null);
   const [approvalStatus, setApprovalStatus] = useState<string>(

--- a/src/components/campaign/gm/__tests__/GmCampaignInterventionControlPlane.test.tsx
+++ b/src/components/campaign/gm/__tests__/GmCampaignInterventionControlPlane.test.tsx
@@ -1,7 +1,10 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import React from 'react';
 
-import type { IGmCampaignProjectedEffect } from '@/types/interventions';
+import type {
+  IGmCampaignProjectedEffect,
+  IGmTimeCascadeProjectedEffect,
+} from '@/types/interventions';
 
 import { createCampaign } from '@/types/campaign/Campaign';
 import { TransactionType } from '@/types/campaign/Transaction';
@@ -13,12 +16,13 @@ function fixedNow(): string {
 }
 
 describe('GmCampaignInterventionControlPlane', () => {
-  it('hydrates player-safe rows from persisted campaign intervention events', () => {
+  it('hydrates player-safe rows from persisted campaign and time intervention events', () => {
     const campaign = {
       ...createCampaign('GM Ledger Reload Test', 'mercenary', {
         startingFunds: 1_000_000,
       }),
       id: 'campaign-gm-reload',
+      currentDate: new Date('3025-01-03T00:00:00.000Z'),
       updatedAt: '3025-01-03T00:00:00.000Z',
       gmInterventionEvents: [
         {
@@ -45,6 +49,42 @@ describe('GmCampaignInterventionControlPlane', () => {
           },
         } satisfies IGmCampaignProjectedEffect,
       ],
+      timeCascadeEvents: [
+        {
+          type: 'gm.campaign.time_cascade_applied',
+          domain: 'time',
+          family: 'time-advance',
+          interventionId: 'gm-ledger-time-cascade',
+          days: 2,
+          before: {
+            currentDate: '3025-01-03T00:00:00.000Z',
+            updatedAt: '3025-01-03T00:00:00.000Z',
+            currentSystemId: 'terra',
+          },
+          after: {
+            currentDate: '3025-01-05T00:00:00.000Z',
+            updatedAt: '3025-01-05T00:00:00.000Z',
+            currentSystemId: 'terra',
+          },
+          afterCampaign: {
+            ...createCampaign('GM Ledger Reload Test', 'mercenary', {
+              startingFunds: 1_000_000,
+            }),
+            id: 'campaign-gm-reload',
+            currentDate: new Date('3025-01-05T00:00:00.000Z'),
+            updatedAt: '3025-01-05T00:00:00.000Z',
+            currentSystemId: 'terra',
+          },
+          daySummaries: [],
+          generatedEvents: [],
+          changedStateRefs: [
+            'campaign:campaign-gm-reload:currentDate',
+            'campaign:campaign-gm-reload:repairQueue',
+          ],
+          externalEffects: [],
+          publicSummary: 'Campaign time corrected by 2 days.',
+        } satisfies IGmTimeCascadeProjectedEffect,
+      ],
     };
 
     render(
@@ -58,14 +98,20 @@ describe('GmCampaignInterventionControlPlane', () => {
     expect(screen.getByTestId('gm-ledger-player-log')).toHaveTextContent(
       'Merchant charge corrected by -2,500.00 C-bills.',
     );
+    expect(screen.getByTestId('gm-ledger-player-log')).toHaveTextContent(
+      'Campaign time corrected by 2 days.',
+    );
     expect(screen.getByTestId('gm-ledger-player-log')).not.toHaveTextContent(
-      /Hidden campaign|black-market|GM-only/i,
+      /Hidden campaign|Hidden time|black-market|GM-only/i,
     );
     expect(screen.getByTestId('gm-ledger-private-log')).toHaveTextContent(
       'Merchant charge corrected by -2,500.00 C-bills.',
     );
+    expect(screen.getByTestId('gm-ledger-private-log')).toHaveTextContent(
+      'Campaign time corrected by 2 days.',
+    );
     expect(screen.getByTestId('gm-ledger-private-log')).not.toHaveTextContent(
-      /Hidden campaign|black-market|GM-only/i,
+      /Hidden campaign|Hidden time|black-market|GM-only/i,
     );
   });
 

--- a/src/lib/campaign/persistence/__tests__/serverFieldMirror.test.ts
+++ b/src/lib/campaign/persistence/__tests__/serverFieldMirror.test.ts
@@ -186,6 +186,39 @@ function buildExtendedCampaign(): ICampaignWithCommand {
         },
       },
     ],
+    timeCascadeEvents: [
+      {
+        type: 'gm.campaign.time_cascade_applied',
+        domain: 'time',
+        family: 'time-advance',
+        interventionId: 'gm-time-event-001',
+        days: 2,
+        before: {
+          currentDate: '3025-02-01T00:00:00.000Z',
+          updatedAt: base.updatedAt,
+          currentSystemId: 'new-avalon',
+        },
+        after: {
+          currentDate: '3025-02-03T00:00:00.000Z',
+          updatedAt: '3025-02-03T00:00:00.000Z',
+          currentSystemId: 'new-avalon',
+        },
+        afterCampaign: {
+          ...base,
+          currentDate: new Date('3025-02-03T00:00:00.000Z'),
+          updatedAt: '3025-02-03T00:00:00.000Z',
+          currentSystemId: 'new-avalon',
+        },
+        daySummaries: [],
+        generatedEvents: [],
+        changedStateRefs: [
+          'campaign:campaign-001:currentDate',
+          'campaign:campaign-001:repairQueue',
+        ],
+        externalEffects: [],
+        publicSummary: 'Campaign time corrected by 2 days.',
+      },
+    ],
     loans: [
       createCampaignLoan({
         id: 'loan-1',
@@ -277,6 +310,13 @@ describe('T3 — server-side campaign serialization field mirror', () => {
       family: 'funds-transaction',
       transactionId: 'gm-event-001',
     });
+    expect(restored.timeCascadeEvents).toHaveLength(1);
+    expect(restored.timeCascadeEvents![0]).toMatchObject({
+      type: 'gm.campaign.time_cascade_applied',
+      family: 'time-advance',
+      interventionId: 'gm-time-event-001',
+      days: 2,
+    });
     expect(restored.personnelMarket).toHaveLength(1);
     expect(restored.personnelMarket![0].hireCost).toBe(25_000);
     expect(restored.contractMarket).toEqual({
@@ -350,6 +390,7 @@ describe('T3 — server-side campaign serialization field mirror', () => {
     expect(restored.currentSystemId).toBeUndefined();
     expect(restored.coopSession).toBeUndefined();
     expect(restored.gmInterventionEvents).toBeUndefined();
+    expect(restored.timeCascadeEvents).toBeUndefined();
     expect(restored.personnelMarket).toBeUndefined();
     expect(restored.contractMarket).toBeUndefined();
     expect(restored.activeContract).toBeUndefined();

--- a/src/lib/campaign/persistence/serializeCampaign.ts
+++ b/src/lib/campaign/persistence/serializeCampaign.ts
@@ -162,6 +162,7 @@ export function serializeCampaign(campaign: ICampaign): SerializedCampaignBody {
     pendingBattleOutcomes: campaign.pendingBattleOutcomes,
     processedBattleIds: campaign.processedBattleIds,
     gmInterventionEvents: campaign.gmInterventionEvents,
+    timeCascadeEvents: campaign.timeCascadeEvents,
     recentlyAppliedOutcomes: campaign.recentlyAppliedOutcomes,
     // The loan ledger (CP2b — `add-campaign-command-ui`, design D4) is
     // a campaign-extension field; every `ICampaignLoan` field is already
@@ -228,6 +229,7 @@ export function deserializeCampaignBody(
     pendingBattleOutcomes: body.pendingBattleOutcomes,
     processedBattleIds: body.processedBattleIds,
     gmInterventionEvents: body.gmInterventionEvents,
+    timeCascadeEvents: body.timeCascadeEvents,
     recentlyAppliedOutcomes: body.recentlyAppliedOutcomes,
     // Restore the loan ledger (design D4). Absent on pre-CP2b snapshots,
     // in which case the campaign simply carries no `loans` field.

--- a/src/lib/interventions/GmTimeCascadeProjection.ts
+++ b/src/lib/interventions/GmTimeCascadeProjection.ts
@@ -35,9 +35,22 @@ function applyGmTimeCascadeProjectedEffect(
   state: IGmTimeCascadeInterventionState,
   effect: IGmTimeCascadeProjectedEffect,
 ): IGmTimeCascadeInterventionState {
+  const storedEffect = sanitizeStoredTimeCascadeEffect(effect);
+
   return {
     ...state,
     ...effect.afterCampaign,
-    timeCascadeEvents: [...(state.timeCascadeEvents ?? []), effect],
+    timeCascadeEvents: [...(state.timeCascadeEvents ?? []), storedEffect],
+  };
+}
+
+function sanitizeStoredTimeCascadeEffect(
+  effect: IGmTimeCascadeProjectedEffect,
+): IGmTimeCascadeProjectedEffect {
+  const { timeCascadeEvents, ...afterCampaign } = effect.afterCampaign;
+  void timeCascadeEvents;
+  return {
+    ...effect,
+    afterCampaign,
   };
 }

--- a/src/lib/interventions/__tests__/GmTimeCascadeInterventionImplementer.test.ts
+++ b/src/lib/interventions/__tests__/GmTimeCascadeInterventionImplementer.test.ts
@@ -262,6 +262,48 @@ describe('GM time cascade intervention implementer', () => {
     expect(replayed.timeCascadeEvents).toHaveLength(1);
   });
 
+  it('stores repeated cascades without recursively nesting prior event history', () => {
+    const first = approveCommand({
+      command: makeCommand(makePayload({ days: 1 })),
+      state: makeState(),
+      interventionId: 'gm-int-time-first-day',
+    });
+    const second = approveCommand({
+      command: makeCommand(
+        makePayload({
+          days: 1,
+          baseUpdatedAt: first.state.updatedAt,
+          baseCurrentDate: first.state.currentDate.toISOString(),
+          generatedAt: '2026-06-22T00:10:00.000Z',
+        }),
+      ),
+      state: first.state,
+      interventionId: 'gm-int-time-second-day',
+    });
+
+    const events = second.state.timeCascadeEvents ?? [];
+    expect(events).toHaveLength(2);
+    expect(events.map((event) => event.interventionId)).toEqual([
+      'gm-int-time-first-day',
+      'gm-int-time-second-day',
+    ]);
+    for (const event of events) {
+      expect(
+        Object.prototype.hasOwnProperty.call(
+          event.afterCampaign,
+          'timeCascadeEvents',
+        ),
+      ).toBe(false);
+    }
+
+    const firstEventBytes = JSON.stringify(
+      first.state.timeCascadeEvents,
+    ).length;
+    const secondEventBytes = JSON.stringify(events).length;
+    expect(JSON.stringify(events)).not.toContain('"timeCascadeEvents":');
+    expect(secondEventBytes).toBeLessThan(firstEventBytes * 2.5);
+  });
+
   it('records action-ledger projections while redacting GM-private context', () => {
     const actionLedger = new ActionLedger();
     actionLedger.appendNormalAction({

--- a/src/stores/campaign/__tests__/campaignPersistenceRoundTrip.test.ts
+++ b/src/stores/campaign/__tests__/campaignPersistenceRoundTrip.test.ts
@@ -350,6 +350,39 @@ describe('D-1 — campaign persistence round-trip (save → reload seam)', () =>
           },
         },
       ],
+      timeCascadeEvents: [
+        {
+          type: 'gm.campaign.time_cascade_applied',
+          domain: 'time',
+          family: 'time-advance',
+          interventionId: 'gm-time-event-001',
+          days: 2,
+          before: {
+            currentDate: '3025-02-01T00:00:00.000Z',
+            updatedAt: base.updatedAt,
+            currentSystemId: 'new-avalon',
+          },
+          after: {
+            currentDate: '3025-02-03T00:00:00.000Z',
+            updatedAt: '3025-02-03T00:00:00.000Z',
+            currentSystemId: 'new-avalon',
+          },
+          afterCampaign: {
+            ...base,
+            currentDate: new Date('3025-02-03T00:00:00.000Z'),
+            updatedAt: '3025-02-03T00:00:00.000Z',
+            currentSystemId: 'new-avalon',
+          },
+          daySummaries: [],
+          generatedEvents: [],
+          changedStateRefs: [
+            'campaign:round-trip:currentDate',
+            'campaign:round-trip:repairQueue',
+          ],
+          externalEffects: [],
+          publicSummary: 'Campaign time corrected by 2 days.',
+        },
+      ],
       combatTeams: [
         { forceId: 'force-1', role: CombatRole.PATROL, battleChance: 60 },
       ],
@@ -441,6 +474,13 @@ describe('D-1 — campaign persistence round-trip (save → reload seam)', () =>
       type: 'gm.campaign.funds_transaction_corrected',
       family: 'funds-transaction',
       transactionId: 'gm-event-001',
+    });
+    expect(reloaded.timeCascadeEvents).toHaveLength(1);
+    expect(reloaded.timeCascadeEvents![0]).toMatchObject({
+      type: 'gm.campaign.time_cascade_applied',
+      family: 'time-advance',
+      interventionId: 'gm-time-event-001',
+      days: 2,
     });
     expect(reloaded.combatTeams).toEqual([
       { forceId: 'force-1', role: CombatRole.PATROL, battleChance: 60 },
@@ -542,6 +582,7 @@ describe('D-1 — campaign persistence round-trip (save → reload seam)', () =>
     expect(loaded.loans).toBeUndefined();
     expect(loaded.finances.loans).toBeUndefined();
     expect(loaded.gmInterventionEvents).toBeUndefined();
+    expect(loaded.timeCascadeEvents).toBeUndefined();
     expect(loaded.refitOrders).toBeUndefined();
     expect(loaded.moraleState).toBeUndefined();
     expect(loaded.currentSystemId).toBeUndefined();

--- a/src/stores/campaign/useCampaignStore.persistence.ts
+++ b/src/stores/campaign/useCampaignStore.persistence.ts
@@ -39,7 +39,10 @@ import type {
   IUnitMaxState,
 } from '@/types/campaign/UnitCombatState';
 import type { ICombatOutcome } from '@/types/combat/CombatOutcome';
-import type { IGmCampaignProjectedEffect } from '@/types/interventions';
+import type {
+  IGmCampaignProjectedEffect,
+  IGmTimeCascadeProjectedEffect,
+} from '@/types/interventions';
 import type { MechBuildConfig } from '@/utils/construction/constructionRules/types';
 
 import {
@@ -125,6 +128,7 @@ export interface SerializedCampaignState {
   salvageAllocations?: Readonly<Record<string, ISalvageAllocation>>;
   salvageReports?: Readonly<Record<string, ISalvageReport>>;
   gmInterventionEvents?: readonly IGmCampaignProjectedEffect[];
+  timeCascadeEvents?: readonly IGmTimeCascadeProjectedEffect[];
   recentlyAppliedOutcomes?: readonly ICombatOutcome[];
   /**
    * Campaign command-tier loan ledger (`ICampaignCommandExtensions.loans`,
@@ -282,6 +286,7 @@ export function serializeCampaign(
     salvageAllocations: campaign.salvageAllocations,
     salvageReports: campaign.salvageReports,
     gmInterventionEvents: campaign.gmInterventionEvents,
+    timeCascadeEvents: campaign.timeCascadeEvents,
     recentlyAppliedOutcomes: campaign.recentlyAppliedOutcomes,
     // D-1 fix: the command-tier loan ledger. The borrowed cash is already
     // persisted as a finances transaction; the debt must travel with it.
@@ -374,6 +379,7 @@ export function deserializeCampaign(
     salvageAllocations: serialized.salvageAllocations,
     salvageReports: serialized.salvageReports,
     gmInterventionEvents: serialized.gmInterventionEvents,
+    timeCascadeEvents: serialized.timeCascadeEvents,
     recentlyAppliedOutcomes: serialized.recentlyAppliedOutcomes,
     // D-1 fix + sweep: command-tier ledger/markets and the
     // refit/prestige/morale/starmap fields. All optional — absent on

--- a/src/types/campaign/Campaign.ts
+++ b/src/types/campaign/Campaign.ts
@@ -12,6 +12,7 @@ import type { MechBuildConfig } from '@/utils/construction/constructionRules/typ
 
 import type { ICombatOutcome } from '../combat/CombatOutcome';
 import type { IGmCampaignProjectedEffect } from '../interventions/GmCampaignInterventionTypes';
+import type { IGmTimeCascadeProjectedEffect } from '../interventions/GmTimeCascadeInterventionTypes';
 import type { IShoppingList } from './acquisition/acquisitionTypes';
 import type { ICampaignOptions } from './CampaignOptions';
 import type { ICoopSession } from './CoopSession';
@@ -178,6 +179,13 @@ export interface ICampaign {
    * GM-only metadata stays in the intervention/action ledger records.
    */
   readonly gmInterventionEvents?: readonly IGmCampaignProjectedEffect[];
+
+  /**
+   * Approved GM time-cascade effects retained for audit/replay surfaces.
+   * Player projections expose only the public summary; GM-private metadata
+   * stays in intervention/action ledger records.
+   */
+  readonly timeCascadeEvents?: readonly IGmTimeCascadeProjectedEffect[];
 
   /** Applied outcomes retained for current morale/windowed processors. */
   readonly recentlyAppliedOutcomes?: readonly ICombatOutcome[];

--- a/src/types/campaign/SerializedCampaign.ts
+++ b/src/types/campaign/SerializedCampaign.ts
@@ -14,7 +14,10 @@
 import type { MechBuildConfig } from '@/utils/construction/constructionRules/types';
 
 import type { ICombatOutcome } from '../combat/CombatOutcome';
-import type { IGmCampaignProjectedEffect } from '../interventions';
+import type {
+  IGmCampaignProjectedEffect,
+  IGmTimeCascadeProjectedEffect,
+} from '../interventions';
 import type { IShoppingList } from './acquisition/acquisitionTypes';
 import type {
   ICampaignActiveContract,
@@ -144,6 +147,7 @@ export interface SerializedCampaignBody {
   readonly pendingBattleOutcomes?: readonly ICombatOutcome[];
   readonly processedBattleIds?: readonly string[];
   readonly gmInterventionEvents?: readonly IGmCampaignProjectedEffect[];
+  readonly timeCascadeEvents?: readonly IGmTimeCascadeProjectedEffect[];
   readonly recentlyAppliedOutcomes?: readonly ICombatOutcome[];
   /**
    * The campaign's loan ledger (CP2b — `add-campaign-command-ui`,


### PR DESCRIPTION
## Summary
- persist GM time-cascade projected effects through campaign types, server/client serializers, and reload-backed store hydration
- hydrate persisted GM time-cascade ledger rows into the campaign GM control plane without exposing hidden GM-only details to player logs
- add reload-backed browser proof for time-cascade state, recursion protection for repeated cascades, and QC registry/graph coverage updates
- harden release validators so generated Electron packaging output does not create false warning-ledger findings or recursive QC indexing failures
- give `next build` a tunable default heap limit through `scripts/next/run-next.mjs` so Electron release build verification is repeatable locally

## Validation
- `npm.cmd run verify:app-completion:release`
- `npm.cmd run electron:test:build`
- `npm.cmd run typecheck -- --pretty false`
- `git diff --check`
- `npm.cmd test -- --watchAll=false --runTestsByPath scripts/__tests__/maintenance-warning-ledger.test.ts --runInBand`
- `npm.cmd test -- --watchAll=false --runTestsByPath scripts/__tests__/qc-registry.test.ts --runInBand`
- `node scripts/qc/validate-maintenance-warning-ledger.mjs`
- `npm.cmd run qc:validate`

## Notes
- Local Electron package verification passed for Windows; macOS/Linux package binaries are configuration-skipped locally and remain CI/platform-owned.