### PR TITLE
Add campaign customizer handoff command flow

### DIFF
--- a/e2e/campaign-customizer-handoff.spec.ts
+++ b/e2e/campaign-customizer-handoff.spec.ts
@@ -1,0 +1,135 @@
+import { expect, test, type Page } from '@playwright/test';
+
+async function waitForCampaignStores(page: Page): Promise<void> {
+  await page.waitForFunction(() => {
+    const win = window as unknown as {
+      __ZUSTAND_STORES__?: { campaign?: unknown; campaignRoster?: unknown };
+    };
+    return Boolean(
+      win.__ZUSTAND_STORES__?.campaign &&
+      win.__ZUSTAND_STORES__?.campaignRoster,
+    );
+  });
+}
+
+async function seedCampaignWithRoster(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    type StoreApi = {
+      getState: () => Record<string, unknown>;
+      setState?: (state: Record<string, unknown>) => void;
+    };
+    const resolveStore = (store: StoreApi | (() => StoreApi)): StoreApi =>
+      typeof (store as StoreApi).getState === 'function'
+        ? (store as StoreApi)
+        : (store as () => StoreApi)();
+    const stores = (
+      window as unknown as {
+        __ZUSTAND_STORES__?: {
+          campaign?: StoreApi | (() => StoreApi);
+          campaignRoster?: StoreApi;
+        };
+      }
+    ).__ZUSTAND_STORES__;
+
+    if (!stores?.campaign || !stores.campaignRoster) {
+      throw new Error('Campaign E2E stores are not exposed');
+    }
+
+    const campaignStore = resolveStore(stores.campaign);
+    const campaignState = campaignStore.getState() as {
+      createCampaign: (
+        name: string,
+        factionId: string,
+        options: Record<string, unknown>,
+      ) => string;
+      getCampaign: () => Record<string, unknown>;
+      updateCampaign: (updates: Record<string, unknown>) => void;
+    };
+    const campaignId = campaignState.createCampaign(
+      'E2E Customizer Handoff',
+      'mercenary',
+      {
+        startingFunds: 2_500_000,
+      },
+    );
+    const campaign = campaignState.getCampaign();
+    campaignState.updateCampaign({
+      ...campaign,
+      currentDate: new Date('3025-01-03T00:00:00.000Z'),
+    });
+    stores.campaignRoster.setState?.({
+      campaignId,
+      units: [
+        {
+          unitId: 'unit-atlas-e2e',
+          unitName: 'Atlas',
+          chassisVariant: 'AS7-D',
+          readiness: 'Ready',
+        },
+      ],
+      pilots: [],
+      missions: [],
+      activeMissionId: null,
+      missionCount: 0,
+    });
+    return campaignId;
+  });
+}
+
+test.describe('campaign customizer handoff @campaign @customizer', () => {
+  test('routes Mech Bay refit into campaign customizer and saves a refit order', async ({
+    page,
+  }) => {
+    await page.goto('/gameplay/campaigns');
+    await waitForCampaignStores(page);
+    const campaignId = await seedCampaignWithRoster(page);
+
+    await page.goto(`/gameplay/campaigns/${campaignId}/mech-bay`);
+    await expect(page.getByTestId('mech-bay-grid')).toBeVisible();
+    await page.getByTestId('mech-bay-refit-unit-atlas-e2e').click();
+
+    await expect(page).toHaveURL(/\/customizer.*mode=campaign-refit/);
+    await expect(page.getByTestId('campaign-refit-command-bar')).toBeVisible();
+    await expect(page.getByTestId('campaign-refit-context')).toContainText(
+      'campaign-owned-refit',
+    );
+    await expect(page.getByTestId('campaign-refit-save')).toBeEnabled();
+
+    await page.getByTestId('campaign-refit-save').click();
+
+    await expect(page).toHaveURL(
+      new RegExp(
+        `/gameplay/campaigns/${campaignId}/mech-bay\\?.*customizerResult=saved`,
+      ),
+    );
+    await expect(page.getByTestId('mech-bay-grid')).toBeVisible();
+
+    const refitOrders = await page.evaluate(() => {
+      type StoreApi = {
+        getState: () => Record<string, unknown>;
+      };
+      const resolveStore = (store: StoreApi | (() => StoreApi)): StoreApi =>
+        typeof (store as StoreApi).getState === 'function'
+          ? (store as StoreApi)
+          : (store as () => StoreApi)();
+      const stores = (
+        window as unknown as {
+          __ZUSTAND_STORES__?: {
+            campaign?: StoreApi | (() => StoreApi);
+          };
+        }
+      ).__ZUSTAND_STORES__;
+      const campaignState = stores?.campaign
+        ? (resolveStore(stores.campaign).getState() as {
+            getCampaign: () => { refitOrders?: readonly unknown[] } | null;
+          })
+        : null;
+      return campaignState?.getCampaign()?.refitOrders ?? [];
+    });
+    expect(refitOrders).toHaveLength(1);
+    expect(refitOrders[0]).toMatchObject({
+      unitId: 'unit-atlas-e2e',
+      status: 'in-progress',
+    });
+  });
+});

--- a/openspec/changes/add-playable-command-screens/tasks.md
+++ b/openspec/changes/add-playable-command-screens/tasks.md
@@ -24,11 +24,11 @@
 
 ## 4. Campaign Customizer Handoff
 
-- [ ] 4.1 Add campaign-origin customizer route state for `campaignId`, `unitId`, optional `missionId`, `returnTo`, campaign date, budget, rules level, and refit constraints.
-- [ ] 4.2 Load campaign-owned unit identity and canonical state in customizer campaign refit mode without mutating free-build sessions.
-- [ ] 4.3 Save valid campaign-origin edits as campaign refit orders or explicit campaign unit updates, and block invalid edits with tab-level resolution links.
-- [ ] 4.4 Return from save/cancel to mission readiness or Mek stable and refresh deployment validation against canonical campaign state.
-- [ ] 4.5 Add tests and a browser journey for stable/readiness -> customizer -> return -> refreshed eligibility.
+- [x] 4.1 Add campaign-origin customizer route state for `campaignId`, `unitId`, optional `missionId`, `returnTo`, campaign date, budget, rules level, and refit constraints.
+- [x] 4.2 Load campaign-owned unit identity and canonical state in customizer campaign refit mode without mutating free-build sessions.
+- [x] 4.3 Save valid campaign-origin edits as campaign refit orders or explicit campaign unit updates, and block invalid edits with tab-level resolution links.
+- [x] 4.4 Return from save/cancel to mission readiness or Mek stable and refresh deployment validation against canonical campaign state.
+- [x] 4.5 Add tests and a browser journey for stable/readiness -> customizer -> return -> refreshed eligibility.
 
 ## 5. Campaign Starmap Logistics
 
@@ -94,3 +94,9 @@
 - 2026-06-30 PR CI repair: added `openspec/active-change-ledger.json` so active staged specs are explicitly accounted until archive, while unaccounted active changes and stale ledger entries still fail `validate-openspec-ci-quality`.
 - Tactical map regression repair: combat projection target overrides now apply only when a supplied tactical projection frame contains combat entries, preserving physical attack target rings during the physical attack phase.
 - PR repair validation: `scripts/__tests__/openspec-ci-quality-qc.test.ts` and `addInteractiveCombatCoreUI.smoke.03.test.tsx` passed together; local CI shards `npx.cmd jest --selectProjects unit --ci --shard=4/6` and `--shard=5/6` passed; `npm.cmd run typecheck`, targeted `npx.cmd oxlint`, targeted `npx.cmd oxfmt --check`, `node scripts/qc/validate-openspec-ci-quality.mjs`, `openspec.cmd validate add-playable-command-screens --strict`, `npm.cmd run maintain:scan:gate`, and `npm.cmd run test:e2e -- e2e/tactical-command-journey.spec.ts` passed.
+- 2026-06-30 Wave 4 campaign customizer handoff slice: added campaign-origin refit route state, editor-session isolation, campaign customizer context, save/cancel command bar, Mech Bay and mission readiness refit entry points, query-preserving customizer tab routing, and stable/readiness return links that request deployment-validation refresh.
+- Campaign customizer proof: route/session unit tests prove campaign refit query round trips and campaign-owned roster identity becomes a separate editor unit; command-bar component tests prove valid refit-order save/return and invalid construction blockers with tab-level resolution links; mission readiness page tests prove per-unit refit editor links preserve campaign/mission context.
+- Browser E2E proof: `npm.cmd run test:e2e -- e2e/campaign-customizer-handoff.spec.ts` passed 4 projects / 4 tests (`chromium`, `Mobile Chrome`, `Tablet Portrait`, `Tablet Landscape`) and validates Mech Bay -> campaign customizer -> save refit order -> Mech Bay return with canonical campaign `refitOrders` updated.
+- Focused Wave 4 regression proof: `npm.cmd test -- --watchAll=false --runTestsByPath src/lib/campaign/customizer/__tests__/campaignCustomizerRoute.test.ts src/lib/campaign/customizer/__tests__/campaignCustomizerSession.test.ts src/components/customizer/campaign/__tests__/CampaignRefitCommandBar.test.tsx src/hooks/__tests__/useCustomizerRouter.test.ts src/__tests__/pages/gameplay/campaigns/mission-launch.coop.test.tsx --runInBand` passed 5 suites / 11 tests; Jest still reports the pre-existing stale `baseline-browser-mapping` warning.
+- Static/spec/maintenance gates for Wave 4: `npm.cmd run typecheck`, targeted `npx.cmd oxlint`, targeted `npx.cmd oxfmt --check`, `git diff --check`, `node scripts/maintenance/scan-maintenance.mjs --scope=... --limit=120`, `npm.cmd run maintain:scan:gate`, `node scripts/qc/validate-openspec-ci-quality.mjs`, and `openspec.cmd validate add-playable-command-screens --strict` passed; scoped maintenance found 0 critical/high findings and only 2 info-level file-bloat advisories.
+- UI/UX evaluation for campaign customizer handoff: Mech Bay and mission readiness expose refit affordances where the player already evaluates blockers; the customizer gains a compact campaign refit command bar instead of a modal detour; invalid edits are blocked before commit with tab-level repair links; save/cancel returns to the originating campaign screen with result/refit id context while free-build customizer sessions stay separate.

