### PR TITLE
Make campaign browser failures diagnosable

### DIFF
--- a/e2e/campaign-acquisition-browser.spec.ts
+++ b/e2e/campaign-acquisition-browser.spec.ts
@@ -10,6 +10,8 @@
 
 import { expect, test, type Page } from '@playwright/test';
 
+import { withBrowserDiagnostics } from './helpers';
+
 const CAMPAIGN_ACQUISITION_NAVIGATION_TIMEOUT_MS = 90_000;
 
 test.setTimeout(150_000);
@@ -107,84 +109,82 @@ test.describe('campaign acquisition browser proof', () => {
   test(
     'adds, reloads, processes, and persists acquisition shopping-list delivery',
     { tag: ['@campaign', '@economy', '@strict'] },
-    async ({ page }) => {
-      const pageErrors: string[] = [];
-      page.on('pageerror', (error) => pageErrors.push(error.message));
+    async ({ page }, testInfo) =>
+      withBrowserDiagnostics(page, testInfo, async () => {
+        await page.goto('/gameplay/campaigns');
+        const seeded = await seedAcquisitionCampaign(page);
 
-      await page.goto('/gameplay/campaigns');
-      const seeded = await seedAcquisitionCampaign(page);
+        await page.goto(
+          `/gameplay/campaigns/${seeded.campaignId}/acquisitions`,
+        );
+        await expect(page.getByTestId('acquisitions-panel')).toBeVisible({
+          timeout: 20_000,
+        });
+        await expect(
+          page.getByRole('link', { name: 'Acquisitions' }),
+        ).toHaveAttribute('aria-current', 'page');
+        await expect(
+          page.getByTestId(`acquisition-status-${seeded.dueRequestId}`),
+        ).toContainText('in transit');
+        await expect(
+          page.getByTestId('acquisitions-transit-count'),
+        ).toContainText('1');
 
-      await page.goto(`/gameplay/campaigns/${seeded.campaignId}/acquisitions`);
-      await expect(page.getByTestId('acquisitions-panel')).toBeVisible({
-        timeout: 20_000,
-      });
-      await expect(
-        page.getByRole('link', { name: 'Acquisitions' }),
-      ).toHaveAttribute('aria-current', 'page');
-      await expect(
-        page.getByTestId(`acquisition-status-${seeded.dueRequestId}`),
-      ).toContainText('in transit');
-      await expect(
-        page.getByTestId('acquisitions-transit-count'),
-      ).toContainText('1');
+        await page.getByTestId('acquisition-part-name').fill('PPC');
+        await page.getByTestId('acquisition-quantity').fill('2');
+        await page.getByTestId('acquisition-availability').selectOption('E');
+        await page.getByTestId('acquisition-add-request').click();
+        await expect(
+          page.getByTestId(`acquisition-request-${seeded.addedRequestId}`),
+        ).toContainText('PPC');
+        await expect(
+          page.getByTestId(`acquisition-status-${seeded.addedRequestId}`),
+        ).toContainText('pending');
+        await expect(
+          page.getByTestId('acquisitions-pending-count'),
+        ).toContainText('1');
 
-      await page.getByTestId('acquisition-part-name').fill('PPC');
-      await page.getByTestId('acquisition-quantity').fill('2');
-      await page.getByTestId('acquisition-availability').selectOption('E');
-      await page.getByTestId('acquisition-add-request').click();
-      await expect(
-        page.getByTestId(`acquisition-request-${seeded.addedRequestId}`),
-      ).toContainText('PPC');
-      await expect(
-        page.getByTestId(`acquisition-status-${seeded.addedRequestId}`),
-      ).toContainText('pending');
-      await expect(
-        page.getByTestId('acquisitions-pending-count'),
-      ).toContainText('1');
+        await page.reload({ waitUntil: 'networkidle' });
+        await waitForCampaignStoresReady(page);
+        await expect(
+          page.getByTestId(`acquisition-status-${seeded.dueRequestId}`),
+        ).toContainText('in transit');
+        await expect(
+          page.getByTestId(`acquisition-status-${seeded.addedRequestId}`),
+        ).toContainText('pending');
 
-      await page.reload({ waitUntil: 'networkidle' });
-      await waitForCampaignStoresReady(page);
-      await expect(
-        page.getByTestId(`acquisition-status-${seeded.dueRequestId}`),
-      ).toContainText('in transit');
-      await expect(
-        page.getByTestId(`acquisition-status-${seeded.addedRequestId}`),
-      ).toContainText('pending');
+        await page.getByTestId('acquisitions-advance-day').click();
+        await expect(
+          page.getByTestId(`acquisition-status-${seeded.dueRequestId}`),
+        ).toContainText('delivered');
+        await expect(
+          page.getByTestId(`acquisition-inventory-${seeded.duePartId}`),
+        ).toContainText('SRM Ammo');
+        await expect(
+          page.getByTestId(`acquisition-inventory-qty-${seeded.duePartId}`),
+        ).toContainText('x2');
+        await expect(
+          page.getByTestId('acquisition-current-date'),
+        ).toContainText('3025-02-02');
 
-      await page.getByTestId('acquisitions-advance-day').click();
-      await expect(
-        page.getByTestId(`acquisition-status-${seeded.dueRequestId}`),
-      ).toContainText('delivered');
-      await expect(
-        page.getByTestId(`acquisition-inventory-${seeded.duePartId}`),
-      ).toContainText('SRM Ammo');
-      await expect(
-        page.getByTestId(`acquisition-inventory-qty-${seeded.duePartId}`),
-      ).toContainText('x2');
-      await expect(page.getByTestId('acquisition-current-date')).toContainText(
-        '3025-02-02',
-      );
+        await page.reload({ waitUntil: 'networkidle' });
+        await waitForCampaignStoresReady(page);
+        await expect(
+          page.getByTestId(`acquisition-status-${seeded.dueRequestId}`),
+        ).toContainText('delivered');
+        await expect(
+          page.getByTestId(`acquisition-inventory-qty-${seeded.duePartId}`),
+        ).toContainText('x2');
 
-      await page.reload({ waitUntil: 'networkidle' });
-      await waitForCampaignStoresReady(page);
-      await expect(
-        page.getByTestId(`acquisition-status-${seeded.dueRequestId}`),
-      ).toContainText('delivered');
-      await expect(
-        page.getByTestId(`acquisition-inventory-qty-${seeded.duePartId}`),
-      ).toContainText('x2');
-
-      await page
-        .getByTestId(`acquisition-remove-${seeded.dueRequestId}`)
-        .click();
-      await expect(
-        page.getByTestId(`acquisition-request-${seeded.dueRequestId}`),
-      ).toHaveCount(0);
-      await expect(
-        page.getByTestId(`acquisition-inventory-qty-${seeded.duePartId}`),
-      ).toContainText('x2');
-
-      expect(pageErrors).toEqual([]);
-    },
+        await page
+          .getByTestId(`acquisition-remove-${seeded.dueRequestId}`)
+          .click();
+        await expect(
+          page.getByTestId(`acquisition-request-${seeded.dueRequestId}`),
+        ).toHaveCount(0);
+        await expect(
+          page.getByTestId(`acquisition-inventory-qty-${seeded.duePartId}`),
+        ).toContainText('x2');
+      }),
   );
 });

