### PR TITLE
Harden campaign acquisition proof against cold starts

### DIFF
--- a/e2e/campaign-acquisition-browser.spec.ts
+++ b/e2e/campaign-acquisition-browser.spec.ts
@@ -10,6 +10,13 @@
 
 import { expect, test, type Page } from '@playwright/test';
 
+const CAMPAIGN_ACQUISITION_NAVIGATION_TIMEOUT_MS = 90_000;
+
+test.setTimeout(150_000);
+test.beforeEach(async ({ page }) => {
+  page.setDefaultNavigationTimeout(CAMPAIGN_ACQUISITION_NAVIGATION_TIMEOUT_MS);
+});
+
 interface SeededAcquisitionCampaign {
   readonly campaignId: string;
   readonly dueRequestId: string;


### PR DESCRIPTION
## Summary
- Adds an explicit 90s navigation budget and 150s test budget to the strict campaign acquisition browser proof.
- Keeps the acquisition UI, reload, day-advance, and persistence assertions unchanged.

## Why
erify:qc:campaign-economy:browser exposed a repeatability failure before assertions: the first cold /gameplay/campaigns navigation hit Playwright's default 30s timeout. The rerun showed that initial route compilation can take about 52s locally, then the full campaign browser aggregate passes.

## Validation
- npm.cmd run verify:qc:campaign-economy:browser
- npx.cmd oxfmt --check e2e/campaign-acquisition-browser.spec.ts
- npx.cmd oxlint e2e/campaign-acquisition-browser.spec.ts
- git diff --check
- npm.cmd run typecheck

## Not run
- Full verify:qc and electron:test:build for this timeout-only harness change.