### PR TITLE
fix(tactical): single home for posture verbs + composer band polish

### DIFF
--- a/e2e/playable-command-feature-screens.spec.ts
+++ b/e2e/playable-command-feature-screens.spec.ts
@@ -789,9 +789,11 @@ async function captureTacticalCommandScreen(
   await expect(
     page.getByTestId('command-btn-facing.rotate-right'),
   ).toContainText('(D)');
-  await expect(page.getByTestId('command-btn-movement.evade')).toContainText(
-    '(E)',
-  );
+  // Single Movement Authority: posture verbs live ONLY in the composer
+  // palette while it is active — the dock must NOT render an Evade button,
+  // and the palette's Evade keeps the (E) hotkey hint.
+  await expect(page.getByTestId('command-btn-movement.evade')).toHaveCount(0);
+  await expect(page.getByTestId('posture-action-EVADE')).toContainText('(E)');
   await expect(page.getByTestId('command-group-utility-danger')).toBeVisible();
   await expect(page.getByTestId('command-btn-utility.concede')).toHaveAttribute(
     'data-command-danger',

--- a/src/components/gameplay/MovementIntentComposer/BudgetResolver.tsx
+++ b/src/components/gameplay/MovementIntentComposer/BudgetResolver.tsx
@@ -44,6 +44,11 @@ export interface BudgetResolverProps {
   readonly onPickMode: (mode: MovementType) => void;
   /** Commit the composed sequence at `pendingMode` atomically. */
   readonly onLockIn: (mode: MovementType) => void;
+  /**
+   * Player-facing enablement hint rendered directly beside Lock In (what to
+   * do next for it to enable). Null when Lock In is actionable.
+   */
+  readonly hint?: string | null;
 }
 
 function formatToHit(modifier: number): string {
@@ -110,6 +115,7 @@ export function BudgetResolver({
   lockBlocked,
   onPickMode,
   onLockIn,
+  hint = null,
 }: BudgetResolverProps): React.ReactElement {
   const forced = affordableBudgets.length === 1;
   const lockInDisabled = lockBlocked || pendingMode === null;
@@ -145,29 +151,43 @@ export function BudgetResolver({
           />
         ))}
       </div>
-      <button
-        type="button"
-        disabled={lockInDisabled}
-        onClick={() => {
-          if (pendingMode !== null && !lockBlocked) onLockIn(pendingMode);
-        }}
-        data-testid="movement-lock-in-btn"
-        aria-disabled={lockInDisabled}
-        aria-label={
-          lockBlocked
-            ? 'Lock in movement (blocked: composition exceeds every budget)'
-            : pendingMode === null
-              ? 'Lock in movement (select a budget first)'
-              : `Lock in movement at ${MODE_LABEL[pendingMode]}`
-        }
-        className={`mt-1 min-h-[40px] rounded px-4 py-2 text-sm font-semibold transition-colors focus:ring-2 focus:ring-offset-2 focus:outline-none ${
-          lockInDisabled
-            ? 'bg-surface-base text-text-theme-secondary cursor-not-allowed opacity-50'
-            : 'cursor-pointer bg-blue-600 text-white hover:bg-blue-500 focus:ring-blue-400'
-        }`}
-      >
-        Lock In
-      </button>
+      {/* Lock In + its enablement hint share one row so the guidance sits
+          directly beside the control it explains (re-audit VD-03/UXF-03). */}
+      <div className="mt-1 flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          disabled={lockInDisabled}
+          onClick={() => {
+            if (pendingMode !== null && !lockBlocked) onLockIn(pendingMode);
+          }}
+          data-testid="movement-lock-in-btn"
+          aria-disabled={lockInDisabled}
+          aria-label={
+            lockBlocked
+              ? 'Lock in movement (blocked: composition exceeds every budget)'
+              : pendingMode === null
+                ? 'Lock in movement (select a budget first)'
+                : `Lock in movement at ${MODE_LABEL[pendingMode]}`
+          }
+          // Disabled state keeps BUTTON chrome (border + fill) so it reads as
+          // a disabled control, not stray dim text (re-audit VD-03/A11Y-R8).
+          className={`min-h-[40px] rounded border px-4 py-2 text-sm font-semibold transition-colors focus:ring-2 focus:ring-offset-2 focus:outline-none ${
+            lockInDisabled
+              ? 'border-border-theme bg-surface-raised/60 text-text-theme-secondary cursor-not-allowed'
+              : 'cursor-pointer border-blue-500 bg-blue-600 text-white hover:bg-blue-500 focus:ring-blue-400'
+          }`}
+        >
+          Lock In
+        </button>
+        {hint && (
+          <span
+            className="text-text-theme-secondary text-xs"
+            data-testid="movement-lock-in-hint"
+          >
+            {hint}
+          </span>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/gameplay/MovementIntentComposer/MovementIntentComposer.tsx
+++ b/src/components/gameplay/MovementIntentComposer/MovementIntentComposer.tsx
@@ -192,8 +192,12 @@ export function MovementIntentComposer({
     // hex map (FOCUS) to a sliver. Side-by-side panels use the dock's spare
     // width and keep the band compact; flex-wrap degrades to stacking only
     // when the viewport is genuinely too narrow.
+    // `w-full` makes the band claim the dock's full row so the three columns
+    // actually flex into the available width (without it the root sizes to
+    // content and strands the right half of the band as dead space —
+    // re-audit VD-03).
     <div
-      className="flex min-w-0 flex-wrap items-start gap-x-6 gap-y-3"
+      className="flex w-full min-w-0 flex-wrap items-start gap-x-6 gap-y-3"
       data-testid="movement-intent-composer"
       role="group"
       aria-label="Movement intent composer"
@@ -218,6 +222,17 @@ export function MovementIntentComposer({
           affordableBudgets={affordableBudgets}
           pendingMode={pendingMode}
           lockBlocked={overEveryBudget}
+          // The enablement hint lives NEXT TO Lock In (re-audit VD-03/UXF-03:
+          // it previously floated ~450px away in the dock's trailing region).
+          hint={
+            overEveryBudget
+              ? 'Over budget — remove items.'
+              : movementIntent.items.length === 0
+                ? 'Pick a movement path or posture to begin.'
+                : pendingMode === null
+                  ? 'Choose a budget, then lock in.'
+                  : null
+          }
           onPickMode={setPendingMode}
           onLockIn={handleLockIn}
         />

--- a/src/components/gameplay/TacticalActionDock/TacticalActionDock.tsx
+++ b/src/components/gameplay/TacticalActionDock/TacticalActionDock.tsx
@@ -263,7 +263,14 @@ export function TacticalActionDock({
   const [gmPreviewState, setGmPreviewState] = useState<IGmPreviewState | null>(
     null,
   );
+  // Single Movement Authority: when the composer is active, the command
+  // registry must know so movement builders drop the posture/traversal verbs
+  // (the composer palette is their only home — re-audit VD-01/UXF-01/IS-02).
+  const composerActive = Boolean(intentComposer?.active);
   const effectiveCtx = useMemo<ITacticalCommandContext>(() => {
+    const base: ITacticalCommandContext = composerActive
+      ? { ...ctx, movementComposerActive: true }
+      : ctx;
     if (
       !previewInputs?.movementInfo &&
       !previewInputs?.combatInfo &&
@@ -271,10 +278,10 @@ export function TacticalActionDock({
       !previewInputs?.physicalAttackOption &&
       !previewInputs?.physicalTargetUnitId
     ) {
-      return ctx;
+      return base;
     }
     return {
-      ...ctx,
+      ...base,
       ...(previewInputs.movementInfo
         ? { targetMovementProjection: previewInputs.movementInfo }
         : {}),
@@ -293,6 +300,7 @@ export function TacticalActionDock({
     };
   }, [
     ctx,
+    composerActive,
     previewInputs?.movementInfo,
     previewInputs?.combatInfo,
     previewInputs?.combatInfoByTargetId,
@@ -426,7 +434,10 @@ export function TacticalActionDock({
         {gmIntervention?.playerLog && (
           <GmInterventionPlayerLog records={gmIntervention.playerLog} />
         )}
-        {infoText && (
+        {/* While the composer is active its Lock-In hint carries the guidance
+            inline — the trailing copy would duplicate it from ~450px away
+            (re-audit VD-03/UXF-03). */}
+        {infoText && !composerActive && (
           <div className="text-text-theme-secondary text-sm">{infoText}</div>
         )}
         {trailingActions && (

--- a/src/components/gameplay/TacticalActionDock/commands/__tests__/movementCommands.01.test.ts
+++ b/src/components/gameplay/TacticalActionDock/commands/__tests__/movementCommands.01.test.ts
@@ -24,6 +24,24 @@ describe('movementCommands', () => {
     ]);
   });
 
+  // Single Movement Authority hardening (re-audit VD-01/UXF-01/IS-02): while
+  // the composer is ACTIVE, posture + traversal verbs leave the dock entirely
+  // — the composer's PosturePalette is their only home (it imports the command
+  // arrays directly, so its legality predicates are unaffected). Equipment /
+  // state commands stay dock-side.
+  it('drops posture + traversal verbs while the composer is active (equipment/state stay)', () => {
+    const gated = buildMovementCommands({
+      ...makeCtx({}),
+      movementComposerActive: true,
+    });
+    expect(gated.map((c) => c.id)).toEqual([
+      'movement.activate-masc',
+      'movement.activate-supercharger',
+      'movement.stabilize',
+      'movement.cancel',
+    ]);
+  });
+
   it('no longer exposes walk / run / sprint / jump movement-verb commands', () => {
     const ids = commands.map((c) => c.id);
     for (const removed of [

--- a/src/components/gameplay/TacticalActionDock/commands/movementCommands.ts
+++ b/src/components/gameplay/TacticalActionDock/commands/movementCommands.ts
@@ -40,9 +40,16 @@ import { buildRuntimeMovementStateCommands } from './runtimeMovementStateCommand
 export function buildMovementCommands(
   ctx?: ITacticalCommandContext,
 ): readonly ITacticalCommand[] {
+  // Single Movement Authority (tactical-movement-intent spec): while the
+  // Movement Intent Composer is active it is the SOLE home for posture and
+  // traversal verbs (its PosturePalette imports the command arrays directly,
+  // so legality stays single-sourced). The dock keeps only equipment/state
+  // commands so the same verb never renders on two surfaces (re-audit
+  // VD-01/UXF-01/IS-02).
+  const composerOwnsComposition = ctx?.movementComposerActive === true;
   return [
-    ...MovementTraversalCommands,
-    ...MovementPostureCommands,
+    ...(composerOwnsComposition ? [] : MovementTraversalCommands),
+    ...(composerOwnsComposition ? [] : MovementPostureCommands),
     MovementActivateMASCCommand,
     MovementActivateSuperchargerCommand,
     ...buildRuntimeMovementStateCommands(ctx),

--- a/src/types/gameplay/TacticalCommandInterfaces.ts
+++ b/src/types/gameplay/TacticalCommandInterfaces.ts
@@ -117,6 +117,15 @@ export interface ITacticalCommandContext {
    * `null` when no active unit (between turns, post-game).
    */
   readonly activeUnitId: string | null;
+  /**
+   * True while the Movement Intent Composer is the active movement surface
+   * (tactical-movement-intent 'Single Movement Authority'). Movement builders
+   * drop the posture/traversal verbs from the dock so the composer's palette
+   * is their ONLY home; equipment/state commands (MASC, Supercharger,
+   * Stabilize, Cancel) stay dock-side. The composer palette itself imports
+   * the command arrays directly, so its legality predicates are unaffected.
+   */
+  readonly movementComposerActive?: boolean;
   /** Map cursor selection — used only by preview, never by availability. */
   readonly selectedUnitId: string | null;
   /** Target the player is aiming at (attack commands). */


### PR DESCRIPTION
## What

Two re-audit clusters on the tactical HUD, implemented per the Single Movement Authority requirement (`openspec/specs/tactical-movement-intent/spec.md`) and the focus-hierarchy doctrine:

1. **Posture verbs get one home** (VD-01/UXF-01/IS-02): while the Movement Intent Composer is active, the dock's MOVEMENT group no longer renders Evade/Stand Up/Careful Stand/Hull Down/Go Prone — the composer's PosturePalette is their sole surface. Gated at the command source (`buildMovementCommands`) via a new `movementComposerActive` context flag; the palette imports the command arrays directly, so posture legality remains single-sourced. Equipment/state commands (MASC, Supercharger, Stabilize, Cancel) stay dock-side; composer-inactive contexts (non-movement phases, non-player units) are byte-identical to before.
2. **Composer band polish** (VD-03/UXF-03/A11Y-R8/VD-06): the band claims the dock's full row (`w-full`) so POSTURE | LEDGER | BUDGET flex into the available width (no more dead right half); Lock In keeps button chrome when disabled (border + fill instead of bare dim text) with a state-aware enablement hint rendered directly beside it; the dock's duplicate trailing guidance is suppressed while the composer is active.

## Verification
- New unit test pins the gate (composer-active → only equipment/state commands; posture/traversal excluded)
- 194/194 composer+dock jest; combat quick-slice 12/12; command-slices QC wrapper 8/8; typecheck + oxfmt clean
- Capture spec re-anchored (dock `command-btn-movement.evade` asserted absent; palette `posture-action-EVADE` carries the `(E)` hint) and evidence re-captured — pixel-verified: full-width band, hint beside Lock In, dock in two compact rows, map dominant, no viewport overflow