--- a/e2e/campaign-economy-browser.spec.ts
+++ b/e2e/campaign-economy-browser.spec.ts
@@ -12,6 +12,8 @@
 
 import { expect, test, type Page } from '@playwright/test';
 
+import { withBrowserDiagnostics } from './helpers';
+
 interface SeededCampaign {
   campaignId: string;
   currentDate: string;
@@ -375,166 +377,164 @@ test.describe('Campaign economy browser proof', () => {
   test(
     'routes post-battle state through dashboard, repair, salvage, finances, and day advance',
     { tag: ['@campaign', '@economy', '@strict'] },
-    async ({ page }) => {
-      const pageErrors: string[] = [];
-      page.on('pageerror', (error) => pageErrors.push(error.message));
+    async ({ page }, testInfo) =>
+      withBrowserDiagnostics(page, testInfo, async () => {
+        await page.goto('/gameplay/campaigns');
+        const seeded = await seedPostBattleCampaign(page);
 
-      await page.goto('/gameplay/campaigns');
-      const seeded = await seedPostBattleCampaign(page);
-
-      await page.goto(`/gameplay/campaigns/${seeded.campaignId}`);
-      await waitForLoadedCampaign(page, seeded.campaignId);
-      await expect(page.getByTestId('dashboard-card-finances')).toBeVisible();
-      await expect(
-        page.getByTestId('dashboard-card-day-advance'),
-      ).toBeVisible();
-      await expect(page.getByTestId('finances-balance')).toContainText(
-        '2,500,000.00 C-bills',
-      );
-      const dateBefore = await page
-        .getByTestId('day-advance-current-date')
-        .textContent();
-      expect(dateBefore).toBe('3025-01-01');
-
-      await page.goto(`/gameplay/campaigns/${seeded.campaignId}/repair-bay`);
-      await waitForLoadedCampaign(page, seeded.campaignId);
-      await expect(page.getByTestId('repair-bay-queue')).toBeVisible();
-      await expect(
-        page.getByTestId('repair-ticket-ticket-armor-ct'),
-      ).toContainText('6h');
-      await page.getByTestId('repair-ticket-down-ticket-armor-ct').click();
-      const repairPriorities = await page.evaluate(() => {
-        type StoreApi = { getState: () => Record<string, any> };
-        type ExposedStore = StoreApi | (() => StoreApi);
-        const resolveStore = (store: ExposedStore): StoreApi =>
-          typeof (store as StoreApi).getState === 'function'
-            ? (store as StoreApi)
-            : (store as () => StoreApi)();
-        const stores = (
-          window as unknown as {
-            __ZUSTAND_STORES__?: { campaign?: ExposedStore };
-          }
-        ).__ZUSTAND_STORES__;
-        if (!stores?.campaign) {
-          throw new Error('Campaign E2E store is not exposed');
-        }
-        const campaign = resolveStore(stores.campaign).getState().getCampaign();
-        return (campaign?.repairQueue ?? []).map(
-          (ticket: { ticketId: string; priority?: number }) => [
-            ticket.ticketId,
-            ticket.priority ?? null,
-          ],
+        await page.goto(`/gameplay/campaigns/${seeded.campaignId}`);
+        await waitForLoadedCampaign(page, seeded.campaignId);
+        await expect(page.getByTestId('dashboard-card-finances')).toBeVisible();
+        await expect(
+          page.getByTestId('dashboard-card-day-advance'),
+        ).toBeVisible();
+        await expect(page.getByTestId('finances-balance')).toContainText(
+          '2,500,000.00 C-bills',
         );
-      });
-      expect(repairPriorities).toEqual([
-        ['ticket-armor-ct', 1],
-        ['ticket-structure-lt', 0],
-      ]);
-      const repairSnapshot = await readCampaignEconomySnapshot(page);
-      expect(repairSnapshot.repairPriorities).toEqual(repairPriorities);
+        const dateBefore = await page
+          .getByTestId('day-advance-current-date')
+          .textContent();
+        expect(dateBefore).toBe('3025-01-01');
 
-      await page.reload({ waitUntil: 'networkidle' });
-      await waitForLoadedCampaign(page, seeded.campaignId);
-      await expect(page.getByTestId('repair-bay-queue')).toBeVisible();
-      await expect(readCampaignEconomySnapshot(page)).resolves.toMatchObject({
-        repairPriorities,
-      });
+        await page.goto(`/gameplay/campaigns/${seeded.campaignId}/repair-bay`);
+        await waitForLoadedCampaign(page, seeded.campaignId);
+        await expect(page.getByTestId('repair-bay-queue')).toBeVisible();
+        await expect(
+          page.getByTestId('repair-ticket-ticket-armor-ct'),
+        ).toContainText('6h');
+        await page.getByTestId('repair-ticket-down-ticket-armor-ct').click();
+        const repairPriorities = await page.evaluate(() => {
+          type StoreApi = { getState: () => Record<string, any> };
+          type ExposedStore = StoreApi | (() => StoreApi);
+          const resolveStore = (store: ExposedStore): StoreApi =>
+            typeof (store as StoreApi).getState === 'function'
+              ? (store as StoreApi)
+              : (store as () => StoreApi)();
+          const stores = (
+            window as unknown as {
+              __ZUSTAND_STORES__?: { campaign?: ExposedStore };
+            }
+          ).__ZUSTAND_STORES__;
+          if (!stores?.campaign) {
+            throw new Error('Campaign E2E store is not exposed');
+          }
+          const campaign = resolveStore(stores.campaign)
+            .getState()
+            .getCampaign();
+          return (campaign?.repairQueue ?? []).map(
+            (ticket: { ticketId: string; priority?: number }) => [
+              ticket.ticketId,
+              ticket.priority ?? null,
+            ],
+          );
+        });
+        expect(repairPriorities).toEqual([
+          ['ticket-armor-ct', 1],
+          ['ticket-structure-lt', 0],
+        ]);
+        const repairSnapshot = await readCampaignEconomySnapshot(page);
+        expect(repairSnapshot.repairPriorities).toEqual(repairPriorities);
 
-      await page.goto(`/gameplay/campaigns/${seeded.campaignId}/salvage`);
-      await waitForLoadedCampaign(page, seeded.campaignId);
-      await expect(page.getByTestId('salvage-panel')).toBeVisible();
-      await expect(page.getByTestId('salvage-row-salvage-atlas')).toContainText(
-        'Atlas AS7-D',
-      );
-      await expect(page.getByTestId('salvage-value-total')).toContainText(
-        '0 C-Bills',
-      );
-      await page.getByTestId('salvage-accept-salvage-atlas').click();
-      await expect(page.getByTestId('salvage-value-total')).toContainText(
-        '2,000,000 C-Bills',
-      );
-      const salvageSnapshot = await readCampaignEconomySnapshot(page);
-      expect(salvageSnapshot).toMatchObject({
-        acceptedSalvageValue: 2_000_000,
-        salvageStatuses: [['salvage-atlas', 'accepted']],
-      });
+        await page.reload({ waitUntil: 'networkidle' });
+        await waitForLoadedCampaign(page, seeded.campaignId);
+        await expect(page.getByTestId('repair-bay-queue')).toBeVisible();
+        await expect(readCampaignEconomySnapshot(page)).resolves.toMatchObject({
+          repairPriorities,
+        });
 
-      await page.reload({ waitUntil: 'networkidle' });
-      await waitForLoadedCampaign(page, seeded.campaignId);
-      await expect(page.getByTestId('salvage-panel')).toBeVisible();
-      await expect(page.getByTestId('salvage-value-total')).toContainText(
-        '2,000,000 C-Bills',
-      );
-      await expect(readCampaignEconomySnapshot(page)).resolves.toMatchObject({
-        acceptedSalvageValue: 2_000_000,
-        salvageStatuses: [['salvage-atlas', 'accepted']],
-      });
+        await page.goto(`/gameplay/campaigns/${seeded.campaignId}/salvage`);
+        await waitForLoadedCampaign(page, seeded.campaignId);
+        await expect(page.getByTestId('salvage-panel')).toBeVisible();
+        await expect(
+          page.getByTestId('salvage-row-salvage-atlas'),
+        ).toContainText('Atlas AS7-D');
+        await expect(page.getByTestId('salvage-value-total')).toContainText(
+          '0 C-Bills',
+        );
+        await page.getByTestId('salvage-accept-salvage-atlas').click();
+        await expect(page.getByTestId('salvage-value-total')).toContainText(
+          '2,000,000 C-Bills',
+        );
+        const salvageSnapshot = await readCampaignEconomySnapshot(page);
+        expect(salvageSnapshot).toMatchObject({
+          acceptedSalvageValue: 2_000_000,
+          salvageStatuses: [['salvage-atlas', 'accepted']],
+        });
 
-      await page.goto(`/gameplay/campaigns/${seeded.campaignId}/finances`);
-      await waitForLoadedCampaign(page, seeded.campaignId);
-      await expect(page.getByTestId('finances-panel')).toBeVisible();
-      await expect(page.getByTestId('finances-balance')).toContainText(
-        '2,500,000.00 C-bills',
-      );
-      await page.getByTestId('loan-submit').click();
-      await expect(page.getByTestId('finances-balance')).toContainText(
-        '3,500,000.00 C-bills',
-      );
-      await expect(page.getByTestId('finances-ledger')).toBeVisible();
-      await expect(page.getByTestId('finances-loan-list')).toBeVisible();
-      const financeSnapshot = await readCampaignEconomySnapshot(page);
-      expect(financeSnapshot).toMatchObject({
-        balance: 3_500_000,
-        loanCount: 1,
-      });
-      expect(financeSnapshot.ledgerDescriptions).toContain(
-        'Loan disbursement: 1,000,000.00 C-bills',
-      );
+        await page.reload({ waitUntil: 'networkidle' });
+        await waitForLoadedCampaign(page, seeded.campaignId);
+        await expect(page.getByTestId('salvage-panel')).toBeVisible();
+        await expect(page.getByTestId('salvage-value-total')).toContainText(
+          '2,000,000 C-Bills',
+        );
+        await expect(readCampaignEconomySnapshot(page)).resolves.toMatchObject({
+          acceptedSalvageValue: 2_000_000,
+          salvageStatuses: [['salvage-atlas', 'accepted']],
+        });
 
-      await page.reload({ waitUntil: 'networkidle' });
-      await waitForLoadedCampaign(page, seeded.campaignId);
-      await expect(page.getByTestId('finances-panel')).toBeVisible();
-      await expect(page.getByTestId('finances-balance')).toContainText(
-        '3,500,000.00 C-bills',
-      );
-      await expect(page.getByTestId('finances-loan-list')).toBeVisible();
-      const reloadedFinanceSnapshot = await readCampaignEconomySnapshot(page);
-      expect(reloadedFinanceSnapshot).toMatchObject({
-        balance: 3_500_000,
-        loanCount: 1,
-      });
-      expect(reloadedFinanceSnapshot.ledgerDescriptions).toContain(
-        'Loan disbursement: 1,000,000.00 C-bills',
-      );
+        await page.goto(`/gameplay/campaigns/${seeded.campaignId}/finances`);
+        await waitForLoadedCampaign(page, seeded.campaignId);
+        await expect(page.getByTestId('finances-panel')).toBeVisible();
+        await expect(page.getByTestId('finances-balance')).toContainText(
+          '2,500,000.00 C-bills',
+        );
+        await page.getByTestId('loan-submit').click();
+        await expect(page.getByTestId('finances-balance')).toContainText(
+          '3,500,000.00 C-bills',
+        );
+        await expect(page.getByTestId('finances-ledger')).toBeVisible();
+        await expect(page.getByTestId('finances-loan-list')).toBeVisible();
+        const financeSnapshot = await readCampaignEconomySnapshot(page);
+        expect(financeSnapshot).toMatchObject({
+          balance: 3_500_000,
+          loanCount: 1,
+        });
+        expect(financeSnapshot.ledgerDescriptions).toContain(
+          'Loan disbursement: 1,000,000.00 C-bills',
+        );
 
-      await page.goto(`/gameplay/campaigns/${seeded.campaignId}`);
-      await waitForLoadedCampaign(page, seeded.campaignId);
-      await page.getByTestId('day-advance-one-day').click();
-      await expect(page.getByTestId('day-advance-current-date')).not.toHaveText(
-        '3025-01-01',
-      );
-      await expect(page.getByTestId('day-advance-current-date')).toHaveText(
-        '3025-01-02',
-      );
-      const advancedSnapshot = await readCampaignEconomySnapshot(page);
-      expect(advancedSnapshot.currentDate).toBe('3025-01-02');
-      expect(advancedSnapshot.balance).toBeLessThan(financeSnapshot.balance);
+        await page.reload({ waitUntil: 'networkidle' });
+        await waitForLoadedCampaign(page, seeded.campaignId);
+        await expect(page.getByTestId('finances-panel')).toBeVisible();
+        await expect(page.getByTestId('finances-balance')).toContainText(
+          '3,500,000.00 C-bills',
+        );
+        await expect(page.getByTestId('finances-loan-list')).toBeVisible();
+        const reloadedFinanceSnapshot = await readCampaignEconomySnapshot(page);
+        expect(reloadedFinanceSnapshot).toMatchObject({
+          balance: 3_500_000,
+          loanCount: 1,
+        });
+        expect(reloadedFinanceSnapshot.ledgerDescriptions).toContain(
+          'Loan disbursement: 1,000,000.00 C-bills',
+        );
 
-      await page.reload({ waitUntil: 'networkidle' });
-      await waitForLoadedCampaign(page, seeded.campaignId);
-      await expect(page.getByTestId('day-advance-current-date')).toHaveText(
-        '3025-01-02',
-      );
-      await expect(readCampaignEconomySnapshot(page)).resolves.toMatchObject({
-        acceptedSalvageValue: 2_000_000,
-        balance: advancedSnapshot.balance,
-        currentDate: '3025-01-02',
-        loanCount: 1,
-        repairPriorities,
-        salvageStatuses: [['salvage-atlas', 'accepted']],
-      });
+        await page.goto(`/gameplay/campaigns/${seeded.campaignId}`);
+        await waitForLoadedCampaign(page, seeded.campaignId);
+        await page.getByTestId('day-advance-one-day').click();
+        await expect(
+          page.getByTestId('day-advance-current-date'),
+        ).not.toHaveText('3025-01-01');
+        await expect(page.getByTestId('day-advance-current-date')).toHaveText(
+          '3025-01-02',
+        );
+        const advancedSnapshot = await readCampaignEconomySnapshot(page);
+        expect(advancedSnapshot.currentDate).toBe('3025-01-02');
+        expect(advancedSnapshot.balance).toBeLessThan(financeSnapshot.balance);
 
-      expect(pageErrors).toEqual([]);
-    },
+        await page.reload({ waitUntil: 'networkidle' });
+        await waitForLoadedCampaign(page, seeded.campaignId);
+        await expect(page.getByTestId('day-advance-current-date')).toHaveText(
+          '3025-01-02',
+        );
+        await expect(readCampaignEconomySnapshot(page)).resolves.toMatchObject({
+          acceptedSalvageValue: 2_000_000,
+          balance: advancedSnapshot.balance,
+          currentDate: '3025-01-02',
+          loanCount: 1,
+          repairPriorities,
+          salvageStatuses: [['salvage-atlas', 'accepted']],
+        });
+      }),
   );
 });

--- a/e2e/campaign-flow.spec.ts
+++ b/e2e/campaign-flow.spec.ts
@@ -12,6 +12,7 @@
 
 import { test, expect, type Page } from '@playwright/test';
 
+import { withBrowserDiagnostics } from './helpers';
 import { getStoreState } from './helpers/store';
 
 interface CampaignStoreState {
@@ -677,67 +678,75 @@ test.describe('Campaign Flow - Store State', () => {
   test(
     'saves a wizard campaign and reloads it from the server campaign list',
     { tag: ['@campaign', '@smoke', '@strict'] },
-    async ({ page }) => {
-      const campaignId = await createRosteredCampaignViaWizard(page);
-      const saved = await saveCampaignThroughDashboard(page, campaignId);
+    async ({ page }, testInfo) =>
+      withBrowserDiagnostics(page, testInfo, async () => {
+        const campaignId = await createRosteredCampaignViaWizard(page);
+        const saved = await saveCampaignThroughDashboard(page, campaignId);
 
-      await clearLiveCampaignClientState(page);
-      await page.goto('/gameplay/campaigns');
-      await waitForE2EHydration(page);
+        await clearLiveCampaignClientState(page);
+        await page.goto('/gameplay/campaigns');
+        await waitForE2EHydration(page);
 
-      const serverBackedCard = page.getByTestId(`campaign-card-${campaignId}`);
-      await expect(serverBackedCard).toContainText(saved.name, {
-        timeout: 20_000,
-      });
-      await expect(serverBackedCard).toContainText('Faction: mercenary');
+        const serverBackedCard = page.getByTestId(
+          `campaign-card-${campaignId}`,
+        );
+        await expect(serverBackedCard).toContainText(saved.name, {
+          timeout: 20_000,
+        });
+        await expect(serverBackedCard).toContainText('Faction: mercenary');
 
-      await serverBackedCard.click();
-      await page.waitForURL(new RegExp(`/gameplay/campaigns/${campaignId}$`), {
-        timeout: 20_000,
-      });
-      await expect(page.getByTestId('campaign-dashboard')).toBeVisible({
-        timeout: 20_000,
-      });
-      await expect(page.getByTestId('campaign-save-status-card')).toBeVisible();
+        await serverBackedCard.click();
+        await page.waitForURL(
+          new RegExp(`/gameplay/campaigns/${campaignId}$`),
+          {
+            timeout: 20_000,
+          },
+        );
+        await expect(page.getByTestId('campaign-dashboard')).toBeVisible({
+          timeout: 20_000,
+        });
+        await expect(
+          page.getByTestId('campaign-save-status-card'),
+        ).toBeVisible();
 
-      const reloaded = await page.evaluate(() => {
-        const stores = (
-          window as unknown as {
-            __ZUSTAND_STORES__?: {
-              campaign?: {
-                getState: () => {
-                  campaign?: { id?: unknown; name?: unknown };
+        const reloaded = await page.evaluate(() => {
+          const stores = (
+            window as unknown as {
+              __ZUSTAND_STORES__?: {
+                campaign?: {
+                  getState: () => {
+                    campaign?: { id?: unknown; name?: unknown };
+                  };
                 };
               };
-            };
-          }
-        ).__ZUSTAND_STORES__;
-        const campaign = stores?.campaign?.getState().campaign;
-        return {
-          id: typeof campaign?.id === 'string' ? campaign.id : null,
-          name: typeof campaign?.name === 'string' ? campaign.name : null,
-        };
-      });
-      expect(reloaded).toEqual({ id: campaignId, name: saved.name });
+            }
+          ).__ZUSTAND_STORES__;
+          const campaign = stores?.campaign?.getState().campaign;
+          return {
+            id: typeof campaign?.id === 'string' ? campaign.id : null,
+            name: typeof campaign?.name === 'string' ? campaign.name : null,
+          };
+        });
+        expect(reloaded).toEqual({ id: campaignId, name: saved.name });
 
-      const serverRecord = await page.evaluate(async (id) => {
-        const response = await fetch(`/api/campaigns/${id}`);
-        if (!response.ok) {
-          throw new Error(`server responded ${response.status}`);
-        }
-        const record = (await response.json()) as {
-          campaignId?: unknown;
-          version?: unknown;
-        };
-        return {
-          campaignId: record.campaignId,
-          version: record.version,
-        };
-      }, campaignId);
-      expect(serverRecord).toEqual({
-        campaignId,
-        version: saved.version,
-      });
-    },
+        const serverRecord = await page.evaluate(async (id) => {
+          const response = await fetch(`/api/campaigns/${id}`);
+          if (!response.ok) {
+            throw new Error(`server responded ${response.status}`);
+          }
+          const record = (await response.json()) as {
+            campaignId?: unknown;
+            version?: unknown;
+          };
+          return {
+            campaignId: record.campaignId,
+            version: record.version,
+          };
+        }, campaignId);
+        expect(serverRecord).toEqual({
+          campaignId,
+          version: saved.version,
+        });
+      }),
   );
 });

--- a/e2e/campaign-organic-contract.spec.ts
+++ b/e2e/campaign-organic-contract.spec.ts
@@ -11,6 +11,8 @@
 
 import { expect, test, type Page } from '@playwright/test';
 
+import { withBrowserDiagnostics } from './helpers';
+
 interface CampaignContractSnapshot {
   readonly campaignId: string | null;
   readonly missionIds: readonly string[];
@@ -165,105 +167,108 @@ test.describe('organic campaign contract acceptance', () => {
   test(
     'creates a rostered campaign, accepts a market contract, and reloads the accepted mission',
     { tag: ['@campaign', '@economy', '@strict'] },
-    async ({ page }) => {
-      const campaignId = await createCampaignViaWizard(page);
+    async ({ page }, testInfo) =>
+      withBrowserDiagnostics(page, testInfo, async () => {
+        const campaignId = await createCampaignViaWizard(page);
 
-      const created = await getCampaignContractSnapshot(page);
-      expect(created.campaignId).toBe(campaignId);
-      expect(created.rosterUnitNames).toContain('Light Mech');
-      expect(created.rosterPilotNames).toContain('MechWarrior 1');
+        const created = await getCampaignContractSnapshot(page);
+        expect(created.campaignId).toBe(campaignId);
+        expect(created.rosterUnitNames).toContain('Light Mech');
+        expect(created.rosterPilotNames).toContain('MechWarrior 1');
 
-      await page.getByTestId('quick-action-browse-contracts').click();
-      await page.waitForURL(
-        new RegExp(`/gameplay/campaigns/${campaignId}/contract-market$`),
-        { timeout: 20_000 },
-      );
-      await expect(page.getByTestId('contract-market-grid')).toBeVisible({
-        timeout: 20_000,
-      });
-
-      const firstOffer = page.locator('[data-testid^="offer-card-"]').first();
-      await expect(firstOffer).toBeVisible();
-      const offerTestId = await firstOffer.getAttribute('data-testid');
-      const offerName = (await firstOffer.locator('h3').textContent())?.trim();
-      const offerId = offerTestId?.replace(/^offer-card-/, '');
-      expect(offerId).toBeTruthy();
-      expect(offerName).toBeTruthy();
-
-      await page.getByTestId(`offer-accept-${offerId}`).click();
-      await expect(page.getByTestId(`offer-card-${offerId}`)).toHaveCount(0);
-
-      const accepted = await getCampaignContractSnapshot(page);
-      expect(accepted.missionIds).toContain(offerId);
-      expect(accepted.missionNames).toContain(offerName);
-      expect(accepted.missionStatuses).toContain('Active');
-      expect(accepted.contractMarketOfferIds).not.toContain(offerId);
-
-      await page.goto(`/gameplay/campaigns/${campaignId}/missions`);
-      await expect(page.getByTestId(`mission-card-${offerId}`)).toContainText(
-        offerName!,
-        {
+        await page.getByTestId('quick-action-browse-contracts').click();
+        await page.waitForURL(
+          new RegExp(`/gameplay/campaigns/${campaignId}/contract-market$`),
+          { timeout: 20_000 },
+        );
+        await expect(page.getByTestId('contract-market-grid')).toBeVisible({
           timeout: 20_000,
-        },
-      );
-      await expect(page.getByTestId(`mission-status-${offerId}`)).toContainText(
-        'Active',
-      );
-      await expect(page.getByText(offerName!)).toBeVisible({
-        timeout: 20_000,
-      });
+        });
 
-      await page.reload({ waitUntil: 'networkidle' });
-      await waitForE2EHydration(page);
-      await expect(page.getByTestId(`mission-card-${offerId}`)).toContainText(
-        offerName!,
-        {
+        const firstOffer = page.locator('[data-testid^="offer-card-"]').first();
+        await expect(firstOffer).toBeVisible();
+        const offerTestId = await firstOffer.getAttribute('data-testid');
+        const offerName = (
+          await firstOffer.locator('h3').textContent()
+        )?.trim();
+        const offerId = offerTestId?.replace(/^offer-card-/, '');
+        expect(offerId).toBeTruthy();
+        expect(offerName).toBeTruthy();
+
+        await page.getByTestId(`offer-accept-${offerId}`).click();
+        await expect(page.getByTestId(`offer-card-${offerId}`)).toHaveCount(0);
+
+        const accepted = await getCampaignContractSnapshot(page);
+        expect(accepted.missionIds).toContain(offerId);
+        expect(accepted.missionNames).toContain(offerName);
+        expect(accepted.missionStatuses).toContain('Active');
+        expect(accepted.contractMarketOfferIds).not.toContain(offerId);
+
+        await page.goto(`/gameplay/campaigns/${campaignId}/missions`);
+        await expect(page.getByTestId(`mission-card-${offerId}`)).toContainText(
+          offerName!,
+          {
+            timeout: 20_000,
+          },
+        );
+        await expect(
+          page.getByTestId(`mission-status-${offerId}`),
+        ).toContainText('Active');
+        await expect(page.getByText(offerName!)).toBeVisible({
           timeout: 20_000,
-        },
-      );
-      await expect(page.getByTestId(`mission-status-${offerId}`)).toContainText(
-        'Active',
-      );
-      await expect(page.getByText(offerName!)).toBeVisible({
-        timeout: 20_000,
-      });
+        });
 
-      const reloaded = await getCampaignContractSnapshot(page);
-      expect(reloaded.campaignId).toBe(campaignId);
-      expect(reloaded.missionIds).toContain(offerId);
-      expect(reloaded.missionNames).toContain(offerName);
-      expect(reloaded.contractMarketOfferIds).not.toContain(offerId);
+        await page.reload({ waitUntil: 'networkidle' });
+        await waitForE2EHydration(page);
+        await expect(page.getByTestId(`mission-card-${offerId}`)).toContainText(
+          offerName!,
+          {
+            timeout: 20_000,
+          },
+        );
+        await expect(
+          page.getByTestId(`mission-status-${offerId}`),
+        ).toContainText('Active');
+        await expect(page.getByText(offerName!)).toBeVisible({
+          timeout: 20_000,
+        });
 
-      await page.goto(
-        `/gameplay/campaigns/${campaignId}/missions/${offerId}/launch`,
-      );
-      await waitForE2EHydration(page);
-      await expect(page.getByTestId('launch-mission-direct')).toBeVisible({
-        timeout: 20_000,
-      });
-      await page.getByTestId('launch-mission-direct').click();
-      await page.waitForURL(
-        (url) =>
-          url.pathname.startsWith('/gameplay/encounters/') &&
-          url.searchParams.get('campaignId') === campaignId &&
-          url.searchParams.get('missionId') === offerId,
-        { timeout: 30_000 },
-      );
-      await expect(page.getByTestId('encounter-detail-page')).toBeVisible({
-        timeout: 20_000,
-      });
-      await expect(page.getByTestId('launch-encounter-btn')).toBeEnabled({
-        timeout: 20_000,
-      });
+        const reloaded = await getCampaignContractSnapshot(page);
+        expect(reloaded.campaignId).toBe(campaignId);
+        expect(reloaded.missionIds).toContain(offerId);
+        expect(reloaded.missionNames).toContain(offerName);
+        expect(reloaded.contractMarketOfferIds).not.toContain(offerId);
 
-      const encounterId = page
-        .url()
-        .match(/\/gameplay\/encounters\/([^/?#]+)/)?.[1];
-      expect(encounterId).toBeTruthy();
-      expect(encounterId).not.toBe(offerId);
+        await page.goto(
+          `/gameplay/campaigns/${campaignId}/missions/${offerId}/launch`,
+        );
+        await waitForE2EHydration(page);
+        await expect(page.getByTestId('launch-mission-direct')).toBeVisible({
+          timeout: 20_000,
+        });
+        await page.getByTestId('launch-mission-direct').click();
+        await page.waitForURL(
+          (url) =>
+            url.pathname.startsWith('/gameplay/encounters/') &&
+            url.searchParams.get('campaignId') === campaignId &&
+            url.searchParams.get('missionId') === offerId,
+          { timeout: 30_000 },
+        );
+        await expect(page.getByTestId('encounter-detail-page')).toBeVisible({
+          timeout: 20_000,
+        });
+        await expect(page.getByTestId('launch-encounter-btn')).toBeEnabled({
+          timeout: 20_000,
+        });
 
-      const materialized = await getCampaignContractSnapshot(page);
-      expect(materialized.missionScenarioIds).toContain(encounterId);
-    },
+        const encounterId = page
+          .url()
+          .match(/\/gameplay\/encounters\/([^/?#]+)/)?.[1];
+        expect(encounterId).toBeTruthy();
+        expect(encounterId).not.toBe(offerId);
+
+        const materialized = await getCampaignContractSnapshot(page);
+        expect(materialized.missionScenarioIds).toContain(encounterId);
+      }),
   );
 });

--- a/e2e/helpers/browserDiagnostics.ts
+++ b/e2e/helpers/browserDiagnostics.ts
@@ -1,0 +1,149 @@
+import {
+  expect,
+  type ConsoleMessage,
+  type Page,
+  type Request,
+  type TestInfo,
+} from '@playwright/test';
+
+import {
+  formatBrowserDiagnosticEvents,
+  isFatalBrowserDiagnosticEvent,
+  shouldCaptureRequestFailure,
+  type BrowserDiagnosticEvent,
+} from './browserDiagnosticsModel';
+
+export {
+  formatBrowserDiagnosticEvents,
+  isFatalBrowserDiagnosticEvent,
+  shouldCaptureRequestFailure,
+  type BrowserDiagnosticEvent,
+} from './browserDiagnosticsModel';
+
+export interface BrowserDiagnostics {
+  readonly events: readonly BrowserDiagnosticEvent[];
+  assertNoErrors(testInfo?: TestInfo): Promise<void>;
+  attach(testInfo?: TestInfo): Promise<void>;
+  dispose(): void;
+}
+
+export async function withBrowserDiagnostics<T>(
+  page: Page,
+  testInfo: TestInfo | undefined,
+  run: (diagnostics: BrowserDiagnostics) => Promise<T>,
+): Promise<T> {
+  const diagnostics = installBrowserDiagnostics(page);
+  let failed = false;
+  try {
+    const result = await run(diagnostics);
+    await diagnostics.assertNoErrors(testInfo);
+    return result;
+  } catch (error) {
+    failed = true;
+    throw error;
+  } finally {
+    if (failed) {
+      await diagnostics.attach(testInfo);
+    }
+    diagnostics.dispose();
+  }
+}
+
+const DEFAULT_CONSOLE_TYPES = new Set(['error']);
+
+export function installBrowserDiagnostics(page: Page): BrowserDiagnostics {
+  const events: BrowserDiagnosticEvent[] = [];
+  let attached = false;
+
+  const now = (): string => new Date().toISOString();
+  const currentPageUrl = (): string => {
+    try {
+      return page.url();
+    } catch {
+      return '<page-url-unavailable>';
+    }
+  };
+
+  const onPageError = (error: Error): void => {
+    events.push({
+      type: 'pageerror',
+      timestamp: now(),
+      pageUrl: currentPageUrl(),
+      message: error.message,
+      name: error.name,
+      stack: error.stack,
+    });
+  };
+
+  const onRequestFailed = (request: Request): void => {
+    const url = request.url();
+    const resourceType = request.resourceType();
+    if (!shouldCaptureRequestFailure(url, resourceType)) {
+      return;
+    }
+
+    events.push({
+      type: 'requestfailed',
+      timestamp: now(),
+      pageUrl: currentPageUrl(),
+      method: request.method(),
+      url,
+      resourceType,
+      failureText: request.failure()?.errorText ?? 'unknown request failure',
+    });
+  };
+
+  const onConsole = (message: ConsoleMessage): void => {
+    const consoleType = message.type();
+    if (!DEFAULT_CONSOLE_TYPES.has(consoleType)) {
+      return;
+    }
+
+    events.push({
+      type: 'console',
+      timestamp: now(),
+      pageUrl: currentPageUrl(),
+      consoleType,
+      text: message.text(),
+      location: message.location(),
+    });
+  };
+
+  page.on('pageerror', onPageError);
+  page.on('requestfailed', onRequestFailed);
+  page.on('console', onConsole);
+
+  const attach = async (testInfo?: TestInfo): Promise<void> => {
+    if (!testInfo || attached || events.length === 0) {
+      return;
+    }
+    attached = true;
+    await testInfo.attach('browser-diagnostics.json', {
+      body: JSON.stringify(events, null, 2),
+      contentType: 'application/json',
+    });
+    await testInfo.attach('browser-diagnostics.txt', {
+      body: formatBrowserDiagnosticEvents(events),
+      contentType: 'text/plain',
+    });
+  };
+
+  return {
+    get events() {
+      return [...events];
+    },
+    async assertNoErrors(testInfo?: TestInfo): Promise<void> {
+      const fatalEvents = events.filter(isFatalBrowserDiagnosticEvent);
+      if (fatalEvents.length > 0) {
+        await attach(testInfo);
+      }
+      expect(fatalEvents, formatBrowserDiagnosticEvents(events)).toEqual([]);
+    },
+    attach,
+    dispose(): void {
+      page.off('pageerror', onPageError);
+      page.off('requestfailed', onRequestFailed);
+      page.off('console', onConsole);
+    },
+  };
+}

--- a/e2e/helpers/browserDiagnosticsModel.ts
+++ b/e2e/helpers/browserDiagnosticsModel.ts
@@ -1,0 +1,95 @@
+export type BrowserDiagnosticEvent =
+  | {
+      readonly type: 'pageerror';
+      readonly timestamp: string;
+      readonly pageUrl: string;
+      readonly message: string;
+      readonly name?: string;
+      readonly stack?: string;
+    }
+  | {
+      readonly type: 'requestfailed';
+      readonly timestamp: string;
+      readonly pageUrl: string;
+      readonly method: string;
+      readonly url: string;
+      readonly resourceType: string;
+      readonly failureText: string;
+    }
+  | {
+      readonly type: 'console';
+      readonly timestamp: string;
+      readonly pageUrl: string;
+      readonly consoleType: string;
+      readonly text: string;
+      readonly location: {
+        readonly url?: string;
+        readonly lineNumber?: number;
+        readonly columnNumber?: number;
+      };
+    };
+
+export function shouldCaptureRequestFailure(
+  url: string,
+  resourceType: string,
+): boolean {
+  return (
+    resourceType === 'fetch' ||
+    resourceType === 'xhr' ||
+    /\/api(\/|\?|$)/.test(url)
+  );
+}
+
+export function isFatalBrowserDiagnosticEvent(
+  event: BrowserDiagnosticEvent,
+): boolean {
+  if (event.type !== 'requestfailed') {
+    return true;
+  }
+
+  return (
+    /\/api(\/|\?|$)/.test(event.url) || event.failureText !== 'net::ERR_ABORTED'
+  );
+}
+
+export function formatBrowserDiagnosticEvents(
+  events: readonly BrowserDiagnosticEvent[],
+): string {
+  if (events.length === 0) {
+    return 'No browser diagnostics captured.';
+  }
+
+  return events
+    .map((event, index) => {
+      const prefix = `${index + 1}. [${event.type}] ${event.timestamp}`;
+      if (event.type === 'pageerror') {
+        return [
+          prefix,
+          `page: ${event.pageUrl}`,
+          `message: ${event.message}`,
+          event.stack ? `stack: ${event.stack}` : null,
+        ]
+          .filter(Boolean)
+          .join('\n');
+      }
+      if (event.type === 'requestfailed') {
+        return [
+          prefix,
+          `page: ${event.pageUrl}`,
+          `request: ${event.method} ${event.url}`,
+          `resource: ${event.resourceType}`,
+          `failure: ${event.failureText}`,
+        ].join('\n');
+      }
+      return [
+        prefix,
+        `page: ${event.pageUrl}`,
+        `console: ${event.consoleType}`,
+        `text: ${event.text}`,
+        event.location.url ? `source: ${event.location.url}` : null,
+      ]
+        .filter(Boolean)
+        .join('\n');
+    })
+    .join('\n\n');
+}

--- a/e2e/helpers/index.ts
+++ b/e2e/helpers/index.ts
@@ -47,3 +47,14 @@ export {
   setStoreValue,
   waitForStoreState,
 } from './store';
+
+// Browser diagnostics
+export {
+  formatBrowserDiagnosticEvents,
+  installBrowserDiagnostics,
+  isFatalBrowserDiagnosticEvent,
+  shouldCaptureRequestFailure,
+  withBrowserDiagnostics,
+  type BrowserDiagnosticEvent,
+  type BrowserDiagnostics,
+} from './browserDiagnostics';

--- a/scripts/__tests__/browser-diagnostics-helper.test.ts
+++ b/scripts/__tests__/browser-diagnostics-helper.test.ts
@@ -1,0 +1,92 @@
+import {
+  formatBrowserDiagnosticEvents,
+  isFatalBrowserDiagnosticEvent,
+  shouldCaptureRequestFailure,
+  type BrowserDiagnosticEvent,
+} from '../../e2e/helpers/browserDiagnosticsModel';
+
+describe('browser diagnostics helper', () => {
+  it('captures fetch, xhr, and API request failures while ignoring static asset noise', () => {
+    expect(shouldCaptureRequestFailure('/api/campaigns/abc', 'document')).toBe(
+      true,
+    );
+    expect(shouldCaptureRequestFailure('/gameplay/campaigns', 'fetch')).toBe(
+      true,
+    );
+    expect(shouldCaptureRequestFailure('/campaigns/save', 'xhr')).toBe(true);
+    expect(
+      shouldCaptureRequestFailure('/_next/static/chunk.js', 'script'),
+    ).toBe(false);
+  });
+
+  it('treats aborted non-API fetches as context while keeping API failures fatal', () => {
+    expect(
+      isFatalBrowserDiagnosticEvent({
+        type: 'requestfailed',
+        timestamp: '3025-01-01T00:00:00.000Z',
+        pageUrl: 'http://localhost:3600/gameplay/campaigns/campaign-1',
+        method: 'GET',
+        url: 'http://localhost:3600/data/equipment/official/ammunition/atm.json',
+        resourceType: 'fetch',
+        failureText: 'net::ERR_ABORTED',
+      }),
+    ).toBe(false);
+
+    expect(
+      isFatalBrowserDiagnosticEvent({
+        type: 'requestfailed',
+        timestamp: '3025-01-01T00:00:00.000Z',
+        pageUrl: 'http://localhost:3600/gameplay/campaigns/campaign-1',
+        method: 'PUT',
+        url: 'http://localhost:3600/api/campaigns/campaign-1',
+        resourceType: 'fetch',
+        failureText: 'net::ERR_ABORTED',
+      }),
+    ).toBe(true);
+  });
+
+  it('formats page, request, and console diagnostics with triage details', () => {
+    const events: BrowserDiagnosticEvent[] = [
+      {
+        type: 'pageerror',
+        timestamp: '3025-01-01T00:00:00.000Z',
+        pageUrl: 'http://localhost:3600/gameplay/campaigns/campaign-1',
+        message: 'Failed to fetch',
+        name: 'TypeError',
+        stack: 'TypeError: Failed to fetch',
+      },
+      {
+        type: 'requestfailed',
+        timestamp: '3025-01-01T00:00:01.000Z',
+        pageUrl: 'http://localhost:3600/gameplay/campaigns/campaign-1',
+        method: 'PUT',
+        url: 'http://localhost:3600/api/campaigns/campaign-1',
+        resourceType: 'fetch',
+        failureText: 'net::ERR_CONNECTION_RESET',
+      },
+      {
+        type: 'console',
+        timestamp: '3025-01-01T00:00:02.000Z',
+        pageUrl: 'http://localhost:3600/gameplay/campaigns/campaign-1',
+        consoleType: 'error',
+        text: 'campaign save failed',
+        location: {
+          url: 'webpack-internal:///campaignPersistence.ts',
+        },
+      },
+    ];
+
+    const formatted = formatBrowserDiagnosticEvents(events);
+
+    expect(formatted).toContain('[pageerror]');
+    expect(formatted).toContain('message: Failed to fetch');
+    expect(formatted).toContain(
+      'request: PUT http://localhost:3600/api/campaigns/campaign-1',
+    );
+    expect(formatted).toContain('failure: net::ERR_CONNECTION_RESET');
+    expect(formatted).toContain('console: error');
+    expect(formatted).toContain(
+      'source: webpack-internal:///campaignPersistence.ts',
+    );
+  });
+});

--- a/src/lib/campaign/turnover/modifiers/__tests__/modifiers.test-helpers.ts
+++ b/src/lib/campaign/turnover/modifiers/__tests__/modifiers.test-helpers.ts
@@ -242,6 +242,16 @@ describe('Turnover Personal Modifiers', () => {
       });
       expect(getRecentPromotionModifier(entry, null, campaign)).toBe(-1);
     });
+
+    it('should accept persisted ISO promotion dates', () => {
+      const campaign = createTestCampaign({
+        currentDate: new Date('3025-06-15'),
+      });
+      const entry = createTestEntry({
+        lastPromotionDate: '3025-03-01T00:00:00.000Z' as unknown as Date,
+      });
+      expect(getRecentPromotionModifier(entry, null, campaign)).toBe(-1);
+    });
   });
 
   describe('getAgeModifier', () => {
@@ -259,6 +269,16 @@ describe('Turnover Personal Modifiers', () => {
         currentDate: new Date('3025-06-15'),
       });
       const entry = createTestEntry({ hireDate: new Date('3000-01-01') });
+      expect(getAgeModifier(entry, null, campaign)).toBe(0);
+    });
+
+    it('should accept persisted ISO hire dates', () => {
+      const campaign = createTestCampaign({
+        currentDate: new Date('3025-06-15'),
+      });
+      const entry = createTestEntry({
+        hireDate: '3000-01-01T00:00:00.000Z' as unknown as Date,
+      });
       expect(getAgeModifier(entry, null, campaign)).toBe(0);
     });
 

--- a/src/lib/campaign/turnover/modifiers/personalModifiers.ts
+++ b/src/lib/campaign/turnover/modifiers/personalModifiers.ts
@@ -20,6 +20,12 @@ const FOUNDER_MODIFIER = -2;
 const OFFICER_MODIFIER = -1;
 const RECENT_PROMOTION_MODIFIER = -1;
 
+function toDate(value: Date | string | undefined): Date | null {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
 /**
  * Returns -2 if the roster entry is a founder, 0 otherwise.
  *
@@ -45,10 +51,12 @@ export function getRecentPromotionModifier(
   _pilot: IPilot | null,
   campaign: ICampaign,
 ): number {
-  if (!entry.lastPromotionDate) return 0;
+  const now = toDate(campaign.currentDate);
+  const promotionDate = toDate(
+    entry.lastPromotionDate as Date | string | undefined,
+  );
 
-  const now = campaign.currentDate;
-  const promotionDate = entry.lastPromotionDate;
+  if (!now || !promotionDate) return 0;
 
   const monthsDiff =
     (now.getFullYear() - promotionDate.getFullYear()) * 12 +
@@ -71,9 +79,11 @@ function getPersonAge(
   _pilot: IPilot | null,
   campaign: ICampaign,
 ): number {
-  const now = campaign.currentDate;
+  const now = toDate(campaign.currentDate);
+  const birth = toDate(entry.hireDate as Date | string);
+  if (!now || !birth) return 0;
+
   // Use hireDate as birth-date proxy.
-  const birth = entry.hireDate;
   let age = now.getFullYear() - birth.getFullYear();
   const monthDiff = now.getMonth() - birth.getMonth();
   if (monthDiff < 0 || (monthDiff === 0 && now.getDate() < birth.getDate())) {


### PR DESCRIPTION
## Summary
- Add shared Playwright browser diagnostics for page errors, console errors, and fetch/API request failures.
- Wrap strict campaign browser flows with the diagnostics helper so failures report useful triage context.
- Normalize persisted ISO campaign roster dates in turnover personal modifiers, fixing the day-advance console failure surfaced by the browser lane.

## Validation
- `npm.cmd test -- --watchAll=false --runTestsByPath scripts/__tests__/browser-diagnostics-helper.test.ts --runInBand`
- `npm.cmd test -- --watchAll=false --runTestsByPath src/lib/campaign/turnover/modifiers/__tests__/modifiers.test.ts --runInBand`
- `npm.cmd run verify:qc:campaign-economy`
- `npm.cmd run qc:logging:validate`
- `npm.cmd run verify:qc:campaign-economy:browser`
- `npm.cmd run typecheck`
- `npm.cmd run lint` (1923 warnings, 0 errors)
- `npm.cmd run format:check`
- `git diff --check`

## Not Run
- Full `npm run verify` / `npm run verify:full`.