### PR TITLE
feat: command-screen declutter wave + intent-first movement decision trail

### DIFF
--- a/docs/adr/0001-intent-first-tactical-movement.md
+++ b/docs/adr/0001-intent-first-tactical-movement.md
@@ -1,0 +1,23 @@
+# Intent-first tactical movement (composer + ledger + explicit budget lock-in)
+
+**Status:** accepted (2026-07-01)
+
+The tactical HUD had two live movement-mode selectors (action-dock buttons and the in-map MP legend), and the de-clutter effort forced the question of which surface owns movement. Both candidate answers — dock-authoritative and map-owned selection — were **budget-first** models: pick walk/run/jump, then fit your actions into it, and go back and re-pick when posture costs (stand up, careful stand) or damage (engine criticals) don't fit. We decided instead that **movement is intent-first**: the player composes the turn (posture actions + a waypointed path with player-placed pivot points) in a Movement Intent Composer; a Cost Ledger totals it live; a **Live Intersection** rule blocks any item or hex that no remaining budget could afford; and the walk/run/jump choice happens **last**, as an explicit **Lock-In** among the budgets that afford the composed intent.
+
+## Why
+
+- Budget-first forces a compose → overflow → uncompose → recompose loop ("rehashing"), worst exactly when it matters (damaged units, posture changes).
+- The resolver must never auto-pick the cheapest affording mode: mode choice carries strategy beyond MP efficiency — running generates heat a TSM unit may _want_; walk/run/jump differ in attack modifiers.
+- The path itself is strategy, not a pathfinding detail: a slower forest route (cover) vs a fast plains route (exposed) reach the same hex with different value. Player-placed waypoints/pivots express this; auto-pathing alone cannot.
+
+## Considered options
+
+- **Dock-authoritative selection** (dock keeps mode buttons; map legend demoted to readout) — rejected: budget-first; rehashing loop remains.
+- **Map-owned selection** (mode picked at the map; envelopes per mode) — rejected as an end-state framing, but its envelope display survives: the per-mode colored reachability envelopes ARE the Live Intersection rendered on the map.
+- **Auto-resolve cheapest affording mode** — rejected: heat-as-resource (TSM) and modifier trade-offs make mode choice deliberate.
+
+## Consequences
+
+- The de-clutter wave's interim dock-authoritative selector consolidation is reverted rather than test-encoded; direction-neutral fixes (hotkey collision, leaked engine tokens, lens tray, layout flex budget) are kept.
+- The composer is a real feature (`tactical-movement-intent-composer`, OpenSpec change to come): per-mode reachability with terrain costs, waypointed path costing with pivot facing costs, forced-mode detection, consequence display at lock-in.
+- Vocabulary is canonical in `openspec/TERMINOLOGY_GLOSSARY.md` § Tactical Movement Intent Terms.

--- a/e2e/campaign-customizer-handoff.spec.ts
+++ b/e2e/campaign-customizer-handoff.spec.ts
@@ -131,7 +131,7 @@ async function makeOneCampaignRefitChange(page: Page): Promise<void> {
     'No refit order will be created',
   );
   await page.getByTestId('structure-heat-sink-increment').click();
