### PR TITLE
Fix replay scanner build tracing

### DIFF
--- a/src/replay-library/index-reader.ts
+++ b/src/replay-library/index-reader.ts
@@ -22,8 +22,6 @@ import { logger } from '@/utils/logger';
 
 import type { IReplayManifestEntry } from './types';
 
-import { scanReplayDirectory } from './backfill-scan';
-
 /**
  * Backfill scan invoked when `replay-index.json` is missing. PR 3 wires the
  * real on-disk scan as the default; tests may still inject a stub through
@@ -41,8 +39,12 @@ export type BackfillScan = (
  * from the on-disk `simulation-reports/` tree. Exported so callers can wrap
  * or compose it without depending on `backfill-scan` directly.
  */
-export const defaultBackfillScan: BackfillScan = (cwd) =>
-  scanReplayDirectory({ cwd });
+export const defaultBackfillScan: BackfillScan = async (cwd) => {
+  // Keep the scanner lazy so normal replay API bundles do not trace the
+  // developer's entire simulation-reports/ tree during standalone builds.
+  const { scanReplayDirectory } = await import('./backfill-scan');
+  return scanReplayDirectory({ cwd });
+};
 
 /**
  * Options for the reader. `cwd` lets tests inject a tmpdir without polluting
@@ -100,7 +102,7 @@ function hasRecognizedReplaySource(
  *   - If `replay-index.json` exists and parses, returns the recognized
  *     entries (skips + debug-logs forward-compat ones).
  *   - If `replay-index.json` does not exist (`ENOENT`), invokes the
- *     `backfillScan` option (default: empty-array stub) and returns its
+ *     `backfillScan` option (default: real on-disk scan) and returns its
  *     result.
  *   - Any other read/parse error propagates — the caller decides whether
  *     to surface it.


### PR DESCRIPTION
## Summary
- Lazy-load replay-library backfill scanning so normal replay API route bundles do not trace the local simulation-reports tree during standalone builds.
- Preserve missing replay-index fallback behavior while unblocking the Electron package validation path.

## Validation
- npm.cmd test -- --watchAll=false --runTestsByPath src/replay-library/__tests__/index-reader.test.ts src/__tests__/api/replay-library/index.test.ts --runInBand
- npm.cmd run build
- npm.cmd run electron:test:build:win
- npm.cmd run qc:app-completion:release -- --json
- npm.cmd run qc:lifecycle:status -- --json
- npm.cmd run qc:manual-automation-gaps:validate
- npm.cmd run qc:surface-browser:validate
- npm.cmd run qc:journeys:validate
- npm.cmd run qc:scenarios:validate
- npm.cmd run maintain:scan:gate
- node scripts/qc/validate-maintenance-warning-ledger.mjs