### PR TITLE
Harden campaign GM authority boundaries

### DIFF
--- a/docs/architecture/gm-campaign-intervention-boundaries.md
+++ b/docs/architecture/gm-campaign-intervention-boundaries.md
@@ -1,23 +1,32 @@
 # GM Campaign Intervention Boundaries
 
-This note documents the first-slice boundary for GM interventions outside active combat. The ledger, authority, redaction, preview, and approval pipeline is live for combat and unit reload. Campaign cascade domains stay explicit deferred domains until their own implementers can prove mutation scope, replay order, and player-safe projection.
+This note documents the current boundary for GM interventions outside active combat. The ledger, authority, redaction, preview, and approval pipeline is live for combat, unit reload, campaign funds corrections, and accumulated campaign time corrections.
+
+Campaign GM controls are owner/host-only surfaces. Single-player campaign owners and co-op hosts may preview, approve, and manually take over supported corrections. Co-op guests may only see player-public ledger projections for approved effects; GM-private reason, default outcome, hidden notes, and manual takeover notes stay out of player mirrors.
+
+## Supported Campaign Domains
+
+| Domain    | Mutable roots                                    | Public projection fields                                   | Current result                                  |
+| --------- | ------------------------------------------------ | ---------------------------------------------------------- | ----------------------------------------------- |
+| `economy` | campaign funds, merchant transaction ledger      | net C-bill delta, public transaction summary, changed refs | supported for funds transaction corrections     |
+| `time`    | campaign clock, repair queue, generated day work | public time delta, visible timeline summary, changed refs  | supported for accumulated time-cascade advances |
 
 ## Deferred Domains
 
-| Domain        | Future mutable roots                                                              | Future public projection fields                                     | First-slice result    |
-| ------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------- | --------------------- |
-| `post-combat` | scenario result, payout summary, injury/death outcomes, salvage offer state       | public result delta, visible casualty/salvage summary, changed refs | deferred, no mutation |
-| `economy`     | campaign funds, merchant transaction ledger, inventory lots, market stock         | net C-bill delta, public inventory delta, merchant transaction ref  | deferred, no mutation |
-| `repair`      | repair queue, parts usage, technician assignment, bay schedule                    | public queue delta, visible repair status, changed unit refs        | deferred, no mutation |
-| `salvage`     | salvage pool, claim assignments, scrapping/selling decisions, inventory additions | public salvage delta, visible inventory delta, claim refs           | deferred, no mutation |
-| `time`        | campaign clock, travel progress, contract deadlines, queued time effects          | public time delta, visible deadline/travel changes, changed refs    | deferred, no mutation |
+| Domain        | Future mutable roots                                                              | Future public projection fields                                     | Current result                |
+| ------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------- | ----------------------------- |
+| `post-combat` | scenario result, payout summary, injury/death outcomes, salvage offer state       | public result delta, visible casualty/salvage summary, changed refs | deferred, no mutation         |
+| `economy`     | inventory lots, market stock, merchant inventory                                  | public inventory delta, merchant transaction ref                    | not covered by funds slice    |
+| `repair`      | repair queue edits, parts usage, technician assignment, bay schedule              | public queue delta, visible repair status, changed unit refs        | deferred beyond time tick     |
+| `salvage`     | salvage pool, claim assignments, scrapping/selling decisions, inventory additions | public salvage delta, visible inventory delta, claim refs           | deferred, no mutation         |
+| `time`        | travel progress, contract deadlines, complex queued time effects                  | visible deadline/travel changes, changed refs                       | deferred beyond 2-day advance |
 
 ## Future Implementer Seams
 
 - Post-combat amendments should wrap combat outcome edits and campaign sync deltas in one preview so payouts, injuries, salvage, and objective state cannot drift independently.
 - Co-op GM arbitration should extend the authority context with host/owner identity and explicit arbitration records before allowing another GM to mutate a campaign owned by someone else.
-- Finance and inventory reversals should treat merchant transactions as reversible ledger entries with net funds, stock, and inventory effects previewed together.
+- Inventory reversals should treat merchant stock and inventory effects as reversible ledger entries with net funds, stock, and inventory effects previewed together.
 - Repair and salvage corrections should validate that unit refs, parts, bay capacity, and technician assignments still exist before approval.
 - Time cascades should preview every accumulated effect caused by the clock change, including travel, deadlines, repair ticks, hiring windows, and contract availability.
 
-Player-facing records for these future domains must show only the resulting public net effect and changed state refs. GM-private reason, default outcome, hidden scenario notes, and manual takeover notes stay in private projection only.
+Player-facing records for supported and future domains must show only the resulting public net effect and changed state refs. GM-private reason, default outcome, hidden scenario notes, and manual takeover notes stay in private projection only.

--- a/e2e/gm-campaign-ledger-control-plane.spec.ts
+++ b/e2e/gm-campaign-ledger-control-plane.spec.ts
@@ -2,10 +2,45 @@ import { expect, test, type Page } from '@playwright/test';
 
 import { createTestCampaign, deleteCampaign } from './fixtures/campaign';
 
+test.setTimeout(120_000);
+
 type CampaignTimeState = {
   readonly currentDate: string | null;
   readonly timeCascadeEventCount: number;
 };
