### PR TITLE
fix(chrome): anchor reset into @layer base — root cause of app-wide dim links

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -144,9 +144,19 @@ body {
   overflow-x: hidden;
 }
 
-a {
-  color: inherit;
-  text-decoration: none;
+/*
+ * Anchor reset lives in @layer base so Tailwind text-* utilities (which live
+ * in @layer utilities) can win the cascade. As a plain unlayered rule this
+ * beat EVERY layered utility regardless of specificity, so all <a> elements
+ * inherited body's --foreground (the light-mode #1e293b) and rendered
+ * near-invisible on dark surfaces — the root cause of the dim nav tabs and
+ * breadcrumbs that survived three audit passes (task #6, A11Y-R1/H11).
+ */
+@layer base {
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
 }
 
 /* Form Elements Styling for Better Visibility */


### PR DESCRIPTION
## What

One-rule fix for the dim nav tabs/breadcrumbs that survived three audit passes: `globals.css` had a plain **unlayered** `a { color: inherit }`. Unlayered CSS beats all `@layer`ed rules regardless of specificity, so every anchor ignored its Tailwind `text-*` utility and inherited body's `--foreground` — the light-mode `#1e293b` — rendering ~1.2:1 on dark surfaces. Elements that weren't anchors (e.g. the page subtitle with the identical class) rendered correctly, which made the token look healthy while links stayed dim.

**Fix:** wrap the anchor reset in `@layer base`. Two lines of structure, app-wide effect — top-bar links and header icons were being dimmed by the same rule.

## Proof
Playwright `getComputedStyle` probe on the campaign starmap page (probe file created for diagnosis, deleted before commit):
- **Before:** nav tab + breadcrumb link → `rgb(30,41,59)` despite `text-text-theme-secondary` and `--text-secondary: #cbd5e1` both present
- **After:** both → `rgb(203,213,225)` = `#cbd5e1` (~12.6:1 against `--surface-deep`)
- Evidence re-captured: all campaign nav tabs, breadcrumbs, and top-bar links crisply legible on screen 01.

Closes the A11Y-R1 (re-audit) / H11 (baseline) finding at its root — the `--text-secondary` token bump from #991 was always correct; this rule was defeating it for anchors only.
