### PR TITLE
Make stale app-shell links recoverable

### DIFF
--- a/docs/qc/mekstation-qc-map.md
+++ b/docs/qc/mekstation-qc-map.md
@@ -184,6 +184,10 @@ flowchart TD
      `npm.cmd run qc:app-shell-routes:validate`, which reports primary,
      recovery, delegated, known-gap, and test-harness route counts before the
      slower Chromium refresh/deep-link proof runs.
+   - 2026-06-29 global not-found recovery now has a MekStation shell page and
+     an unmatched deep-link proof path, so stale external links land on a
+     recoverable dashboard/gameplay/replay handoff instead of the framework
+     default 404.
    - Dynamic generated-ID session recovery is intentionally left to the
      campaign, combat continuity, multiplayer, and replay lanes where seeded
      state can prove recovery without weakening this static route sweep.

--- a/e2e/app-shell-route-manifest.json
+++ b/e2e/app-shell-route-manifest.json
@@ -36,6 +36,11 @@
       "path": "/share/e2e-missing-token",
       "pattern": "/share/[token]",
       "label": "invalid share token"
+    },
+    {
+      "path": "/app-shell-e2e-missing-route",
+      "pattern": "/404",
+      "label": "global not found"
     }
   ],
   "delegatedRoutes": [

--- a/e2e/app-shell-route-proof.spec.ts
+++ b/e2e/app-shell-route-proof.spec.ts
@@ -406,6 +406,32 @@ const routeProofs: readonly RouteProof[] = [
     ],
   },
   {
+    path: '/app-shell-e2e-missing-route',
+    label: 'global not found',
+    pageTitle: 'Page Not Found',
+    text: /This route does not exist or has moved/i,
+    allowedConsoleErrors: [
+      'Failed to load resource: the server responded with a status of 404 (Not Found)',
+    ],
+    affordances: [
+      {
+        label: 'global not found recovery panel',
+        testId: 'global-not-found-recovery',
+      },
+      {
+        label: 'dashboard recovery link',
+        role: 'link',
+        name: /Go to Dashboard/i,
+      },
+      { label: 'gameplay recovery link', role: 'link', name: /Open Gameplay/i },
+      {
+        label: 'replay library recovery link',
+        role: 'link',
+        name: /Open Replay Library/i,
+      },
+    ],
+  },
+  {
     path: '/settings#vault',
     label: 'settings vault hash',
     pageTitle: 'Settings',

--- a/scripts/qc/validate-qc-registry.mjs
+++ b/scripts/qc/validate-qc-registry.mjs
@@ -492,6 +492,9 @@ function appShellRecoveryRoutePatterns(issues) {
 
     const normalizedPath = pathValue.trim();
     const normalizedPattern = patternValue.trim();
+    if (!normalizedPath.startsWith('/')) {
+      issues.push(fail(`${label}.path must start with "/": ${normalizedPath}`));
+    }
     if (seenPaths.has(normalizedPath)) {
       issues.push(
         fail(
@@ -501,7 +504,12 @@ function appShellRecoveryRoutePatterns(issues) {
     }
     seenPaths.add(normalizedPath);
 
-    if (!routeReferenceExists(normalizedPath)) {
+    const isNotFoundFallback =
+      normalizedPattern === '/404' &&
+      knownPatterns.has('/404') &&
+      !routeReferenceExists(normalizedPath);
+
+    if (!routeReferenceExists(normalizedPath) && !isNotFoundFallback) {
       issues.push(
         fail(
           `${label}.path does not resolve to a Next.js page route: ${normalizedPath}`,
@@ -519,7 +527,7 @@ function appShellRecoveryRoutePatterns(issues) {
     }
 
     const actualPattern = pageRoutePatternForPath(normalizedPath);
-    if (actualPattern !== normalizedPattern) {
+    if (!isNotFoundFallback && actualPattern !== normalizedPattern) {
       issues.push(
         fail(
           `${label}.path ${normalizedPath} resolves to ${actualPattern ?? 'no route'}, not declared pattern ${normalizedPattern}`,

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,0 +1,53 @@
+import Head from 'next/head';
+import Link from 'next/link';
+
+import { Card, PageLayout } from '@/components/ui';
+
+export default function NotFoundPage(): React.ReactElement {
+  return (
+    <>
+      <Head>
+        <title>Page Not Found | MekStation</title>
+      </Head>
+
+      <PageLayout
+        title="Page Not Found"
+        subtitle="This route does not exist or has moved."
+        backLink="/"
+        backLabel="Return Home"
+      >
+        <Card
+          variant="dark"
+          className="mx-auto max-w-2xl"
+          data-testid="global-not-found-recovery"
+        >
+          <p className="text-text-theme-secondary mb-6">
+            Use the dashboard to get back to your unit library, campaign work,
+            combat tools, or replay history without losing your place in the
+            app.
+          </p>
+          <div className="flex flex-wrap gap-3">
+            <Link
+              href="/"
+              className="bg-accent-hover hover:bg-accent text-text-theme-primary inline-flex min-h-[44px] items-center justify-center rounded-lg border border-transparent px-4 py-2 text-sm font-medium transition-colors"
+            >
+              Go to Dashboard
+            </Link>
+            <Link
+              href="/gameplay"
+              className="bg-surface-raised hover:bg-border-theme border-border-theme inline-flex min-h-[44px] items-center justify-center rounded-lg border px-4 py-2 text-sm font-medium text-slate-300 transition-colors"
+            >
+              Open Gameplay
+            </Link>
+            <Link
+              href="/replay-library"
+              className="bg-surface-raised hover:bg-border-theme border-border-theme inline-flex min-h-[44px] items-center justify-center rounded-lg border px-4 py-2 text-sm font-medium text-slate-300 transition-colors"
+            >
+              Open Replay Library
+            </Link>
+          </div>
+        </Card>
+      </PageLayout>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add a MekStation-styled global 404 recovery page for stale external/deep links
- extend the app-shell route manifest and Chromium proof to exercise the unmatched-route fallback
- tighten QC validation so only an explicit `/404` fallback may point at an unmatched path

## Validation
- `npm.cmd run qc:validate`
- `npm.cmd run verify:qc:app-shell`
- `npm.cmd run typecheck`
- `npm.cmd run format:check`
- `npm.cmd run lint` (warnings-only baseline: 1923 warnings, 0 errors)
- `git diff --check`

## Notes
- Full `verify:qc`, `verify:rules`, and `electron:test:build` were already green before this narrow app-shell slice but were not rerun after this commit.
- Browser proof regenerates `next-env.d.ts` to `.next/dev/types/routes.d.ts`; it was restored before commit.