--- a/src/__tests__/pages/gameplay/campaigns/mission-launch.coop.test.tsx
+++ b/src/__tests__/pages/gameplay/campaigns/mission-launch.coop.test.tsx
@@ -242,6 +242,15 @@ describe('CoopMissionLaunchPage - staged participation sync', () => {
       render(<CoopMissionLaunchPage />);
     });
 
+    expect(
+      screen.getByTestId('mission-readiness-customize-atlas-as7-d'),
+    ).toHaveAttribute(
+      'href',
+      expect.stringContaining(
+        '/customizer?mode=campaign-refit&campaignId=campaign-coop-1&unitId=atlas-as7-d',
+      ),
+    );
+
     await act(async () => {
       screen.getByTestId('launch-mission-direct').click();
     });

--- a/src/components/customizer/CustomizerWithRouter.tsx
+++ b/src/components/customizer/CustomizerWithRouter.tsx
@@ -8,6 +8,7 @@
  * @spec openspec/specs/unit-store-architecture/spec.md
  */
 
+import { useRouter as useNextRouter } from 'next/router';
 import React, {
   useCallback,
   useEffect,
@@ -20,6 +21,9 @@ import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 
 import { ErrorBoundary } from '@/components/common';
+import { CampaignCustomizerSessionProvider } from '@/components/customizer/campaign/CampaignCustomizerSessionContext';
+import { CampaignUnitUnavailableState } from '@/components/customizer/campaign/CampaignUnitUnavailableState';
+import { useCampaignCustomizerRouting } from '@/components/customizer/campaign/useCampaignCustomizerRouting';
 // Components
 import { MultiUnitTabs } from '@/components/customizer/tabs';
 // Hooks
@@ -252,6 +256,7 @@ function InvalidUnitState({
  * Runs only on client side (dynamically imported with SSR disabled)
  */
 export default function CustomizerWithRouter(): React.ReactElement {
+  const nextRouter = useNextRouter();
   const [isHydrated, setIsHydrated] = useState(false);
 
   // Tab manager store (for multi-unit tabs)
@@ -259,6 +264,7 @@ export default function CustomizerWithRouter(): React.ReactElement {
   const activeTabId = useTabManagerStore((s) => s.activeTabId);
   const isLoading = useTabManagerStore((s) => s.isLoading);
   const selectTab = useTabManagerStore((s) => s.selectTab);
+  const addTab = useTabManagerStore((s) => s.addTab);
   const setLastSubTab = useTabManagerStore((s) => s.setLastSubTab);
   const getLastSubTab = useTabManagerStore((s) => s.getLastSubTab);
 
@@ -285,6 +291,23 @@ export default function CustomizerWithRouter(): React.ReactElement {
   const routerSyncUrl = router.syncUrl;
   const routerNavigateToIndex = router.navigateToIndex;
   const routerNavigateToTab = router.navigateToTab;
+  const {
+    campaignSession,
+    isCampaignLoading,
+    isCampaignSyncPending,
+    returnToCampaign,
+    unavailableUnitId,
+  } = useCampaignCustomizerRouting({
+    activeTabId,
+    addTab,
+    isHydrated,
+    nextRouter,
+    routerIsReady,
+    routerTabId,
+    selectTab,
+    setLastSubTab,
+    tabs,
+  });
 
   // Get effective tab ID: URL tab takes precedence, then stored lastSubTab, then default
   const effectiveUnitId = routerUnitId || activeTabId;
@@ -314,6 +337,7 @@ export default function CustomizerWithRouter(): React.ReactElement {
   useEffect(() => {
     // Wait for the Next router to parse the URL — before `isReady`,
     // `routerUnitId` is null even for a deep link (e2e triage RC15).
+    if (isCampaignSyncPending) return;
     syncUrlToState({
       routerIsReady,
       isHydrated,
@@ -334,6 +358,7 @@ export default function CustomizerWithRouter(): React.ReactElement {
     routerUnitId,
     routerIsValid,
     activeTabId,
+    isCampaignSyncPending,
     tabs,
     selectTab,
     routerNavigateToIndex,
@@ -350,6 +375,7 @@ export default function CustomizerWithRouter(): React.ReactElement {
     // clobbering `/customizer/<id>[/<tab>]` deep links (e2e triage RC15).
     // Deep links must win; the URL->State effect above handles them once
     // `routerIsReady` flips.
+    if (isCampaignSyncPending) return;
     syncStateToUrl({
       routerIsReady,
       isHydrated,
@@ -366,6 +392,7 @@ export default function CustomizerWithRouter(): React.ReactElement {
     isHydrated,
     isLoading,
     activeTabId,
+    isCampaignSyncPending,
     routerUnitId,
     routerSyncUrl,
     getLastSubTab,
@@ -389,6 +416,19 @@ export default function CustomizerWithRouter(): React.ReactElement {
     return <LoadingCustomizerState />;
   }
 
+  if (isCampaignLoading) {
+    return <LoadingCustomizerState />;
+  }
+
+  if (unavailableUnitId) {
+    return (
+      <CampaignUnitUnavailableState
+        unitId={unavailableUnitId}
+        onReturn={returnToCampaign}
+      />
+    );
+  }
+
   // Invalid unit ID in URL
   if (!routerIsValid && !routerIsIndex) {
     return <InvalidUnitState onNavigateToIndex={routerNavigateToIndex} />;
@@ -397,17 +437,19 @@ export default function CustomizerWithRouter(): React.ReactElement {
   return (
     <ErrorBoundary componentName="CustomizerWithRouter">
       <DndProvider backend={HTML5Backend}>
-        <div className="bg-surface-deep flex min-h-screen flex-col">
-          <MultiUnitTabs>
-            <ErrorBoundary componentName="UnitTypeRouter">
-              <UnitTypeRouter
-                activeTab={activeTab}
-                activeTabId={effectiveTabId}
-                onTabChange={handleTabChange}
-              />
-            </ErrorBoundary>
-          </MultiUnitTabs>
-        </div>
+        <CampaignCustomizerSessionProvider session={campaignSession}>
+          <div className="bg-surface-deep flex min-h-screen flex-col">
+            <MultiUnitTabs>
+              <ErrorBoundary componentName="UnitTypeRouter">
+                <UnitTypeRouter
+                  activeTab={activeTab}
+                  activeTabId={effectiveTabId}
+                  onTabChange={handleTabChange}
+                />
+              </ErrorBoundary>
+            </MultiUnitTabs>
+          </div>
+        </CampaignCustomizerSessionProvider>
       </DndProvider>
     </ErrorBoundary>
   );

--- a/src/components/customizer/UnitEditorWithRouting.tsx
+++ b/src/components/customizer/UnitEditorWithRouting.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react';
 
 import { ErrorBoundary } from '@/components/common';
+import { CampaignRefitCommandBar } from '@/components/customizer/campaign/CampaignRefitCommandBar';
 import { ResponsiveLoadoutTray } from '@/components/customizer/equipment/ResponsiveLoadoutTray';
 import { UnitInfoBanner } from '@/components/customizer/shared/UnitInfoBanner';
 import {
@@ -128,6 +129,8 @@ export function UnitEditorWithRouting({
 
   return (
     <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+      <CampaignRefitCommandBar onTabChange={handleTabChange} />
+
       <div className="bg-surface-deep border-border-theme flex-shrink-0 border-b p-2">
         <UnitInfoBanner
           stats={unitStats}

--- a/src/components/customizer/campaign/CampaignCustomizerSessionContext.tsx
+++ b/src/components/customizer/campaign/CampaignCustomizerSessionContext.tsx
@@ -1,0 +1,34 @@
+import React, { createContext, useContext } from 'react';
+
+import type { CampaignCustomizerRouteState } from '@/lib/campaign/customizer/campaignCustomizerRoute';
+import type { IRosterUnitProjection } from '@/types/campaign/RosterUnitProjection';
+import type { MechBuildConfig } from '@/utils/construction/constructionRules/types';
+
+export interface CampaignCustomizerSession {
+  readonly route: CampaignCustomizerRouteState;
+  readonly unit: IRosterUnitProjection;
+  readonly campaignName: string;
+  readonly currentConfiguration: MechBuildConfig;
+  readonly returnHref: string;
+}
+
+const CampaignCustomizerSessionContext =
+  createContext<CampaignCustomizerSession | null>(null);
+
+export function CampaignCustomizerSessionProvider({
+  children,
+  session,
+}: {
+  readonly children: React.ReactNode;
+  readonly session: CampaignCustomizerSession | null;
+}): React.ReactElement {
+  return (
+    <CampaignCustomizerSessionContext.Provider value={session}>
+      {children}
+    </CampaignCustomizerSessionContext.Provider>
+  );
+}
+
+export function useCampaignCustomizerSession(): CampaignCustomizerSession | null {
+  return useContext(CampaignCustomizerSessionContext);
+}

--- a/src/components/customizer/campaign/CampaignRefitCommandBar.tsx
+++ b/src/components/customizer/campaign/CampaignRefitCommandBar.tsx
@@ -1,0 +1,242 @@
+import { useRouter } from 'next/router';
+import React, { useCallback, useMemo, useState } from 'react';
+
+import type { CustomizerTabId } from '@/hooks/useCustomizerRouter';
+
+import { Badge } from '@/components/ui';
+import { buildCampaignCustomizerReturnHref } from '@/lib/campaign/customizer/campaignCustomizerRoute';
+import { extractMechBuildConfigFromUnitState } from '@/lib/campaign/customizer/campaignCustomizerSession';
+import { commitRefitOrder } from '@/stores/campaign/campaignRefitActions';
+import { useUnitStore, useUnitStoreApi } from '@/stores/useUnitStore';
+import { validateConstruction } from '@/utils/construction/constructionRules/validation';
+
+import { useCampaignCustomizerSession } from './CampaignCustomizerSessionContext';
+
+function validationTabFor(message: string): CustomizerTabId {
+  const lower = message.toLowerCase();
+  if (lower.includes('armor')) return 'armor';
+  if (
+    lower.includes('engine') ||
+    lower.includes('heat') ||
+    lower.includes('jump') ||
+    lower.includes('tonnage') ||
+    lower.includes('gyro') ||
+    lower.includes('cockpit') ||
+    lower.includes('structure')
+  ) {
+    return 'structure';
+  }
+  return 'overview';
+}
+
+function countConfigurationChanges(
+  current: ReturnType<typeof extractMechBuildConfigFromUnitState>,
+  target: ReturnType<typeof extractMechBuildConfigFromUnitState>,
+): number {
+  return (Object.keys(current) as Array<keyof typeof current>).filter(
+    (key) => current[key] !== target[key],
+  ).length;
+}
+
+export function CampaignRefitCommandBar({
+  onTabChange,
+}: {
+  readonly onTabChange: (tabId: CustomizerTabId) => void;
+}): React.ReactElement | null {
+  const session = useCampaignCustomizerSession();
+  const router = useRouter();
+  const store = useUnitStoreApi();
+  const isModified = useUnitStore((state) => state.isModified);
+  const armorAllocation = useUnitStore((state) => state.armorAllocation);
+  const armorType = useUnitStore((state) => state.armorType);
+  const cockpitType = useUnitStore((state) => state.cockpitType);
+  const configuration = useUnitStore((state) => state.configuration);
+  const engineRating = useUnitStore((state) => state.engineRating);
+  const engineType = useUnitStore((state) => state.engineType);
+  const gyroType = useUnitStore((state) => state.gyroType);
+  const heatSinkCount = useUnitStore((state) => state.heatSinkCount);
+  const heatSinkType = useUnitStore((state) => state.heatSinkType);
+  const internalStructureType = useUnitStore(
+    (state) => state.internalStructureType,
+  );
+  const jumpMP = useUnitStore((state) => state.jumpMP);
+  const tonnage = useUnitStore((state) => state.tonnage);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const targetConfiguration = useMemo(
+    () =>
+      extractMechBuildConfigFromUnitState({
+        armorAllocation,
+        armorType,
+        cockpitType,
+        configuration,
+        engineRating,
+        engineType,
+        gyroType,
+        heatSinkCount,
+        heatSinkType,
+        internalStructureType,
+        jumpMP,
+        tonnage,
+      }),
+    [
+      armorAllocation,
+      armorType,
+      cockpitType,
+      configuration,
+      engineRating,
+      engineType,
+      gyroType,
+      heatSinkCount,
+      heatSinkType,
+      internalStructureType,
+      jumpMP,
+      tonnage,
+    ],
+  );
+  const validation = useMemo(
+    () => validateConstruction(targetConfiguration),
+    [targetConfiguration],
+  );
+  const changeCount = useMemo(
+    () =>
+      session
+        ? countConfigurationChanges(
+            session.currentConfiguration,
+            targetConfiguration,
+          )
+        : 0,
+    [session, targetConfiguration],
+  );
+
+  const handleCancel = useCallback(() => {
+    if (!session) return;
+    void router.push(
+      buildCampaignCustomizerReturnHref(session.route, {
+        status: 'cancelled',
+      }),
+    );
+  }, [router, session]);
+
+  const handleSave = useCallback(() => {
+    if (!session) return;
+    setSaveError(null);
+
+    const latestTarget = extractMechBuildConfigFromUnitState(store.getState());
+    const latestValidation = validateConstruction(latestTarget);
+    if (!latestValidation.isValid) {
+      setSaveError('Resolve construction blockers before saving this refit.');
+      return;
+    }
+
+    const result = commitRefitOrder({
+      unitId: session.route.unitId,
+      currentConfiguration: session.currentConfiguration,
+      targetConfiguration: latestTarget,
+    });
+    if (!result.applied) {
+      setSaveError(result.reason ?? 'Campaign refit order could not be saved.');
+      return;
+    }
+
+    store.getState().markModified(false);
+    void router.push(
+      buildCampaignCustomizerReturnHref(session.route, {
+        status: 'saved',
+        refitOrderId: result.order?.id,
+      }),
+    );
+  }, [router, session, store]);
+
+  if (!session) return null;
+
+  return (
+    <section
+      className="border-border-theme bg-surface-base flex flex-wrap items-start justify-between gap-3 border-b px-3 py-3"
+      data-testid="campaign-refit-command-bar"
+    >
+      <div className="min-w-0">
+        <div className="flex flex-wrap items-center gap-2">
+          <h2 className="text-text-theme-primary text-sm font-semibold">
+            Campaign refit: {session.unit.unitName}
+          </h2>
+          <Badge variant={validation.isValid ? 'success' : 'red'} size="sm">
+            {validation.isValid ? 'Valid target' : 'Blocked target'}
+          </Badge>
+          {isModified ? (
+            <Badge variant="warning" size="sm">
+              Unsaved editor changes
+            </Badge>
+          ) : null}
+        </div>
+        <p
+          className="text-text-theme-secondary mt-1 text-xs"
+          data-testid="campaign-refit-context"
+        >
+          {session.campaignName} | {session.route.campaignDate} | Budget{' '}
+          {session.route.budget.toLocaleString()} C-bills |{' '}
+          {session.route.rulesLevel} rules | {session.route.refitConstraints} |{' '}
+          {changeCount} build field{changeCount === 1 ? '' : 's'} changed
+        </p>
+
+        {!validation.isValid ? (
+          <div className="mt-2" data-testid="campaign-refit-validation">
+            <p className="text-xs font-semibold text-rose-200">
+              Resolve before saving
+            </p>
+            <ul className="mt-1 flex flex-wrap gap-2">
+              {validation.errors.slice(0, 4).map((error) => {
+                const tab = validationTabFor(error);
+                return (
+                  <li key={error}>
+                    <button
+                      type="button"
+                      onClick={() => onTabChange(tab)}
+                      className="rounded border border-rose-700/70 px-2 py-1 text-left text-xs text-rose-100 hover:border-rose-400"
+                    >
+                      {tab}: {error}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        ) : null}
+
+        {saveError ? (
+          <p
+            role="alert"
+            className="mt-2 text-xs text-rose-200"
+            data-testid="campaign-refit-save-error"
+          >
+            {saveError}
+          </p>
+        ) : null}
+      </div>
+
+      <div className="flex flex-wrap justify-end gap-2">
+        <button
+          type="button"
+          onClick={handleCancel}
+          className="border-border-theme-subtle text-text-theme-secondary hover:text-text-theme-primary rounded border px-3 py-2 text-sm"
+          data-testid="campaign-refit-cancel"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={!validation.isValid}
+          className={
+            validation.isValid
+              ? 'rounded border border-sky-500/60 bg-sky-600/20 px-3 py-2 text-sm font-semibold text-sky-100'
+              : 'cursor-not-allowed rounded border border-slate-700 bg-slate-900/40 px-3 py-2 text-sm font-semibold text-slate-500'
+          }
+          data-testid="campaign-refit-save"
+        >
+          Save refit order
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/components/customizer/campaign/CampaignUnitUnavailableState.tsx
+++ b/src/components/customizer/campaign/CampaignUnitUnavailableState.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+export function CampaignUnitUnavailableState({
+  onReturn,
+  unitId,
+}: {
+  readonly onReturn: () => void;
+  readonly unitId: string;
+}): React.ReactElement {
+  return (
+    <div className="bg-surface-deep flex min-h-screen items-center justify-center">
+      <div className="text-text-theme-secondary p-8 text-center">
+        <p className="mb-2 text-lg">Campaign unit unavailable</p>
+        <p className="mb-4 text-sm">
+          The campaign unit {unitId} could not be loaded for refit.
+        </p>
+        <button
+          onClick={onReturn}
+          className="bg-accent text-surface-deep hover:bg-accent-hover rounded px-4 py-2 transition-colors"
+        >
+          Return to campaign
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/customizer/campaign/__tests__/CampaignRefitCommandBar.test.tsx
+++ b/src/components/customizer/campaign/__tests__/CampaignRefitCommandBar.test.tsx
@@ -1,0 +1,135 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { buildCampaignEditorUnitState } from '@/lib/campaign/customizer/campaignCustomizerSession';
+import { DEFAULT_UNIT_CONFIGURATION } from '@/lib/campaign/refit/unitConfiguration';
+import { commitRefitOrder } from '@/stores/campaign/campaignRefitActions';
+import { UnitStoreContext, createUnitStore } from '@/stores/useUnitStore';
+import { RefitClass } from '@/types/campaign/Refit';
+import { RulesLevel } from '@/types/enums/RulesLevel';
+
+import { CampaignCustomizerSessionProvider } from '../CampaignCustomizerSessionContext';
+import { CampaignRefitCommandBar } from '../CampaignRefitCommandBar';
+
+const mockPush = jest.fn();
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}));
+
+jest.mock('@/stores/campaign/campaignRefitActions', () => ({
+  commitRefitOrder: jest.fn(),
+}));
+
+const mockCommitRefitOrder = commitRefitOrder as jest.MockedFunction<
+  typeof commitRefitOrder
+>;
+
+function renderCommandBar(options?: { readonly invalid?: boolean }) {
+  const unit = {
+    unitId: 'campaign-unit-atlas',
+    unitName: 'Atlas',
+    chassisVariant: 'AS7-D',
+    readiness: 'Ready' as const,
+  };
+  const route = {
+    mode: 'campaign-refit' as const,
+    campaignId: 'campaign-1',
+    unitId: unit.unitId,
+    missionId: 'mission-1',
+    returnTo: 'mission-readiness' as const,
+    campaignDate: '3025-01-03T00:00:00.000Z',
+    budget: 1000000,
+    rulesLevel: RulesLevel.STANDARD,
+    refitConstraints: 'campaign-owned-refit',
+    editorUnitId: '11111111-1111-4111-8111-111111111111',
+  };
+  const state = buildCampaignEditorUnitState({
+    editorUnitId: route.editorUnitId,
+    unit,
+    currentConfiguration: DEFAULT_UNIT_CONFIGURATION,
+    rulesLevel: RulesLevel.STANDARD,
+  });
+  const store = createUnitStore({
+    ...state,
+    engineRating: options?.invalid ? 9999 : state.engineRating,
+  });
+  const onTabChange = jest.fn();
+  render(
+    <CampaignCustomizerSessionProvider
+      session={{
+        route,
+        unit,
+        campaignName: 'Gray Death Legion',
+        currentConfiguration: DEFAULT_UNIT_CONFIGURATION,
+        returnHref: '/gameplay/campaigns/campaign-1/missions/mission-1/launch',
+      }}
+    >
+      <UnitStoreContext.Provider value={store}>
+        <CampaignRefitCommandBar onTabChange={onTabChange} />
+      </UnitStoreContext.Provider>
+    </CampaignCustomizerSessionProvider>,
+  );
+  return { onTabChange, route };
+}
+
+describe('CampaignRefitCommandBar', () => {
+  beforeEach(() => {
+    mockPush.mockReset();
+    mockCommitRefitOrder.mockReset().mockReturnValue({
+      applied: true,
+      order: {
+        id: 'refit-1',
+        unitId: 'campaign-unit-atlas',
+        targetConfiguration: DEFAULT_UNIT_CONFIGURATION,
+        refitClass: RefitClass.EquipmentSwap,
+        estimatedCost: 0,
+        estimatedHours: 0,
+        hoursCompleted: 0,
+        status: 'in-progress',
+        createdAt: '3025-01-03T00:00:00.000Z',
+      },
+    });
+  });
+
+  it('commits a valid campaign-origin edit as a refit order and returns to readiness', () => {
+    renderCommandBar();
+
+    expect(screen.getByTestId('campaign-refit-command-bar')).toHaveTextContent(
+      'Campaign refit: Atlas',
+    );
+
+    fireEvent.click(screen.getByTestId('campaign-refit-save'));
+
+    expect(mockCommitRefitOrder).toHaveBeenCalledWith(
+      expect.objectContaining({
+        unitId: 'campaign-unit-atlas',
+        currentConfiguration: DEFAULT_UNIT_CONFIGURATION,
+      }),
+    );
+    expect(mockPush).toHaveBeenCalledWith(
+      '/gameplay/campaigns/campaign-1/missions/mission-1/launch?unit=campaign-unit-atlas&refresh=deployment-validation&customizerResult=saved&refitOrderId=refit-1',
+    );
+  });
+
+  it('blocks invalid refit targets with tab-level resolution controls', () => {
+    const { onTabChange } = renderCommandBar({ invalid: true });
+
+    expect(screen.getByTestId('campaign-refit-save')).toBeDisabled();
+    expect(screen.getByTestId('campaign-refit-validation')).toHaveTextContent(
+      'Resolve before saving',
+    );
+
+    const resolutionButton = screen
+      .getAllByRole('button')
+      .find((button) =>
+        /^(structure|armor|overview):/i.test(button.textContent ?? ''),
+      );
+    expect(resolutionButton).toBeDefined();
+    fireEvent.click(resolutionButton!);
+    expect(onTabChange).toHaveBeenCalledWith(expect.any(String));
+    expect(mockCommitRefitOrder).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/customizer/campaign/useCampaignCustomizerRouting.ts
+++ b/src/components/customizer/campaign/useCampaignCustomizerRouting.ts
@@ -1,0 +1,214 @@
+import type { NextRouter } from 'next/router';
+
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useStore } from 'zustand';
+
+import type { CustomizerTabId } from '@/hooks/useCustomizerRouter';
+import type { TabInfo, TabManagerState } from '@/stores/useTabManagerStore';
+
+import {
+  buildCampaignCustomizerHref,
+  buildCampaignCustomizerReturnHref,
+  parseCampaignCustomizerRouteState,
+  type CampaignCustomizerRouteState,
+} from '@/lib/campaign/customizer/campaignCustomizerRoute';
+import {
+  buildCampaignEditorUnitState,
+  campaignEditorSessionKey,
+} from '@/lib/campaign/customizer/campaignCustomizerSession';
+import { resolveUnitConfiguration } from '@/lib/campaign/refit/unitConfiguration';
+import { installCampaignPersistenceWiring } from '@/stores/campaign/campaignPersistenceWiring';
+import { useCampaignPersistenceStore } from '@/stores/campaign/useCampaignPersistenceStore';
+import { useCampaignRosterStore } from '@/stores/campaign/useCampaignRosterStore';
+import { useCampaignStore } from '@/stores/campaign/useCampaignStore';
+import {
+  createUnitFromFullState,
+  getUnitStore,
+} from '@/stores/unitStoreRegistry';
+import { generateUUID } from '@/utils/uuid';
+
+import type { CampaignCustomizerSession } from './CampaignCustomizerSessionContext';
+
+interface UseCampaignCustomizerRoutingArgs {
+  readonly activeTabId: string | null;
+  readonly addTab: TabManagerState['addTab'];
+  readonly isHydrated: boolean;
+  readonly nextRouter: NextRouter;
+  readonly routerIsReady: boolean;
+  readonly routerTabId: CustomizerTabId;
+  readonly selectTab: TabManagerState['selectTab'];
+  readonly setLastSubTab: TabManagerState['setLastSubTab'];
+  readonly tabs: readonly TabInfo[];
+}
+
+interface CampaignCustomizerRoutingResult {
+  readonly campaignRoute: CampaignCustomizerRouteState | null;
+  readonly campaignSession: CampaignCustomizerSession | null;
+  readonly isCampaignLoading: boolean;
+  readonly isCampaignSyncPending: boolean;
+  readonly returnToCampaign: () => void;
+  readonly unavailableUnitId: string | null;
+}
+
+export function useCampaignCustomizerRouting({
+  activeTabId,
+  addTab,
+  isHydrated,
+  nextRouter,
+  routerIsReady,
+  routerTabId,
+  selectTab,
+  setLastSubTab,
+  tabs,
+}: UseCampaignCustomizerRoutingArgs): CampaignCustomizerRoutingResult {
+  const ensuredCampaignSessionRef = useRef<string | null>(null);
+  const campaignStore = useCampaignStore();
+  const campaign = useStore(campaignStore, (state) => state.campaign);
+  const loadCampaign = useCampaignPersistenceStore(
+    (state) => state.loadCampaign,
+  );
+  const rosterUnits = useCampaignRosterStore((state) => state.units);
+
+  const campaignRoute = useMemo(
+    () => parseCampaignCustomizerRouteState(nextRouter.query),
+    [nextRouter.query],
+  );
+  const campaignUnit = useMemo(
+    () =>
+      campaignRoute
+        ? (rosterUnits.find((unit) => unit.unitId === campaignRoute.unitId) ??
+          null)
+        : null,
+    [campaignRoute, rosterUnits],
+  );
+  const campaignSession = useMemo(() => {
+    if (!campaignRoute || !campaign || !campaignUnit) return null;
+    if (campaign.id !== campaignRoute.campaignId) return null;
+    return {
+      route: campaignRoute,
+      unit: campaignUnit,
+      campaignName: campaign.name,
+      currentConfiguration: resolveUnitConfiguration(
+        campaign,
+        campaignRoute.unitId,
+      ),
+      returnHref: buildCampaignCustomizerReturnHref(campaignRoute),
+    };
+  }, [campaign, campaignRoute, campaignUnit]);
+
+  useEffect(() => {
+    if (!campaignRoute) return;
+    installCampaignPersistenceWiring();
+  }, [campaignRoute]);
+
+  useEffect(() => {
+    if (!campaignRoute) return;
+    if (campaign?.id === campaignRoute.campaignId) return;
+    void loadCampaign(campaignRoute.campaignId);
+  }, [campaign?.id, campaignRoute, loadCampaign]);
+
+  useEffect(() => {
+    if (
+      !campaignRoute ||
+      !campaign ||
+      !campaignUnit ||
+      !isHydrated ||
+      !routerIsReady
+    ) {
+      return;
+    }
+    if (campaign.id !== campaignRoute.campaignId) return;
+
+    if (!campaignRoute.editorUnitId) {
+      const editorUnitId = generateUUID();
+      void nextRouter.replace(
+        buildCampaignCustomizerHref({
+          ...campaignRoute,
+          editorUnitId,
+          tabId: routerTabId,
+        }),
+        undefined,
+        { shallow: true },
+      );
+      return;
+    }
+
+    const sessionKey = campaignEditorSessionKey(
+      campaignRoute.campaignId,
+      campaignRoute.unitId,
+      campaignRoute.editorUnitId,
+    );
+    if (ensuredCampaignSessionRef.current !== sessionKey) {
+      const currentConfiguration = resolveUnitConfiguration(
+        campaign,
+        campaignRoute.unitId,
+      );
+      if (!getUnitStore(campaignRoute.editorUnitId)) {
+        createUnitFromFullState(
+          buildCampaignEditorUnitState({
+            editorUnitId: campaignRoute.editorUnitId,
+            unit: campaignUnit,
+            currentConfiguration,
+            rulesLevel: campaignRoute.rulesLevel,
+          }),
+        );
+      }
+
+      if (!tabs.some((tab) => tab.id === campaignRoute.editorUnitId)) {
+        addTab({
+          id: campaignRoute.editorUnitId,
+          name: campaignUnit.unitName,
+          tonnage: currentConfiguration.tonnage,
+        });
+      }
+      setLastSubTab(campaignRoute.editorUnitId, routerTabId);
+      ensuredCampaignSessionRef.current = sessionKey;
+    }
+
+    if (activeTabId !== campaignRoute.editorUnitId) {
+      selectTab(campaignRoute.editorUnitId);
+    }
+  }, [
+    activeTabId,
+    addTab,
+    campaign,
+    campaignRoute,
+    campaignUnit,
+    isHydrated,
+    nextRouter,
+    routerIsReady,
+    routerTabId,
+    selectTab,
+    setLastSubTab,
+    tabs,
+  ]);
+
+  const isCampaignSyncPending = Boolean(
+    campaignRoute &&
+    (!campaignRoute.editorUnitId ||
+      !tabs.some((tab) => tab.id === campaignRoute.editorUnitId)),
+  );
+  const isCampaignLoading = Boolean(
+    campaignRoute &&
+    (!campaign ||
+      campaign.id !== campaignRoute.campaignId ||
+      !campaignRoute.editorUnitId),
+  );
+  const unavailableUnitId =
+    campaignRoute && !isCampaignLoading && !campaignUnit
+      ? campaignRoute.unitId
+      : null;
+  const returnToCampaign = useCallback(() => {
+    if (!campaignRoute) return;
+    void nextRouter.push(buildCampaignCustomizerReturnHref(campaignRoute));
+  }, [campaignRoute, nextRouter]);
+
+  return {
+    campaignRoute,
+    campaignSession,
+    isCampaignLoading,
+    isCampaignSyncPending,
+    returnToCampaign,
+    unavailableUnitId,
+  };
+}

--- a/src/components/customizer/tabs/useMultiUnitTabsController.ts
+++ b/src/components/customizer/tabs/useMultiUnitTabsController.ts
@@ -7,6 +7,8 @@ import type { IExportableUnit, IImportHandlers } from '@/types/vault';
 import { useToast } from '@/components/shared/Toast';
 import {
   DEFAULT_TAB,
+  buildCustomizerIndexUrl,
+  buildCustomizerUrl,
   isValidTabId,
   type CustomizerTabId,
 } from '@/hooks/useCustomizerRouter';
@@ -100,9 +102,13 @@ export function useMultiUnitTabsController(): UseMultiUnitTabsControllerResult {
 
   const navigateToTab = useCallback(
     (tabId: string) => {
-      router.push(`/customizer/${tabId}/${DEFAULT_TAB}`, undefined, {
-        shallow: true,
-      });
+      router.push(
+        buildCustomizerUrl(tabId, DEFAULT_TAB, router.query),
+        undefined,
+        {
+          shallow: true,
+        },
+      );
     },
     [router],
   );
@@ -113,9 +119,13 @@ export function useMultiUnitTabsController(): UseMultiUnitTabsControllerResult {
       const lastSubTab = getLastSubTab(tabId);
       const tabToNavigate: CustomizerTabId =
         lastSubTab && isValidTabId(lastSubTab) ? lastSubTab : DEFAULT_TAB;
-      router.push(`/customizer/${tabId}/${tabToNavigate}`, undefined, {
-        shallow: true,
-      });
+      router.push(
+        buildCustomizerUrl(tabId, tabToNavigate, router.query),
+        undefined,
+        {
+          shallow: true,
+        },
+      );
     },
     [storeSelectTab, router, getLastSubTab],
   );
@@ -126,10 +136,12 @@ export function useMultiUnitTabsController(): UseMultiUnitTabsControllerResult {
 
       const newState = useTabManagerStore.getState();
       if (newState.tabs.length === 0) {
-        router.push('/customizer', undefined, { shallow: true });
+        router.push(buildCustomizerIndexUrl(router.query), undefined, {
+          shallow: true,
+        });
       } else if (newState.activeTabId && newState.activeTabId !== tabId) {
         router.push(
-          `/customizer/${newState.activeTabId}/${DEFAULT_TAB}`,
+          buildCustomizerUrl(newState.activeTabId, DEFAULT_TAB, router.query),
           undefined,
           {
             shallow: true,

--- a/src/hooks/__tests__/useCustomizerRouter.test.ts
+++ b/src/hooks/__tests__/useCustomizerRouter.test.ts
@@ -1,0 +1,30 @@
+import {
+  buildCustomizerIndexUrl,
+  buildCustomizerUrl,
+} from '@/hooks/useCustomizerRouter';
+
+describe('useCustomizerRouter helpers', () => {
+  it('preserves campaign refit query state while changing customizer tabs', () => {
+    const query = {
+      slug: ['11111111-1111-4111-8111-111111111111', 'structure'],
+      mode: 'campaign-refit',
+      campaignId: 'campaign-1',
+      unitId: 'unit-atlas',
+      returnTo: 'mission-readiness',
+    };
+
+    expect(
+      buildCustomizerUrl(
+        '11111111-1111-4111-8111-111111111111',
+        'armor',
+        query,
+      ),
+    ).toBe(
+      '/customizer/11111111-1111-4111-8111-111111111111/armor?mode=campaign-refit&campaignId=campaign-1&unitId=unit-atlas&returnTo=mission-readiness',
+    );
+
+    expect(buildCustomizerIndexUrl(query)).toBe(
+      '/customizer?mode=campaign-refit&campaignId=campaign-1&unitId=unit-atlas&returnTo=mission-readiness',
+    );
+  });
+});

--- a/src/hooks/useCustomizerRouter.ts
+++ b/src/hooks/useCustomizerRouter.ts
@@ -12,6 +12,8 @@
  * @spec openspec/specs/customizer-tabs/spec.md
  */
 
+import type { ParsedUrlQuery } from 'querystring';
+
 import { useRouter } from 'next/router';
 import { useCallback, useMemo, useRef } from 'react';
 
@@ -53,6 +55,8 @@ export const VALID_TAB_IDS: readonly CustomizerTabId[] = [
  * Default tab when none specified
  */
 export const DEFAULT_TAB: CustomizerTabId = 'structure';
+
+type CustomizerRouteQuery = ParsedUrlQuery | undefined;
 
 /**
  * Parsed route parameters
@@ -150,6 +154,24 @@ function parseUnitId(rawUnitId: string | string[] | undefined): string | null {
   return null;
 }
 
+function appendQuery(path: string, query: CustomizerRouteQuery): string {
+  const params = new URLSearchParams();
+  if (query) {
+    for (const [key, value] of Object.entries(query)) {
+      if (key === 'slug' || value === undefined) continue;
+      if (Array.isArray(value)) {
+        for (const entry of value) {
+          params.append(key, entry);
+        }
+      } else {
+        params.set(key, value);
+      }
+    }
+  }
+  const serialized = params.toString();
+  return serialized ? `${path}?${serialized}` : path;
+}
+
 // =============================================================================
 // Hook Implementation
 // =============================================================================
@@ -236,7 +258,7 @@ export function useCustomizerRouter(
       }
 
       isNavigatingRef.current = true;
-      router.push(`/customizer/${unitId}/${tabId}`, undefined, {
+      router.push(buildCustomizerUrl(unitId, tabId, router.query), undefined, {
         shallow: true,
       });
     },
@@ -263,16 +285,22 @@ export function useCustomizerRouter(
       }
 
       isNavigatingRef.current = true;
-      router.push(`/customizer/${effectiveUnitId}/${tabId}`, undefined, {
-        shallow: true,
-      });
+      router.push(
+        buildCustomizerUrl(effectiveUnitId, tabId, router.query),
+        undefined,
+        {
+          shallow: true,
+        },
+      );
     },
     [router, params.unitId, fallbackUnitId],
   );
 
   const navigateToIndex = useCallback(() => {
     isNavigatingRef.current = true;
-    router.push('/customizer', undefined, { shallow: true });
+    router.push(buildCustomizerIndexUrl(router.query), undefined, {
+      shallow: true,
+    });
   }, [router]);
 
   const syncUrl = useCallback(
@@ -287,9 +315,13 @@ export function useCustomizerRouter(
       }
 
       isNavigatingRef.current = true;
-      router.replace(`/customizer/${unitId}/${tabId}`, undefined, {
-        shallow: true,
-      });
+      router.replace(
+        buildCustomizerUrl(unitId, tabId, router.query),
+        undefined,
+        {
+          shallow: true,
+        },
+      );
     },
     [router, params.unitId, params.tabId],
   );
@@ -309,11 +341,16 @@ export function useCustomizerRouter(
 export function buildCustomizerUrl(
   unitId: string,
   tabId?: CustomizerTabId,
+  query?: CustomizerRouteQuery,
 ): string {
   if (tabId && isValidTabId(tabId)) {
-    return `/customizer/${unitId}/${tabId}`;
+    return appendQuery(`/customizer/${unitId}/${tabId}`, query);
   }
-  return `/customizer/${unitId}`;
+  return appendQuery(`/customizer/${unitId}`, query);
+}
+
+export function buildCustomizerIndexUrl(query?: CustomizerRouteQuery): string {
+  return appendQuery('/customizer', query);
 }
 
 /**

--- a/src/lib/campaign/customizer/__tests__/campaignCustomizerRoute.test.ts
+++ b/src/lib/campaign/customizer/__tests__/campaignCustomizerRoute.test.ts
@@ -1,0 +1,78 @@
+import { RulesLevel } from '@/types/enums/RulesLevel';
+
+import {
+  buildCampaignCustomizerHref,
+  buildCampaignCustomizerReturnHref,
+  parseCampaignCustomizerRouteState,
+} from '../campaignCustomizerRoute';
+
+describe('campaignCustomizerRoute', () => {
+  it('round-trips campaign refit route state including optional mission context', () => {
+    const href = buildCampaignCustomizerHref({
+      campaignId: 'campaign-1',
+      unitId: 'unit-atlas',
+      missionId: 'mission-1',
+      returnTo: 'mission-readiness',
+      campaignDate: '3025-01-03T00:00:00.000Z',
+      budget: 1250000,
+      rulesLevel: RulesLevel.ADVANCED,
+      refitConstraints: 'campaign-owned-refit',
+      editorUnitId: '11111111-1111-4111-8111-111111111111',
+      tabId: 'armor',
+    });
+
+    expect(href).toContain(
+      '/customizer/11111111-1111-4111-8111-111111111111/armor?',
+    );
+
+    const parsed = parseCampaignCustomizerRouteState(
+      Object.fromEntries(new URL(`http://test.local${href}`).searchParams),
+    );
+
+    expect(parsed).toEqual({
+      mode: 'campaign-refit',
+      campaignId: 'campaign-1',
+      unitId: 'unit-atlas',
+      missionId: 'mission-1',
+      returnTo: 'mission-readiness',
+      campaignDate: '3025-01-03T00:00:00.000Z',
+      budget: 1250000,
+      rulesLevel: RulesLevel.ADVANCED,
+      refitConstraints: 'campaign-owned-refit',
+      editorUnitId: '11111111-1111-4111-8111-111111111111',
+    });
+  });
+
+  it('builds readiness and stable return hrefs that request validation refresh', () => {
+    const readiness = parseCampaignCustomizerRouteState({
+      mode: 'campaign-refit',
+      campaignId: 'campaign-1',
+      unitId: 'unit-atlas',
+      missionId: 'mission-1',
+      returnTo: 'mission-readiness',
+      campaignDate: '3025-01-03T00:00:00.000Z',
+      budget: '100',
+      rulesLevel: RulesLevel.STANDARD,
+      refitConstraints: 'campaign-owned-refit',
+    });
+    expect(readiness).not.toBeNull();
+
+    expect(
+      buildCampaignCustomizerReturnHref(readiness!, {
+        status: 'saved',
+        refitOrderId: 'refit-1',
+      }),
+    ).toBe(
+      '/gameplay/campaigns/campaign-1/missions/mission-1/launch?unit=unit-atlas&refresh=deployment-validation&customizerResult=saved&refitOrderId=refit-1',
+    );
+
+    expect(
+      buildCampaignCustomizerReturnHref({
+        ...readiness!,
+        returnTo: 'mek-stable',
+      }),
+    ).toBe(
+      '/gameplay/campaigns/campaign-1/mech-bay?unit=unit-atlas&refresh=deployment-validation',
+    );
+  });
+});

--- a/src/lib/campaign/customizer/__tests__/campaignCustomizerSession.test.ts
+++ b/src/lib/campaign/customizer/__tests__/campaignCustomizerSession.test.ts
@@ -1,0 +1,65 @@
+import { DEFAULT_UNIT_CONFIGURATION } from '@/lib/campaign/refit/unitConfiguration';
+import { RulesLevel } from '@/types/enums/RulesLevel';
+
+import {
+  buildCampaignEditorUnitState,
+  extractMechBuildConfigFromUnitState,
+} from '../campaignCustomizerSession';
+
+describe('campaignCustomizerSession', () => {
+  it('creates a separate editor unit from canonical campaign roster identity', () => {
+    const editorUnitId = '11111111-1111-4111-8111-111111111111';
+    const state = buildCampaignEditorUnitState({
+      editorUnitId,
+      unit: {
+        unitId: 'campaign-unit-atlas',
+        unitName: 'Atlas',
+        chassisVariant: 'AS7-D',
+        readiness: 'Ready',
+      },
+      currentConfiguration: {
+        ...DEFAULT_UNIT_CONFIGURATION,
+        tonnage: 100,
+        engineRating: 300,
+        totalArmorPoints: 250,
+      },
+      rulesLevel: RulesLevel.ADVANCED,
+    });
+
+    expect(state.id).toBe(editorUnitId);
+    expect(state.id).not.toBe('campaign-unit-atlas');
+    expect(state.name).toBe('Atlas');
+    expect(state.model).toBe('AS7-D');
+    expect(state.tonnage).toBe(100);
+    expect(state.engineRating).toBe(300);
+    expect(state.rulesLevel).toBe(RulesLevel.ADVANCED);
+    expect(state.isModified).toBe(false);
+  });
+
+  it('extracts a refit target config from the editor state without campaign ids', () => {
+    const state = buildCampaignEditorUnitState({
+      editorUnitId: '11111111-1111-4111-8111-111111111111',
+      unit: {
+        unitId: 'campaign-unit-atlas',
+        unitName: 'Atlas',
+        chassisVariant: 'AS7-D',
+        readiness: 'Ready',
+      },
+      currentConfiguration: DEFAULT_UNIT_CONFIGURATION,
+      rulesLevel: RulesLevel.STANDARD,
+    });
+
+    const config = extractMechBuildConfigFromUnitState({
+      ...state,
+      engineRating: 275,
+      jumpMP: 3,
+    });
+
+    expect(config).toMatchObject({
+      tonnage: DEFAULT_UNIT_CONFIGURATION.tonnage,
+      engineRating: 275,
+      jumpMP: 3,
+      engineType: DEFAULT_UNIT_CONFIGURATION.engineType,
+    });
+  });
+});

--- a/src/lib/campaign/customizer/campaignCustomizerRoute.ts
+++ b/src/lib/campaign/customizer/campaignCustomizerRoute.ts
@@ -1,0 +1,145 @@
+import type { ParsedUrlQuery } from 'querystring';
+
+import {
+  DEFAULT_TAB,
+  type CustomizerTabId,
+  isValidTabId,
+} from '@/hooks/useCustomizerRouter';
+import { RulesLevel, ALL_RULES_LEVELS } from '@/types/enums/RulesLevel';
+import { isValidUnitId } from '@/utils/uuid';
+
+export const CAMPAIGN_CUSTOMIZER_MODE = 'campaign-refit' as const;
+
+export type CampaignCustomizerReturnTo = 'mek-stable' | 'mission-readiness';
+
+export interface CampaignCustomizerRouteState {
+  readonly mode: typeof CAMPAIGN_CUSTOMIZER_MODE;
+  readonly campaignId: string;
+  readonly unitId: string;
+  readonly missionId?: string;
+  readonly returnTo: CampaignCustomizerReturnTo;
+  readonly campaignDate: string;
+  readonly budget: number;
+  readonly rulesLevel: RulesLevel;
+  readonly refitConstraints: string;
+  readonly editorUnitId?: string;
+}
+
+export interface BuildCampaignCustomizerHrefOptions extends Omit<
+  CampaignCustomizerRouteState,
+  'mode'
+> {
+  readonly tabId?: CustomizerTabId;
+}
+
+function firstQueryValue(value: string | string[] | undefined): string | null {
+  if (Array.isArray(value)) return value[0] ?? null;
+  return value ?? null;
+}
+
+function parseBudget(value: string | null): number | null {
+  if (!value) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseReturnTo(
+  value: string | null,
+): CampaignCustomizerReturnTo | null {
+  return value === 'mek-stable' || value === 'mission-readiness' ? value : null;
+}
+
+function parseRulesLevel(value: string | null): RulesLevel {
+  const match = ALL_RULES_LEVELS.find((level) => level === value);
+  return match ?? RulesLevel.STANDARD;
+}
+
+function appendOptional(
+  params: URLSearchParams,
+  key: string,
+  value: string | number | undefined,
+): void {
+  if (value === undefined || value === '') return;
+  params.set(key, String(value));
+}
+
+export function parseCampaignCustomizerRouteState(
+  query: ParsedUrlQuery,
+): CampaignCustomizerRouteState | null {
+  if (firstQueryValue(query.mode) !== CAMPAIGN_CUSTOMIZER_MODE) {
+    return null;
+  }
+
+  const campaignId = firstQueryValue(query.campaignId);
+  const unitId = firstQueryValue(query.unitId);
+  const returnTo = parseReturnTo(firstQueryValue(query.returnTo));
+  const campaignDate = firstQueryValue(query.campaignDate);
+  const budget = parseBudget(firstQueryValue(query.budget));
+  const editorUnitId = firstQueryValue(query.editorUnitId) ?? undefined;
+
+  if (!campaignId || !unitId || !returnTo || !campaignDate || budget === null) {
+    return null;
+  }
+
+  return {
+    mode: CAMPAIGN_CUSTOMIZER_MODE,
+    campaignId,
+    unitId,
+    missionId: firstQueryValue(query.missionId) ?? undefined,
+    returnTo,
+    campaignDate,
+    budget,
+    rulesLevel: parseRulesLevel(firstQueryValue(query.rulesLevel)),
+    refitConstraints:
+      firstQueryValue(query.refitConstraints) ?? 'campaign-owned-refit',
+    editorUnitId:
+      editorUnitId && isValidUnitId(editorUnitId) ? editorUnitId : undefined,
+  };
+}
+
+export function buildCampaignCustomizerHref(
+  options: BuildCampaignCustomizerHrefOptions,
+): string {
+  const tabId =
+    options.tabId && isValidTabId(options.tabId) ? options.tabId : DEFAULT_TAB;
+  const path = options.editorUnitId
+    ? `/customizer/${encodeURIComponent(options.editorUnitId)}/${tabId}`
+    : '/customizer';
+  const params = new URLSearchParams({
+    mode: CAMPAIGN_CUSTOMIZER_MODE,
+    campaignId: options.campaignId,
+    unitId: options.unitId,
+    returnTo: options.returnTo,
+    campaignDate: options.campaignDate,
+    budget: String(options.budget),
+    rulesLevel: options.rulesLevel,
+    refitConstraints: options.refitConstraints,
+  });
+
+  appendOptional(params, 'missionId', options.missionId);
+  appendOptional(params, 'editorUnitId', options.editorUnitId);
+
+  return `${path}?${params.toString()}`;
+}
+
+export function buildCampaignCustomizerReturnHref(
+  state: CampaignCustomizerRouteState,
+  result?: {
+    readonly status?: 'saved' | 'cancelled' | 'blocked';
+    readonly refitOrderId?: string;
+  },
+): string {
+  const path =
+    state.returnTo === 'mission-readiness' && state.missionId
+      ? `/gameplay/campaigns/${encodeURIComponent(
+          state.campaignId,
+        )}/missions/${encodeURIComponent(state.missionId)}/launch`
+      : `/gameplay/campaigns/${encodeURIComponent(state.campaignId)}/mech-bay`;
+  const params = new URLSearchParams({
+    unit: state.unitId,
+    refresh: 'deployment-validation',
+  });
+  appendOptional(params, 'customizerResult', result?.status);
+  appendOptional(params, 'refitOrderId', result?.refitOrderId);
+  return `${path}?${params.toString()}`;
+}

--- a/src/lib/campaign/customizer/campaignCustomizerSession.ts
+++ b/src/lib/campaign/customizer/campaignCustomizerSession.ts
@@ -1,0 +1,124 @@
+import type { UnitState } from '@/stores/unitState';
+import type { IRosterUnitProjection } from '@/types/campaign/RosterUnitProjection';
+import type { RulesLevel } from '@/types/enums/RulesLevel';
+import type { MechBuildConfig } from '@/utils/construction/constructionRules/types';
+
+import {
+  armorResultToAllocation,
+  createDefaultUnitState,
+  getTotalAllocatedArmor,
+} from '@/stores/unitState';
+import { TechBase } from '@/types/enums/TechBase';
+import { UnitType } from '@/types/unit/BattleMechInterfaces';
+import {
+  calculateArmorWeight,
+  calculateOptimalArmorAllocation,
+} from '@/utils/construction/armorCalculations';
+
+export interface BuildCampaignEditorUnitStateParams {
+  readonly editorUnitId: string;
+  readonly unit: IRosterUnitProjection;
+  readonly currentConfiguration: MechBuildConfig;
+  readonly rulesLevel: RulesLevel;
+}
+
+function walkMpFrom(config: MechBuildConfig): number {
+  if (config.tonnage <= 0) return 4;
+  return Math.max(1, Math.floor(config.engineRating / config.tonnage));
+}
+
+function buildArmorAllocation(
+  config: MechBuildConfig,
+): UnitState['armorAllocation'] {
+  return armorResultToAllocation(
+    calculateOptimalArmorAllocation(
+      config.totalArmorPoints,
+      config.tonnage,
+      undefined,
+    ),
+  );
+}
+
+export function buildCampaignEditorUnitState({
+  currentConfiguration,
+  editorUnitId,
+  rulesLevel,
+  unit,
+}: BuildCampaignEditorUnitStateParams): UnitState {
+  const defaultState = createDefaultUnitState({
+    id: editorUnitId,
+    name: unit.unitName,
+    tonnage: currentConfiguration.tonnage,
+    techBase: TechBase.INNER_SPHERE,
+    walkMP: walkMpFrom(currentConfiguration),
+  });
+
+  return {
+    ...defaultState,
+    name: unit.unitName,
+    chassis: unit.unitName,
+    model: unit.chassisVariant,
+    rulesLevel,
+    unitType: UnitType.BATTLEMECH,
+    tonnage: currentConfiguration.tonnage,
+    engineRating: currentConfiguration.engineRating,
+    engineType: currentConfiguration.engineType,
+    gyroType: currentConfiguration.gyroType,
+    internalStructureType: currentConfiguration.internalStructureType,
+    armorType: currentConfiguration.armorType,
+    armorTonnage: calculateArmorWeight(
+      currentConfiguration.totalArmorPoints,
+      currentConfiguration.armorType,
+    ),
+    armorAllocation: buildArmorAllocation(currentConfiguration),
+    cockpitType: currentConfiguration.cockpitType,
+    heatSinkType: currentConfiguration.heatSinkType,
+    heatSinkCount: currentConfiguration.totalHeatSinks,
+    jumpMP: currentConfiguration.jumpMP,
+    isModified: false,
+    lastModifiedAt: Date.now(),
+  };
+}
+
+export function extractMechBuildConfigFromUnitState(
+  state: Pick<
+    UnitState,
+    | 'armorAllocation'
+    | 'armorType'
+    | 'cockpitType'
+    | 'configuration'
+    | 'engineRating'
+    | 'engineType'
+    | 'gyroType'
+    | 'heatSinkCount'
+    | 'heatSinkType'
+    | 'internalStructureType'
+    | 'jumpMP'
+    | 'tonnage'
+  >,
+): MechBuildConfig {
+  return {
+    tonnage: state.tonnage,
+    engineRating: state.engineRating,
+    engineType: state.engineType,
+    gyroType: state.gyroType,
+    internalStructureType: state.internalStructureType,
+    armorType: state.armorType,
+    totalArmorPoints: getTotalAllocatedArmor(
+      state.armorAllocation,
+      state.configuration,
+    ),
+    cockpitType: state.cockpitType,
+    heatSinkType: state.heatSinkType,
+    totalHeatSinks: state.heatSinkCount,
+    jumpMP: state.jumpMP,
+  };
+}
+
+export function campaignEditorSessionKey(
+  campaignId: string,
+  unitId: string,
+  editorUnitId: string,
+): string {
+  return `${campaignId}:${unitId}:${editorUnitId}`;
+}

--- a/src/lib/finances/loanService.ts
+++ b/src/lib/finances/loanService.ts
@@ -16,11 +16,10 @@
  * @module lib/finances/loanService
  */
 
-import { randomUUID } from 'crypto';
-
 import type { ILoan } from '@/types/campaign/Loan';
 
 import { Money } from '@/types/campaign/Money';
+import { generateUUID } from '@/utils/uuid';
 
 /**
  * Payment breakdown for a single loan payment
@@ -110,7 +109,7 @@ export function createLoan(
   nextPaymentDate.setMonth(nextPaymentDate.getMonth() + 1);
 
   return {
-    id: randomUUID(),
+    id: generateUUID(),
     principal,
     annualRate,
     termMonths,

--- a/src/pages-modules/gameplay/campaigns/missionLaunchReadinessPanel.tsx
+++ b/src/pages-modules/gameplay/campaigns/missionLaunchReadinessPanel.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import React from 'react';
 
 import type {
@@ -16,9 +17,11 @@ function readinessStatusVariant(
 }
 
 export function MissionReadinessPanel({
+  buildCustomizeHref,
   projection,
   onToggleUnit,
 }: {
+  readonly buildCustomizeHref?: (unitId: string) => string;
   readonly projection: IMissionReadinessProjection;
   readonly onToggleUnit: (unitId: string) => void;
 }): React.ReactElement {
@@ -95,6 +98,15 @@ export function MissionReadinessPanel({
                       </li>
                     ))}
                   </ul>
+                ) : null}
+                {buildCustomizeHref ? (
+                  <Link
+                    href={buildCustomizeHref(unit.unitId)}
+                    className="text-accent hover:text-accent/80 mt-2 inline-flex text-xs font-medium"
+                    data-testid={`mission-readiness-customize-${unit.unitId}`}
+                  >
+                    Open refit editor
+                  </Link>
                 ) : null}
               </span>
             </label>

--- a/src/pages/gameplay/campaigns/[id]/mech-bay.tsx
+++ b/src/pages/gameplay/campaigns/[id]/mech-bay.tsx
@@ -8,16 +8,16 @@
  * @spec openspec/changes/add-campaign-bay-ui/specs/campaign-bay-ui/spec.md
  */
 
-import React, { useState } from 'react';
+import { useRouter } from 'next/router';
+import React from 'react';
 
 import { MechBay } from '@/components/campaign/bays/MechBay';
-import { RefitLaunchPanel } from '@/components/campaign/bays/RefitLaunchPanel';
+import { buildCampaignCustomizerHref } from '@/lib/campaign/customizer/campaignCustomizerRoute';
 import { buildMissionReadinessProjection } from '@/lib/campaign/readiness/missionReadinessProjection';
-import { resolveUnitConfiguration } from '@/lib/campaign/refit/unitConfiguration';
 import * as CampaignShell from '@/pages-modules/gameplay/campaigns/campaignPageShell';
 import { selectRepairBay } from '@/stores/campaign/campaignBaySelectors';
-import { commitRefitOrder } from '@/stores/campaign/campaignRefitActions';
 import { useCampaignRosterStore } from '@/stores/campaign/useCampaignRosterStore';
+import { RulesLevel } from '@/types/enums/RulesLevel';
 
 const MECH_BAY_LOADING = {
   title: 'Mech Bay',
@@ -26,6 +26,7 @@ const MECH_BAY_LOADING = {
 } as const;
 
 export default function MechBayPage(): React.ReactElement {
+  const router = useRouter();
   const shell = CampaignShell.useCampaignPageShell('Mech Bay');
   const units = useCampaignRosterStore((state) => state.units);
   const pilots = useCampaignRosterStore((state) => state.pilots);
@@ -33,8 +34,6 @@ export default function MechBayPage(): React.ReactElement {
     state.getActiveMission(),
   );
   const loadStatus = CampaignShell.useCampaignLoadStatus();
-  // The unit currently selected for the refit launch flow (CP3, design D6).
-  const [refitUnitId, setRefitUnitId] = useState<string | null>(null);
 
   const pendingPage = CampaignShell.renderPendingCampaignPage(
     shell,
@@ -75,45 +74,32 @@ export default function MechBayPage(): React.ReactElement {
     loadStatus,
   );
 
-  // The unit selected for refit, and its current configuration.
-  const refitUnit = refitUnitId
-    ? (units.find((u) => u.unitId === refitUnitId) ?? null)
-    : null;
-  const refitCurrentConfig = refitUnit
-    ? resolveUnitConfiguration(campaign, refitUnit.unitId)
-    : null;
-
   return (
     <CampaignShell.CampaignPageFrameFromShell shell={shell} frame={frame}>
       {saveError ?? (
         <>
           {/* Refit launch flow (CP3, design D6) — opens above the grid
               when the player picks a unit's Refit affordance. */}
-          {refitUnit && refitCurrentConfig ? (
-            <div className="mb-6">
-              <RefitLaunchPanel
-                unitId={refitUnit.unitId}
-                unitName={refitUnit.unitName}
-                currentConfiguration={refitCurrentConfig}
-                onCommit={(target) =>
-                  commitRefitOrder({
-                    unitId: refitUnit.unitId,
-                    currentConfiguration: refitCurrentConfig,
-                    targetConfiguration: target,
-                  })
-                }
-                onCancel={() => setRefitUnitId(null)}
-              />
-            </div>
-          ) : null}
-
           <MechBay
             units={units}
             readinessByUnitId={readinessByUnitId}
             unitTonnageById={unitTonnageById}
             repairBay={repairBay}
             campaignId={campaign.id}
-            onLaunchRefit={(unitId) => setRefitUnitId(unitId)}
+            onLaunchRefit={(unitId) => {
+              void router.push(
+                buildCampaignCustomizerHref({
+                  campaignId: campaign.id,
+                  unitId,
+                  missionId: activeMissionRecord?.id,
+                  returnTo: 'mek-stable',
+                  campaignDate: campaign.currentDate.toISOString(),
+                  budget: campaign.finances.balance.amount,
+                  rulesLevel: RulesLevel.STANDARD,
+                  refitConstraints: 'campaign-owned-refit',
+                }),
+              );
+            }}
           />
         </>
       )}

--- a/src/pages/gameplay/campaigns/[id]/missions/[missionId]/launch.tsx
+++ b/src/pages/gameplay/campaigns/[id]/missions/[missionId]/launch.tsx
@@ -36,6 +36,7 @@ import {
   publishCoopParticipation,
   subscribeCoopParticipation,
 } from '@/lib/campaign/coop/coopRuntimeSession';
+import { buildCampaignCustomizerHref } from '@/lib/campaign/customizer/campaignCustomizerRoute';
 import { materializeCampaignMissionEncounter } from '@/lib/campaign/encounter/materializeCampaignMissionEncounter';
 import {
   buildMissionReadinessProjection,
@@ -56,6 +57,7 @@ import {
 import { MissionReadinessPanel } from '@/pages-modules/gameplay/campaigns/missionLaunchReadinessPanel';
 import { selectRepairBay } from '@/stores/campaign/campaignBaySelectors';
 import { useCampaignRosterStore } from '@/stores/campaign/useCampaignRosterStore';
+import { RulesLevel } from '@/types/enums/RulesLevel';
 
 function localPlayerNameForMode(mode: 'host' | 'guest'): string {
   return mode === 'host' ? 'You (Host)' : 'You (Guest)';
@@ -327,6 +329,18 @@ export default function CoopMissionLaunchPage(): React.ReactElement {
           <MissionReadinessPanel
             projection={readinessProjection}
             onToggleUnit={handleToggleRosterUnit}
+            buildCustomizeHref={(unitId) =>
+              buildCampaignCustomizerHref({
+                campaignId: loadedCampaign.id,
+                unitId,
+                missionId: missionKey ?? undefined,
+                returnTo: 'mission-readiness',
+                campaignDate: loadedCampaign.currentDate.toISOString(),
+                budget: loadedCampaign.finances.balance.amount,
+                rulesLevel: RulesLevel.STANDARD,
+                refitConstraints: 'campaign-owned-refit',
+              })
+            }
           />
 
           {launchError ? (


### PR DESCRIPTION
## Summary
- Add campaign-origin customizer route/session helpers and isolated campaign refit editor sessions.
- Add a campaign refit command bar that validates construction, saves refit orders, and returns to Mech Bay or mission readiness with refresh context.
- Preserve campaign refit query context across customizer tab navigation and add stable/readiness browser coverage.
- Mark Wave 4 OpenSpec tasks complete with UI/UX, maintenance, unit, E2E, and spec evidence.

## Validation
- npm.cmd run typecheck
- npm.cmd test -- --watchAll=false --runTestsByPath src/lib/campaign/customizer/__tests__/campaignCustomizerRoute.test.ts src/lib/campaign/customizer/__tests__/campaignCustomizerSession.test.ts src/components/customizer/campaign/__tests__/CampaignRefitCommandBar.test.tsx src/hooks/__tests__/useCustomizerRouter.test.ts src/__tests__/pages/gameplay/campaigns/mission-launch.coop.test.tsx --runInBand
- npm.cmd run test:e2e -- e2e/campaign-customizer-handoff.spec.ts
- targeted npx.cmd oxlint
- targeted npx.cmd oxfmt --check
- git diff --check
- node scripts/maintenance/scan-maintenance.mjs --scope=... --limit=120
- npm.cmd run maintain:scan:gate
- node scripts/qc/validate-openspec-ci-quality.mjs
- openspec.cmd validate add-playable-command-screens --strict