-  await expect(page.getByTestId('campaign-refit-context')).toContainText(
+  await expect(page.getByTestId('campaign-refit-change-count')).toContainText(
     '1 build field changed',
   );
   await expect(page.getByTestId('campaign-refit-save')).toBeEnabled();

--- a/e2e/campaign-starmap-logistics.spec.ts
+++ b/e2e/campaign-starmap-logistics.spec.ts
@@ -161,11 +161,11 @@ test.describe('campaign starmap logistics', () => {
           'high',
         );
         await expect(page.getByTestId('starmap-detail-status')).toContainText(
-          'Detail',
+          'Zoom',
         );
-        await expect(page.getByTestId('starmap-map-toolbar')).toContainText(
-          'Detail',
-        );
+        await expect(
+          page.getByTestId('starmap-detail-status'),
+        ).not.toContainText('Detail');
         await expect(
           page.getByTestId('starmap-detail-status'),
         ).not.toContainText('LOD');

--- a/e2e/gm-campaign-ledger-control-plane.spec.ts
+++ b/e2e/gm-campaign-ledger-control-plane.spec.ts
@@ -7,6 +7,19 @@ test.setTimeout(120_000);
 
 const GM_LEDGER_NAVIGATION_TIMEOUT_MS = 60_000;
 
+// The GM control plane now exposes one "Generate correction" control driven by a
+// correction-type <select>. Pick the type, then fire the single control — this
+// mirrors how a GM drives the screen and replaces the old per-type buttons.
+async function generateCorrection(
+  page: Page,
+  correctionType: string,
+): Promise<void> {
+  await page
+    .getByTestId('gm-ledger-correction-type')
+    .selectOption(correctionType);
+  await page.getByTestId('gm-ledger-preview-btn').click();
+}
+
 test.beforeEach(async ({ page }) => {
   page.setDefaultNavigationTimeout(GM_LEDGER_NAVIGATION_TIMEOUT_MS);
 });
@@ -736,7 +749,7 @@ test.describe('GM campaign ledger control plane @gm-ledger', () => {
       });
       await assertNoMekStationLoading(page);
 
-      await page.getByTestId('gm-ledger-conflict-preview-btn').click();
+      await generateCorrection(page, 'merchant-conflict');
       await expect(page.getByTestId('gm-ledger-preview-status')).toContainText(
         'requires-manual-takeover',
       );
@@ -781,7 +794,7 @@ test.describe('GM campaign ledger control plane @gm-ledger', () => {
       await assertNoMekStationLoading(page);
       await seedCampaignBaseFixState(page);
 
-      await page.getByTestId('gm-ledger-repair-preview-btn').click();
+      await generateCorrection(page, 'repair');
       await expect(page.getByTestId('gm-ledger-preview-status')).toContainText(
         'ready',
       );
@@ -799,7 +812,7 @@ test.describe('GM campaign ledger control plane @gm-ledger', () => {
           repairRemainingHours: 0,
         });
 
-      await page.getByTestId('gm-ledger-salvage-preview-btn').click();
+      await generateCorrection(page, 'salvage');
       await expect(
         page.getByTestId('gm-ledger-preview-state-summary'),
       ).toContainText('Salvage allocation match-1: processed=false');
@@ -813,7 +826,7 @@ test.describe('GM campaign ledger control plane @gm-ledger', () => {
           salvageProcessed: true,
         });
 
-      await page.getByTestId('gm-ledger-unit-reload-preview-btn').click();
+      await generateCorrection(page, 'unit-reload');
       await expect(
         page.getByTestId('gm-ledger-preview-state-summary'),
       ).toContainText('Unit unit-1: combatReady=false');
@@ -894,7 +907,7 @@ test.describe('GM campaign ledger control plane @gm-ledger', () => {
         new Date(initialState.currentDate).getTime() + 2 * 24 * 60 * 60 * 1000,
       ).toISOString();
 
-      await page.getByTestId('gm-ledger-time-preview-btn').click();
+      await generateCorrection(page, 'time');
       await expect(page.getByTestId('gm-ledger-preview-status')).toContainText(
         'ready',
       );
@@ -970,7 +983,7 @@ test.describe('GM campaign ledger control plane @gm-ledger', () => {
       });
       await assertNoMekStationLoading(page);
 
-      await page.getByTestId('gm-ledger-time-conflict-preview-btn').click();
+      await generateCorrection(page, 'time-conflict');
       await expect(page.getByTestId('gm-ledger-preview-status')).toContainText(
         'requires-manual-takeover',
       );

--- a/e2e/playable-command-feature-screens.spec.ts
+++ b/e2e/playable-command-feature-screens.spec.ts
@@ -236,9 +236,9 @@ async function captureStarmapScreens(
       'ready',
     );
     await expect(page.getByTestId('starmap-detail-status')).toContainText(
-      'Detail',
+      'Zoom',
     );
-    await expect(page.getByTestId('starmap-map-toolbar')).toContainText(
+    await expect(page.getByTestId('starmap-detail-status')).not.toContainText(
       'Detail',
     );
     await expect(page.getByTestId('starmap-detail-status')).not.toContainText(
@@ -456,7 +456,7 @@ async function captureMissionReadinessScreens(
     });
 
     await page.getByTestId('structure-heat-sink-increment').click();
-    await expect(page.getByTestId('campaign-refit-context')).toContainText(
+    await expect(page.getByTestId('campaign-refit-change-count')).toContainText(
       '1 build field changed',
     );
     await expect(page.getByTestId('campaign-refit-save')).toBeEnabled();

--- a/openspec/TERMINOLOGY_GLOSSARY.md
+++ b/openspec/TERMINOLOGY_GLOSSARY.md
@@ -1,7 +1,7 @@
 # OpenSpec Terminology Glossary
 
-**Version**: 1.0
-**Last Updated**: 2025-11-28
+**Version**: 1.1
+**Last Updated**: 2026-07-01
 **Purpose**: Canonical terminology reference for all MekStation OpenSpec specifications
 
 ---
@@ -1193,3 +1193,67 @@ This glossary establishes **canonical terminology** for all MekStation OpenSpec 
 ---
 
 **Questions or suggestions?** Update this glossary and increment the version number.
+
+---
+
+## Command-Screen UI Doctrine Terms (v1.1, 2026-07-01)
+
+Source: `openspec/council-decisions/2026-06-30-command-screen-focus-doctrine.md`.
+
+#### Command Screen
+
+Any campaign- or combat-tier surface where the player reads state and issues orders (Starmap, Mission Launch, Refit Customizer, Tactical HUD, GM Ledger). Every command screen is classified by **Screen Archetype** before layout work.
+
+#### Screen Archetype
+
+Binary classification that decides what "supporting UI" means on a command screen. **Single-Action**: one decisive commit (approve travel, launch, GM approve); the object and its metrics frame that action. **Simultaneous-Instrument**: a work surface plus a co-primary scoreboard the task reads continuously (refit stat strip, tactical heat/armor). Test: "does the task require an always-glanceable scoreboard in real time?"
+
+#### Focus-Hierarchy Zones
+
+The five layout zones every command-screen control must declare: **FOCUS** (the one primary object/work-surface, largest and central), **INSTRUMENT** (co-primary always-visible scoreboard; only on simultaneous-instrument screens; never demotable), **CONTEXT-FRAME** (read-only state the action depends on, one source object), **PRIMARY-ACTION ANCHOR** (exactly one highest-contrast CTA on the FOCUS border, state-derived), **AMBIENT CHROME** (nav, lenses, zoom; dimmer but ≥4.5:1). A control with no zone doesn't ship.
+
+#### Commitment Contract
+
+On one-shot irreversible commits (e.g. Approve Travel), the consequence metrics (jumps, days, fees, funds) placed between object and action. Never demoted to border.
+
+---
+
+## Tactical Movement Intent Terms (v1.1, 2026-07-01)
+
+Source: intent-first movement decision, `docs/adr/0001-intent-first-tactical-movement.md`.
+
+#### Movement Intent Composer
+
+The tactical-HUD module where the active player composes a movement turn as a set of **Intent Items** before any budget is chosen. Replaces budget-first mode selection.
+
+#### Intent Item
+
+One composable element of a movement turn. Two kinds: **Posture Action** and **Locomotion Path**. Every intent item carries a real MP cost.
+
+#### Posture Action
+
+A movement-phase action with an MP cost but no destination: Stand Up, Careful Stand, Go Prone, Hull Down. Lives in the composer palette, not on the map.
+
+#### Locomotion Path
+
+The map-expressed part of movement intent: an ordered sequence of **Waypoints** forming legs, plus final facing. Costs accrue per hex entered (terrain-adjusted) and per facing change at pivots.
+
+#### Waypoint / Pivot Point
+
+A player-placed hex that anchors a leg of the Locomotion Path. A waypoint where travel direction changes is a **Pivot Point**; its facing-change MP cost is computed there. Waypoint placement is deliberate strategy (cover route vs speed route), not a pathfinding detail.
+
+#### Cost Ledger
+
+The live running total of all composed Intent Items' MP costs, displayed against each candidate **Movement Budget**.
+
+#### Live Intersection
+
+The composer's core rule: as intent is composed, the set of still-affordable Movement Budgets recomputes on the fly, and any intent item (or map hex) that no remaining budget can afford is blocked **at the source**. An impossible turn cannot be composed.
+
+#### Movement Budget
+
+The MP pool granted by a locomotion mode for the turn: Walk, Run, or Jump MP (as modified by damage such as engine criticals, heat, TSM, etc.).
+
+#### Budget Resolver / Lock-In
+
+The final step of the composed flow: the affordable Movement Budgets are presented with their consequences (heat, attack modifiers). If exactly one affords the intent, the player is in **Forced Mode** (single option, still explicit). The resolver **never auto-picks** — heat can be a strategic resource (e.g. TSM activation), so mode choice is always the player's explicit **Lock-In** that commits the whole composed sequence.

--- a/openspec/active-change-ledger.json
+++ b/openspec/active-change-ledger.json
@@ -1,3 +1,10 @@
 {
-  "allowedActiveChanges": []
+  "allowedActiveChanges": [
+    {
+      "name": "tactical-movement-intent-composer",
+      "status": "apply-ready",
+      "reason": "Intent-first movement composer (ADR 0001) authored ahead of implementation; applies on a fresh branch after PR #992 merges. Artifacts complete, openspec validate --strict passes.",
+      "lastReviewed": "2026-07-01"
+    }
+  ]
 }

--- a/openspec/changes/tactical-movement-intent-composer/.openspec.yaml
+++ b/openspec/changes/tactical-movement-intent-composer/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-01

--- a/openspec/changes/tactical-movement-intent-composer/design.md
+++ b/openspec/changes/tactical-movement-intent-composer/design.md
@@ -1,0 +1,114 @@
+# Design: tactical-movement-intent-composer
+
+## Context
+
+Movement on the tactical HUD is budget-first today: the `TacticalActionDock` renders movement-verb buttons (Walk/Run/Sprint/Evade/Jump with hotkeys) and the in-map MP legend renders a second cost-labeled selector — both wired to `onMovementModeSelect` on the gameplay store. The map already has the key building blocks: a per-mode reachable-hex overlay requirement (MegaMek palette, non-color encodings), an A\*-pathfinder hover path preview, movement range/`hoverMpCost`/`highlightPath` props through `HexMapDisplay`, and a Facing Picker Overlay at the destination. `movement-system` already specifies MP budgets (walk/run/jump), prone/standing costs, heat MP reduction, and movement heat.
+
+The decision record is `docs/adr/0001-intent-first-tactical-movement.md`; canonical vocabulary is `openspec/TERMINOLOGY_GLOSSARY.md` § Tactical Movement Intent Terms. This design covers HOW the intent-first flow lands on the existing components, stores, and engine surface.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One movement authority: the Movement Intent Composer (dock-hosted panel + map interaction) replaces both legacy selectors.
+- Compose-forward flow: posture actions + waypointed path composed first; budget chosen last via explicit Lock-In.
+- Live Intersection enforced at the source (unaffordable items/hexes blocked, envelopes shrink live).
+- Reuse the existing A\* pathfinder, reachability computation, and Facing Picker; consume `movement-system` cost rules verbatim.
+
+**Non-Goals:**
+- No movement-rule changes; no bot/AI planner changes; no attack-phase composition; no multiplayer protocol changes (the committed sequence enters the existing declaration path).
+
+## Decisions
+
+### D1 — Intent-first replaces budget-first (ADR 0001)
+Alternatives (dock-authoritative selection; map-owned mode selection) both preserve the compose→overflow→recompose loop. Rejected per ADR. The composer is the only movement surface; the dock's movement-verb buttons are removed (dock keeps facing/phase/utility and hosts the composer's posture palette); the in-map MP legend is superseded by the Cost Ledger + envelopes.
+
+### D2 — Click-is-a-waypoint with auto-route between anchors
+Every click on an affordable hex appends a Waypoint; the A\* pathfinder routes the cheapest path between consecutive anchors; a single click to a destination is the degenerate fast case. Clicking the last waypoint (or Backspace) pops it. Alternatives rejected: pure hex-by-hex stepping (tedious, kills the one-smooth-flow goal on open terrain) and auto-path + drag-to-bend (imprecise at the pivot hex, hostile to keyboard/touch).
+
+### D3 — Live Intersection is computed against the maximal still-affordable budget set
+After each composition edit, recompute: `affordableBudgets = budgets.filter(b => ledgerTotal <= b.mp)` where `budgets` are walk/run/jump MP after damage/heat modifiers (from existing `movement-system` hooks). The map's reachable envelopes render **all** affordable modes simultaneously (existing MegaMek palette + non-color encodings retained) and shrink as the remaining MP decreases. Posture palette items grey out when `ledgerTotal + itemCost` exceeds every budget. Alternative (free composition + red deficit ledger) rejected: reintroduces the rehashing loop.
+
+### D4 — Budget Resolver never auto-picks
+The resolver lists affordable modes with consequence lines (heat generated per `movement-system` "Movement Generates Heat"; attacker to-hit modifier). Exactly one affordable mode = Forced Mode: single option, still an explicit click. Rationale: heat can be a strategic resource (TSM activation); mode choice carries modifier trade-offs. Lock-In commits the entire composed sequence atomically.
+
+### D5 — State: a `movementIntent` slice on the gameplay store (Zustand)
+
+```typescript
+type PostureActionType = 'STAND_UP' | 'CAREFUL_STAND' | 'GO_PRONE' | 'HULL_DOWN';
+
+interface IWaypoint {
+  readonly hex: { readonly q: number; readonly r: number };
+  /** Facing change applied at this waypoint (hexsides turned); MP cost derives from it. */
+  readonly facingChange: number;
+}
+
+interface ILocomotionLeg {
+  readonly from: IWaypoint;
+  readonly to: IWaypoint;
+  /** A*-routed hex sequence between the anchors (inclusive of `to`). */
+  readonly path: readonly { readonly q: number; readonly r: number }[];
+  readonly mpCost: number; // terrain-adjusted, per movement-system
+}
+
+type IIntentItem =
+  | { readonly kind: 'posture'; readonly action: PostureActionType; readonly mpCost: number }
+  | { readonly kind: 'locomotion'; readonly legs: readonly ILocomotionLeg[]; readonly finalFacing: Facing };
+
+interface IBudgetOption {
+  readonly mode: MovementMode; // WALK | RUN | JUMP (existing enum)
+  readonly budgetMp: number;   // damage/heat-adjusted
+  readonly affordable: boolean;
+  readonly heatGenerated: number;
+  readonly attackerToHitModifier: number;
+}
+
+interface IMovementIntentState {
+  readonly items: readonly IIntentItem[];
+  readonly ledgerTotalMp: number;             // derived
+  readonly budgetOptions: readonly IBudgetOption[]; // derived, drives Live Intersection
+  readonly lockedMode: MovementMode | null;   // set at Lock-In
+}
+```
+
+Derived values are selectors, not stored (single source: `items` + unit state). `onMovementModeSelect` and its prop-drilling are replaced by `commitComposedMovement(intent, lockedMode)`, which feeds the existing movement declaration path.
+
+### D6 — Component hierarchy and data flow
+
+```
+GameplayLayout
+├── HexMapDisplay (FOCUS)
+│   ├── EnvelopeOverlay        ← budgetOptions (simultaneous, shrinking)
+│   ├── WaypointLayer          ← waypoints, legs, per-leg cost chips, pop-on-click
+│   ├── PathPreview (A*)       ← anchored at last waypoint → hover hex
+│   └── FacingPickerOverlay    ← existing, at last waypoint
+├── TacticalActionDock (PRIMARY-ACTION)
+│   └── MovementIntentComposer
+│       ├── PosturePalette     ← posture items, greyed via Live Intersection
+│       ├── CostLedger         ← per-item rows + total vs budget columns
+│       └── BudgetResolver     ← consequence lines, Forced Mode, Lock-In button
+└── DesktopRightTray (INSTRUMENT — heat/armor stays glanceable; unchanged)
+```
+
+Data flows one way: composition edits → store → derived budgets → map overlays + palette gating; Lock-In → `commitComposedMovement` → existing resolution pipeline → store reset.
+
+### D7 — Validation and error handling
+- Composition edits validate against `movement-system` hooks at insert time (Live Intersection); an invalid insert is impossible by construction, so there is no "over budget" error state to render.
+- Commit revalidates the full sequence server-of-truth-side (same rules); a drift between composed preview and commit legality rejects with an explicit error per the existing `playable-command-screens` "Preview and commit agreement" requirement.
+- Engine-crit/heat changes mid-composition (e.g. interactive events) trigger a budget recompute; items rendered newly unaffordable flag the ledger row and block Lock-In until the player removes them — this is the one recompose path, caused by world change, not by the flow.
+
+## Risks / Trade-offs
+
+- [Per-mode reachability recompute on every waypoint edit could be hot on large maps] → memoize per (unitId, mode, remainingMp, terrain revision); reuse existing movement-range computation which already runs per selection.
+- [Removing dock movement buttons breaks e2e/capture specs anchored on them] → the change re-anchors specs in the same PR (`tactical-action-dock:movement` ready-marker and combat quick-slice specs), mirroring the wave's test-coupling discipline.
+- [Posture costs interact with budgets non-linearly (e.g. careful stand)] → all costs come from `movement-system` hooks; no local cost math in UI.
+- [Keyboard/touch waypoint placement] → hotkeys retained for posture actions; waypoints placeable via keyboard hex cursor (existing map keyboard nav) and touch taps; Backspace pops. A11y: envelopes keep the spec'd non-color encodings; ledger rows are text; Lock-In is a real button with aria-disabled semantics.
+- [Interim wave artifacts encoded dock-authoritative selection] → reverted before this change lands (ADR Consequences); direction-neutral fixes kept.
+
+## Migration Plan
+
+Single change, no feature flag: the composer replaces the legacy flow in one PR (the legacy selectors are contradictory with Live Intersection rendering). Rollback = revert the PR; the store slice is additive and self-contained. Evidence captures re-shot; e2e re-anchored in-change.
+
+## Open Questions
+
+- Sprint/Evade handling: Evade is modeled as a Posture Action (no destination); Sprint (if enabled by rules level) enters as a fourth Movement Budget — confirm against `movement-system` rules-level gating during implementation.
+- Whether the per-leg cost chips render at all zoom levels or gate on the existing LOD thresholds (recommend: gate below `medium` zoom).

--- a/openspec/changes/tactical-movement-intent-composer/proposal.md
+++ b/openspec/changes/tactical-movement-intent-composer/proposal.md
@@ -1,0 +1,41 @@
+# Proposal: tactical-movement-intent-composer
+
+## Why
+
+The tactical HUD's movement flow is budget-first: the player picks walk/run/jump, then discovers mid-composition that posture costs (stand up, careful stand) or damage (engine criticals, heat MP reduction) don't fit, and must back out and re-pick — a compose → overflow → uncompose loop that is worst exactly when decisions matter most (damaged units). The screen also carried two competing movement-mode selectors (action-dock buttons and the in-map MP legend). ADR `docs/adr/0001-intent-first-tactical-movement.md` decided the replacement model: **intent-first movement** — compose the turn, total it live, choose the budget last.
+
+## What Changes
+
+- **New Movement Intent Composer** on the tactical HUD: the active player composes a movement turn as Intent Items — Posture Actions (Stand Up, Careful Stand, Go Prone, Hull Down) plus a waypointed Locomotion Path — before any movement mode is chosen.
+- **Click-is-a-waypoint map interaction**: every click on a reachable hex adds a waypoint; the engine auto-routes the cheapest path between consecutive waypoints; a single click to a destination is the fast default; clicking the last waypoint (or Backspace) pops it. Pivot Points (direction changes at waypoints) accrue facing-change MP where they occur.
+- **Cost Ledger + per-leg cost chips**: a live MP total of the composed intent, with per-leg and per-pivot costs rendered on the map along the path.
+- **Live Intersection**: as intent is composed, the set of still-affordable Movement Budgets (Walk/Run/Jump, damage- and heat-adjusted) recomputes on the fly; intent items and hexes that no remaining budget can afford are blocked at the source. Per-mode reachability envelopes are this rule rendered on the map.
+- **Budget Resolver with explicit Lock-In**: affordable modes are presented with consequences (heat generated, attacker to-hit modifier); exactly-one-affordable is Forced Mode (single option, still explicit). The resolver **never auto-picks** — heat can be a strategic resource (e.g. TSM activation). Lock-In commits the whole composed sequence.
+- **Single movement authority**: the composer replaces both legacy selectors — the action dock's movement-verb buttons are removed (dock retains posture palette hosting, facing, phase, utility); the in-map MP legend is superseded by the ledger/envelopes.
+- Interim artifacts from the de-clutter wave that encoded dock-authoritative selection are reverted rather than shipped (per ADR Consequences).
+
+## Capabilities
+
+### New Capabilities
+- `tactical-movement-intent`: the intent-first movement flow — Intent Items (Posture Action, Locomotion Path), waypoint/pivot mechanics and auto-routing between anchors, Cost Ledger, Live Intersection block-at-source rule, Budget Resolver semantics (consequence display, Forced Mode, explicit Lock-In, never-auto-pick), commit of the composed sequence into the existing movement resolution pipeline.
+
+### Modified Capabilities
+- `tactical-map-interface`: "Reachable Hex Overlay by MP Type" changes from player-selected-mode rendering to simultaneous affordable-mode envelopes that shrink under Live Intersection; "Path Preview on Hover" re-anchors from the selected unit to the last placed waypoint, and its click-commits-destination scenario becomes click-adds-waypoint; a new Waypoint Composition Interaction requirement is added (waypoint add/pop, auto-route between anchors, per-leg cost chips). The existing Facing Picker Overlay requirement is unchanged (final facing at the last waypoint).
+
+_Not modified_: `movement-system` (MP calculation, prone/standing costs, heat MP reduction, movement heat are consumed as-is — this change reorders the player's decision flow, not the rules); `playable-command-screens` (the composer complies with the existing "Preview and commit agreement" requirement — ledger/resolver are the preview, Lock-In is the commit — no requirement change needed).
+
+## Non-goals
+
+- No changes to movement **rules** (MP formulas, PSR triggers, terrain costs, heat effects) — the composer consumes `movement-system` requirements verbatim.
+- No AI/bot movement changes — bots keep their existing planners; this is the human interaction surface.
+- No attack-phase or physical-attack composition — intent-first applies to the movement phase only in this change.
+- No networked-play protocol changes — the committed sequence enters the same declaration path as today's moves.
+
+## Impact
+
+- **Components**: `src/components/gameplay/TacticalActionDock/` (movement group removed, posture palette hosted), `src/components/gameplay/HexMapDisplay/` (waypoint interaction, envelopes, cost chips; MP legend superseded), new composer/ledger/resolver components under `src/components/gameplay/`, `GameplayLayout.*` wiring.
+- **State**: gameplay store gains composed-intent state (intent items, waypoints, affordable-budget set, lock-in); existing `onMovementModeSelect` path is replaced by the commit-of-sequence path.
+- **Engine surface**: needs per-mode reachability with terrain-adjusted costs and waypoint-constrained cheapest-path routing (builds on existing movement range/path utilities); posture-action MP costs already specified in `movement-system`.
+- **Tests**: tactical e2e specs and the command-screen evidence capture flow re-anchor from mode-buttons to composer interactions; unit tests for ledger math, live intersection, forced-mode detection, waypoint routing.
+- **Docs**: canonical vocabulary already in `openspec/TERMINOLOGY_GLOSSARY.md` § Tactical Movement Intent Terms; decision record in `docs/adr/0001-intent-first-tactical-movement.md`.
+- **Tech-base/temporal considerations**: consequence display must reflect equipment-conditional strategy (TSM heat thresholds, MASC/Supercharger interactions already computed by `movement-system` hooks).

--- a/openspec/changes/tactical-movement-intent-composer/specs/tactical-map-interface/spec.md
+++ b/openspec/changes/tactical-movement-intent-composer/specs/tactical-map-interface/spec.md
@@ -1,0 +1,115 @@
+# tactical-map-interface (delta)
+
+Delta for `tactical-movement-intent-composer`: the reachable-hex overlay becomes simultaneous affordable-mode envelopes driven by Live Intersection; the hover path preview re-anchors to the last placed waypoint and its click becomes waypoint-add; a new Waypoint Composition Interaction requirement covers waypoint mechanics and per-leg cost chips. The Facing Picker Overlay requirement is intentionally unchanged (final facing picks at the last waypoint).
+
+## MODIFIED Requirements
+
+### Requirement: Reachable Hex Overlay by MP Type
+
+The tactical map interface SHALL render a reachable-hex overlay during the Movement phase for the selected Player-side unit, coloring each tile by the movement type (Walk, Run, Jump) required to reach it using the MegaMek movement palette: Walk cyan, Run yellow, Jump red, and projected illegal/blocked movement dark gray. The overlay SHALL render the envelopes of **all still-affordable Movement Budgets simultaneously** (no player-selected MP type is required) and SHALL recompute against the **remaining** MP of each budget as the composed movement intent consumes it (Live Intersection, per `tactical-movement-intent`). Each overlay state SHALL also carry a non-color encoding so movement legality and movement type remain distinguishable without relying on hue alone.
+
+**Priority**: Critical
+
+#### Scenario: Walk-range tiles rendered cyan
+
+- **GIVEN** a selected unit has 5 walk MP remaining under the composed intent
+- **WHEN** the overlay renders
+- **THEN** every hex with `mpCost <= 5` via walk SHALL be tinted cyan (`#67e8f9`)
+- **AND** each tile SHALL display its MP cost in small text
+
+#### Scenario: Run-range tiles rendered yellow
+
+- **GIVEN** the unit's run budget affords more reach than its walk budget
+- **WHEN** the overlay renders
+- **THEN** tiles reachable only with run MP SHALL be tinted yellow (`#fef08a`)
+- **AND** walk-reachable fallback tiles SHALL retain Walk movement metadata when the Run projection is blocked
+
+#### Scenario: Jump-range tiles rendered red with pattern
+
+- **GIVEN** the unit has an affordable Jump budget
+- **WHEN** the overlay renders
+- **THEN** landing hexes reachable with jump SHALL be tinted red (`#f87171`) with a distinct diagonal pattern
+
+#### Scenario: Blocked movement projections rendered dark gray
+
+- **GIVEN** a movement projection exists for an illegal or over-capacity destination
+- **WHEN** the overlay renders that projected blocked tile
+- **THEN** the blocked movement tile SHALL be tinted dark gray (`#64748b`)
+- **AND** tiles with no movement projection SHALL have no movement overlay tint
+
+#### Scenario: Blocked tiles carry a non-color encoding
+
+- **GIVEN** a movement projection marks a destination blocked or illegal
+- **WHEN** the overlay renders that tile
+- **THEN** the tile SHALL render a distinct non-hue encoding (such as a cross-hatch pattern or blocked glyph) in addition to the dark gray tint
+- **AND** the encoding SHALL be distinguishable from the jump diagonal pattern
+
+#### Scenario: Walk and run reach distinguishable without hue
+
+- **GIVEN** the overlay renders walk-reachable and run-only-reachable tiles
+- **WHEN** the tiles render at a playable zoom level
+- **THEN** run-only tiles SHALL carry a non-hue encoding (such as a dashed border) distinguishing them from walk tiles
+- **AND** the overlay legend SHALL document the non-color encodings alongside the palette colors
+
+#### Scenario: Envelopes shrink as composed intent consumes budget
+
+- **GIVEN** a unit with Walk 4 / Run 6 and an empty composition renders 4-MP walk and 6-MP run envelopes
+- **WHEN** the player composes a 2 MP posture action
+- **THEN** the overlay SHALL re-render with at most 2-MP walk and 4-MP run envelopes
+- **AND** a budget made entirely unaffordable SHALL have no envelope rendered
+
+### Requirement: Path Preview on Hover
+
+The tactical map interface SHALL render a hover-driven path preview using the existing A\* pathfinder, anchored at the **last placed waypoint** of the composed Locomotion Path (or at the selected unit when no waypoint is placed) and ending at the hovered reachable hex.
+
+**Priority**: Critical
+
+#### Scenario: Hover reachable hex draws path
+
+- **GIVEN** a selected unit at {0,0} with no waypoints placed
+- **WHEN** the user hovers a reachable hex at {3,0}
+- **THEN** every hex along the pathfinder's cheapest path SHALL be highlighted yellow (`#fef9c3`)
+- **AND** the hovered hex SHALL display cumulative MP cost including all composed intent
+
+#### Scenario: Hover preview anchors at the last waypoint
+
+- **GIVEN** a composed path with a waypoint at {2,1}
+- **WHEN** the user hovers a hex reachable from {2,1}
+- **THEN** the preview path SHALL start at {2,1}, not at the unit's position
+- **AND** the displayed cumulative MP SHALL include the already-composed legs and posture actions
+
+#### Scenario: Hover unreachable hex shows tooltip
+
+- **GIVEN** a hex not reachable under any remaining affordable budget
+- **WHEN** the user hovers it
+- **THEN** no path SHALL be drawn
+- **AND** a tooltip SHALL display `"Unreachable"`
+
+#### Scenario: Clicking a reachable hex adds a waypoint
+
+- **GIVEN** a hover path is visible
+- **WHEN** the user clicks the hovered hex
+- **THEN** the hex SHALL be appended to the Locomotion Path as a Waypoint
+- **AND** the previewed leg SHALL persist as a composed leg (further hovers anchor at this new waypoint)
+
+## ADDED Requirements
+
+### Requirement: Waypoint Composition Interaction
+
+During movement composition, the map SHALL render the composed Locomotion Path as anchored legs with a distinct marker at every Waypoint, a Pivot Point indicator (with its facing-change MP) wherever travel direction changes at a waypoint, and a per-leg cost chip showing each leg's MP along the path. Clicking the last waypoint marker (or pressing Backspace) SHALL remove the final leg. Waypoint markers, pivot indicators, and cost chips SHALL be non-interactive except for the pop affordance on the last waypoint.
+
+**Priority**: Critical
+
+#### Scenario: Per-leg cost chips render along the path
+
+- **GIVEN** a composed path unit → forest waypoint (4 MP) → destination (2 MP)
+- **WHEN** the path renders
+- **THEN** a chip reading `4 MP` SHALL render on the first leg and `2 MP` on the second
+- **AND** a pivot indicator with its facing-change MP SHALL render at the forest waypoint if travel direction changes there
+
+#### Scenario: Pop affordance is limited to the last waypoint
+
+- **GIVEN** a composed path with waypoints A then B
+- **WHEN** the player clicks waypoint A
+- **THEN** the composition SHALL NOT change
+- **AND** clicking waypoint B SHALL remove the leg A→B

--- a/openspec/changes/tactical-movement-intent-composer/specs/tactical-movement-intent/spec.md
+++ b/openspec/changes/tactical-movement-intent-composer/specs/tactical-movement-intent/spec.md
@@ -1,0 +1,116 @@
+# tactical-movement-intent
+
+Intent-first movement flow for the tactical HUD: the active player composes a movement turn (Posture Actions + a waypointed Locomotion Path), a Cost Ledger totals it live, Live Intersection blocks unaffordable intent at the source, and the movement mode is chosen last via an explicit Lock-In. Vocabulary: `openspec/TERMINOLOGY_GLOSSARY.md` § Tactical Movement Intent Terms. Decision record: `docs/adr/0001-intent-first-tactical-movement.md`.
+
+## ADDED Requirements
+
+### Requirement: Movement Intent Composition
+
+During the Movement phase, the tactical HUD SHALL provide a Movement Intent Composer for the active player-side unit in which the player composes the turn as Intent Items — zero or more Posture Actions plus at most one Locomotion Path — before any movement mode is selected. Every Intent Item SHALL carry an MP cost derived from `movement-system` requirements (no UI-local cost formulas).
+
+#### Scenario: Composing posture and locomotion before any mode choice
+
+- **GIVEN** a prone unit with Walk 4 / Run 6 budgets is active in the Movement phase
+- **WHEN** the player adds a Stand Up posture action and then places a waypoint 3 hexes away
+- **THEN** both Intent Items SHALL appear in the composition with their MP costs
+- **AND** no movement mode SHALL be selected or required at this point
+
+#### Scenario: Costs come from movement-system rules
+
+- **WHEN** any Intent Item is added to the composition
+- **THEN** its MP cost SHALL equal the cost defined by `movement-system` (posture costs, terrain-adjusted hex entry costs, facing-change costs)
+
+### Requirement: Posture Action Palette
+
+The composer SHALL present a palette of the Posture Actions legal for the unit's current state (Stand Up, Careful Stand, Go Prone, Hull Down, Evade where legal), each labeled with its MP cost. Palette items that Live Intersection marks unaffordable SHALL be disabled with a non-color-only disabled encoding.
+
+#### Scenario: Illegal and unaffordable posture actions are gated
+
+- **GIVEN** a standing unit whose composed intent already consumes all but 1 MP of its best budget
+- **WHEN** the palette renders
+- **THEN** posture actions illegal for a standing unit (Stand Up, Careful Stand) SHALL NOT be offered
+- **AND** legal actions costing more than 1 MP SHALL render disabled with both a dimmed style and a disabled glyph or text
+
+### Requirement: Waypointed Locomotion Path
+
+The Locomotion Path SHALL be an ordered sequence of player-placed Waypoints. The system SHALL auto-route the cheapest legal path between consecutive anchors (unit position → waypoint 1 → … → final waypoint) using the existing pathfinder, accruing terrain-adjusted MP per hex entered and facing-change MP at each Pivot Point where travel direction changes. Removing the most recent waypoint SHALL restore the prior composition state exactly.
+
+#### Scenario: Single click is the fast default
+
+- **WHEN** the player clicks a reachable destination hex with no prior waypoints
+- **THEN** the system SHALL route the cheapest path from the unit to that hex as one leg
+
+#### Scenario: Intermediate waypoint forces a strategic route
+
+- **GIVEN** a destination reachable via a cheap open-ground route and a costlier wooded route
+- **WHEN** the player clicks a wooded hex first and then the destination
+- **THEN** the path SHALL route unit → wooded waypoint → destination
+- **AND** the Cost Ledger SHALL reflect the costlier wooded legs, not the cheapest direct route
+
+#### Scenario: Popping the last waypoint
+
+- **GIVEN** a composed path with two waypoints
+- **WHEN** the player clicks the last waypoint (or presses Backspace)
+- **THEN** the final leg SHALL be removed
+- **AND** the ledger total, envelopes, and palette gating SHALL recompute to the one-waypoint state
+
+### Requirement: Cost Ledger
+
+The composer SHALL display a Cost Ledger listing every composed Intent Item with its MP cost and a running total, evaluated against each candidate Movement Budget (Walk/Run/Jump MP as modified by damage and heat). The ledger SHALL update on every composition edit.
+
+#### Scenario: Ledger totals against damaged budgets
+
+- **GIVEN** a unit with 2 engine criticals reducing budgets to Walk 2 / Run 3
+- **WHEN** the player composes Careful Stand (2 MP)
+- **THEN** the ledger SHALL show total 2 MP with Walk marked affordable-exhausted (0 MP remaining) and Run marked affordable (1 MP remaining)
+
+### Requirement: Live Intersection
+
+On every composition edit, the system SHALL recompute the set of Movement Budgets that afford the composed total and SHALL block unaffordable additions at the source: map hexes no remaining budget can reach SHALL NOT be placeable as waypoints, and palette items whose cost exceeds every remaining budget SHALL be disabled. It SHALL NOT be possible to compose an intent that no budget affords through composer interactions.
+
+#### Scenario: Reach shrinks as posture consumes budget
+
+- **GIVEN** a unit with Walk 4 / Run 6 and an empty composition
+- **WHEN** the player adds a 2 MP posture action
+- **THEN** the placeable-hex set SHALL recompute to at most 2 MP of walk reach and 4 MP of run reach
+
+#### Scenario: World change mid-composition is the only recompose path
+
+- **GIVEN** a composed intent affordable under Run
+- **WHEN** an external state change (e.g. heat gain) reduces the Run budget below the composed total
+- **THEN** the newly unaffordable ledger rows SHALL be flagged
+- **AND** Lock-In SHALL be blocked until the player removes items to fit an affordable budget
+
+### Requirement: Budget Resolver and Explicit Lock-In
+
+After composition, the resolver SHALL present every Movement Budget that affords the composed intent, each with its consequences (heat generated per `movement-system`, attacker to-hit modifier). The resolver SHALL NOT auto-select any mode, including the cheapest, and SHALL NOT commit without an explicit player Lock-In. When exactly one budget affords the intent, the resolver SHALL present it as Forced Mode — a single option that still requires the explicit Lock-In. Lock-In SHALL commit the entire composed sequence atomically into the existing movement declaration path.
+
+#### Scenario: Multiple affordable modes require an explicit choice
+
+- **GIVEN** a composed intent of 3 MP for a unit with Walk 4 / Run 6
+- **WHEN** the resolver renders
+- **THEN** Walk and Run SHALL both be offered with their heat and attacker to-hit consequences
+- **AND** no mode SHALL be pre-committed (a TSM-equipped unit MAY deliberately choose Run for the heat)
+
+#### Scenario: Forced Mode is still explicit
+
+- **GIVEN** a composed intent only Run can afford
+- **WHEN** the resolver renders
+- **THEN** Run SHALL be presented as the single Forced Mode option
+- **AND** the sequence SHALL NOT commit until the player activates Lock-In
+
+#### Scenario: Lock-In commits the whole sequence
+
+- **WHEN** the player activates Lock-In
+- **THEN** the posture actions, path legs, pivot facing changes, and final facing SHALL enter the movement declaration path as one atomic declaration
+- **AND** the composition SHALL reset for the next activation
+
+### Requirement: Single Movement Authority
+
+The Movement Intent Composer SHALL be the sole surface for movement composition and mode selection on the tactical HUD. The action dock SHALL NOT render movement-mode selector buttons, and the map SHALL NOT render a second interactive mode selector; the dock retains facing, phase, and utility commands and hosts the composer's posture palette.
+
+#### Scenario: No competing movement selector exists
+
+- **WHEN** the Movement phase HUD renders for the active unit
+- **THEN** exactly one movement composition surface (the composer) SHALL be interactive
+- **AND** any map-rendered mode/cost readout SHALL be non-interactive

--- a/openspec/changes/tactical-movement-intent-composer/tasks.md
+++ b/openspec/changes/tactical-movement-intent-composer/tasks.md
@@ -1,0 +1,37 @@
+# Tasks: tactical-movement-intent-composer
+
+## 1. Pre-flight and state foundation
+
+- [ ] 1.1 Verify the de-clutter wave's interim dock-authoritative selector edits are reverted on the working branch (per ADR 0001 Consequences); keep direction-neutral fixes
+- [ ] 1.2 Add the `movementIntent` slice to the gameplay store (`IIntentItem`, `IWaypoint`, `ILocomotionLeg`, `IBudgetOption`, `IMovementIntentState` per design D5) with unit tests for reducers
+- [ ] 1.3 Implement derived selectors: `ledgerTotalMp`, `budgetOptions` (walk/run/jump budgets via existing `movement-system` hooks, damage/heat-adjusted), `affordableBudgets`; unit-test the engine-crit case (Walk 2 / Run 3)
+- [ ] 1.4 Implement `commitComposedMovement(intent, lockedMode)` feeding the existing movement declaration path; deprecate `onMovementModeSelect` wiring
+
+## 2. Waypoint routing engine surface
+
+- [ ] 2.1 Add waypoint-constrained routing: cheapest A\* path between consecutive anchors, accruing terrain-adjusted MP per hex and facing-change MP at pivots; memoize per (unitId, mode, remainingMp, terrain revision)
+- [ ] 2.2 Compute per-leg costs and pivot facing costs for the ledger; unit tests: single-click fast default, forced wooded-route waypoint, pop-last restores prior state exactly
+- [ ] 2.3 Implement Live Intersection: recompute placeable-hex set and palette gating from remaining MP of every affordable budget after each edit; unit tests: reach shrinks after posture add; impossible composition unreachable by construction
+
+## 3. Map interaction (tactical-map-interface delta)
+
+- [ ] 3.1 Simultaneous affordable-mode envelopes: render all affordable budgets at once with the existing MegaMek palette + non-color encodings, recomputed against remaining MP (MODIFIED Reachable Hex Overlay scenarios, incl. envelope-shrink)
+- [ ] 3.2 Re-anchor hover path preview at the last placed waypoint (falling back to the unit); cumulative MP includes composed intent (MODIFIED Path Preview scenarios)
+- [ ] 3.3 Click-adds-waypoint: append waypoint on reachable-hex click; persist previewed leg; Backspace/last-waypoint-click pops (spec: pop limited to last waypoint)
+- [ ] 3.4 WaypointLayer rendering: waypoint markers, pivot indicators with facing-change MP, per-leg cost chips (gate chips below medium zoom per design open question resolution)
+- [ ] 3.5 Keep Facing Picker Overlay working at the last waypoint (final facing feeds the composed intent)
+
+## 4. Composer UI (tactical-movement-intent capability)
+
+- [ ] 4.1 `MovementIntentComposer` hosted in the action dock; remove the dock's movement-verb buttons (dock retains facing/phase/utility); demote any in-map mode/cost readout to non-interactive (Single Movement Authority)
+- [ ] 4.2 `PosturePalette`: legal posture actions with MP costs, Live-Intersection disabling with non-color-only encoding (illegal-for-state actions not offered)
+- [ ] 4.3 `CostLedger`: per-item rows, running total, per-budget affordability columns; world-change recompute flags rows and blocks Lock-In
+- [ ] 4.4 `BudgetResolver`: affordable modes with heat + attacker to-hit consequence lines; Forced Mode single-option; explicit Lock-In button (never auto-pick); Lock-In commits atomically and resets composition
+- [ ] 4.5 Keyboard + touch: posture hotkeys retained, keyboard hex-cursor waypoint placement, Backspace pop; aria semantics on palette/resolver disabled states
+
+## 5. Test migration and verification
+
+- [ ] 5.1 Re-anchor tactical e2e specs and the command-screen evidence capture flow (`tactical-action-dock:movement` ready-marker, combat quick-slice) from mode buttons to composer interactions
+- [ ] 5.2 Unit/integration tests for the full flow: prone engine-crit unit composes Careful Stand + 2-hex move → Forced Mode Run → Lock-In commits sequence
+- [ ] 5.3 Run `npm run typecheck`, targeted jest, `npm run qc:command:combat:quick`, `npm run qc:command-evidence` (capture + validate); read PNG 09 to confirm composer renders, single authority, envelopes visible
+- [ ] 5.4 `openspec.cmd validate tactical-movement-intent-composer --strict` passes; update evidence manifest if ready-markers changed

--- a/openspec/specs/unit-info-banner/spec.md
+++ b/openspec/specs/unit-info-banner/spec.md
@@ -50,9 +50,10 @@ The banner SHALL display key unit statistics in a balanced grid using BalancedGr
 #### Scenario: BV and Engine stats display
 
 - **WHEN** single-value stats render
-- **THEN** BV appears first with cyan color
-- **AND** ENGINE appears second with orange color
+- **THEN** BV appears first with neutral primary text color
+- **AND** ENGINE appears second with neutral primary text color
 - **AND** both use SimpleStat component
+- **AND** neither uses a decorative accent hue (per command-screen focus doctrine, color is reserved for out-of-budget / invalid states)
 
 #### Scenario: Weight stat with capacity format
 
@@ -84,7 +85,7 @@ The banner SHALL display key unit statistics in a balanced grid using BalancedGr
 - **THEN** label shows "HEAT"
 - **AND** value shows "generated / dissipation" format (e.g., "15 / 10")
 - **AND** value text is red if generated exceeds dissipation (overheating)
-- **AND** value text is green if dissipation meets or exceeds generation
+- **AND** value text uses neutral primary color when dissipation meets or exceeds generation (in-budget states are not accent-highlighted, per command-screen focus doctrine)
 
 #### Scenario: Balanced row distribution
 
@@ -200,8 +201,8 @@ The banner SHALL display Battle Value (BV) in the statistics grid.
 #### Scenario: BV color styling
 
 - **WHEN** BV stat renders
-- **THEN** value text uses cyan color (text-cyan-400)
-- **AND** color is distinct from other stats for quick identification
+- **THEN** value text uses the neutral primary color (text-text-theme-primary)
+- **AND** the instrument strip relies on layout and label — not a per-stat accent hue — for quick identification (command-screen focus doctrine, principle 9)
 
 #### Scenario: BV reactive updates
 

--- a/scripts/qc/validate-gm-campaign-ledger.mjs
+++ b/scripts/qc/validate-gm-campaign-ledger.mjs
@@ -224,7 +224,8 @@ const defaultSourceAnchors = [
       'gm-ledger-player-log',
       'gm-ledger-private-log',
       'gm-ledger-player-only-notice',
-      'getByRole("navigation", { name: "Campaign sections" })',
+      // Token must match the spec file's oxfmt-normalized single-quote style.
+      "getByRole('navigation', { name: 'Campaign sections' })",
       'not.toContainText',
     ],
   },

--- a/scripts/qc/validate-gm-campaign-ledger.mjs
+++ b/scripts/qc/validate-gm-campaign-ledger.mjs
@@ -171,12 +171,12 @@ const defaultSourceAnchors = [
     id: 'campaign-gm-ledger-actions',
     path: 'src/components/campaign/gm/GmCampaignInterventionActions.tsx',
     tokens: [
+      // The 8 equal-weight per-type preview buttons collapsed into one
+      // "Generate correction" control + a correction-type <select>. The action
+      // is "preview a correction"; the type is a parameter, not its own button.
+      'gm-ledger-correction-type',
       'gm-ledger-preview-btn',
       'gm-ledger-approve-btn',
-      'gm-ledger-conflict-preview-btn',
-      'gm-ledger-repair-preview-btn',
-      'gm-ledger-salvage-preview-btn',
-      'gm-ledger-unit-reload-preview-btn',
       'gm-ledger-manual-btn',
     ],
   },
@@ -224,7 +224,7 @@ const defaultSourceAnchors = [
       'gm-ledger-player-log',
       'gm-ledger-private-log',
       'gm-ledger-player-only-notice',
-      "getByRole('navigation', { name: 'Campaign sections' })",
+      'getByRole("navigation", { name: "Campaign sections" })',
       'not.toContainText',
     ],
   },

--- a/scripts/qc/validate-gm-time-cascade-ledger.mjs
+++ b/scripts/qc/validate-gm-time-cascade-ledger.mjs
@@ -257,9 +257,12 @@ const defaultSourceAnchors = [
     id: 'time-cascade-gm-ledger-actions',
     path: 'src/components/campaign/gm/GmCampaignInterventionActions.tsx',
     tokens: [
-      'gm-ledger-time-preview-btn',
-      'gm-ledger-time-conflict-preview-btn',
-      'onTimePreview',
+      // Time previews now flow through the unified correction-type <select>
+      // ("time" / "time-conflict" options) + the single "Generate correction"
+      // control, not standalone per-type buttons.
+      'gm-ledger-correction-type',
+      "onTimePreview(false)",
+      "onTimePreview(true)",
     ],
   },
   {
@@ -268,7 +271,7 @@ const defaultSourceAnchors = [
     tokens: [
       'previews and approves a time cascade with player-safe output',
       'previews and applies roster recovery external effects on time approval',
-      'gm-ledger-time-preview-btn',
+      'gm-ledger-correction-type',
       'gm-ledger-preview-time-effect',
       'gm-ledger-preview-external-effects',
       'Mira Holt recovery advanced 2 days',
@@ -282,8 +285,8 @@ const defaultSourceAnchors = [
     tokens: [
       'previews and approves an accumulated time cascade',
       'blocks unprojected external time effects until manual takeover',
-      'gm-ledger-time-preview-btn',
-      'gm-ledger-time-conflict-preview-btn',
+      'gm-ledger-correction-type',
+      'generateCorrection',
       'timeCascadeEventCount',
       'Campaign time corrected by 2 days.',
       'not.toContainText',

--- a/scripts/qc/validate-gm-time-cascade-ledger.mjs
+++ b/scripts/qc/validate-gm-time-cascade-ledger.mjs
@@ -261,8 +261,8 @@ const defaultSourceAnchors = [
       // ("time" / "time-conflict" options) + the single "Generate correction"
       // control, not standalone per-type buttons.
       'gm-ledger-correction-type',
-      "onTimePreview(false)",
-      "onTimePreview(true)",
+      'onTimePreview(false)',
+      'onTimePreview(true)',
     ],
   },
   {

--- a/src/components/campaign/StarmapDisplay.tsx
+++ b/src/components/campaign/StarmapDisplay.tsx
@@ -182,7 +182,9 @@ const StarSystemNode = React.memo(function StarSystemNode({
 
       {annotation && lod !== 'far' && (
         <Text
-          text={annotation.label}
+          // Prefix a CVD-safe glyph by tone so annotation status does not rely
+          // on color alone (doctrine AMBIENT-CHROME rule: no color-only status).
+          text={`${annotationToneGlyph(annotation.tone)}${annotation.label}`}
           x={-displaySize - 8}
           y={displaySize + 8}
           fontSize={10}
@@ -209,6 +211,8 @@ export function StarmapDisplay({
   const [zoom, setZoom] = useState(1);
   const [position, setPosition] = useState(INITIAL_POSITION);
   const [hoveredSystem, setHoveredSystem] = useState<string | null>(null);
+  // Faction legend starts collapsed (pill) so it never crowds the canvas.
+  const [legendOpen, setLegendOpen] = useState(false);
 
   const lod = useMemo(() => getLODLevel(zoom), [zoom]);
 
@@ -297,18 +301,9 @@ export function StarmapDisplay({
       className={`flex flex-col overflow-hidden bg-slate-900 ${className}`}
       style={{ width: '100%', height: '100%' }}
     >
-      <div
-        className="border-b border-slate-700/80 bg-slate-950/80 px-3 py-2 text-xs text-slate-100"
-        data-testid="starmap-map-toolbar"
-      >
-        <span
-          className="rounded bg-slate-800/80 px-2 py-1"
-          data-testid="starmap-detail-status"
-        >
-          Zoom {(zoom * 100).toFixed(0)}% | Detail {detailLabel(lod)}
-        </span>
-      </div>
-
+      {/* No top toolbar: the zoom readout now lives in the bottom-right control
+          corner so the canvas (the single-action FOCUS object) reclaims the
+          height. See command-screen focus doctrine, starmap row. */}
       <div ref={containerRef} className="relative min-h-0 flex-1">
         <Stage
           width={stageSize.width}
@@ -339,10 +334,58 @@ export function StarmapDisplay({
           </Layer>
         </Stage>
 
+        {/* Collapsible faction legend: default is a small pill; expanding it
+            reveals the full grid without permanently occupying the canvas. */}
+        <div className="absolute top-3 right-3 text-xs text-slate-200">
+          {legendOpen ? (
+            <div className="rounded border border-slate-700/80 bg-slate-900/90 p-3 shadow-lg">
+              <button
+                type="button"
+                onClick={() => setLegendOpen(false)}
+                className="mb-2 flex w-full items-center justify-between gap-4 font-semibold text-slate-100"
+                data-testid="starmap-legend-toggle"
+                aria-expanded="true"
+              >
+                <span>Factions</span>
+                <span aria-hidden="true">×</span>
+              </button>
+              <div className="grid grid-cols-2 gap-x-4 gap-y-1">
+                {Object.entries(FACTION_COLORS).map(([faction, color]) => (
+                  <div key={faction} className="flex items-center gap-2">
+                    <div
+                      className="h-3 w-3 rounded-full"
+                      style={{ backgroundColor: color }}
+                    />
+                    <span>{faction}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setLegendOpen(true)}
+              className="rounded border border-slate-700/80 bg-slate-900/90 px-3 py-1.5 font-semibold text-slate-100 shadow-lg transition-colors hover:bg-slate-800"
+              data-testid="starmap-legend-toggle"
+              aria-expanded="false"
+            >
+              Legend
+            </button>
+          )}
+        </div>
+
         <div
-          className="absolute right-4 bottom-4 flex flex-col gap-1"
+          className="absolute right-4 bottom-4 flex flex-col items-end gap-1"
           data-testid="zoom-controls"
         >
+          {/* Relocated zoom readout: engineering "Detail" word dropped, keep the
+              data-testid the e2e specs reference. */}
+          <span
+            className="rounded bg-slate-800/90 px-2 py-1 text-xs text-slate-100 shadow-lg"
+            data-testid="starmap-detail-status"
+          >
+            Zoom {(zoom * 100).toFixed(0)}%
+          </span>
           <button
             type="button"
             onClick={handleZoomIn}
@@ -371,21 +414,6 @@ export function StarmapDisplay({
             O
           </button>
         </div>
-
-        <div className="absolute top-3 right-3 rounded border border-slate-700/80 bg-slate-900/90 p-3 text-xs text-slate-200 shadow-lg">
-          <div className="mb-2 font-semibold text-slate-100">Factions</div>
-          <div className="grid grid-cols-2 gap-x-4 gap-y-1">
-            {Object.entries(FACTION_COLORS).map(([faction, color]) => (
-              <div key={faction} className="flex items-center gap-2">
-                <div
-                  className="h-3 w-3 rounded-full"
-                  style={{ backgroundColor: color }}
-                />
-                <span>{faction}</span>
-              </div>
-            ))}
-          </div>
-        </div>
       </div>
     </div>
   );
@@ -393,13 +421,15 @@ export function StarmapDisplay({
 
 export default StarmapDisplay;
 
-function detailLabel(lod: LODLevel): string {
-  switch (lod) {
-    case 'far':
-      return 'far';
-    case 'medium':
-      return 'medium';
-    case 'close':
-      return 'close';
+// Maps annotation tone to a colorblind-safe leading glyph so status reads
+// without depending on the fill color (risk / warn / safe).
+function annotationToneGlyph(tone: IStarmapSystemAnnotation['tone']): string {
+  switch (tone) {
+    case 'risk':
+      return '! ';
+    case 'warn':
+      return '▲ ';
+    case 'safe':
+      return '✓ ';
   }
 }

--- a/src/components/campaign/gm/GmCampaignInterventionActions.tsx
+++ b/src/components/campaign/gm/GmCampaignInterventionActions.tsx
@@ -1,6 +1,41 @@
-import React from 'react';
+import React, { useState } from 'react';
 
-import { Button } from '@/components/ui';
+import { Button, Select } from '@/components/ui';
+
+// The GM approve flow is a single-action screen: the decisive act is "preview a
+// correction". The *type* of correction (merchant / repair / salvage / etc.) is a
+// parameter of that one action, not eight competing primary buttons. So the type
+// lives in a <select> and one high-contrast "Generate correction" control fires it.
+// Approve + Take-manual-control remain separate state-derived controls.
+type CorrectionType =
+  | 'merchant'
+  | 'merchant-conflict'
+  | 'repair'
+  | 'salvage'
+  | 'unit-reload'
+  | 'time'
+  | 'time-conflict';
+
+// Player-facing copy for each correction the GM can generate. No internal family
+// tokens (e.g. `funds-transaction`, `time-advance`) leak into these labels.
+const CORRECTION_OPTIONS: ReadonlyArray<{
+  readonly value: CorrectionType;
+  readonly label: string;
+}> = [
+  { value: 'merchant', label: 'Merchant charge reversal' },
+  {
+    value: 'merchant-conflict',
+    label: 'Merchant charge reversal (conflicted)',
+  },
+  { value: 'repair', label: 'Repair completion fix' },
+  { value: 'salvage', label: 'Salvage allocation fix' },
+  { value: 'unit-reload', label: 'Unit reload reconciliation' },
+  { value: 'time', label: 'Campaign time advance' },
+  {
+    value: 'time-conflict',
+    label: 'Campaign time advance (external conflict)',
+  },
+];
 
 interface GmCampaignInterventionActionsProps {
   readonly canApprove: boolean;
@@ -25,15 +60,61 @@ export function GmCampaignInterventionActions({
   onTimePreview,
   onManualTakeover,
 }: GmCampaignInterventionActionsProps): React.ReactElement {
+  // Default to the merchant reversal so the single "Generate correction" click
+  // (the capture flow + the basic e2e path) produces a merchant preview with no
+  // extra selection step.
+  const [correctionType, setCorrectionType] =
+    useState<CorrectionType>('merchant');
+
+  // Dispatch the one "Generate correction" action to the handler for the chosen
+  // correction type. Each preview handler is unchanged — only the entry point is
+  // unified.
+  const handleGenerateCorrection = (): void => {
+    switch (correctionType) {
+      case 'merchant':
+        onMerchantPreview(false);
+        return;
+      case 'merchant-conflict':
+        onMerchantPreview(true);
+        return;
+      case 'repair':
+        onRepairPreview();
+        return;
+      case 'salvage':
+        onSalvagePreview();
+        return;
+      case 'unit-reload':
+        onUnitReloadPreview();
+        return;
+      case 'time':
+        onTimePreview(false);
+        return;
+      case 'time-conflict':
+        onTimePreview(true);
+        return;
+    }
+  };
+
   return (
-    <div className="flex flex-wrap gap-3">
+    <div className="flex flex-wrap items-end gap-3">
+      <div className="min-w-[16rem] flex-1">
+        <Select
+          label="Correction type"
+          options={[...CORRECTION_OPTIONS]}
+          value={correctionType}
+          onChange={(event) =>
+            setCorrectionType(event.target.value as CorrectionType)
+          }
+          data-testid="gm-ledger-correction-type"
+        />
+      </div>
       <Button
         type="button"
         variant="primary"
-        onClick={() => onMerchantPreview(false)}
+        onClick={handleGenerateCorrection}
         data-testid="gm-ledger-preview-btn"
       >
-        Preview merchant reversal
+        Generate correction
       </Button>
       <Button
         type="button"
@@ -43,54 +124,6 @@ export function GmCampaignInterventionActions({
         data-testid="gm-ledger-approve-btn"
       >
         Approve cascade
-      </Button>
-      <Button
-        type="button"
-        variant="secondary"
-        onClick={() => onMerchantPreview(true)}
-        data-testid="gm-ledger-conflict-preview-btn"
-      >
-        Preview conflicted cascade
-      </Button>
-      <Button
-        type="button"
-        variant="primary"
-        onClick={onRepairPreview}
-        data-testid="gm-ledger-repair-preview-btn"
-      >
-        Preview repair fix
-      </Button>
-      <Button
-        type="button"
-        variant="primary"
-        onClick={onSalvagePreview}
-        data-testid="gm-ledger-salvage-preview-btn"
-      >
-        Preview salvage fix
-      </Button>
-      <Button
-        type="button"
-        variant="primary"
-        onClick={onUnitReloadPreview}
-        data-testid="gm-ledger-unit-reload-preview-btn"
-      >
-        Preview unit reload
-      </Button>
-      <Button
-        type="button"
-        variant="primary"
-        onClick={() => onTimePreview(false)}
-        data-testid="gm-ledger-time-preview-btn"
-      >
-        Preview time cascade
-      </Button>
-      <Button
-        type="button"
-        variant="secondary"
-        onClick={() => onTimePreview(true)}
-        data-testid="gm-ledger-time-conflict-preview-btn"
-      >
-        Preview external time conflict
       </Button>
       <Button
         type="button"

--- a/src/components/campaign/gm/GmCampaignInterventionControlPlane.tsx
+++ b/src/components/campaign/gm/GmCampaignInterventionControlPlane.tsx
@@ -365,9 +365,7 @@ export function GmCampaignInterventionControlPlane({
     >
       <GmCampaignLedgerStatusCards
         balanceLabel={campaign.finances.balance.format()}
-        previewStatus={preview?.status ?? 'Not generated'}
         approvalStatus={approvalStatus}
-        approvalReason={approvalReason}
       />
 
       <GmCampaignInterventionActions
@@ -382,7 +380,9 @@ export function GmCampaignInterventionControlPlane({
         onManualTakeover={handleManualTakeover}
       />
 
-      {preview ? <GmPreviewPanel preview={preview} /> : null}
+      {preview ? (
+        <GmPreviewPanel preview={preview} approvalReason={approvalReason} />
+      ) : null}
 
       {manualTakeover ? (
         <ManualTakeoverPanel manualTakeover={manualTakeover} />

--- a/src/components/campaign/gm/GmCampaignLedgerProjection.tsx
+++ b/src/components/campaign/gm/GmCampaignLedgerProjection.tsx
@@ -5,6 +5,31 @@ import type {
   PlayerLedgerRow,
 } from './GmCampaignInterventionControlPlane.helpers';
 
+// Player copy for the internal correction-family tokens. These `family` values
+// (`time-advance`, `funds-transaction`, ...) are engine identifiers; players see
+// plain-language category names instead of the raw token in the ledger meta line.
+const FAMILY_PLAYER_LABEL: Readonly<Record<string, string>> = {
+  'time-advance': 'Campaign time',
+  'funds-transaction': 'Finances',
+  'repair-ticket': 'Repairs',
+  'salvage-allocation': 'Salvage',
+  'unit-reload': 'Unit readiness',
+  'base-unit-state': 'Unit readiness',
+  'inventory-lot': 'Inventory',
+};
+
+// Resolve a row's correction family to player copy, falling back to a Title-Cased
+// version of any unmapped token so no raw kebab-case identifier ever leaks.
+function familyToPlayerLabel(family: string | undefined): string {
+  if (!family) return 'GM correction';
+  const mapped = FAMILY_PLAYER_LABEL[family];
+  if (mapped) return mapped;
+  return family
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
 export function LedgerProjection({
   rows,
   testId,
@@ -38,7 +63,7 @@ export function LedgerProjection({
                 {row.publicEffect.summary}
               </p>
               <p className="text-text-theme-secondary mt-1 text-xs">
-                {row.status} - {row.domain} - {row.action}
+                {familyToPlayerLabel(row.publicEffect.family)} - {row.status}
               </p>
             </div>
           ))}

--- a/src/components/campaign/gm/GmCampaignLedgerStatusCards.tsx
+++ b/src/components/campaign/gm/GmCampaignLedgerStatusCards.tsx
@@ -2,21 +2,21 @@ import React from 'react';
 
 import { Card } from '@/components/ui';
 
+// Standing CONTEXT-FRAME for the GM approve screen: only the two facts that are
+// always meaningful stay as cards — the campaign balance the corrections act on,
+// and the running approval summary. Preview status + approval-blocked reason are
+// transient (only meaningful mid-preview) and now live inside the preview panel.
 interface GmCampaignLedgerStatusCardsProps {
   readonly balanceLabel: string;
-  readonly previewStatus: string;
   readonly approvalStatus: string;
-  readonly approvalReason: string | null;
 }
 
 export function GmCampaignLedgerStatusCards({
   balanceLabel,
-  previewStatus,
   approvalStatus,
-  approvalReason,
 }: GmCampaignLedgerStatusCardsProps): React.ReactElement {
   return (
-    <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+    <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
       <Card className="p-4" data-testid="gm-ledger-balance">
         <p className="text-text-theme-secondary text-xs uppercase">
           Campaign balance
@@ -24,15 +24,6 @@ export function GmCampaignLedgerStatusCards({
         <p className="text-text-theme-primary mt-1 text-2xl font-semibold">
           {balanceLabel}
         </p>
-      </Card>
-      <Card className="p-4" data-testid="gm-ledger-preview-status">
-        <p className="text-text-theme-secondary text-xs uppercase">Preview</p>
-        <p className="text-text-theme-primary mt-1 text-lg font-semibold">
-          {previewStatus}
-        </p>
-        {approvalReason ? (
-          <p className="mt-1 text-sm text-amber-300">{approvalReason}</p>
-        ) : null}
       </Card>
       <Card className="p-4" data-testid="gm-ledger-approval-status">
         <p className="text-text-theme-secondary text-xs uppercase">Approval</p>

--- a/src/components/campaign/gm/GmCampaignPreviewPanels.tsx
+++ b/src/components/campaign/gm/GmCampaignPreviewPanels.tsx
@@ -19,8 +19,12 @@ export interface ManualTakeoverState {
 
 export function GmPreviewPanel({
   preview,
+  approvalReason,
 }: {
   readonly preview: GmLedgerPreview;
+  // The approval-blocked reason folds into the live preview because it is only
+  // meaningful while a preview is on screen — it never stands on its own card.
+  readonly approvalReason?: string | null;
 }): React.ReactElement {
   const fundsEffect = findFundsEffect(preview.projectedEvents);
   const timeEffect = findTimeEffect(preview.projectedEvents);
@@ -33,8 +37,20 @@ export function GmPreviewPanel({
       <div className="flex flex-wrap items-center gap-2">
         <Badge>{preview.domain}</Badge>
         <Badge>{preview.kind}</Badge>
-        <Badge>{preview.status}</Badge>
+        {/* Preview status folded off the status-card bar into the live preview,
+            where the GM reads it alongside the projected effect it describes. */}
+        <span data-testid="gm-ledger-preview-status">
+          <Badge>{preview.status}</Badge>
+        </span>
       </div>
+      {approvalReason ? (
+        <p
+          className="mt-3 text-sm text-amber-300"
+          data-testid="gm-ledger-approval-reason"
+        >
+          {approvalReason}
+        </p>
+      ) : null}
       <p
         className="text-text-theme-primary mt-3 text-sm"
         data-testid="gm-ledger-preview-summary"

--- a/src/components/campaign/gm/__tests__/GmCampaignInterventionControlPlane.test.tsx
+++ b/src/components/campaign/gm/__tests__/GmCampaignInterventionControlPlane.test.tsx
@@ -25,6 +25,16 @@ function fixedNow(): string {
   return '3025-01-01T00:00:00.000Z';
 }
 
+// The 8 equal-weight preview buttons collapsed into one "Generate correction"
+// control + a correction-type <select>. Tests pick the type then fire the single
+// control, mirroring how the GM now drives the screen.
+function generateCorrection(correctionType: string): void {
+  fireEvent.change(screen.getByTestId('gm-ledger-correction-type'), {
+    target: { value: correctionType },
+  });
+  fireEvent.click(screen.getByTestId('gm-ledger-preview-btn'));
+}
+
 describe('GmCampaignInterventionControlPlane', () => {
   beforeEach(() => {
     useCampaignRosterStore.getState().reset();
@@ -208,7 +218,7 @@ describe('GmCampaignInterventionControlPlane', () => {
       />,
     );
 
-    fireEvent.click(screen.getByTestId('gm-ledger-time-preview-btn'));
+    generateCorrection('time');
 
     expect(screen.getByTestId('gm-ledger-preview-status')).toHaveTextContent(
       'ready',
@@ -251,7 +261,7 @@ describe('GmCampaignInterventionControlPlane', () => {
       />,
     );
 
-    fireEvent.click(screen.getByTestId('gm-ledger-repair-preview-btn'));
+    generateCorrection('repair');
 
     expect(screen.getByTestId('gm-ledger-preview-status')).toHaveTextContent(
       'ready',
@@ -286,7 +296,7 @@ describe('GmCampaignInterventionControlPlane', () => {
       'Hidden repair correction',
     );
 
-    fireEvent.click(screen.getByTestId('gm-ledger-salvage-preview-btn'));
+    generateCorrection('salvage');
 
     expect(
       screen.getByTestId('gm-ledger-preview-state-summary'),
@@ -310,7 +320,7 @@ describe('GmCampaignInterventionControlPlane', () => {
       'Hidden salvage correction',
     );
 
-    fireEvent.click(screen.getByTestId('gm-ledger-unit-reload-preview-btn'));
+    generateCorrection('unit-reload');
 
     expect(
       screen.getByTestId('gm-ledger-preview-state-summary'),
@@ -377,7 +387,7 @@ describe('GmCampaignInterventionControlPlane', () => {
       />,
     );
 
-    fireEvent.click(screen.getByTestId('gm-ledger-time-preview-btn'));
+    generateCorrection('time');
 
     expect(screen.getByTestId('gm-ledger-preview-status')).toHaveTextContent(
       'ready',
@@ -431,7 +441,7 @@ describe('GmCampaignInterventionControlPlane', () => {
       />,
     );
 
-    fireEvent.click(screen.getByTestId('gm-ledger-conflict-preview-btn'));
+    generateCorrection('merchant-conflict');
 
     expect(screen.getByTestId('gm-ledger-preview-status')).toHaveTextContent(
       'requires-manual-takeover',

--- a/src/components/customizer/campaign/CampaignRefitCommandBar.tsx
+++ b/src/components/customizer/campaign/CampaignRefitCommandBar.tsx
@@ -110,6 +110,17 @@ export function CampaignRefitCommandBar({
   );
   const canSaveRefit = validation.isValid && changeCount > 0;
 
+  // Single muted context string: campaign, plain campaign date (never raw ISO),
+  // budget, rules level, and the refit constraint label. Shown truncated with a
+  // title tooltip; the build-delta count is surfaced separately above it.
+  const refitContextSummary = session
+    ? `${session.campaignName} | ${formatCampaignDate(
+        session.route.campaignDate,
+      )} | Budget ${session.route.budget.toLocaleString()} C-bills | ${
+        session.route.rulesLevel
+      } rules | ${formatRefitConstraintLabel(session.route.refitConstraints)}`
+    : '';
+
   const handleCancel = useCallback(() => {
     if (!session) return;
     void router.push(
@@ -178,16 +189,23 @@ export function CampaignRefitCommandBar({
             </Badge>
           ) : null}
         </div>
+        {/* Command-bar context slim (focus doctrine, refit CONTEXT-FRAME): the
+            build-delta count stays prominent; campaign / date / budget / rules /
+            constraint collapse into one muted, truncated line whose full value
+            is available on hover (title). The full context text stays in the DOM
+            so it remains glanceable and assertable. */}
         <p
-          className="text-text-theme-secondary mt-1 text-xs"
-          data-testid="campaign-refit-context"
+          className="text-text-theme-primary mt-1 text-xs font-medium"
+          data-testid="campaign-refit-change-count"
         >
-          {session.campaignName} |{' '}
-          {formatCampaignDate(session.route.campaignDate)} | Budget{' '}
-          {session.route.budget.toLocaleString()} C-bills |{' '}
-          {session.route.rulesLevel} rules |{' '}
-          {formatRefitConstraintLabel(session.route.refitConstraints)} |{' '}
           {changeCount} build field{changeCount === 1 ? '' : 's'} changed
+        </p>
+        <p
+          className="text-text-theme-secondary mt-0.5 max-w-full truncate text-xs"
+          data-testid="campaign-refit-context"
+          title={refitContextSummary}
+        >
+          {refitContextSummary}
         </p>
 
         {!validation.isValid ? (

--- a/src/components/customizer/campaign/__tests__/CampaignRefitCommandBar.test.tsx
+++ b/src/components/customizer/campaign/__tests__/CampaignRefitCommandBar.test.tsx
@@ -106,7 +106,9 @@ describe('CampaignRefitCommandBar', () => {
     expect(screen.getByTestId('campaign-refit-command-bar')).toHaveTextContent(
       'Campaign refit: Atlas',
     );
-    expect(screen.getByTestId('campaign-refit-context')).toHaveTextContent(
+    // Build-count moved to its own prominent element (declutter wave) —
+    // the context line now carries only the campaign metadata.
+    expect(screen.getByTestId('campaign-refit-change-count')).toHaveTextContent(
       '1 build field changed',
     );
     expect(screen.getByTestId('campaign-refit-context')).toHaveTextContent(
@@ -138,7 +140,7 @@ describe('CampaignRefitCommandBar', () => {
   it('keeps no-delta refit saves disabled', () => {
     renderCommandBar();
 
-    expect(screen.getByTestId('campaign-refit-context')).toHaveTextContent(
+    expect(screen.getByTestId('campaign-refit-change-count')).toHaveTextContent(
       '0 build fields changed',
     );
     expect(screen.getByTestId('campaign-refit-no-delta')).toHaveTextContent(

--- a/src/components/customizer/shared/UnitInfoBanner.tsx
+++ b/src/components/customizer/shared/UnitInfoBanner.tsx
@@ -60,13 +60,20 @@ interface UnitInfoBannerProps {
 const styles = {
   label:
     'text-[9px] sm:text-[10px] font-medium text-text-theme-secondary uppercase tracking-wider',
+  // Instrument strip color ramp (command-screen focus doctrine, principle 9):
+  // neutral luminance for in-budget values; color is reserved for out-of-budget
+  // / invalid states only. The old decorative ramp (BV cyan, ENGINE orange,
+  // HEAT green) is collapsed to the neutral primary token so "over budget"
+  // (amber/red) is the only signal that draws the eye.
   value: {
-    normal: 'text-white',
+    normal: 'text-text-theme-primary',
     warning: 'text-amber-400',
     error: 'text-red-400',
-    success: 'text-green-400',
-    engine: 'text-orange-500',
-    bv: 'text-cyan-400',
+    // success = heat within dissipation: no longer green-highlighted, it is the
+    // normal in-budget state.
+    success: 'text-text-theme-primary',
+    engine: 'text-text-theme-primary',
+    bv: 'text-text-theme-primary',
   },
   muted: 'text-slate-500',
   box: 'flex flex-col items-center px-2 sm:px-3 py-0.5 sm:py-1 bg-surface-raised/50 rounded',

--- a/src/components/gameplay/GameplayLayout.desktopRightTray.tsx
+++ b/src/components/gameplay/GameplayLayout.desktopRightTray.tsx
@@ -40,7 +40,12 @@ export function DesktopRightTray({
   return (
     <ShellSlot id="right-tray" ownerId="RecordSheetPanel">
       <div
-        className="flex-1 overflow-auto"
+        // INSTRUMENT rail. `min-h-0 overflow-y-auto` keeps the full
+        // armor/structure/heat table reachable by scrolling within the
+        // rail once the FOCUS row is height-bounded (tactical-map-flex-basis)
+        // — every location stays glanceable instead of clipping below the
+        // map band's bottom edge.
+        className="min-h-0 flex-1 overflow-y-auto"
         style={{ width: `${100 - mapPanelWidth}%` }}
         data-testid="record-sheet-panel"
       >

--- a/src/components/gameplay/GameplayLayout.mainContent.tsx
+++ b/src/components/gameplay/GameplayLayout.mainContent.tsx
@@ -25,7 +25,7 @@ import type { PhysicalAttackIntent } from './PhysicalAttackPanel';
 
 import { DesktopRightTray } from './GameplayLayout.desktopRightTray';
 import { GameplayMapPanel } from './GameplayLayout.mapPanel';
-import { ShellSlot } from './TacticalCommandShell';
+import { ShellSlot, useTacticalShell } from './TacticalCommandShell';
 import { TacticalLensControls } from './TacticalLensControls';
 
 export type GameplayLayoutLensState = Pick<
@@ -109,7 +109,15 @@ export function GameplayMainContentArea({
   return (
     <div
       ref={containerRef}
-      className="flex min-h-[60vh] flex-1 overflow-hidden"
+      // FOCUS row (map + trays). `flex-1 min-h-0` gives the map band the
+      // whole remaining column height after the bounded bands/dock/log —
+      // the dominant share on any viewport — while `min-h-0` lets the row
+      // shrink below its content so the right tray's own `overflow-y-auto`
+      // engages instead of the page paging. Replaces the prior
+      // `min-h-[60vh]` floor, which on short viewports summed with the
+      // dock + event log past 100vh and clipped the armor/structure rail
+      // (tactical-map-flex-basis: the truncation the doctrine flagged).
+      className="flex min-h-0 flex-1 overflow-hidden"
       data-testid="gameplay-main-content"
     >
       {!isNarrow && <LeftTray lensState={lensState} />}
@@ -159,14 +167,69 @@ export function GameplayMainContentArea({
   );
 }
 
+/**
+ * Desktop map-lens tray. Collapses behind a narrow toggle rail so the hex
+ * map (FOCUS) reclaims the 112px `w-28` column by default (per the
+ * command-screen focus doctrine — lenses are AMBIENT CHROME, hidden until
+ * the player wants them). Collapsed/expanded state lives in the shell's
+ * per-match `leftTrayCollapsed` slice, so the choice persists across
+ * reloads via the shell's sessionStorage write-through.
+ */
 function LeftTray({
   lensState,
 }: {
   readonly lensState: GameplayLayoutLensState;
 }): React.ReactElement {
+  const { state, updateState } = useTacticalShell();
+  const collapsed = state.leftTrayCollapsed;
+  const toggle = React.useCallback(() => {
+    updateState({ leftTrayCollapsed: !collapsed });
+  }, [collapsed, updateState]);
+
+  if (collapsed) {
+    // Collapsed rail — a single vertical toggle button that reclaims the
+    // canvas width. `aria-expanded` + a descriptive label keep the
+    // affordance discoverable for keyboard / screen-reader users.
+    return (
+      <ShellSlot id="left-tray" ownerId="TacticalLensControls">
+        <div className="flex w-8 flex-shrink-0 flex-col border-r border-gray-200 bg-white">
+          <button
+            type="button"
+            onClick={toggle}
+            aria-expanded={false}
+            aria-label="Show map lenses"
+            title="Show map lenses"
+            data-testid="left-tray-toggle"
+            className="hover:bg-surface-deep focus:ring-border-theme flex w-full flex-1 cursor-pointer items-center justify-center text-gray-500 focus:ring-2 focus:outline-none"
+          >
+            <span
+              className="text-xs font-semibold tracking-wide uppercase"
+              style={{ writingMode: 'vertical-rl' }}
+            >
+              Lenses
+            </span>
+          </button>
+        </div>
+      </ShellSlot>
+    );
+  }
+
   return (
     <ShellSlot id="left-tray" ownerId="TacticalLensControls">
       <div className="flex w-28 flex-shrink-0 flex-col border-r border-gray-200 bg-white">
+        <div className="flex items-center justify-end px-1 pt-1">
+          <button
+            type="button"
+            onClick={toggle}
+            aria-expanded={true}
+            aria-label="Hide map lenses"
+            title="Hide map lenses"
+            data-testid="left-tray-toggle"
+            className="hover:bg-surface-deep focus:ring-border-theme cursor-pointer rounded px-1 text-xs text-gray-500 focus:ring-2 focus:outline-none"
+          >
+            {'«'}
+          </button>
+        </div>
         <TacticalLensControls
           activeLens={lensState.activeLens}
           onLensChange={lensState.setActiveLens}

--- a/src/components/gameplay/TacticalCommandShell/__tests__/TacticalCommandShell.04.test.tsx
+++ b/src/components/gameplay/TacticalCommandShell/__tests__/TacticalCommandShell.04.test.tsx
@@ -35,7 +35,8 @@ describe('TacticalCommandShell — PR-C: state + updateState', () => {
     expect(probe.current?.state.selectedUnit).toBeNull();
     expect(probe.current?.state.activeUnit).toBeNull();
     expect(probe.current?.state.inspectedUnit).toBeNull();
-    expect(probe.current?.state.leftTrayCollapsed).toBe(false);
+    // Desktop lens tray defaults to collapsed (map reclaims the column).
+    expect(probe.current?.state.leftTrayCollapsed).toBe(true);
     expect(probe.current?.state.rightTrayPinned).toBe(false);
   });
 

--- a/src/components/gameplay/TacticalCommandShell/__tests__/TacticalCommandShell.05.test.tsx
+++ b/src/components/gameplay/TacticalCommandShell/__tests__/TacticalCommandShell.05.test.tsx
@@ -95,13 +95,16 @@ describe('TacticalCommandShell — PR-C: per-match sessionStorage persistence', 
         selectedUnit: 'unit-a',
         activeUnit: 'unit-b',
         inspectedUnit: 'unit-c',
-        leftTrayCollapsed: true,
+        // Set the NON-default value (false) so the persist write-through
+        // actually fires — `true` is the collapsed-by-default seed and a
+        // no-op update is intentionally not written.
+        leftTrayCollapsed: false,
       });
     });
 
     const raw = window.sessionStorage.getItem('tactical-shell:match-42');
     const parsed = JSON.parse(raw ?? '{}') as Record<string, unknown>;
-    expect(parsed.leftTrayCollapsed).toBe(true);
+    expect(parsed.leftTrayCollapsed).toBe(false);
     expect(parsed.selectedUnit).toBeUndefined();
     expect(parsed.activeUnit).toBeUndefined();
     expect(parsed.inspectedUnit).toBeUndefined();
@@ -137,14 +140,17 @@ describe('TacticalCommandShell — PR-C: per-match sessionStorage persistence', 
       </TacticalCommandShell>,
     );
 
+    // Match-A explicitly sets the NON-default value (false = expanded) so
+    // the leak-check has a real signal: if match-B picked up match-A's
+    // state it would read false; a clean per-session default reads true.
     act(() => {
-      probeA.current?.updateState({ leftTrayCollapsed: true });
+      probeA.current?.updateState({ leftTrayCollapsed: false });
     });
 
     unmount();
 
     // Mount a different session — should start with defaults, not
-    // pick up match-A's collapsed=true.
+    // pick up match-A's expanded=false.
     const probeB: {
       current: ReturnType<typeof useTacticalShell> | null;
     } = { current: null };
@@ -155,7 +161,7 @@ describe('TacticalCommandShell — PR-C: per-match sessionStorage persistence', 
       </TacticalCommandShell>,
     );
 
-    expect(probeB.current?.state.leftTrayCollapsed).toBe(false);
+    expect(probeB.current?.state.leftTrayCollapsed).toBe(true);
   });
 
   it('tolerates malformed sessionStorage payload gracefully', () => {
@@ -172,7 +178,7 @@ describe('TacticalCommandShell — PR-C: per-match sessionStorage persistence', 
     );
 
     // Falls back to defaults — does not throw.
-    expect(probe.current?.state.leftTrayCollapsed).toBe(false);
+    expect(probe.current?.state.leftTrayCollapsed).toBe(true);
     expect(probe.current?.state.rightTrayPinned).toBe(false);
   });
 });

--- a/src/types/gameplay/TacticalShellInterfaces.ts
+++ b/src/types/gameplay/TacticalShellInterfaces.ts
@@ -201,7 +201,11 @@ export function createDefaultShellState(
   return {
     shellMode: 'combat',
     activeContext: { hoveredHexId: null, pinnedDrawerId: null },
-    leftTrayCollapsed: false,
+    // Desktop lens tray starts collapsed so the hex map (FOCUS) reclaims
+    // the 112px `w-28` column by default; the player expands it on demand
+    // and the choice persists per-match (tactical-map-flex-basis / lens
+    // tray de-clutter). Progressive disclosure per the focus doctrine.
+    leftTrayCollapsed: true,
     rightTrayPinned: false,
     bottomDockActiveTab: null,
     selectedUnit: null,

--- a/src/types/gameplay/__tests__/TacticalShellInterfaces.test.ts
+++ b/src/types/gameplay/__tests__/TacticalShellInterfaces.test.ts
@@ -88,7 +88,8 @@ describe('TacticalShellInterfaces', () => {
       expect(state.selectedUnit).toBeNull();
       expect(state.activeUnit).toBeNull();
       expect(state.inspectedUnit).toBeNull();
-      expect(state.leftTrayCollapsed).toBe(false);
+      // Desktop lens tray defaults to collapsed (map reclaims the column).
+      expect(state.leftTrayCollapsed).toBe(true);
       expect(state.rightTrayPinned).toBe(false);
       expect(state.bottomDockActiveTab).toBeNull();
       expect(state.activeContext.hoveredHexId).toBeNull();


### PR DESCRIPTION
## What

Executes the council-decided de-clutter follow-ups across four command surfaces (per the focus-hierarchy doctrine, `openspec/council-decisions/2026-06-30-command-screen-focus-doctrine.md`), plus the decision trail for the next feature.

### Declutter wave (commit 1)
- **Starmap** — top detail toolbar merged into the zoom corner (canvas reclaims the height); faction legend collapsed to a "Legend" pill; CVD-safe tone glyphs (`!`/`▲`/`✓`) on route annotations.
- **Refit** — stat-strip rainbow unified to a neutral instrument ramp (color now only signals over-budget/invalid); command-bar context slimmed ("N build fields changed" prominent; campaign/date/budget/rules to one muted line + tooltip). **Disclosure:** `openspec/specs/unit-info-banner/spec.md` had 3 scenarios mandating the removed rainbow colors — synced in-change to describe the neutral ramp (no unit test asserted the colors).
- **GM Ledger** — ~8 per-type preview buttons collapsed to one **"Generate correction"** + correction-type select; status cards 4→2; public/private log duality preserved untouched; internal family tokens de-jargoned to player copy; e2e + QC validators re-anchored.
- **Tactical (neutral scope)** — Map-Lens tray collapsible (default collapsed, shell-persisted); `min-h-[60vh]` replaced with a proper `flex-1 min-h-0` budget + right-tray `overflow-y-auto` — fixes the armor/structure rail truncation and short-viewport page scroll. **Movement selectors intentionally untouched**: both the dock verb buttons and the in-map MP legend remain, per `docs/adr/0001-intent-first-tactical-movement.md` — the movement flow is being replaced wholesale by the intent-first composer, so consolidating selectors here would encode a doomed contract.

### Decision trail (commit 2)
- `docs/adr/0001-intent-first-tactical-movement.md` — intent-first movement (composer + cost ledger + live intersection + explicit lock-in) over both budget-first selector models; rejected options recorded.
- `openspec/TERMINOLOGY_GLOSSARY.md` v1.1 — Command-Screen UI Doctrine terms + Tactical Movement Intent terms.
- `openspec/changes/tactical-movement-intent-composer/` — apply-ready change (proposal, design, spec deltas, 21 tasks; `openspec validate --strict` passes).

## Verification
- Per step: typecheck + oxlint/oxfmt + evidence re-capture + PNG read-back; GM unit tests 7/7; tactical suites 89/89.
- Independent final verify: `qc:command-evidence` (capture + validate 6/6 slices), `qc:command:browser:quick` 10/10, `qc:command:networked-browser:quick` 1/1, `qc:command-slices:validate` 6/6; all 8 product screens re-graded against the doctrine (every screen honors its archetype; INSTRUMENT clusters intact).

## Follow-ups (tracked)
- `tactical-movement-intent-composer` implementation (apply-ready in this PR's docs commit).
- Re-audit backlog: nav-chrome contrast (measure pixels before further fixes), heat-strip threshold label collisions, lens-legend clipping, starmap label overlaps.
