### PR TITLE
Harden app-shell route and build reliability

### DIFF
--- a/e2e/app-shell-route-proof.spec.ts
+++ b/e2e/app-shell-route-proof.spec.ts
@@ -2,6 +2,13 @@ import { expect, test, type Page } from '@playwright/test';
 
 import appShellRouteManifest from './app-shell-route-manifest.json';
 
+const APP_SHELL_NAVIGATION_TIMEOUT_MS = 60_000;
+
+test.setTimeout(90_000);
+test.beforeEach(async ({ page }) => {
+  page.setDefaultNavigationTimeout(APP_SHELL_NAVIGATION_TIMEOUT_MS);
+});
+
 type RouteRole = Parameters<Page['getByRole']>[0];
 
 interface RouteAffordance {

--- a/scripts/next/run-next.mjs
+++ b/scripts/next/run-next.mjs
@@ -18,7 +18,7 @@ const nextCli = path.join(
   'next',
 );
 const nextArgs = process.argv.slice(2);
-const defaultNextBuildOldSpaceMb = '8192';
+const defaultNextBuildOldSpaceMb = '12288';
 
 function hasExplicitOldSpaceLimit(nodeOptions) {
   return /(?:^|\s)--max-old-space-size(?:=|\s)\S*/.test(nodeOptions ?? '');


### PR DESCRIPTION
## Summary
- extend the strict app-shell route proof timeout/navigation budget so cold Next compiles do not mask real route failures
- raise the centralized Next build wrapper default old-space budget from 8GB to 12GB while preserving caller overrides

## Evidence
- npm.cmd run verify:qc:app-shell
- npm.cmd run build
- npm.cmd run qc:validate
- npm.cmd run qc:app-completion -- --json
- npm.cmd run qc:lifecycle:status -- --only=weak
- npm.cmd run qc:openspec-ci:validate
- npm.cmd run typecheck
- npm.cmd run format:check -- e2e/app-shell-route-proof.spec.ts
- npm.cmd run format:check -- scripts/next/run-next.mjs

## Notes
The first app-shell proof failed locally because the initial cold compile took longer than the global 30s Playwright navigation/test timeout. The direct production build also proved the previous 8GB wrapper default could OOM during webpack sealing; 12GB completed successfully.