### PR TITLE
Harden app shell proof against cold starts

### DIFF
--- a/e2e/app-shell-route-proof.spec.ts
+++ b/e2e/app-shell-route-proof.spec.ts
@@ -2,9 +2,9 @@ import { expect, test, type Page } from '@playwright/test';
 
 import appShellRouteManifest from './app-shell-route-manifest.json';
 
-const APP_SHELL_NAVIGATION_TIMEOUT_MS = 60_000;
+const APP_SHELL_NAVIGATION_TIMEOUT_MS = 90_000;
 
-test.setTimeout(90_000);
+test.setTimeout(150_000);
 test.beforeEach(async ({ page }) => {
   page.setDefaultNavigationTimeout(APP_SHELL_NAVIGATION_TIMEOUT_MS);
 });


### PR DESCRIPTION
## Summary
- Increases the app-shell route proof navigation budget from 60s to 90s and the per-test budget from 90s to 150s.
- Keeps the strict route identity, refresh, dropdown, mobile navigation, and recovery assertions unchanged.

## Why
The Wave 1 app-shell proof failed before assertions when the first Next dev cold compile reached 61s. The failure snapshot showed the dashboard had rendered, so this is a harness repeatability fix rather than an app behavior relaxation.

## Validation
- npm.cmd run verify:qc:roadmap
- npm.cmd run verify:qc:app-shell
- npx.cmd oxfmt --check e2e/app-shell-route-proof.spec.ts
- npx.cmd oxlint e2e/app-shell-route-proof.spec.ts
- git diff --check
- npm.cmd run typecheck

## Not run
- Full verify:qc and electron:test:build for this timeout-only harness change.