+
+async function stampGuestCoopSession(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    type CampaignStoreApi = {
+      getState: () => {
+        updateCampaign: (updates: Record<string, unknown>) => void;
+      };
+    };
+    type ExposedCampaignStore = CampaignStoreApi | (() => CampaignStoreApi);
+
+    const stores = (
+      window as unknown as {
+        __ZUSTAND_STORES__?: {
+          campaign?: ExposedCampaignStore;
+        };
+      }
+    ).__ZUSTAND_STORES__;
+
+    if (!stores?.campaign) {
+      throw new Error('Campaign store not exposed');
+    }
+
+    const exposed = stores.campaign;
+    const store = 'getState' in exposed ? exposed : exposed();
+    store.getState().updateCampaign({
+      coopSession: {
+        mode: 'guest',
+        roomCode: 'GUESTGM',
+        hostMatchId: 'match-gm-ledger-host',
+      },
+    });
+  });
+}
 
 async function readCampaignTimeState(page: Page): Promise<CampaignTimeState> {
   return page.evaluate(() => {
@@ -107,6 +142,63 @@ test.describe('GM campaign ledger control plane @gm-ledger', () => {
       await expect(page.getByTestId('gm-ledger-private-log')).not.toContainText(
         /Hidden campaign|black-market|GM-only/i,
       );
+    } finally {
+      if (campaignId) {
+        await deleteCampaign(page, campaignId);
+      }
+    }
+  });
+
+  test('guest direct route shows only player-safe ledger projection', async ({
+    page,
+  }) => {
+    let campaignId = '';
+
+    await page.goto('/gameplay/campaigns', { waitUntil: 'domcontentloaded' });
+    campaignId = await createTestCampaign(page, {
+      name: 'GM Ledger Guest Direct Proof',
+      cBills: 1_000_000,
+    });
+
+    try {
+      await page.goto(`/gameplay/campaigns/${campaignId}/gm-ledger`, {
+        waitUntil: 'domcontentloaded',
+      });
+      await page.getByTestId('gm-ledger-preview-btn').click();
+      await page.getByTestId('gm-ledger-approve-btn').click();
+      await expect(page.getByTestId('gm-ledger-approval-status')).toContainText(
+        'Approved and applied',
+      );
+
+      await stampGuestCoopSession(page);
+      await page.goto(`/gameplay/campaigns/${campaignId}/gm-ledger`, {
+        waitUntil: 'domcontentloaded',
+      });
+
+      await expect(page.getByTestId('page-title')).toContainText('GM Ledger');
+      await expect(page.getByTestId('coop-session-badge')).toContainText(
+        'Co-op session: Guest',
+      );
+      await expect(
+        page.getByTestId('gm-ledger-player-only-notice'),
+      ).toContainText(
+        'GM controls are available only to the campaign owner or co-op host',
+      );
+      await expect(page.getByTestId('gm-ledger-player-log')).toContainText(
+        'Merchant charge corrected by -2,500.00 C-bills.',
+      );
+      await expect(page.getByTestId('gm-ledger-player-log')).not.toContainText(
+        /Hidden campaign|black-market|GM-only|default outcome/i,
+      );
+      await expect(page.getByTestId('gm-ledger-preview-btn')).toHaveCount(0);
+      await expect(page.getByTestId('gm-ledger-approve-btn')).toHaveCount(0);
+      await expect(page.getByTestId('gm-ledger-manual-btn')).toHaveCount(0);
+      await expect(page.getByTestId('gm-ledger-private-log')).toHaveCount(0);
+      await expect(
+        page
+          .getByRole('navigation', { name: 'Campaign sections' })
+          .getByRole('link', { name: 'GM Ledger' }),
+      ).toHaveCount(0);
     } finally {
       if (campaignId) {
         await deleteCampaign(page, campaignId);

--- a/openspec/changes/archive/2026-06-29-harden-gm-authority-operator-flow/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-29-harden-gm-authority-operator-flow/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-29

--- a/openspec/changes/archive/2026-06-29-harden-gm-authority-operator-flow/design.md
+++ b/openspec/changes/archive/2026-06-29-harden-gm-authority-operator-flow/design.md
@@ -1,0 +1,23 @@
+## Overview
+
+Use the existing campaign authority signal instead of introducing a new auth system. A campaign without `coopSession` is a local owner-controlled campaign. A co-op campaign with `coopSession.mode === 'host'` is also GM-owned locally. A co-op campaign with `coopSession.mode === 'guest'` is a player mirror with no campaign-write authority.
+
+## Decisions
+
+- Add a small campaign authority helper that resolves GM/player capabilities from `campaign.coopSession`.
+- Gate the `GM Ledger` campaign command tab with that helper.
+- Keep direct route recovery safe: an unauthorized guest who enters `/gameplay/campaigns/[id]/gm-ledger` sees the player action log projection only, not preview/approval controls or GM-private metadata.
+- Preserve all existing owner/host GM ledger tests and browser flows.
+- Update stale boundary documentation to match the current implemented economy and time-cascade slices.
+
+## Validation
+
+- Component tests for command navigation visibility.
+- Component tests for guest/player ledger projection redaction.
+- Browser test for a guest mirror direct route: no GM controls, no private log, player-safe public history only.
+- Focused GM ledger validator and existing GM browser proof continue passing.
+
+## Risks
+
+- This does not prove account-level ownership. It only hardens the current authority model encoded in campaign session state.
+- Some older campaign pages instantiate `CampaignNavigation` directly; those call sites need the same authority behavior through the shared component default.

--- a/openspec/changes/archive/2026-06-29-harden-gm-authority-operator-flow/proposal.md
+++ b/openspec/changes/archive/2026-06-29-harden-gm-authority-operator-flow/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+The GM ledger engine now validates economy and time-cascade corrections, but the app still exposes the GM Ledger as a normal campaign command tab and the control plane assumes GM authority. The next operator-flow slice needs the UI to distinguish owner/host GM authority from guest/player mirrors so private GM reasoning cannot be reached through normal navigation or direct routes.
+
+## What Changes
+
+- Gate the campaign GM Ledger tab to users with campaign GM authority: single-player campaign owners and co-op hosts.
+- Make guest/player mirrors that deep-link to the GM Ledger route render only the player-safe ledger projection and a clear authority explanation.
+- Keep existing GM preview, approval, manual takeover, and redaction behavior unchanged for owner/host campaigns.
+- Update the intervention boundary documentation so economy and time cascade domains are no longer described as deferred when current implementers and QC gates support them.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `coop-campaign-sync`: Host-as-GM authority must gate campaign GM ledger controls and private projection visibility.
+- `campaign-command-ui`: Campaign command navigation must expose GM Ledger only to authorized campaign GM viewers.
+- `gm-campaign-intervention-boundaries`: Campaign GM correction surfaces must distinguish mutable GM control access from player-safe public ledger projection.
+
+## Non-goals
+
+- Adding full authentication or account ownership beyond the current single-player/co-op host/guest authority model.
+- Implementing new campaign correction families beyond the existing economy and time-cascade browser control plane.
+- Expanding tactical combat GM interventions; that remains a separate combat UI slice.
+
+## Impact
+
+- `src/components/campaign/CampaignNavigation.tsx`
+- `src/pages/gameplay/campaigns/[id]/gm-ledger.tsx`
+- `src/components/campaign/gm/*`
+- `src/lib/campaign/*`
+- `src/components/campaign/**/__tests__`
+- `e2e/gm-campaign-ledger-control-plane.spec.ts`
+- `docs/architecture/gm-campaign-intervention-boundaries.md`

--- a/openspec/changes/archive/2026-06-29-harden-gm-authority-operator-flow/specs/campaign-command-ui/spec.md
+++ b/openspec/changes/archive/2026-06-29-harden-gm-authority-operator-flow/specs/campaign-command-ui/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: GM Ledger Command Tab Is Authority-Gated
+
+The campaign command navigation SHALL expose the GM Ledger tab only when the local viewer has campaign GM authority. Single-player campaigns and co-op host campaigns SHALL have campaign GM authority. Co-op guest campaign mirrors SHALL not render the GM Ledger tab.
+
+#### Scenario: Single-player campaign shows GM Ledger
+
+- **GIVEN** a single-player campaign with no `coopSession`
+- **WHEN** campaign navigation renders
+- **THEN** the Command group SHALL include the GM Ledger tab
+
+#### Scenario: Co-op guest campaign hides GM Ledger
+
+- **GIVEN** a co-op campaign with `coopSession.mode === 'guest'`
+- **WHEN** campaign navigation renders
+- **THEN** the Command group SHALL not include the GM Ledger tab

--- a/openspec/changes/archive/2026-06-29-harden-gm-authority-operator-flow/specs/coop-campaign-sync/spec.md
+++ b/openspec/changes/archive/2026-06-29-harden-gm-authority-operator-flow/specs/coop-campaign-sync/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Campaign GM Ledger Respects Host Authority
+
+The co-op campaign route surface SHALL treat the host as the campaign GM and the guest as a player mirror for GM ledger controls. Guest mirrors SHALL NOT expose controls that preview, approve, manually take over, or reveal GM-private campaign correction context.
+
+#### Scenario: Host sees campaign GM ledger controls
+
+- **GIVEN** a co-op campaign with `coopSession.mode === 'host'`
+- **WHEN** the campaign command navigation renders
+- **THEN** the GM Ledger route SHALL be visible
+- **AND** the GM Ledger page SHALL render preview, approval, and manual-takeover controls
+
+#### Scenario: Guest sees only player-safe ledger projection
+
+- **GIVEN** a co-op campaign with `coopSession.mode === 'guest'`
+- **WHEN** the guest deep-links to `/gameplay/campaigns/[id]/gm-ledger`
+- **THEN** the page SHALL omit GM preview, approval, and manual-takeover controls
+- **AND** it SHALL omit GM-private ledger projection
+- **AND** it SHALL show only player-public ledger summaries and an authority explanation

--- a/openspec/changes/archive/2026-06-29-harden-gm-authority-operator-flow/specs/gm-campaign-intervention-boundaries/spec.md
+++ b/openspec/changes/archive/2026-06-29-harden-gm-authority-operator-flow/specs/gm-campaign-intervention-boundaries/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Player-Safe Campaign Ledger Route
+
+The campaign GM intervention route SHALL separate mutable GM controls from player-public ledger review. A viewer without campaign GM authority SHALL be allowed to inspect public campaign correction effects when they are part of that campaign mirror, but SHALL NOT access GM-private metadata or mutation controls.
+
+#### Scenario: Player mirror direct route is read-only
+
+- **GIVEN** a campaign mirror containing approved GM campaign or time-cascade projected effects
+- **AND** the local viewer has no campaign GM authority
+- **WHEN** the viewer opens the GM ledger route directly
+- **THEN** the route SHALL render public summaries for the projected effects
+- **AND** it SHALL not render preview, approve, or manual-takeover buttons
+- **AND** it SHALL not render GM rationale, hidden notes, default outcome, or manual takeover notes
+
+#### Scenario: Owning GM route remains mutable
+
+- **GIVEN** a single-player campaign owner or co-op host opens the GM ledger route
+- **WHEN** the route renders
+- **THEN** the GM preview, approval, and manual-takeover controls SHALL remain available
+- **AND** the GM-private projection MAY include private metadata for that owner/host viewer

--- a/openspec/changes/archive/2026-06-29-harden-gm-authority-operator-flow/tasks.md
+++ b/openspec/changes/archive/2026-06-29-harden-gm-authority-operator-flow/tasks.md
@@ -1,0 +1,8 @@
+# Tasks
+
+- [x] Add campaign authority helper for owner/host versus guest/player mirrors.
+- [x] Gate campaign navigation GM Ledger tab by resolved authority.
+- [x] Add read-only player-safe GM ledger route state for unauthorized direct links.
+- [x] Update stale GM campaign intervention boundary documentation.
+- [x] Add/adjust component and browser tests for host/guest authority behavior.
+- [x] Run focused OpenSpec, GM ledger, typecheck, and browser validations.

--- a/openspec/specs/campaign-command-ui/spec.md
+++ b/openspec/specs/campaign-command-ui/spec.md
@@ -124,3 +124,18 @@ consistent with the existing `campaign-ui` conventions.
 - **WHEN** the action is invoked
 - **THEN** the action SHALL fail gracefully with an error state rather than corrupting campaign state
 
+### Requirement: GM Ledger Command Tab Is Authority-Gated
+
+The campaign command navigation SHALL expose the GM Ledger tab only when the local viewer has campaign GM authority. Single-player campaigns and co-op host campaigns SHALL have campaign GM authority. Co-op guest campaign mirrors SHALL not render the GM Ledger tab.
+
+#### Scenario: Single-player campaign shows GM Ledger
+
+- **GIVEN** a single-player campaign with no `coopSession`
+- **WHEN** campaign navigation renders
+- **THEN** the Command group SHALL include the GM Ledger tab
+
+#### Scenario: Co-op guest campaign hides GM Ledger
+
+- **GIVEN** a co-op campaign with `coopSession.mode === 'guest'`
+- **WHEN** campaign navigation renders
+- **THEN** the Command group SHALL not include the GM Ledger tab

--- a/openspec/specs/coop-campaign-sync/spec.md
+++ b/openspec/specs/coop-campaign-sync/spec.md
@@ -464,3 +464,22 @@ The host-as-GM arbiter SHALL auto-veto a `pending` guest proposal that sits unan
 **WHEN** the host clicks `approve` or `veto` before the timeout fires
 **THEN** the arbiter SHALL emit the host's decision normally
 **AND** the timeout watchdog SHALL NOT fire (the proposal is no longer pending)
+
+### Requirement: Campaign GM Ledger Respects Host Authority
+
+The co-op campaign route surface SHALL treat the host as the campaign GM and the guest as a player mirror for GM ledger controls. Guest mirrors SHALL NOT expose controls that preview, approve, manually take over, or reveal GM-private campaign correction context.
+
+#### Scenario: Host sees campaign GM ledger controls
+
+- **GIVEN** a co-op campaign with `coopSession.mode === 'host'`
+- **WHEN** the campaign command navigation renders
+- **THEN** the GM Ledger route SHALL be visible
+- **AND** the GM Ledger page SHALL render preview, approval, and manual-takeover controls
+
+#### Scenario: Guest sees only player-safe ledger projection
+
+- **GIVEN** a co-op campaign with `coopSession.mode === 'guest'`
+- **WHEN** the guest deep-links to `/gameplay/campaigns/[id]/gm-ledger`
+- **THEN** the page SHALL omit GM preview, approval, and manual-takeover controls
+- **AND** it SHALL omit GM-private ledger projection
+- **AND** it SHALL show only player-public ledger summaries and an authority explanation

--- a/openspec/specs/gm-campaign-intervention-boundaries/spec.md
+++ b/openspec/specs/gm-campaign-intervention-boundaries/spec.md
@@ -135,3 +135,23 @@ The campaign intervention boundary SHALL expose a QC coverage matrix for the sup
 - **WHEN** the time-cascade QC validator runs
 - **THEN** it SHALL verify anchors for date, travel, repair, contract, market, finance, and campaign-owned unit-state roots
 - **AND** it SHALL verify external-store effects remain explicit projected effects or manual-takeover conflicts
+
+### Requirement: Player-Safe Campaign Ledger Route
+
+The campaign GM intervention route SHALL separate mutable GM controls from player-public ledger review. A viewer without campaign GM authority SHALL be allowed to inspect public campaign correction effects when they are part of that campaign mirror, but SHALL NOT access GM-private metadata or mutation controls.
+
+#### Scenario: Player mirror direct route is read-only
+
+- **GIVEN** a campaign mirror containing approved GM campaign or time-cascade projected effects
+- **AND** the local viewer has no campaign GM authority
+- **WHEN** the viewer opens the GM ledger route directly
+- **THEN** the route SHALL render public summaries for the projected effects
+- **AND** it SHALL not render preview, approve, or manual-takeover buttons
+- **AND** it SHALL not render GM rationale, hidden notes, default outcome, or manual takeover notes
+
+#### Scenario: Owning GM route remains mutable
+
+- **GIVEN** a single-player campaign owner or co-op host opens the GM ledger route
+- **WHEN** the route renders
+- **THEN** the GM preview, approval, and manual-takeover controls SHALL remain available
+- **AND** the GM-private projection MAY include private metadata for that owner/host viewer

--- a/scripts/__tests__/gm-campaign-ledger-qc.test.ts
+++ b/scripts/__tests__/gm-campaign-ledger-qc.test.ts
@@ -62,7 +62,7 @@ describe('GM campaign ledger QC validator', () => {
       status: string;
       requiredDomains: string[];
       requiredFamilies: string[];
-      anchors: unknown[];
+      anchors: Array<{ id: string }>;
       surface: { surfaceId: string; parentId: string };
     };
     expect(manifest.status).toBe('pass');
@@ -79,7 +79,13 @@ describe('GM campaign ledger QC validator', () => {
       'inventory-lot',
       'base-unit-state',
     ]);
-    expect(manifest.anchors).toHaveLength(14);
+    expect(manifest.anchors).toHaveLength(16);
+    expect(manifest.anchors.map((anchor) => anchor.id)).toEqual(
+      expect.arrayContaining([
+        'campaign-gm-ledger-authority-helper',
+        'campaign-gm-ledger-player-view',
+      ]),
+    );
     expect(manifest.surface).toMatchObject({
       surfaceId: 'post-combat-base-economy-gm-ledger',
       parentId: 'campaign-economy-progression',

--- a/scripts/qc/validate-gm-campaign-ledger.mjs
+++ b/scripts/qc/validate-gm-campaign-ledger.mjs
@@ -135,8 +135,22 @@ const defaultSourceAnchors = [
     path: 'src/pages/gameplay/campaigns/[id]/gm-ledger.tsx',
     tokens: [
       'GmCampaignInterventionControlPlane',
+      'GmCampaignPlayerLedgerView',
+      'resolveCampaignAuthorityFromSession',
       "currentPage: 'gm-ledger'",
       'onApplyCampaignUpdate',
+    ],
+  },
+  {
+    id: 'campaign-gm-ledger-authority-helper',
+    path: 'src/lib/campaign/campaignAuthority.ts',
+    tokens: [
+      'resolveCampaignAuthorityFromSession',
+      'canUseCampaignGmControls',
+      'single-player-owner',
+      'coop-host',
+      'coop-guest',
+      'canViewGmPrivateLedger',
     ],
   },
   {
@@ -164,6 +178,16 @@ const defaultSourceAnchors = [
     ],
   },
   {
+    id: 'campaign-gm-ledger-player-view',
+    path: 'src/components/campaign/gm/GmCampaignPlayerLedgerView.tsx',
+    tokens: [
+      'gm-ledger-player-only-view',
+      'gm-ledger-player-only-notice',
+      'buildPersistedCampaignEventRows',
+      'GM controls are available only to the campaign owner or co-op host',
+    ],
+  },
+  {
     id: 'campaign-gm-ledger-projections',
     path: 'src/components/campaign/gm/GmCampaignLedgerProjection.tsx',
     tokens: [
@@ -177,9 +201,12 @@ const defaultSourceAnchors = [
     path: 'e2e/gm-campaign-ledger-control-plane.spec.ts',
     tokens: [
       'previews, approves, and redacts a merchant reversal',
+      'guest direct route shows only player-safe ledger projection',
       'blocks conflicted cascades until the GM takes manual control',
       'gm-ledger-player-log',
       'gm-ledger-private-log',
+      'gm-ledger-player-only-notice',
+      "getByRole('navigation', { name: 'Campaign sections' })",
       'not.toContainText',
     ],
   },
@@ -188,6 +215,8 @@ const defaultSourceAnchors = [
     path: 'src/components/campaign/gm/__tests__/GmCampaignInterventionControlPlane.test.tsx',
     tokens: [
       'previews and approves a funds correction with player-safe output',
+      'GmCampaignPlayerLedgerView',
+      'renders only player-safe persisted ledger rows',
       'blocks conflicted approval and records manual takeover without mutating state',
       'Hidden campaign',
       'No campaign state changed',

--- a/src/components/campaign/CampaignNavigation.tsx
+++ b/src/components/campaign/CampaignNavigation.tsx
@@ -28,6 +28,8 @@ import Link from 'next/link';
 
 import type { ICoopSession } from '@/types/campaign/CoopSession';
 
+import { canUseCampaignGmControls } from '@/lib/campaign/campaignAuthority';
+
 /**
  * Identifier of the currently-active campaign page. The bay pages
  * (`mech-bay`, `repair-bay`, `medical-bay`, `salvage`) were added by CP2a;
@@ -73,6 +75,8 @@ export function CampaignNavigation({
   currentPage,
   coopSession,
 }: CampaignNavigationProps): React.ReactElement {
+  const canUseGmLedger = canUseCampaignGmControls(coopSession);
+
   const tabs: readonly NavTab[] = [
     {
       id: 'dashboard',
@@ -159,11 +163,15 @@ export function CampaignNavigation({
       label: 'Prestige & Morale',
       href: `/gameplay/campaigns/${campaignId}/prestige-morale`,
     },
-    {
-      id: 'gm-ledger',
-      label: 'GM Ledger',
-      href: `/gameplay/campaigns/${campaignId}/gm-ledger`,
-    },
+    ...(canUseGmLedger
+      ? [
+          {
+            id: 'gm-ledger',
+            label: 'GM Ledger',
+            href: `/gameplay/campaigns/${campaignId}/gm-ledger`,
+          } satisfies NavTab,
+        ]
+      : []),
   ];
 
   const renderTab = (tab: NavTab): React.ReactElement => (

--- a/src/components/campaign/__tests__/CampaignNavigation.test.tsx
+++ b/src/components/campaign/__tests__/CampaignNavigation.test.tsx
@@ -11,6 +11,11 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 
+import {
+  createGuestCoopSession,
+  createHostCoopSession,
+} from '@/types/campaign/CoopSession';
+
 import { CampaignNavigation } from '../CampaignNavigation';
 
 describe('CampaignNavigation — Bays group', () => {
@@ -103,6 +108,37 @@ describe('CampaignNavigation — Command group', () => {
     expect(screen.getByText('GM Ledger')).toHaveAttribute(
       'href',
       '/gameplay/campaigns/campaign-1/gm-ledger',
+    );
+  });
+
+  it('shows GM Ledger for co-op hosts', () => {
+    render(
+      <CampaignNavigation
+        campaignId="campaign-1"
+        currentPage="dashboard"
+        coopSession={createHostCoopSession('HOST1', 'match-host')}
+      />,
+    );
+    expect(screen.getByText('GM Ledger')).toHaveAttribute(
+      'href',
+      '/gameplay/campaigns/campaign-1/gm-ledger',
+    );
+    expect(screen.getByTestId('coop-session-badge')).toHaveTextContent(
+      'Co-op session: Host',
+    );
+  });
+
+  it('hides GM Ledger for co-op guests', () => {
+    render(
+      <CampaignNavigation
+        campaignId="campaign-1"
+        currentPage="dashboard"
+        coopSession={createGuestCoopSession('match-host', 'GUEST1')}
+      />,
+    );
+    expect(screen.queryByText('GM Ledger')).not.toBeInTheDocument();
+    expect(screen.getByTestId('coop-session-badge')).toHaveTextContent(
+      'Co-op session: Guest',
     );
   });
 

--- a/src/components/campaign/gm/GmCampaignPlayerLedgerView.tsx
+++ b/src/components/campaign/gm/GmCampaignPlayerLedgerView.tsx
@@ -1,0 +1,61 @@
+import React, { useMemo } from 'react';
+
+import type { ICampaign } from '@/types/campaign/Campaign';
+
+import { Card } from '@/components/ui';
+
+import {
+  buildPersistedCampaignEventRows,
+  GM_ACTOR_ID,
+} from './GmCampaignInterventionControlPlane.helpers';
+import { LedgerProjection } from './GmCampaignLedgerProjection';
+
+interface GmCampaignPlayerLedgerViewProps {
+  readonly campaign: ICampaign;
+  readonly actorId?: string;
+}
+
+export function GmCampaignPlayerLedgerView({
+  campaign,
+  actorId = GM_ACTOR_ID,
+}: GmCampaignPlayerLedgerViewProps): React.ReactElement {
+  const playerRows = useMemo(
+    () =>
+      buildPersistedCampaignEventRows(
+        campaign.gmInterventionEvents,
+        campaign.timeCascadeEvents,
+        campaign.updatedAt,
+        actorId,
+      ).playerRows,
+    [
+      actorId,
+      campaign.gmInterventionEvents,
+      campaign.timeCascadeEvents,
+      campaign.updatedAt,
+    ],
+  );
+
+  return (
+    <section
+      className="space-y-6"
+      data-testid="gm-ledger-player-only-view"
+      aria-label="Player campaign ledger"
+    >
+      <Card className="p-4" data-testid="gm-ledger-player-only-notice">
+        <p className="text-text-theme-secondary text-xs uppercase">
+          GM authority required
+        </p>
+        <p className="text-text-theme-primary mt-2 text-sm">
+          GM controls are available only to the campaign owner or co-op host.
+          This mirror shows player-visible ledger effects only.
+        </p>
+      </Card>
+
+      <LedgerProjection
+        title="Player Action Log"
+        rows={playerRows}
+        testId="gm-ledger-player-log"
+      />
+    </section>
+  );
+}

--- a/src/components/campaign/gm/__tests__/GmCampaignInterventionControlPlane.test.tsx
+++ b/src/components/campaign/gm/__tests__/GmCampaignInterventionControlPlane.test.tsx
@@ -10,6 +10,7 @@ import { createCampaign } from '@/types/campaign/Campaign';
 import { TransactionType } from '@/types/campaign/Transaction';
 
 import { GmCampaignInterventionControlPlane } from '../GmCampaignInterventionControlPlane';
+import { GmCampaignPlayerLedgerView } from '../GmCampaignPlayerLedgerView';
 
 function fixedNow(): string {
   return '3025-01-01T00:00:00.000Z';
@@ -255,6 +256,108 @@ describe('GmCampaignInterventionControlPlane', () => {
     );
     expect(screen.getByTestId('gm-ledger-private-log')).toHaveTextContent(
       'Manual takeover selected',
+    );
+  });
+});
+
+describe('GmCampaignPlayerLedgerView', () => {
+  it('renders only player-safe persisted ledger rows', () => {
+    const campaign = {
+      ...createCampaign('GM Ledger Guest Mirror Test', 'mercenary', {
+        startingFunds: 1_000_000,
+      }),
+      id: 'campaign-gm-guest',
+      updatedAt: '3025-01-03T00:00:00.000Z',
+      gmInterventionEvents: [
+        {
+          type: 'gm.campaign.funds_transaction_corrected',
+          domain: 'economy',
+          family: 'funds-transaction',
+          interventionId: 'gm-ledger-merchant-reversal',
+          transactionId: 'gm-ledger-merchant-reversal',
+          changedStateRefs: ['campaign:campaign-gm-guest:finances'],
+          publicSummary: 'Merchant charge corrected by -2,500.00 C-bills.',
+          before: {
+            balanceCents: 100_000_000,
+            transactionIds: [],
+          },
+          after: {
+            balanceCents: 99_750_000,
+            transaction: {
+              id: 'gm-ledger-merchant-reversal',
+              type: TransactionType.PartPurchase,
+              amountCents: -250_000,
+              date: '3025-01-03T00:00:00.000Z',
+              description: 'GM merchant charge reversal',
+            },
+          },
+        } satisfies IGmCampaignProjectedEffect,
+      ],
+      timeCascadeEvents: [
+        {
+          type: 'gm.campaign.time_cascade_applied',
+          domain: 'time',
+          family: 'time-advance',
+          interventionId: 'gm-ledger-time-cascade',
+          days: 2,
+          before: {
+            currentDate: '3025-01-03T00:00:00.000Z',
+            updatedAt: '3025-01-03T00:00:00.000Z',
+            currentSystemId: 'terra',
+          },
+          after: {
+            currentDate: '3025-01-05T00:00:00.000Z',
+            updatedAt: '3025-01-05T00:00:00.000Z',
+            currentSystemId: 'terra',
+          },
+          afterCampaign: {
+            ...createCampaign('GM Ledger Guest Mirror Test', 'mercenary', {
+              startingFunds: 1_000_000,
+            }),
+            id: 'campaign-gm-guest',
+            currentDate: new Date('3025-01-05T00:00:00.000Z'),
+            updatedAt: '3025-01-05T00:00:00.000Z',
+            currentSystemId: 'terra',
+          },
+          daySummaries: [],
+          generatedEvents: [],
+          changedStateRefs: [
+            'campaign:campaign-gm-guest:currentDate',
+            'campaign:campaign-gm-guest:repairQueue',
+          ],
+          externalEffects: [],
+          publicSummary: 'Campaign time corrected by 2 days.',
+        } satisfies IGmTimeCascadeProjectedEffect,
+      ],
+    };
+
+    render(<GmCampaignPlayerLedgerView campaign={campaign} />);
+
+    expect(
+      screen.getByTestId('gm-ledger-player-only-notice'),
+    ).toHaveTextContent(
+      'GM controls are available only to the campaign owner or co-op host',
+    );
+    expect(screen.getByTestId('gm-ledger-player-log')).toHaveTextContent(
+      'Merchant charge corrected by -2,500.00 C-bills.',
+    );
+    expect(screen.getByTestId('gm-ledger-player-log')).toHaveTextContent(
+      'Campaign time corrected by 2 days.',
+    );
+    expect(
+      screen.queryByTestId('gm-ledger-private-log'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('gm-ledger-preview-btn'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('gm-ledger-approve-btn'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('gm-ledger-manual-btn'),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId('gm-ledger-player-log')).not.toHaveTextContent(
+      /Hidden campaign|Hidden time|black-market|GM-only|default outcome/i,
     );
   });
 });

--- a/src/components/campaign/gm/index.ts
+++ b/src/components/campaign/gm/index.ts
@@ -1,1 +1,2 @@
 export { GmCampaignInterventionControlPlane } from './GmCampaignInterventionControlPlane';
+export { GmCampaignPlayerLedgerView } from './GmCampaignPlayerLedgerView';

--- a/src/lib/campaign/__tests__/campaignAuthority.test.ts
+++ b/src/lib/campaign/__tests__/campaignAuthority.test.ts
@@ -1,0 +1,54 @@
+import {
+  createGuestCoopSession,
+  createHostCoopSession,
+} from '@/types/campaign/CoopSession';
+
+import {
+  canUseCampaignGmControls,
+  resolveCampaignAuthorityFromSession,
+} from '../campaignAuthority';
+
+describe('campaignAuthority', () => {
+  it('treats single-player campaigns as local GM-owned campaigns', () => {
+    const authority = resolveCampaignAuthorityFromSession();
+
+    expect(authority).toMatchObject({
+      role: 'gm',
+      reason: 'single-player-owner',
+      canUseGmControls: true,
+      canViewGmPrivateLedger: true,
+      canViewPlayerLedger: true,
+    });
+    expect(canUseCampaignGmControls()).toBe(true);
+  });
+
+  it('treats co-op hosts as GM-authorized viewers', () => {
+    const authority = resolveCampaignAuthorityFromSession(
+      createHostCoopSession('HOST1', 'match-host'),
+    );
+
+    expect(authority).toMatchObject({
+      role: 'gm',
+      reason: 'coop-host',
+      canUseGmControls: true,
+      canViewGmPrivateLedger: true,
+    });
+  });
+
+  it('treats co-op guests as player mirrors', () => {
+    const authority = resolveCampaignAuthorityFromSession(
+      createGuestCoopSession('match-host', 'GUEST1'),
+    );
+
+    expect(authority).toMatchObject({
+      role: 'player',
+      reason: 'coop-guest',
+      canUseGmControls: false,
+      canViewGmPrivateLedger: false,
+      canViewPlayerLedger: true,
+    });
+    expect(
+      canUseCampaignGmControls(createGuestCoopSession('match-host', 'GUEST1')),
+    ).toBe(false);
+  });
+});

--- a/src/lib/campaign/campaignAuthority.ts
+++ b/src/lib/campaign/campaignAuthority.ts
@@ -1,0 +1,52 @@
+import type { ICoopSession } from '@/types/campaign/CoopSession';
+
+export type CampaignViewerRole = 'gm' | 'player';
+
+export type CampaignAuthorityReason =
+  | 'single-player-owner'
+  | 'coop-host'
+  | 'coop-guest';
+
+export interface ICampaignAuthority {
+  readonly role: CampaignViewerRole;
+  readonly reason: CampaignAuthorityReason;
+  readonly canUseGmControls: boolean;
+  readonly canViewGmPrivateLedger: boolean;
+  readonly canViewPlayerLedger: boolean;
+}
+
+export function resolveCampaignAuthorityFromSession(
+  coopSession?: ICoopSession,
+): ICampaignAuthority {
+  if (!coopSession) {
+    return {
+      role: 'gm',
+      reason: 'single-player-owner',
+      canUseGmControls: true,
+      canViewGmPrivateLedger: true,
+      canViewPlayerLedger: true,
+    };
+  }
+
+  if (coopSession.mode === 'host') {
+    return {
+      role: 'gm',
+      reason: 'coop-host',
+      canUseGmControls: true,
+      canViewGmPrivateLedger: true,
+      canViewPlayerLedger: true,
+    };
+  }
+
+  return {
+    role: 'player',
+    reason: 'coop-guest',
+    canUseGmControls: false,
+    canViewGmPrivateLedger: false,
+    canViewPlayerLedger: true,
+  };
+}
+
+export function canUseCampaignGmControls(coopSession?: ICoopSession): boolean {
+  return resolveCampaignAuthorityFromSession(coopSession).canUseGmControls;
+}

--- a/src/pages/gameplay/campaigns/[id]/gm-ledger.tsx
+++ b/src/pages/gameplay/campaigns/[id]/gm-ledger.tsx
@@ -1,6 +1,10 @@
 import React, { useState } from 'react';
 
-import { GmCampaignInterventionControlPlane } from '@/components/campaign/gm';
+import {
+  GmCampaignInterventionControlPlane,
+  GmCampaignPlayerLedgerView,
+} from '@/components/campaign/gm';
+import { resolveCampaignAuthorityFromSession } from '@/lib/campaign/campaignAuthority';
 import {
   CampaignPageFrameFromShell,
   getLoadedCampaign,
@@ -20,21 +24,28 @@ export default function GmLedgerPage(): React.ReactElement {
   if (pendingPage) return pendingPage;
 
   const campaign = getLoadedCampaign(shell);
+  const authority = resolveCampaignAuthorityFromSession(campaign.coopSession);
   const frame = {
     title: 'GM Ledger',
-    subtitle: `${campaign.name} - intervention control plane`,
+    subtitle: authority.canUseGmControls
+      ? `${campaign.name} - intervention control plane`
+      : `${campaign.name} - player-visible ledger`,
     currentPage: 'gm-ledger',
   } as const;
 
   return (
     <CampaignPageFrameFromShell shell={shell} frame={frame}>
-      <GmCampaignInterventionControlPlane
-        campaign={campaign}
-        onApplyCampaignUpdate={(updates) => {
-          shell.store.getState().updateCampaign(updates);
-          setActionTick((tick) => tick + 1);
-        }}
-      />
+      {authority.canUseGmControls ? (
+        <GmCampaignInterventionControlPlane
+          campaign={campaign}
+          onApplyCampaignUpdate={(updates) => {
+            shell.store.getState().updateCampaign(updates);
+            setActionTick((tick) => tick + 1);
+          }}
+        />
+      ) : (
+        <GmCampaignPlayerLedgerView campaign={campaign} />
+      )}
     </CampaignPageFrameFromShell>
   );
 }

--- a/src/pages/gameplay/campaigns/[id]/missions.tsx
+++ b/src/pages/gameplay/campaigns/[id]/missions.tsx
@@ -234,7 +234,11 @@ export default function MissionsPage(): React.ReactElement {
       breadcrumbs={breadcrumbs}
     >
       {/* Navigation Tabs */}
-      <CampaignNavigation campaignId={campaign.id} currentPage="missions" />
+      <CampaignNavigation
+        campaignId={campaign.id}
+        currentPage="missions"
+        coopSession={campaign.coopSession}
+      />
 
       {/* Filter Tabs */}
       {allMissions.length > 0 && (

--- a/src/pages/gameplay/campaigns/[id]/starmap.tsx
+++ b/src/pages/gameplay/campaigns/[id]/starmap.tsx
@@ -133,7 +133,11 @@ export default function CampaignStarmapPage(): React.ReactElement {
       maxWidth="wide"
       breadcrumbs={breadcrumbs}
     >
-      <CampaignNavigation campaignId={campaign.id} currentPage="starmap" />
+      <CampaignNavigation
+        campaignId={campaign.id}
+        currentPage="starmap"
+        coopSession={campaign.coopSession}
+      />
 
       {/* Selection / travel control strip. Sits above the canvas so
        * the operator can read the destination + commit a jump


### PR DESCRIPTION
## Summary
- Adds an OpenSpec slice for owner/host GM authority versus guest/player mirrors.
- Gates the campaign GM Ledger nav tab to single-player owners and co-op hosts.
- Sends guest direct links to a player-safe ledger projection with no GM controls or private notes.
- Extends GM ledger QC anchors and browser coverage so the authority boundary is durable.
- Updates GM intervention boundary docs to reflect supported campaign funds and time-cascade slices.

## Prioritized Inventory From Council
1. P0: GM authority hardening is the release-trust item to close first. This PR implements and verifies it.
2. P1: Preserve public/private GM projection redaction whenever new campaign correction families are added.
3. P2: Keep non-BattleMech runtime expansion scoped by family-specific matrices; do not promote the 147 out-of-scope rows generically.
4. P3: Multiplayer roster UX needs player-confidence proof beyond route mount smoke before broad release claims.
5. P4: Maintenance/import-health remains follow-up debt while gates stay green.

## Validation
- `openspec.cmd validate harden-gm-authority-operator-flow --strict`
- `openspec.cmd validate --all --strict`
- `npm.cmd run typecheck`
- `npm.cmd run verify:qc:gm:campaign-ledger`
- `npm.cmd run qc:nonbattlemech:scope:validate`
- `npm.cmd run validate:multiplayer:coop-runtime`
- `npm.cmd run qc:known-gaps:validate`
- `npm.cmd run verify:qc:maintenance`
- `npm.cmd run qc:app-completion -- --json`
- `npm.cmd run qc:lifecycle:status -- --only=weak`

## Not Run
- Full `verify:app-completion` release suite after this narrow slice.