### PR TITLE
feat: command-screen focus-hierarchy visual pass

### DIFF
--- a/openspec/council-decisions/2026-06-30-command-screen-focus-doctrine.md
+++ b/openspec/council-decisions/2026-06-30-command-screen-focus-doctrine.md
@@ -86,3 +86,22 @@ The doctrine survives **only if each screen is correctly classified single-actio
 - **Refit stat strip (decided for Momus):** Hephaestus proposed FOCUS = editor body, *shrink the stat strip*. Momus refuted — the stat strip is the primary instrument. **Council adopts Momus**; the strip is co-primary (INSTRUMENT zone), not chrome. This is the single most important correction in the decision.
 - **Tactical movement selector (open sub-decision):** both agree the dock-group and the map `mpLegend` duplicate the movement vocabulary; *which* surface becomes the single selector (dock readout vs point-of-action map control) is left to implementation, leaning toward point-of-action per Momus's "decisions happen at the map."
 - **Audit drift:** several original audit findings are **already fixed** in current code (readiness amber badge, save-at-0-delta disable, inline Assign-pilot, the 50t→100t Atlas, screen-02 disabled CTA) — the doctrine must not re-prescribe them.
+
+---
+
+## Review verdict (OMO Council, Lean++ thin, 2026-06-30) — SHIP after one must-fix
+
+Seats: Oracle · Explore-Deep · Momus (+ Phase-0 Metis). All three independently flagged the **same single regression**; everything else verified safe or survivable.
+
+- **FIXED (must-fix) — theme-token bypass.** The chrome-contrast batch was first done with hardcoded `text-slate-300/400`, which severs nav + breadcrumb from `theme-neon` (cyan) / `theme-tactical` (amber) / `theme-minimal` (no `--text-secondary` override → genuine contrast case). Reverted all hardcodes to `text-text-theme-secondary` and raised `--text-secondary` `#94a3b8`→`#cbd5e1` (one line, theme-aware, zero className/snapshot churn). *Dissent:* Momus preferred a targeted new `--text-secondary-strong`; Oracle's global bump adopted (the generic secondary was genuinely too dim; a new token is additive complexity Oracle rejected).
+- **FIXED — readiness echo.** Dropped the redundant "Readiness" row from the launch briefing aside (Momus: it shipped a 4th copy of the readiness state the doctrine's own row-2 flags for merge). The FOCUS-panel badge stays the single authority; the button label still conveys the warning state.
+- **VERIFIED SAFE (Explore-Deep, empirical):** launch.tsx restructure — all 8 consuming specs key off `getByTestId`, no DOM-hierarchy/snapshot coupling; `min-h-[60vh]` — single consumer, narrow mode drops the trays; starmap labels — clean in the captured viewport (13 of 80 systems, no overlap).
+
+### Follow-up changes (named so they don't rot — Momus tracking-anchor)
+
+1. **`declutter-tactical-command-surface`** — merge the duplicate movement selector (dock group + interactive map `mpLegend`, both call `onMovementModeSelect`); de-leak `select_movement` → player copy; fix the `E`/`E` hotkey collision; collapse the lens `LeftTray`. Test-coupled → updates tactical e2e in the same change.
+2. **`declutter-gm-ledger-actions`** — 5 preview buttons → one "Generate correction" + type selector; preserve the public/private log duality. Test-coupled → updates `gm-campaign-ledger-control-plane.spec.ts`.
+3. **`starmap-refit-declutter`** — starmap detail-bar merge + collapsible legend + status glyphs; refit stat-strip color-ramp unification + context-line slim; verify starmap label density at a dense cluster (Draconis core).
+4. **`tactical-map-flex-basis`** (tech-debt) — replace the `min-h-[60vh]` floor with a proper flex-basis/shrink budget so short viewports don't page-scroll the HUD (Momus band-aid critique).
+
+Each per-screen follow-up MUST carry an explicit `archetype:` field (single-action | simultaneous-instrument) — the doctrine's load-bearing guardrail.

--- a/openspec/council-decisions/2026-06-30-command-screen-focus-doctrine.md
+++ b/openspec/council-decisions/2026-06-30-command-screen-focus-doctrine.md
@@ -1,0 +1,88 @@
+# Council Decision — Command-Screen Focus Hierarchy Doctrine
+
+> OMO Council (Lean+, 5 seats: Oracle, Hephaestus, Librarian, Explore-Deep, Momus + Phase-0 Metis). 2026-06-30.
+> Question: "What is THE focus on each screen? What supports/borders it? Un-wrap the clutter into principles."
+
+---
+
+## HEADLINE
+
+A command screen has **exactly one FOCUS region** — but the screens split into **two archetypes** that decide what "supporting" means. **Classify the screen first; then apply.** The recurring clutter exists because the team's current sense of "primary" is inverted (the tactical hex map was literally the smallest element on the combat screen), so a focus doctrine applied without the archetype classification will *systematize* the wrong instinct — collapsing the very instruments the BattleTech task depends on.
+
+---
+
+## THE DECISION RULE (Oracle)
+
+> **A command screen is built around its primary OBJECT; the primary ACTION is anchored to the edge of that object and reads its enabled-state from the same source of truth the object renders — the action never floats in a separate half, and is never the smallest load-bearing element.**
+
+- **Object-first for layout, action-first for prominence.** The object owns the largest, most central region (it is what the screen *is*). The action is the single highest-contrast control *on the border of that region*, co-located so eye and decision land together.
+- **State-derived action.** The action's enabled/label state comes from the same object it acts on — not hand-styled (this is what kills the "bright CTA whose state contradicts the object" class of bug).
+
+## THE ARCHETYPE SPLIT (Momus — the deciding correction)
+
+| Archetype | Screens | What "supporting" means |
+|---|---|---|
+| **Single-action** | Starmap, Mission Launch, GM-Ledger (GM approve) | One decisive CTA. The object + its metrics frame it. **Exception (one-shot irreversible commits):** the consequence metrics are the *commitment contract*, placed between object and action — never demoted to "border." |
+| **Simultaneous-instrument** | Refit Customizer, Tactical HUD | FOCUS is the *work surface* (editor tab body / hex map), but a persistent **instrument cluster** (stat strip / heat+armor+pilot) is **CO-PRIMARY and always glanceable — NOT chrome, never collapsed to hover/drawer.** |
+
+**Why this matters:** the refit stat strip *is* the cognitive instrument — the user is solving a tonnage/slots/heat/BV constraint problem and evaluates every edit against it in real time. The tactical action dock + heat/armor are where turn decisions are *made* (a 5-hex run may overheat — you must see heat while path-planning). Demoting either "to satisfy the layout rule" produces a beautiful screen you cannot actually play on.
+
+## THE ZONE TEMPLATE (Oracle, refined by Momus)
+
+Every control must declare its zone before it ships. No zone → it doesn't ship.
+
+| Zone | Belongs here | Must NOT contain |
+|---|---|---|
+| **FOCUS** | The one primary object/work-surface — largest, centered, `flex-1`. | Chrome, dead margin. If FOCUS doesn't dominate, the screen is broken. |
+| **INSTRUMENT** *(simultaneous-instrument screens only)* | The co-primary always-visible scoreboard (refit stat strip; tactical heat/armor/pilot). | — (it is never demotable to AMBIENT). |
+| **CONTEXT-FRAME** | Read-only state the action depends on — itinerary metrics, readiness warnings, ledger rows. One bordering rail, one source object. | Duplicate controls; a *second* primary action; metrics from a stale/different source. |
+| **PRIMARY-ACTION ANCHOR** | Exactly one highest-contrast CTA on the FOCUS border, state-derived. Inline point-of-need affordances (Assign pilot) adjacent to their warning. | A second competing primary; destructive verbs without danger+confirm separation; bright styling on a disabled/no-op state. |
+| **AMBIENT CHROME** | Nav, breadcrumb, lenses, zoom/detail — all dimmer than FOCUS but ≥4.5:1. | Anything load-bearing; engine tokens / raw ids in player copy; color-only status. |
+
+---
+
+## PER-SCREEN APPLICATION
+
+> Each row: ARCHETYPE · FOCUS · what frames it · top de-clutter moves (component-grounded; Hephaestus, with Momus must-preserve). Items already shipped on `feat/playable-command-visual-pass` are marked ✅.
+
+### 1. Starmap — `starmap.tsx` + `StarmapDisplay.tsx` · **single-action (one-shot commit)**
+- **FOCUS:** the reachability map (canvas). **Action:** `Approve travel`, anchored to the destination card, state-derived (✅ already disables to "Already at Luthien"). **Commitment contract:** the JUMPS/ELAPSED/ARRIVAL/FEES/UPKEEP/FUNDS grid — keep prominent between object and action; it is *not* border.
+- **De-clutter:** ✅ system labels at zoom + faction legend in-view. Next: **MERGE** the top detail-status bar into the bottom-right zoom cluster (one control corner, reclaim canvas height); **SHRINK** the always-open faction legend to a collapsible pill; **MOVE** status off color-only — add a glyph (`!`/`▲`/`✓`) to node annotations for CVD.
+
+### 2. Mission Launch — `launch.tsx` + `missionLaunchReadinessPanel.tsx` · **single-action**
+- **FOCUS:** the unit-readiness list ("is my force deployable?"). **Action:** `Launch` (✅ amber badge + briefing aside already shipped). Badge is fully projection-derived (`launchReadinessVariant`/`launchReadinessLabel`) — safe to restyle without touching logic.
+- **De-clutter (Momus: do NOT over-engineer — it's already right-sized):** **MERGE** the 3× redundant readiness echo (top badge + footer consequences + briefing "Readiness") to one authority; **SHRINK** `launchConsequences` to one line. **Real remaining bugs are data hygiene, not focus:** strip raw `mission-<epoch>` id from the subtitle; decide whether no-pilot should hard-block launch.
+
+### 3. Refit Customizer — `CampaignRefitCommandBar.tsx` + `tabs/` · **simultaneous-instrument**
+- **FOCUS:** the active editor tab body. **INSTRUMENT (co-primary, do NOT shrink — Momus):** the live stat strip (TONNAGE/BV/ENGINE/ARMOR/SLOTS/HEAT) — it is the scoreboard, always visible. **Action:** `Save refit order` (✅ already disables at 0-delta).
+- **De-clutter:** **UNIFY** the stat-strip color ramp — today BV cyan / ENGINE orange / HEAT green is noise; use neutral tiles + one accent token only on the value *changed this session* (makes "what did I just change" the signal). **SHRINK** the command-bar context line (campaign/date/budget/rules/constraint) — keep `{N} build fields changed` prominent, move the rest to a tooltip; verify `formatCampaignDate` is fed a sliced date (not raw ISO). *(Current capture shows a correct 100-ton Atlas — the 50t fixture bug is largely resolved.)*
+
+### 4. Tactical HUD — `GameplayLayout.*` + `TacticalActionDock/` + `HexMapDisplay.mpLegend.tsx` · **simultaneous-instrument**
+- **FOCUS:** the hex map (✅ `min-h-[60vh]` shipped — keep pushing toward ~60-70% viewport). **INSTRUMENT (must stay glanceable WITH the map — Momus):** heat (current/total), armor front/rear, pilot G/P, phase label, MP used/remaining. **Action surface:** the single bottom `TacticalActionDock` (Explore-Deep confirms it is *one* clean grouped row, hotkeys inline).
+- **De-clutter:** **MERGE the duplicate movement selector** — the dock's movement group AND the interactive in-map `mpLegend` both call `onMovementModeSelect`. Keep ONE. *(Open sub-decision: keep selection at point-of-action on the map and make the dock group a readout, OR vice-versa — flagged for implementation.)* **COLLAPSE** the `w-28` Map-Lens `LeftTray` behind a toggle on desktop (reclaim 112px of canvas). **De-leak:** map `Interactive: select_movement` → player copy. **Fix** the `E`/`E` hotkey collision (Evade vs Rotate Right).
+
+### 5. GM Ledger — `GmCampaignInterventionControlPlane.tsx` · **single-action (GM) / read-only (guest)**
+- **FOCUS (GM, 06/07):** the transaction-preview card (the live correction) + the **public/private two-column log — the duality IS the point; never collapse one log to a toggle (Momus).** **Action:** approve/commit the previewed correction.
+- **De-clutter:** **MERGE** the 5 equal-weight preview buttons (merchant/repair/salvage/unit-reload/time) into one "Generate correction" + type selector (the action is "preview a correction"; type is a parameter). **SHRINK** the 4-card status bar — fold preview/approval-reason into the preview panel; keep balance + approval-summary standing. **De-jargon** the internal `family` token in player rows.
+- **FOCUS (guest, 08):** the "GM authority required" wall + the player-only log (correctly redacted — nothing else to render).
+
+### 6. Networked proof — dev E2E harness · **out of product scope**
+- It is a test scaffold ("Networked Command E2E Proof"), not product UI — label it as such; do not apply product chrome doctrine.
+
+---
+
+## BACKING PRINCIPLES (Librarian — named sources)
+
+1. One primary action per screen; rest secondary/tertiary *(Refactoring UI)*. 2. Three-tier button weight: filled/outlined/text *(Material 3)*. 3. Progressive disclosure — hide advanced controls *(NN/g)*. 4. **Map/canvas dominant at 60-70%; panels are literal margins** *(game-HUD; Fluent 2)* → validates the tactical/starmap canvas-fill. 5. Gestalt proximity/common-region chunking reduces *perceived* item count *(NN/g)*. 6. Whitespace is load-bearing — tight intra-group, wide inter-group *(Refactoring UI)*. 7. F/Z scan → primary action at the terminal scan point *(NN/g)*. 8. **Hide/disable non-applicable actions unambiguously rather than greying** *(Apple HIG)*. 9. **On dark themes use luminance steps, reserve ONE accent hue exclusively for the primary action** *(Material 3 dark)* — today amber/blue/green/orange compete; reserve amber for the single primary.
+
+---
+
+## SURVIVAL SCORE: **Intact — with one load-bearing guardrail**
+
+The doctrine survives **only if each screen is correctly classified single-action vs simultaneous-instrument before any layout change.** Kill signal (Momus): the team's current "primary" instinct is already inverted, so without the archetype tag they will collapse the refit stat strip and the tactical heat panel "to satisfy the rule" and make the screens unusable. **Guardrail = the archetype column + the must-preserve lists above are mandatory inputs to every screen's implementation.**
+
+## PRESERVED DISSENT
+
+- **Refit stat strip (decided for Momus):** Hephaestus proposed FOCUS = editor body, *shrink the stat strip*. Momus refuted — the stat strip is the primary instrument. **Council adopts Momus**; the strip is co-primary (INSTRUMENT zone), not chrome. This is the single most important correction in the decision.
+- **Tactical movement selector (open sub-decision):** both agree the dock-group and the map `mpLegend` duplicate the movement vocabulary; *which* surface becomes the single selector (dock readout vs point-of-action map control) is left to implementation, leaning toward point-of-action per Momus's "decisions happen at the map."
+- **Audit drift:** several original audit findings are **already fixed** in current code (readiness amber badge, save-at-0-delta disable, inline Assign-pilot, the 50t→100t Atlas, screen-02 disabled CTA) — the doctrine must not re-prescribe them.

--- a/src/components/campaign/CampaignNavigation.tsx
+++ b/src/components/campaign/CampaignNavigation.tsx
@@ -178,10 +178,10 @@ export function CampaignNavigation({
     <Link
       key={tab.id}
       href={tab.href}
-      className={`px-4 py-3 font-medium transition-colors ${
+      className={`px-4 py-3 transition-colors ${
         currentPage === tab.id
-          ? 'text-accent border-accent border-b-2'
-          : 'text-text-theme-secondary hover:text-text-theme-primary'
+          ? 'text-accent border-accent border-b-2 font-semibold'
+          : 'font-medium text-slate-300 hover:text-white'
       }`}
       aria-current={currentPage === tab.id ? 'page' : undefined}
     >
@@ -200,7 +200,7 @@ export function CampaignNavigation({
 
         {/* "Bays" group — visually separated, semantically labelled. */}
         <span
-          className="border-border-theme-subtle ml-2 border-l pl-3 text-xs font-semibold tracking-wider text-slate-500 uppercase"
+          className="border-border-theme-subtle ml-2 border-l pl-3 text-xs font-semibold tracking-wider text-slate-400 uppercase"
           data-testid="campaign-nav-bays-group"
         >
           Bays
@@ -215,7 +215,7 @@ export function CampaignNavigation({
 
         {/* "Command" group — visually separated, semantically labelled. */}
         <span
-          className="border-border-theme-subtle ml-2 border-l pl-3 text-xs font-semibold tracking-wider text-slate-500 uppercase"
+          className="border-border-theme-subtle ml-2 border-l pl-3 text-xs font-semibold tracking-wider text-slate-400 uppercase"
           data-testid="campaign-nav-command-group"
         >
           Command

--- a/src/components/campaign/CampaignNavigation.tsx
+++ b/src/components/campaign/CampaignNavigation.tsx
@@ -181,7 +181,7 @@ export function CampaignNavigation({
       className={`px-4 py-3 transition-colors ${
         currentPage === tab.id
           ? 'text-accent border-accent border-b-2 font-semibold'
-          : 'font-medium text-slate-300 hover:text-white'
+          : 'text-text-theme-secondary hover:text-text-theme-primary font-medium'
       }`}
       aria-current={currentPage === tab.id ? 'page' : undefined}
     >
@@ -200,7 +200,7 @@ export function CampaignNavigation({
 
         {/* "Bays" group — visually separated, semantically labelled. */}
         <span
-          className="border-border-theme-subtle ml-2 border-l pl-3 text-xs font-semibold tracking-wider text-slate-400 uppercase"
+          className="border-border-theme-subtle text-text-theme-secondary ml-2 border-l pl-3 text-xs font-semibold tracking-wider uppercase"
           data-testid="campaign-nav-bays-group"
         >
           Bays
@@ -215,7 +215,7 @@ export function CampaignNavigation({
 
         {/* "Command" group — visually separated, semantically labelled. */}
         <span
-          className="border-border-theme-subtle ml-2 border-l pl-3 text-xs font-semibold tracking-wider text-slate-400 uppercase"
+          className="border-border-theme-subtle text-text-theme-secondary ml-2 border-l pl-3 text-xs font-semibold tracking-wider uppercase"
           data-testid="campaign-nav-command-group"
         >
           Command

--- a/src/components/campaign/StarmapDisplay.tsx
+++ b/src/components/campaign/StarmapDisplay.tsx
@@ -119,6 +119,7 @@ const StarSystemNode = React.memo(function StarSystemNode({
     Boolean(annotation) ||
     isSelected ||
     isHovered ||
+    lod === 'close' ||
     (lod === 'medium' && isMajorSystem(system));
   const showFactionIndicator = lod === 'close';
 
@@ -371,20 +372,18 @@ export function StarmapDisplay({
           </button>
         </div>
 
-        <div className="absolute bottom-4 left-4 rounded bg-slate-800/90 p-3 text-xs text-slate-300 shadow-lg">
-          <div className="mb-2 font-semibold text-slate-200">Factions</div>
+        <div className="absolute top-3 right-3 rounded border border-slate-700/80 bg-slate-900/90 p-3 text-xs text-slate-200 shadow-lg">
+          <div className="mb-2 font-semibold text-slate-100">Factions</div>
           <div className="grid grid-cols-2 gap-x-4 gap-y-1">
-            {Object.entries(FACTION_COLORS)
-              .slice(0, 6)
-              .map(([faction, color]) => (
-                <div key={faction} className="flex items-center gap-2">
-                  <div
-                    className="h-3 w-3 rounded-full"
-                    style={{ backgroundColor: color }}
-                  />
-                  <span>{faction}</span>
-                </div>
-              ))}
+            {Object.entries(FACTION_COLORS).map(([faction, color]) => (
+              <div key={faction} className="flex items-center gap-2">
+                <div
+                  className="h-3 w-3 rounded-full"
+                  style={{ backgroundColor: color }}
+                />
+                <span>{faction}</span>
+              </div>
+            ))}
           </div>
         </div>
       </div>

--- a/src/components/gameplay/GameplayLayout.mainContent.tsx
+++ b/src/components/gameplay/GameplayLayout.mainContent.tsx
@@ -109,7 +109,7 @@ export function GameplayMainContentArea({
   return (
     <div
       ref={containerRef}
-      className="flex flex-1 overflow-hidden"
+      className="flex min-h-[60vh] flex-1 overflow-hidden"
       data-testid="gameplay-main-content"
     >
       {!isNarrow && <LeftTray lensState={lensState} />}

--- a/src/components/ui/Breadcrumb.tsx
+++ b/src/components/ui/Breadcrumb.tsx
@@ -78,7 +78,7 @@ export function Breadcrumb({
               {isClickable ? (
                 <Link
                   href={item.href!}
-                  className="hover:text-accent max-w-[150px] truncate text-slate-300 transition-colors duration-150 sm:max-w-none"
+                  className="hover:text-accent text-text-theme-secondary max-w-[150px] truncate transition-colors duration-150 sm:max-w-none"
                   title={item.label}
                 >
                   {item.label}
@@ -88,7 +88,7 @@ export function Breadcrumb({
                   className={`max-w-[150px] truncate sm:max-w-none ${
                     isLast
                       ? 'text-text-theme-primary font-medium'
-                      : 'text-slate-300'
+                      : 'text-text-theme-secondary'
                   }`}
                   title={item.label}
                   aria-current={isLast ? 'page' : undefined}

--- a/src/components/ui/Breadcrumb.tsx
+++ b/src/components/ui/Breadcrumb.tsx
@@ -78,7 +78,7 @@ export function Breadcrumb({
               {isClickable ? (
                 <Link
                   href={item.href!}
-                  className="text-text-theme-secondary hover:text-accent max-w-[150px] truncate transition-colors duration-150 sm:max-w-none"
+                  className="hover:text-accent max-w-[150px] truncate text-slate-300 transition-colors duration-150 sm:max-w-none"
                   title={item.label}
                 >
                   {item.label}
@@ -88,7 +88,7 @@ export function Breadcrumb({
                   className={`max-w-[150px] truncate sm:max-w-none ${
                     isLast
                       ? 'text-text-theme-primary font-medium'
-                      : 'text-text-theme-secondary'
+                      : 'text-slate-300'
                   }`}
                   title={item.label}
                   aria-current={isLast ? 'page' : undefined}

--- a/src/pages/gameplay/campaigns/[id]/missions/[missionId]/launch.tsx
+++ b/src/pages/gameplay/campaigns/[id]/missions/[missionId]/launch.tsx
@@ -360,51 +360,99 @@ export default function CoopMissionLaunchPage(): React.ReactElement {
           currentPage="missions"
           coopSession={loadedCampaign.coopSession}
         />
-        <div className="mt-6 space-y-4">
-          <MissionRefitReturnStatus customizerResult={customizerResult} />
+        <div className="mt-6 grid gap-6 lg:grid-cols-3">
+          <div className="space-y-4 lg:col-span-2">
+            <MissionRefitReturnStatus customizerResult={customizerResult} />
 
-          <MissionReadinessPanel
-            projection={readinessProjection}
-            onToggleUnit={handleToggleRosterUnit}
-            buildCustomizeHref={(unitId) =>
-              buildCampaignCustomizerHref({
-                campaignId: loadedCampaign.id,
-                unitId,
-                missionId: missionKey ?? undefined,
-                returnTo: 'mission-readiness',
-                campaignDate: loadedCampaign.currentDate.toISOString(),
-                budget: loadedCampaign.finances.balance.amount,
-                rulesLevel: RulesLevel.STANDARD,
-                refitConstraints: 'campaign-owned-refit',
-              })
-            }
-          />
+            <MissionReadinessPanel
+              projection={readinessProjection}
+              onToggleUnit={handleToggleRosterUnit}
+              buildCustomizeHref={(unitId) =>
+                buildCampaignCustomizerHref({
+                  campaignId: loadedCampaign.id,
+                  unitId,
+                  missionId: missionKey ?? undefined,
+                  returnTo: 'mission-readiness',
+                  campaignDate: loadedCampaign.currentDate.toISOString(),
+                  budget: loadedCampaign.finances.balance.amount,
+                  rulesLevel: RulesLevel.STANDARD,
+                  refitConstraints: 'campaign-owned-refit',
+                })
+              }
+            />
+          </div>
 
-          {launchError ? (
-            <p
-              role="alert"
-              data-testid="mission-launch-error"
-              className="text-sm text-rose-300"
-            >
-              {launchError}
-            </p>
-          ) : null}
-          <button
-            type="button"
-            data-testid="launch-mission-direct"
-            disabled={isLaunching || !readinessProjection.canLaunch}
-            onClick={handleLaunch}
-            className={directLaunchButtonClass({
-              canLaunch: readinessProjection.canLaunch,
-              isLaunching,
-              warningCount: readinessProjection.warnings.length,
-            })}
+          <aside
+            className="lg:sticky lg:top-6 lg:self-start"
+            data-testid="mission-launch-briefing"
           >
-            {directLaunchButtonLabel({
-              isLaunching,
-              warningCount: readinessProjection.warnings.length,
-            })}
-          </button>
+            <div className="border-border-theme-subtle bg-surface-base/70 rounded-lg border p-4">
+              <h2 className="text-text-theme-primary text-lg font-semibold">
+                Mission briefing
+              </h2>
+              <dl className="mt-3 space-y-2 text-sm">
+                <div className="flex items-center justify-between gap-3">
+                  <dt className="text-text-theme-secondary">Mission</dt>
+                  <dd className="text-text-theme-primary text-right font-medium">
+                    {missionDisplayName}
+                  </dd>
+                </div>
+                <div className="flex items-center justify-between gap-3">
+                  <dt className="text-text-theme-secondary">Company</dt>
+                  <dd className="text-text-theme-primary text-right font-medium">
+                    {loadedCampaign.name}
+                  </dd>
+                </div>
+                <div className="flex items-center justify-between gap-3">
+                  <dt className="text-text-theme-secondary">Units selected</dt>
+                  <dd className="text-text-theme-primary text-right font-medium">
+                    {readinessProjection.selectedUnits.length} /{' '}
+                    {readinessProjection.units.length}
+                  </dd>
+                </div>
+                <div className="flex items-center justify-between gap-3">
+                  <dt className="text-text-theme-secondary">Readiness</dt>
+                  <dd className="text-right font-medium">
+                    {readinessProjection.warnings.length > 0 ? (
+                      <span className="text-amber-300">
+                        {readinessProjection.warnings.length} warning
+                        {readinessProjection.warnings.length === 1 ? '' : 's'}
+                      </span>
+                    ) : (
+                      <span className="text-emerald-300">Ready</span>
+                    )}
+                  </dd>
+                </div>
+              </dl>
+
+              {launchError ? (
+                <p
+                  role="alert"
+                  data-testid="mission-launch-error"
+                  className="mt-3 text-sm text-rose-300"
+                >
+                  {launchError}
+                </p>
+              ) : null}
+
+              <button
+                type="button"
+                data-testid="launch-mission-direct"
+                disabled={isLaunching || !readinessProjection.canLaunch}
+                onClick={handleLaunch}
+                className={`mt-4 w-full ${directLaunchButtonClass({
+                  canLaunch: readinessProjection.canLaunch,
+                  isLaunching,
+                  warningCount: readinessProjection.warnings.length,
+                })}`}
+              >
+                {directLaunchButtonLabel({
+                  isLaunching,
+                  warningCount: readinessProjection.warnings.length,
+                })}
+              </button>
+            </div>
+          </aside>
         </div>
       </PageLayout>
     );

--- a/src/pages/gameplay/campaigns/[id]/missions/[missionId]/launch.tsx
+++ b/src/pages/gameplay/campaigns/[id]/missions/[missionId]/launch.tsx
@@ -410,19 +410,6 @@ export default function CoopMissionLaunchPage(): React.ReactElement {
                     {readinessProjection.units.length}
                   </dd>
                 </div>
-                <div className="flex items-center justify-between gap-3">
-                  <dt className="text-text-theme-secondary">Readiness</dt>
-                  <dd className="text-right font-medium">
-                    {readinessProjection.warnings.length > 0 ? (
-                      <span className="text-amber-300">
-                        {readinessProjection.warnings.length} warning
-                        {readinessProjection.warnings.length === 1 ? '' : 's'}
-                      </span>
-                    ) : (
-                      <span className="text-emerald-300">Ready</span>
-                    )}
-                  </dd>
-                </div>
               </dl>
 
               {launchError ? (

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -68,7 +68,7 @@
 
   /* Text Colors */
   --text-primary: #f8fafc; /* slate-50 */
-  --text-secondary: #94a3b8; /* slate-400 */
+  --text-secondary: #cbd5e1; /* slate-300 — raised from slate-400 for legible secondary text + chrome (council review 2026-06-30) */
   --text-muted: #9ca3af; /* gray-400 - WCAG AA compliant (5:1 contrast) */
 
   /* Accent Color System (defaults to amber, updated by GlobalStyleProvider) */


### PR DESCRIPTION
## What

A visual-design pass on the playable command screens, applying a focus-hierarchy doctrine — **object-first for layout, action-first for prominence**, with each screen classified **single-action** vs **simultaneous-instrument** (see `openspec/council-decisions/2026-06-30-command-screen-focus-doctrine.md`).

## Changes
- **Chrome contrast** — brighter nav tabs (bold active tab) + breadcrumbs, theme-aware via the `--text-secondary` token (raised `#94a3b8`→`#cbd5e1`). An initial hardcoded-`slate-*` approach was caught in review for breaking the neon/tactical/minimal themes and reverted to the token.
- **Starmap** — systems now label at close zoom (the gate previously *dropped* labels when zoomed in); faction legend relocated into view with all 10 factions.
- **Mission Launch** — two-column readiness + mission-briefing layout: removes the dead-space void and anchors the launch action to a bordering context card.
- **Tactical HUD** — `min-h-[60vh]` on the map row so the hex map leads the HUD instead of being squeezed by the control rows.
- **Docs** — focus-hierarchy council decision + review verdict + named follow-up changes.

## Verification
- `tsc --noEmit` clean; `oxlint` clean; pre-commit full `next build` passes on both commits.
- Seeded Playwright evidence re-captured (`qc:command-evidence:capture`) after every change — all 11 command screens render.
- Reviewed by OMO Council (doctrine + change review; judge VERIFIED). One theme-token regression caught and fixed before push.

## Deferred (named follow-ups, tracked in the decision doc)
`declutter-tactical-command-surface`, `declutter-gm-ledger-actions`, `starmap-refit-declutter`, `tactical-map-flex-basis` — the test-coupled behavior merges (duplicate movement selector, GM-ledger 5→1 buttons) land there with their e2e updates.
