### PR TITLE
Prove post-battle campaign reloads from server state

### DIFF
--- a/e2e/campaign-flow.spec.ts
+++ b/e2e/campaign-flow.spec.ts
@@ -38,6 +38,8 @@ interface SeededDamagedCampaign {
   readonly campaignId: string;
   readonly auditDate: string;
   readonly matchId: string;
+  readonly repairTicketId: string;
+  readonly unitId: string;
 }
 
 interface SavedCampaignSnapshot {
@@ -325,6 +327,83 @@ async function clearLiveCampaignClientState(page: Page): Promise<void> {
     .toBeNull();
 }
 
+async function readPostBattleCarryForwardSnapshot(
+  page: Page,
+  seeded: SeededDamagedCampaign,
+): Promise<{
+  readonly campaignId: string | null;
+  readonly repairTicketIds: readonly string[];
+  readonly salvageReportCount: number;
+  readonly salvageReportValue: number | null;
+  readonly auditEntryCount: number;
+  readonly auditMatchIds: readonly string[];
+  readonly balance: number | null;
+  readonly centerTorsoArmor: number | null;
+  readonly destroyedComponentNames: readonly string[];
+}> {
+  return page.evaluate(({ matchId, unitId }) => {
+    const campaign = (
+      window as unknown as {
+        __ZUSTAND_STORES__?: {
+          campaign?: { getState: () => { getCampaign?: () => any } };
+        };
+      }
+    ).__ZUSTAND_STORES__?.campaign
+      ?.getState()
+      .getCampaign?.();
+
+    const salvageReport = campaign?.salvageReports?.[matchId];
+    const unitCombatState = campaign?.unitCombatStates?.[unitId];
+
+    return {
+      campaignId: typeof campaign?.id === 'string' ? campaign.id : null,
+      repairTicketIds: Array.isArray(campaign?.repairQueue)
+        ? campaign.repairQueue
+            .map((ticket: { ticketId?: unknown }) => ticket.ticketId)
+            .filter((id: unknown): id is string => typeof id === 'string')
+        : [],
+      salvageReportCount: Object.keys(campaign?.salvageReports ?? {}).length,
+      salvageReportValue:
+        typeof salvageReport?.totalValueMercenary === 'number'
+          ? salvageReport.totalValueMercenary
+          : typeof salvageReport?.totalValue === 'number'
+            ? salvageReport.totalValue
+            : null,
+      auditEntryCount: Array.isArray(campaign?.dailyBattleAudit)
+        ? campaign.dailyBattleAudit.length
+        : 0,
+      auditMatchIds: Array.isArray(campaign?.dailyBattleAudit)
+        ? campaign.dailyBattleAudit.flatMap(
+            (entry: { matches?: readonly { matchId?: unknown }[] }) =>
+              Array.isArray(entry.matches)
+                ? entry.matches
+                    .map((match) => match.matchId)
+                    .filter(
+                      (matchId: unknown): matchId is string =>
+                        typeof matchId === 'string',
+                    )
+                : [],
+          )
+        : [],
+      balance:
+        typeof campaign?.finances?.balance?.amount === 'number'
+          ? campaign.finances.balance.amount
+          : null,
+      centerTorsoArmor:
+        typeof unitCombatState?.currentArmorPerLocation?.CT === 'number'
+          ? unitCombatState.currentArmorPerLocation.CT
+          : null,
+      destroyedComponentNames: Array.isArray(
+        unitCombatState?.destroyedComponents,
+      )
+        ? unitCombatState.destroyedComponents
+            .map((component: { name?: unknown }) => component.name)
+            .filter((name: unknown): name is string => typeof name === 'string')
+        : [],
+    };
+  }, seeded);
+}
+
 async function seedDamagedPostBattleCampaign(
   page: Page,
 ): Promise<SeededDamagedCampaign> {
@@ -366,6 +445,22 @@ async function seedDamagedPostBattleCampaign(
     const auditDate = '3025-01-01';
     const matchId = 'match-campaign-flow-damage';
     const unitId = 'unit-damaged-atlas';
+    const salvageCandidate = {
+      source: 'part',
+      unitId: 'enemy-locust',
+      designation: 'Medium Laser',
+      destroyedFromBattle: matchId,
+      finalStatus: 'destroyed',
+      damageLevel: 'heavy',
+      originalValue: 1_000_000,
+      recoveredValue: 250_000,
+      recoveryPercentage: 0.25,
+      repairCostEstimate: 25_000,
+      partId: 'salvage-medium-laser',
+      location: 'RA',
+      disposition: 'mercenary',
+      status: 'awarded',
+    };
 
     stores.campaignRoster.setState?.({
       campaignId,
@@ -452,10 +547,38 @@ async function seedDamagedPostBattleCampaign(
       ],
       salvageReports: {
         [matchId]: {
-          battleId: matchId,
+          matchId,
           contractId: 'contract-damage-carry-forward',
-          totalCandidates: 1,
-          totalValue: 250_000,
+          candidates: [salvageCandidate],
+          totalValueEmployer: 0,
+          totalValueMercenary: 250_000,
+          hostileTerritoryPenalty: 1,
+          auctionRequired: false,
+        },
+      },
+      salvageAllocations: {
+        [matchId]: {
+          pool: {
+            battleId: matchId,
+            contractId: 'contract-damage-carry-forward',
+            candidates: [salvageCandidate],
+            totalEstimatedValue: 250_000,
+            hostileTerritory: false,
+          },
+          employerAward: {
+            side: 'employer',
+            candidates: [],
+            totalValue: 0,
+            estimatedRepairCost: 0,
+          },
+          mercenaryAward: {
+            side: 'mercenary',
+            candidates: [salvageCandidate],
+            totalValue: 250_000,
+            estimatedRepairCost: 25_000,
+          },
+          splitMethod: 'contract',
+          processed: true,
         },
       },
       unitCombatStates: {
@@ -490,7 +613,13 @@ async function seedDamagedPostBattleCampaign(
       },
     });
 
-    return { campaignId, auditDate, matchId };
+    return {
+      campaignId,
+      auditDate,
+      matchId,
+      repairTicketId: 'ticket-damage-carry-forward-ct',
+      unitId,
+    };
   });
 }
 
@@ -610,54 +739,184 @@ test.describe('Campaign Flow - Mission Generation', () => {
 
 test.describe('Campaign Flow - Damage Carry-Forward', () => {
   test(
-    'shows damaged roster state, audit entry, repair queue, and salvage report',
-    { tag: ['@campaign', '@smoke'] },
-    async ({ page }) => {
-      const seeded = await seedDamagedPostBattleCampaign(page);
+    'persists damaged roster state, audit entry, repair queue, and salvage report after reload',
+    { tag: ['@campaign', '@smoke', '@strict'] },
+    async ({ page }, testInfo) =>
+      withBrowserDiagnostics(page, testInfo, async () => {
+        const seeded = await seedDamagedPostBattleCampaign(page);
 
-      await page.goto(`/gameplay/campaigns/${seeded.campaignId}`);
-      await expect(page.getByTestId('campaign-dashboard')).toBeVisible({
-        timeout: 20_000,
-      });
-      await expect(page.getByTestId('roster-unit-card')).toContainText(
-        'Atlas AS7-D',
-      );
-      await expect(page.getByTestId('roster-unit-card')).toContainText(
-        'Damaged',
-      );
-      await expect(page.getByTestId('daily-battle-audit-feed')).toBeVisible();
-      await expect(
-        page.getByTestId(`audit-entry-${seeded.auditDate}`),
-      ).toContainText('Repairs: 1');
-      await expect(
-        page.getByTestId(`audit-match-link-${seeded.matchId}`),
-      ).toBeVisible();
+        await page.goto(`/gameplay/campaigns/${seeded.campaignId}`);
+        await expect(page.getByTestId('campaign-dashboard')).toBeVisible({
+          timeout: 20_000,
+        });
+        await expect(page.getByTestId('roster-unit-card')).toContainText(
+          'Atlas AS7-D',
+        );
+        await expect(page.getByTestId('roster-unit-card')).toContainText(
+          'Damaged',
+        );
+        await expect(page.getByTestId('daily-battle-audit-feed')).toBeVisible();
+        await expect(
+          page.getByTestId(`audit-entry-${seeded.auditDate}`),
+        ).toContainText('Repairs: 1');
+        await expect(
+          page.getByTestId(`audit-match-link-${seeded.matchId}`),
+        ).toBeVisible();
 
-      const postBattleState = await page.evaluate(() => {
-        const campaign = (
-          window as unknown as {
-            __ZUSTAND_STORES__?: {
-              campaign?: { getState: () => { getCampaign?: () => any } };
-            };
+        const postBattleState = await page.evaluate(() => {
+          const campaign = (
+            window as unknown as {
+              __ZUSTAND_STORES__?: {
+                campaign?: { getState: () => { getCampaign?: () => any } };
+              };
+            }
+          ).__ZUSTAND_STORES__?.campaign
+            ?.getState()
+            .getCampaign?.();
+
+          return {
+            repairTicketCount: campaign?.repairQueue?.length ?? 0,
+            salvageReportCount: Object.keys(campaign?.salvageReports ?? {})
+              .length,
+            auditEntryCount: campaign?.dailyBattleAudit?.length ?? 0,
+          };
+        });
+
+        expect(postBattleState).toEqual({
+          repairTicketCount: 1,
+          salvageReportCount: 1,
+          auditEntryCount: 1,
+        });
+
+        const saved = await saveCampaignThroughDashboard(
+          page,
+          seeded.campaignId,
+        );
+        await clearLiveCampaignClientState(page);
+
+        await page.goto(`/gameplay/campaigns/${seeded.campaignId}`);
+        await waitForE2EHydration(page);
+        await expect(page.getByTestId('campaign-dashboard')).toBeVisible({
+          timeout: 20_000,
+        });
+        await expect(page.getByTestId('roster-unit-card')).toContainText(
+          'Atlas AS7-D',
+        );
+        await expect(page.getByTestId('roster-unit-card')).toContainText(
+          'Damaged',
+        );
+        await expect(page.getByTestId('daily-battle-audit-feed')).toBeVisible();
+        await expect(
+          page.getByTestId(`audit-entry-${seeded.auditDate}`),
+        ).toContainText('Repairs: 1');
+        await expect(
+          page.getByTestId(`audit-match-link-${seeded.matchId}`),
+        ).toBeVisible();
+
+        await page.goto(`/gameplay/campaigns/${seeded.campaignId}/repair-bay`);
+        await waitForE2EHydration(page);
+        await expect(page.getByTestId('repair-bay-queue')).toBeVisible({
+          timeout: 20_000,
+        });
+        await expect(
+          page.getByTestId(`repair-ticket-${seeded.repairTicketId}`),
+        ).toContainText('6h');
+        await expect(
+          page.getByTestId(`repair-ticket-${seeded.repairTicketId}`),
+        ).toContainText('queued');
+
+        await page.goto(`/gameplay/campaigns/${seeded.campaignId}/salvage`);
+        await waitForE2EHydration(page);
+        await expect(page.getByTestId('salvage-panel')).toBeVisible({
+          timeout: 20_000,
+        });
+        await expect(page.getByTestId('salvage-value-total')).toContainText(
+          '250,000 C-Bills',
+        );
+
+        await page.goto(`/gameplay/campaigns/${seeded.campaignId}/finances`);
+        await waitForE2EHydration(page);
+        await expect(page.getByTestId('finances-panel')).toBeVisible({
+          timeout: 20_000,
+        });
+        await expect(page.getByTestId('finances-balance')).toContainText(
+          '2,500,000.00 C-bills',
+        );
+
+        const reloadedState = await readPostBattleCarryForwardSnapshot(
+          page,
+          seeded,
+        );
+        expect(reloadedState).toMatchObject({
+          campaignId: seeded.campaignId,
+          repairTicketIds: [seeded.repairTicketId],
+          salvageReportCount: 1,
+          salvageReportValue: 250_000,
+          auditEntryCount: 1,
+          auditMatchIds: [seeded.matchId],
+          balance: 2_500_000,
+          centerTorsoArmor: 20,
+          destroyedComponentNames: ['Medium Laser'],
+        });
+
+        const serverRecord = await page.evaluate(async (id) => {
+          const response = await fetch(`/api/campaigns/${id}`);
+          if (!response.ok) {
+            throw new Error(`server responded ${response.status}`);
           }
-        ).__ZUSTAND_STORES__?.campaign
-          ?.getState()
-          .getCampaign?.();
-
-        return {
-          repairTicketCount: campaign?.repairQueue?.length ?? 0,
-          salvageReportCount: Object.keys(campaign?.salvageReports ?? {})
-            .length,
-          auditEntryCount: campaign?.dailyBattleAudit?.length ?? 0,
-        };
-      });
-
-      expect(postBattleState).toEqual({
-        repairTicketCount: 1,
-        salvageReportCount: 1,
-        auditEntryCount: 1,
-      });
-    },
+          const record = (await response.json()) as {
+            campaignId?: unknown;
+            version?: unknown;
+            body?: {
+              dailyBattleAudit?: unknown[];
+              repairQueue?: unknown[];
+              salvageReports?: Record<
+                string,
+                { totalValue?: unknown; totalValueMercenary?: unknown }
+              >;
+              unitCombatStates?: Record<
+                string,
+                { destroyedComponents?: unknown[] }
+              >;
+            };
+          };
+          const body = record.body;
+          return {
+            campaignId: record.campaignId,
+            version: record.version,
+            repairTicketCount: Array.isArray(body?.repairQueue)
+              ? body.repairQueue.length
+              : 0,
+            salvageReportValue:
+              typeof body?.salvageReports?.['match-campaign-flow-damage']
+                ?.totalValueMercenary === 'number'
+                ? body.salvageReports['match-campaign-flow-damage']
+                    .totalValueMercenary
+                : typeof body?.salvageReports?.['match-campaign-flow-damage']
+                      ?.totalValue === 'number'
+                  ? body.salvageReports['match-campaign-flow-damage'].totalValue
+                  : null,
+            auditEntryCount: Array.isArray(body?.dailyBattleAudit)
+              ? body.dailyBattleAudit.length
+              : 0,
+            destroyedComponentCount: Array.isArray(
+              body?.unitCombatStates?.['unit-damaged-atlas']
+                ?.destroyedComponents,
+            )
+              ? body.unitCombatStates['unit-damaged-atlas'].destroyedComponents
+                  .length
+              : 0,
+          };
+        }, seeded.campaignId);
+        expect(serverRecord).toEqual({
+          campaignId: seeded.campaignId,
+          version: saved.version,
+          repairTicketCount: 1,
+          salvageReportValue: 250_000,
+          auditEntryCount: 1,
+          destroyedComponentCount: 1,
+        });
+      }),
   );
 });
 

--- a/src/lib/campaign/persistence/__tests__/serverFieldMirror.test.ts
+++ b/src/lib/campaign/persistence/__tests__/serverFieldMirror.test.ts
@@ -33,6 +33,7 @@
  */
 
 import type { ICampaignWithCommand } from '@/types/campaign/CampaignCommandExtensions';
+import type { IDailyBattleAuditEntry } from '@/types/campaign/IDailyBattleAuditEntry';
 import type { ILoan } from '@/types/campaign/Loan';
 import type { SerializedCampaignBody } from '@/types/campaign/SerializedCampaign';
 import type { MechBuildConfig } from '@/utils/construction/constructionRules/types';
@@ -107,7 +108,9 @@ function makeAmortizedLoan(): ILoan {
  * Extend the populated fixture campaign with every field the pre-fix
  * server serializer dropped — the full-shape sweep input.
  */
-function buildExtendedCampaign(): ICampaignWithCommand {
+function buildExtendedCampaign(): ICampaignWithCommand & {
+  readonly dailyBattleAudit: readonly IDailyBattleAuditEntry[];
+} {
   const base = buildPopulatedCampaign();
   return {
     ...base,
@@ -217,6 +220,26 @@ function buildExtendedCampaign(): ICampaignWithCommand {
         ],
         externalEffects: [],
         publicSummary: 'Campaign time corrected by 2 days.',
+      },
+    ],
+    dailyBattleAudit: [
+      {
+        date: '3025-02-01',
+        matchesProcessed: 1,
+        matches: [
+          {
+            matchId: 'match-001',
+            contractId: 'contract-77',
+            summary: 'Victory - damage carry-forward proof',
+          },
+        ],
+        totalXpAwarded: 2,
+        pilotsWounded: 1,
+        pilotsKia: 0,
+        pilotsMia: 0,
+        salvageValueSecured: 250_000,
+        repairTicketsCreated: 1,
+        contractsClosed: ['contract-77'],
       },
     ],
     loans: [
@@ -333,6 +356,19 @@ describe('T3 — server-side campaign serialization field mirror', () => {
     });
     expect(restored.unitMarket).toHaveLength(1);
     expect(restored.unitMarket![0].unitName).toBe('Atlas AS7-D');
+    const auditRestored = restored as ICampaignWithCommand & {
+      readonly dailyBattleAudit?: readonly IDailyBattleAuditEntry[];
+    };
+    expect(auditRestored.dailyBattleAudit).toHaveLength(1);
+    expect(auditRestored.dailyBattleAudit![0]).toMatchObject({
+      date: '3025-02-01',
+      matchesProcessed: 1,
+      repairTicketsCreated: 1,
+      salvageValueSecured: 250_000,
+    });
+    expect(auditRestored.dailyBattleAudit![0].matches[0].matchId).toBe(
+      'match-001',
+    );
   });
 
   it('the amortization ledger rehydrates with live Money / Date instances', () => {
@@ -395,6 +431,13 @@ describe('T3 — server-side campaign serialization field mirror', () => {
     expect(restored.contractMarket).toBeUndefined();
     expect(restored.activeContract).toBeUndefined();
     expect(restored.unitMarket).toBeUndefined();
+    expect(
+      (
+        restored as ICampaignWithCommand & {
+          readonly dailyBattleAudit?: readonly IDailyBattleAuditEntry[];
+        }
+      ).dailyBattleAudit,
+    ).toBeUndefined();
   });
 
   it('compile-time: SerializedCampaignBody covers every ICampaignWithCommand field (drift guard)', () => {

--- a/src/lib/campaign/persistence/campaignEnvelope.ts
+++ b/src/lib/campaign/persistence/campaignEnvelope.ts
@@ -13,6 +13,7 @@ import type { ICampaign } from '@/types/campaign/Campaign';
 import type {
   ICampaignSummary,
   SerializedCampaign,
+  SerializedCampaignRosterState,
 } from '@/types/campaign/SerializedCampaign';
 
 import { CURRENT_CAMPAIGN_SCHEMA_VERSION } from './campaignMigration';
@@ -32,14 +33,16 @@ export function buildSerializedCampaign(
   campaign: ICampaign,
   originDeviceId: string,
   version: number,
+  rosterProjection?: SerializedCampaignRosterState,
 ): SerializedCampaign {
+  const body = serializeCampaign(campaign);
   return {
     schemaVersion: CURRENT_CAMPAIGN_SCHEMA_VERSION,
     campaignId: campaign.id,
     savedAt: new Date().toISOString(),
     originDeviceId,
     version,
-    body: serializeCampaign(campaign),
+    body: rosterProjection ? { ...body, rosterProjection } : body,
   };
 }
 

--- a/src/lib/campaign/persistence/serializeCampaign.ts
+++ b/src/lib/campaign/persistence/serializeCampaign.ts
@@ -14,6 +14,7 @@
 
 import type { ICampaign } from '@/types/campaign/Campaign';
 import type { ICampaignWithCommand } from '@/types/campaign/CampaignCommandExtensions';
+import type { IDailyBattleAuditEntry } from '@/types/campaign/IDailyBattleAuditEntry';
 import type { IFinances } from '@/types/campaign/IFinances';
 import type { ILoan } from '@/types/campaign/Loan';
 import type {
@@ -128,6 +129,12 @@ export function serializeCampaign(campaign: ICampaign): SerializedCampaignBody {
   // sees them (same convention as the store-path serializer in
   // stores/campaign/useCampaignStore.persistence.ts).
   const extended = campaign as ICampaignWithCommand;
+  const dailyBattleAudit =
+    (
+      campaign as ICampaign & {
+        dailyBattleAudit?: readonly IDailyBattleAuditEntry[];
+      }
+    ).dailyBattleAudit ?? undefined;
   return {
     id: campaign.id,
     name: campaign.name,
@@ -164,6 +171,7 @@ export function serializeCampaign(campaign: ICampaign): SerializedCampaignBody {
     gmInterventionEvents: campaign.gmInterventionEvents,
     timeCascadeEvents: campaign.timeCascadeEvents,
     recentlyAppliedOutcomes: campaign.recentlyAppliedOutcomes,
+    dailyBattleAudit,
     // The loan ledger (CP2b — `add-campaign-command-ui`, design D4) is
     // a campaign-extension field; every `ICampaignLoan` field is already
     // a JSON-safe scalar so it serializes directly. Omitted when absent.
@@ -231,6 +239,7 @@ export function deserializeCampaignBody(
     gmInterventionEvents: body.gmInterventionEvents,
     timeCascadeEvents: body.timeCascadeEvents,
     recentlyAppliedOutcomes: body.recentlyAppliedOutcomes,
+    dailyBattleAudit: body.dailyBattleAudit,
     // Restore the loan ledger (design D4). Absent on pre-CP2b snapshots,
     // in which case the campaign simply carries no `loans` field.
     ...(body.loans !== undefined ? { loans: body.loans } : {}),

--- a/src/stores/campaign/__tests__/useCampaignPersistenceStore.test.ts
+++ b/src/stores/campaign/__tests__/useCampaignPersistenceStore.test.ts
@@ -20,12 +20,15 @@ import type { SerializedCampaign } from '@/types/campaign/SerializedCampaign';
 
 import { buildPopulatedCampaign } from '@/lib/campaign/persistence/__tests__/campaignFixture';
 import { buildSerializedCampaign } from '@/lib/campaign/persistence/campaignEnvelope';
+import { CampaignPilotStatus } from '@/types/campaign/CampaignInterfaces';
+import { CampaignPersonnelRole } from '@/types/campaign/enums/CampaignPersonnelRole';
 
 import { registerCampaignStoreAccessor } from '../campaignStoreAccessor';
 import {
   AUTO_SAVE_DEBOUNCE_MS,
   useCampaignPersistenceStore,
 } from '../useCampaignPersistenceStore';
+import { useCampaignRosterStore } from '../useCampaignRosterStore';
 
 // =============================================================================
 // Minimal mock campaign store for the live-campaign seam
@@ -69,6 +72,53 @@ function jsonResponse(status: number, body: unknown): Response {
   } as Response;
 }
 
+function seedRosterProjection(campaignId: string): void {
+  useCampaignRosterStore.setState({
+    campaignId,
+    units: [
+      {
+        unitId: 'unit-atlas-as7d',
+        unitName: 'Atlas AS7-D',
+        pilotId: 'pilot-morgan-kell',
+        chassisVariant: 'AS7-D',
+        readiness: 'Damaged',
+      },
+    ],
+    pilots: [
+      {
+        pilotId: 'pilot-morgan-kell',
+        pilotName: 'Morgan Kell',
+        status: CampaignPilotStatus.Active,
+        wounds: 1,
+        xp: 2,
+        campaignXpEarned: 2,
+        campaignKills: 1,
+        campaignMissions: 1,
+        recoveryTime: 0,
+        hireDate: new Date('3025-01-01T00:00:00.000Z'),
+        primaryRole: CampaignPersonnelRole.PILOT,
+        rankIndex: 0,
+        assignedUnitId: 'unit-atlas-as7d',
+      },
+    ],
+    missions: [
+      {
+        id: 'mission-damage-carry-forward',
+        missionNumber: 1,
+        name: 'Damage Carry Forward',
+        result: 'victory',
+        encounterId: 'encounter-damage-carry-forward',
+        campaignId,
+        deployedUnitIds: ['unit-atlas-as7d'],
+        completedAt: '3025-01-02T00:00:00.000Z',
+        turnsPlayed: 5,
+      },
+    ],
+    activeMissionId: null,
+    missionCount: 1,
+  });
+}
+
 // =============================================================================
 // Setup
 // =============================================================================
@@ -84,6 +134,7 @@ describe('useCampaignPersistenceStore', () => {
       () => mockStore as unknown as ReturnType<MockAccessor>,
     );
     useCampaignPersistenceStore.getState().reset();
+    useCampaignRosterStore.getState().reset();
   });
 
   afterEach(() => {
@@ -151,6 +202,73 @@ describe('useCampaignPersistenceStore', () => {
     expect(ok).toBe(true);
     expect(useCampaignPersistenceStore.getState().baseVersion).toBe(3);
     expect(useCampaignPersistenceStore.getState().saveState).toBe('saved');
+  });
+
+  it('loadCampaign rehydrates the server roster projection', async () => {
+    const envelope = buildSerializedCampaign(campaign, 'device-y', 3, {
+      campaignId: campaign.id,
+      units: [
+        {
+          unitId: 'unit-atlas-as7d',
+          unitName: 'Atlas AS7-D',
+          pilotId: 'pilot-morgan-kell',
+          chassisVariant: 'AS7-D',
+          readiness: 'Damaged',
+        },
+      ],
+      pilots: [
+        {
+          pilotId: 'pilot-morgan-kell',
+          pilotName: 'Morgan Kell',
+          status: CampaignPilotStatus.Active,
+          wounds: 1,
+          xp: 2,
+          campaignXpEarned: 2,
+          campaignKills: 1,
+          campaignMissions: 1,
+          recoveryTime: 0,
+          hireDate: '3025-01-01T00:00:00.000Z',
+          primaryRole: CampaignPersonnelRole.PILOT,
+          rankIndex: 0,
+          assignedUnitId: 'unit-atlas-as7d',
+        },
+      ],
+      missions: [
+        {
+          id: 'mission-damage-carry-forward',
+          missionNumber: 1,
+          name: 'Damage Carry Forward',
+          result: 'victory',
+          encounterId: 'encounter-damage-carry-forward',
+          campaignId: campaign.id,
+          deployedUnitIds: ['unit-atlas-as7d'],
+          completedAt: '3025-01-02T00:00:00.000Z',
+          turnsPlayed: 5,
+        },
+      ],
+      activeMissionId: null,
+      missionCount: 1,
+    });
+    jest.spyOn(global, 'fetch').mockResolvedValue(jsonResponse(200, envelope));
+
+    const ok = await useCampaignPersistenceStore
+      .getState()
+      .loadCampaign(campaign.id);
+
+    expect(ok).toBe(true);
+    const roster = useCampaignRosterStore.getState();
+    expect(roster.campaignId).toBe(campaign.id);
+    expect(roster.units[0]).toMatchObject({
+      unitId: 'unit-atlas-as7d',
+      unitName: 'Atlas AS7-D',
+      readiness: 'Damaged',
+    });
+    expect(roster.pilots[0].hireDate).toBeInstanceOf(Date);
+    expect(roster.pilots[0].hireDate.toISOString()).toBe(
+      '3025-01-01T00:00:00.000Z',
+    );
+    expect(roster.missions[0].deployedUnitIds).toEqual(['unit-atlas-as7d']);
+    expect(roster.missionCount).toBe(1);
   });
 
   it('loadCampaign returns false on a 404', async () => {
@@ -257,5 +375,45 @@ describe('useCampaignPersistenceStore', () => {
 
     // Issued immediately — no timer advance needed.
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('saveCampaign includes the matching roster projection in the server envelope', async () => {
+    seedRosterProjection(campaign.id);
+    const putBodies: Array<{
+      envelope: SerializedCampaign;
+      baseVersion: number;
+    }> = [];
+    const fetchMock = jest
+      .spyOn(global, 'fetch')
+      .mockImplementation(async (_input, init) => {
+        const putBody = JSON.parse(
+          String((init as RequestInit).body),
+        ) as (typeof putBodies)[number];
+        putBodies.push(putBody);
+        return jsonResponse(200, putBody.envelope);
+      });
+
+    await useCampaignPersistenceStore.getState().saveCampaign();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(putBodies).toHaveLength(1);
+    const savedPutBody = putBodies[0];
+    expect(savedPutBody.envelope.body.rosterProjection).toBeDefined();
+    expect(savedPutBody.envelope.body.rosterProjection?.campaignId).toBe(
+      campaign.id,
+    );
+    expect(savedPutBody.envelope.body.rosterProjection?.units[0]).toMatchObject(
+      {
+        unitId: 'unit-atlas-as7d',
+        unitName: 'Atlas AS7-D',
+        readiness: 'Damaged',
+      },
+    );
+    expect(
+      savedPutBody.envelope.body.rosterProjection?.pilots[0].hireDate,
+    ).toBe('3025-01-01T00:00:00.000Z');
+    expect(
+      savedPutBody.envelope.body.rosterProjection?.missions[0].deployedUnitIds,
+    ).toEqual(['unit-atlas-as7d']);
   });
 });

--- a/src/stores/campaign/useCampaignPersistenceStore.ts
+++ b/src/stores/campaign/useCampaignPersistenceStore.ts
@@ -15,6 +15,9 @@ import type { ICampaign } from '@/types/campaign/Campaign';
 import type {
   ICampaignSaveMetadata,
   SerializedCampaign,
+  SerializedCampaignRosterEntry,
+  SerializedCampaignRosterMissionRecord,
+  SerializedCampaignRosterState,
 } from '@/types/campaign/SerializedCampaign';
 
 import {
@@ -24,8 +27,10 @@ import {
   getDeviceId,
   migrateSerializedCampaign,
 } from '@/lib/campaign/persistence';
+import { Money } from '@/types/campaign/Money';
 
 import { getCampaignStoreForRoster } from './campaignStoreAccessor';
+import { useCampaignRosterStore } from './useCampaignRosterStore';
 
 export const AUTO_SAVE_DEBOUNCE_MS = 2000;
 
@@ -98,6 +103,105 @@ function writeLiveCampaign(campaign: ICampaign): void {
   store?.getState().switchCampaign(campaign);
 }
 
+function dateToIso(value: Date | string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+}
+
+function deserializeOptionalDate(value: string | undefined): Date | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+}
+
+function serializeRosterEntry(
+  entry: ReturnType<typeof useCampaignRosterStore.getState>['pilots'][number],
+): SerializedCampaignRosterEntry {
+  const { hireDate, lastPromotionDate, salary, ...rest } = entry;
+  const serialized: SerializedCampaignRosterEntry = {
+    ...rest,
+    hireDate: dateToIso(hireDate) ?? new Date(0).toISOString(),
+  };
+  const promotionDate = dateToIso(lastPromotionDate);
+  return {
+    ...serialized,
+    ...(salary ? { salary: salary.amount } : {}),
+    ...(promotionDate ? { lastPromotionDate: promotionDate } : {}),
+  };
+}
+
+function deserializeRosterEntry(
+  entry: SerializedCampaignRosterEntry,
+): ReturnType<typeof useCampaignRosterStore.getState>['pilots'][number] {
+  const { hireDate, lastPromotionDate, salary, ...rest } = entry;
+  return {
+    ...rest,
+    hireDate: deserializeOptionalDate(hireDate) ?? new Date(0),
+    ...(salary !== undefined ? { salary: new Money(salary) } : {}),
+    ...(lastPromotionDate
+      ? { lastPromotionDate: deserializeOptionalDate(lastPromotionDate) }
+      : {}),
+  };
+}
+
+function cloneRosterMission(
+  mission: ReturnType<
+    typeof useCampaignRosterStore.getState
+  >['missions'][number],
+): SerializedCampaignRosterMissionRecord {
+  return {
+    ...mission,
+    deployedUnitIds: [...mission.deployedUnitIds],
+  };
+}
+
+function readLiveRosterSnapshot(
+  campaignId: string,
+): SerializedCampaignRosterState | undefined {
+  const roster = useCampaignRosterStore.getState();
+  if (roster.campaignId !== campaignId) {
+    return undefined;
+  }
+  return {
+    campaignId,
+    units: roster.units.map((unit) => ({ ...unit })),
+    pilots: roster.pilots.map(serializeRosterEntry),
+    missions: roster.missions.map(cloneRosterMission),
+    activeMissionId: roster.activeMissionId,
+    missionCount: roster.missionCount,
+  };
+}
+
+function restoreRosterProjection(
+  campaignId: string,
+  rosterProjection: SerializedCampaignRosterState | undefined,
+): void {
+  if (!rosterProjection) {
+    const roster = useCampaignRosterStore.getState();
+    if (roster.campaignId !== campaignId) {
+      roster.initRoster(campaignId);
+    }
+    return;
+  }
+
+  useCampaignRosterStore.setState({
+    campaignId,
+    units: rosterProjection.units.map((unit) => ({ ...unit })),
+    pilots: rosterProjection.pilots.map(deserializeRosterEntry),
+    missions: rosterProjection.missions.map((mission) => ({
+      ...mission,
+      deployedUnitIds: [...mission.deployedUnitIds],
+    })),
+    activeMissionId: rosterProjection.activeMissionId,
+    missionCount: rosterProjection.missionCount,
+  });
+}
+
 function metadataFrom(record: SerializedCampaign): ICampaignSaveMetadata {
   return {
     lastSavedAt: record.savedAt,
@@ -122,6 +226,7 @@ async function performSave(
     campaign,
     getDeviceId(),
     baseVersion + 1,
+    readLiveRosterSnapshot(campaign.id),
   );
   set({ saveState: 'saving', errorMessage: null });
 
@@ -182,6 +287,7 @@ function loadCampaignAction(
         (await response.json()) as SerializedCampaign,
       );
       writeLiveCampaign(deserializeCampaignBody(migrated.body));
+      restoreRosterProjection(id, migrated.body.rosterProjection);
       set({
         campaignId: id,
         dirty: false,
@@ -256,6 +362,10 @@ function resolveConflictTakeServerAction(
     }
     const migrated = migrateSerializedCampaign(serverRecord);
     writeLiveCampaign(deserializeCampaignBody(migrated.body));
+    restoreRosterProjection(
+      migrated.campaignId,
+      migrated.body.rosterProjection,
+    );
     set({
       campaignId: migrated.campaignId,
       dirty: false,

--- a/src/types/campaign/SerializedCampaign.ts
+++ b/src/types/campaign/SerializedCampaign.ts
@@ -25,10 +25,12 @@ import type {
 } from './CampaignCommandExtensions';
 import type { ICampaignLoan } from './CampaignLoan';
 import type { ICampaignOptions } from './CampaignOptions';
+import type { ICampaignRosterEntry } from './CampaignRosterEntry';
 import type { CampaignType } from './CampaignType';
 import type { ICoopSession } from './CoopSession';
 import type { IFactionStanding } from './factionStanding/IFactionStanding';
 import type { IForce } from './Force';
+import type { IDailyBattleAuditEntry } from './IDailyBattleAuditEntry';
 import type {
   IPersonnelMarketOffer,
   IUnitMarketOffer,
@@ -38,6 +40,7 @@ import type { IPartsInventoryItem } from './PartsInventory';
 import type { IMoraleTransition, IUnitPrestige, MoraleState } from './Prestige';
 import type { IRefitOrder } from './Refit';
 import type { IRepairTicket } from './RepairTicket';
+import type { IRosterUnitProjection } from './RosterUnitProjection';
 import type { ISalvageAllocation, ISalvageReport } from './Salvage';
 import type { ICombatTeam } from './scenario/scenarioTypes';
 import type { IUnitCombatState, IUnitMaxState } from './UnitCombatState';
@@ -106,6 +109,52 @@ export interface SerializedFinances {
 }
 
 /**
+ * JSON-safe roster entry carried beside the campaign body. Campaign roster
+ * state lives outside `ICampaign`, but server-backed load/reload flows need
+ * this projection to rebuild the dashboard roster and personnel surfaces.
+ */
+export interface SerializedCampaignRosterEntry extends Omit<
+  ICampaignRosterEntry,
+  'hireDate' | 'lastPromotionDate' | 'salary'
+> {
+  /** ISO 8601 string. */
+  readonly hireDate: string;
+  /** Salary in C-bills (the `Money.amount` scalar). */
+  readonly salary?: number;
+  /** ISO 8601 string. */
+  readonly lastPromotionDate?: string;
+}
+
+/** JSON-safe campaign mission-history projection from the roster store. */
+export interface SerializedCampaignRosterMissionRecord {
+  readonly id: string;
+  readonly missionNumber: number;
+  readonly name: string;
+  readonly result: 'victory' | 'defeat' | 'draw' | 'pending';
+  readonly encounterId?: string;
+  readonly gameSessionId?: string;
+  readonly campaignId: string;
+  readonly deployedUnitIds: readonly string[];
+  readonly completedAt?: string;
+  readonly turnsPlayed?: number;
+}
+
+/**
+ * Thin server snapshot of `useCampaignRosterStore`. Damage remains canonical
+ * on `SerializedCampaignBody.unitCombatStates`; this snapshot is only the
+ * display/personnel/mission projection required to recover campaign UI after
+ * local client state is cleared.
+ */
+export interface SerializedCampaignRosterState {
+  readonly campaignId: string;
+  readonly units: readonly IRosterUnitProjection[];
+  readonly pilots: readonly SerializedCampaignRosterEntry[];
+  readonly missions: readonly SerializedCampaignRosterMissionRecord[];
+  readonly activeMissionId: string | null;
+  readonly missionCount: number;
+}
+
+/**
  * `ICampaign` with every `Map` field replaced by an array of
  * `[key, value]` pairs and every `Date` field replaced by an ISO 8601
  * string. This is the JSON-safe campaign body wrapped by the envelope.
@@ -149,6 +198,8 @@ export interface SerializedCampaignBody {
   readonly gmInterventionEvents?: readonly IGmCampaignProjectedEffect[];
   readonly timeCascadeEvents?: readonly IGmTimeCascadeProjectedEffect[];
   readonly recentlyAppliedOutcomes?: readonly ICombatOutcome[];
+  /** Daily post-battle audit entries shown on the campaign dashboard. */
+  readonly dailyBattleAudit?: readonly IDailyBattleAuditEntry[];
   /**
    * The campaign's loan ledger (CP2b — `add-campaign-command-ui`,
    * design D4). Optional and absent on pre-CP2b snapshots. Every
@@ -198,6 +249,8 @@ export interface SerializedCampaignBody {
   readonly activeContract?: ICampaignActiveContract;
   /** Unit-market offers stored by unitMarketProcessor (audit D-7, W3.4). */
   readonly unitMarket?: readonly IUnitMarketOffer[];
+  /** Server-backed projection of the separate campaign roster store. */
+  readonly rosterProjection?: SerializedCampaignRosterState;
 }
 
 // =============================================================================


### PR DESCRIPTION
﻿## Summary
- Persist the thin campaign roster projection in the server campaign envelope, including units, pilots, mission history, active mission, and mission count.
- Mirror daily battle audit entries through server serialization/deserialization.
- Strengthen the strict campaign-flow browser proof so post-battle roster, audit, repair queue, salvage, finances, store state, and API body all survive save, client-state reset, and route reload.

## Validation
- npx.cmd oxfmt --check targeted files
- npm.cmd run typecheck -- --pretty false
- npm.cmd run test -- useCampaignPersistenceStore.test.ts serverFieldMirror.test.ts --runInBand
- node scripts/playwright/run-playwright.mjs test --project=chromium e2e/campaign-flow.spec.ts --grep "persists damaged roster state" --workers=1
- npm.cmd run verify:qc:campaign-economy:browser
- npm.cmd run qc:app-completion -- --json
- npm.cmd run qc:lifecycle:status -- --json
- npm.cmd run qc:journeys:validate -- --json
- npm.cmd run qc:surface-browser:validate -- --json
- npm.cmd run qc:manual-automation-gaps:validate -- --json
- npm.cmd run maintain:scan:gate
- node scripts/qc/validate-maintenance-warning-ledger.mjs
- git diff --check

## Status Inventory
- App completion: 0 errors, 0 release gaps, 27/27 surfaces ready-with-scope.
- Lifecycle: 27 surfaces, 0 blockers, 0 warnings.
- Journeys: 7 journeys, graph 259 nodes, 7 UI flows, 0 errors, 0 warnings.
- Browser proof: 17/17 browser-required surfaces backed.
- Manual automation: 21/21 manual surfaces machine-backed.
- Campaign economy browser suite: 12/12 passed.
- Maintenance scan: 0 critical/high findings, 0 baseline regressions; warning ledger tracked=54, untracked=0, errors=0.
