### PR TITLE
fix(gm-ledger): action hierarchy, post-approval state, and DC-02 reversal sign

### DIFF
--- a/e2e/gm-campaign-ledger-control-plane.spec.ts
+++ b/e2e/gm-campaign-ledger-control-plane.spec.ts
@@ -535,7 +535,7 @@ test.describe('GM campaign ledger control plane @gm-ledger', () => {
       await expect(
         page.getByTestId('gm-ledger-preview-net-effect'),
       ).toContainText(
-        '1,000,000.00 C-bills -> 997,500.00 C-bills (-2,500.00 C-bills)',
+        '1,000,000.00 C-bills -> 1,002,500.00 C-bills (+2,500.00 C-bills)',
       );
 
       await page.getByTestId('gm-ledger-approve-btn').click();
@@ -544,10 +544,10 @@ test.describe('GM campaign ledger control plane @gm-ledger', () => {
         'Approved and applied',
       );
       await expect(page.getByTestId('gm-ledger-balance')).toContainText(
-        '997,500.00 C-bills',
+        '1,002,500.00 C-bills',
       );
       await expect(page.getByTestId('gm-ledger-player-log')).toContainText(
-        'Merchant charge corrected by -2,500.00 C-bills.',
+        'Merchant charge corrected by +2,500.00 C-bills.',
       );
       await expect(page.getByTestId('gm-ledger-player-log')).not.toContainText(
         /Hidden campaign|black-market|GM-only/i,
@@ -560,16 +560,16 @@ test.describe('GM campaign ledger control plane @gm-ledger', () => {
       await assertNoMekStationLoading(page);
       await expect(page.getByTestId('page-title')).toContainText('GM Ledger');
       await expect(page.getByTestId('gm-ledger-balance')).toContainText(
-        '997,500.00 C-bills',
+        '1,002,500.00 C-bills',
       );
       await expect(page.getByTestId('gm-ledger-player-log')).toContainText(
-        'Merchant charge corrected by -2,500.00 C-bills.',
+        'Merchant charge corrected by +2,500.00 C-bills.',
       );
       await expect(page.getByTestId('gm-ledger-player-log')).not.toContainText(
         /Hidden campaign|black-market|GM-only/i,
       );
       await expect(page.getByTestId('gm-ledger-private-log')).toContainText(
-        'Merchant charge corrected by -2,500.00 C-bills.',
+        'Merchant charge corrected by +2,500.00 C-bills.',
       );
       await expect(page.getByTestId('gm-ledger-private-log')).not.toContainText(
         /Hidden campaign|black-market|GM-only/i,
@@ -620,7 +620,7 @@ test.describe('GM campaign ledger control plane @gm-ledger', () => {
         'GM controls are available only to the campaign owner or co-op host',
       );
       await expect(page.getByTestId('gm-ledger-player-log')).toContainText(
-        'Merchant charge corrected by -2,500.00 C-bills.',
+        'Merchant charge corrected by +2,500.00 C-bills.',
       );
       await expect(page.getByTestId('gm-ledger-player-log')).not.toContainText(
         /Hidden campaign|black-market|GM-only|default outcome/i,
@@ -669,9 +669,9 @@ test.describe('GM campaign ledger control plane @gm-ledger', () => {
       await expect
         .poll(async () => readClientLedgerSnapshot(page))
         .toMatchObject({
-          balance: 997_500,
+          balance: 1_002_500,
           gmInterventionEventCount: 1,
-          playerSummaries: ['Merchant charge corrected by -2,500.00 C-bills.'],
+          playerSummaries: ['Merchant charge corrected by +2,500.00 C-bills.'],
         });
 
       const saved = await saveCampaignThroughDashboard(page, campaignId);
@@ -679,9 +679,9 @@ test.describe('GM campaign ledger control plane @gm-ledger', () => {
       await expect
         .poll(async () => readServerLedgerSnapshot(page, campaignId))
         .toMatchObject({
-          balance: 997_500,
+          balance: 1_002_500,
           gmInterventionEventCount: 1,
-          playerSummaries: ['Merchant charge corrected by -2,500.00 C-bills.'],
+          playerSummaries: ['Merchant charge corrected by +2,500.00 C-bills.'],
         });
 
       await clearLiveCampaignClientState(page);
@@ -702,16 +702,16 @@ test.describe('GM campaign ledger control plane @gm-ledger', () => {
       await assertNoMekStationLoading(page);
       await expect(page.getByTestId('page-title')).toContainText('GM Ledger');
       await expect(page.getByTestId('gm-ledger-balance')).toContainText(
-        '997,500.00 C-bills',
+        '1,002,500.00 C-bills',
       );
       await expect(page.getByTestId('gm-ledger-player-log')).toContainText(
-        'Merchant charge corrected by -2,500.00 C-bills.',
+        'Merchant charge corrected by +2,500.00 C-bills.',
       );
       await expect(page.getByTestId('gm-ledger-player-log')).not.toContainText(
         /Hidden campaign|black-market|GM-only/i,
       );
       await expect(page.getByTestId('gm-ledger-private-log')).toContainText(
-        'Merchant charge corrected by -2,500.00 C-bills.',
+        'Merchant charge corrected by +2,500.00 C-bills.',
       );
       await expect(page.getByTestId('gm-ledger-private-log')).not.toContainText(
         /Hidden campaign|black-market|GM-only/i,
@@ -719,9 +719,9 @@ test.describe('GM campaign ledger control plane @gm-ledger', () => {
       await expect
         .poll(async () => readClientLedgerSnapshot(page))
         .toMatchObject({
-          balance: 997_500,
+          balance: 1_002_500,
           gmInterventionEventCount: 1,
-          playerSummaries: ['Merchant charge corrected by -2,500.00 C-bills.'],
+          playerSummaries: ['Merchant charge corrected by +2,500.00 C-bills.'],
         });
     } finally {
       if (campaignId) {

--- a/src/components/campaign/gm/GmCampaignInterventionActions.tsx
+++ b/src/components/campaign/gm/GmCampaignInterventionActions.tsx
@@ -108,9 +108,18 @@ export function GmCampaignInterventionActions({
           data-testid="gm-ledger-correction-type"
         />
       </div>
+      {/* Exactly ONE filled primary per state (doctrine / re-audit VD-02):
+          before a preview exists, generating one is the decisive act; once a
+          preview is ready (or requires takeover), the resolution action takes
+          the filled treatment and the generator demotes to secondary. Dark
+          text on the amber/emerald fills keeps the labels >= 4.5:1
+          (re-audit A11Y-R3 — white-on-amber measured ~2:1). */}
       <Button
         type="button"
-        variant="primary"
+        variant={canApprove || canTakeManualControl ? 'secondary' : 'primary'}
+        className={
+          canApprove || canTakeManualControl ? '' : 'font-bold !text-slate-950'
+        }
         onClick={handleGenerateCorrection}
         data-testid="gm-ledger-preview-btn"
       >
@@ -118,16 +127,21 @@ export function GmCampaignInterventionActions({
       </Button>
       <Button
         type="button"
-        variant="success"
+        variant={canApprove ? 'success' : 'secondary'}
+        className={canApprove ? 'font-bold !text-slate-950' : ''}
         onClick={onApprove}
         disabled={!canApprove}
         data-testid="gm-ledger-approve-btn"
       >
         Approve cascade
       </Button>
+      {/* Destructive takeover is deliberately LOW-salience: outline styling,
+          separated to the row's end — never a third filled CTA competing with
+          the happy path (re-audit IS-03). */}
       <Button
         type="button"
-        variant="danger"
+        variant="ghost"
+        className="ml-auto border border-red-500/60 !text-red-300 hover:!bg-red-950/40"
         onClick={onManualTakeover}
         disabled={!canTakeManualControl}
         data-testid="gm-ledger-manual-btn"

--- a/src/components/campaign/gm/GmCampaignInterventionControlPlane.helpers.ts
+++ b/src/components/campaign/gm/GmCampaignInterventionControlPlane.helpers.ts
@@ -26,7 +26,7 @@ import { TransactionType } from '@/types/campaign/Transaction';
 export const MERCHANT_REVERSAL_ID = 'gm-ledger-merchant-reversal';
 export const TIME_CASCADE_ID = 'gm-ledger-time-cascade';
 export const TIME_CASCADE_MANUAL_ID = 'gm-ledger-time-cascade-manual';
-const MERCHANT_REVERSAL_AMOUNT_CENTS = -250_000;
+const MERCHANT_REVERSAL_AMOUNT_CENTS = 250_000;
 export const GM_ACTOR_ID = 'gm-browser-control-plane';
 
 export type GmLedgerPublicEffect =
@@ -100,7 +100,7 @@ export function buildMerchantReversalCommand({
         hiddenNotes:
           'Merchant inventory clue remains GM-only until the players discover it in play.',
       },
-      publicSummary: 'Merchant charge corrected by -2,500.00 C-bills.',
+      publicSummary: 'Merchant charge corrected by +2,500.00 C-bills.',
       conflicts: conflicted
         ? [
             {

--- a/src/components/campaign/gm/GmCampaignInterventionControlPlane.tsx
+++ b/src/components/campaign/gm/GmCampaignInterventionControlPlane.tsx
@@ -99,6 +99,13 @@ export function GmCampaignInterventionControlPlane({
     ],
   );
   const [preview, setPreview] = useState<GmLedgerPreview | null>(null);
+  // Post-approval latch (re-audit IS-01/UXF-05): the preview type has no
+  // 'approved' status by design (a preview is a pre-approval artifact), so the
+  // control plane tracks "this preview was already applied" itself. It gates
+  // canApprove (no re-approving an applied correction) and swaps the preview
+  // card's stale 'ready' tag for an 'approved' one. Cleared when the next
+  // preview is generated.
+  const [approvedApplied, setApprovedApplied] = useState(false);
   const [approvalStatus, setApprovalStatus] = useState<string>(
     'No approved GM corrections yet.',
   );
@@ -122,8 +129,9 @@ export function GmCampaignInterventionControlPlane({
     setGmRows(persistedRows.gmRows);
   }, [actionLedger, persistedRows]);
 
-  const canApprove = preview?.status === 'ready';
-  const canTakeManualControl = preview?.status === 'requires-manual-takeover';
+  const canApprove = preview?.status === 'ready' && !approvedApplied;
+  const canTakeManualControl =
+    preview?.status === 'requires-manual-takeover' && !approvedApplied;
 
   const handleMerchantPreview = (conflicted: boolean): void => {
     const nextPreview = createGmCascadePreview({
@@ -278,6 +286,7 @@ export function GmCampaignInterventionControlPlane({
       );
       applyPilotPatches(rosterPatches);
       onApplyCampaignUpdate(result.state);
+      setApprovedApplied(true);
       setApprovalStatus('Approved and applied to campaign state.');
       setApprovalReason(null);
       refreshLedgerRows(actionLedger, setPlayerRows, setGmRows);
@@ -305,6 +314,7 @@ export function GmCampaignInterventionControlPlane({
     }
 
     onApplyCampaignUpdate(result.state);
+    setApprovedApplied(true);
     setApprovalStatus('Approved and applied to campaign state.');
     setApprovalReason(null);
     refreshLedgerRows(actionLedger, setPlayerRows, setGmRows);
@@ -348,6 +358,7 @@ export function GmCampaignInterventionControlPlane({
 
   const setNextPreview = (nextPreview: GmLedgerPreview): void => {
     setPreview(nextPreview);
+    setApprovedApplied(false);
     setManualTakeover(null);
     setApprovalReason(null);
     setApprovalStatus(
@@ -381,7 +392,11 @@ export function GmCampaignInterventionControlPlane({
       />
 
       {preview ? (
-        <GmPreviewPanel preview={preview} approvalReason={approvalReason} />
+        <GmPreviewPanel
+          preview={preview}
+          approvalReason={approvalReason}
+          approvedApplied={approvedApplied}
+        />
       ) : null}
 
       {manualTakeover ? (

--- a/src/components/campaign/gm/GmCampaignPreviewPanels.tsx
+++ b/src/components/campaign/gm/GmCampaignPreviewPanels.tsx
@@ -20,11 +20,18 @@ export interface ManualTakeoverState {
 export function GmPreviewPanel({
   preview,
   approvalReason,
+  approvedApplied = false,
 }: {
   readonly preview: GmLedgerPreview;
   // The approval-blocked reason folds into the live preview because it is only
   // meaningful while a preview is on screen — it never stands on its own card.
   readonly approvalReason?: string | null;
+  /**
+   * True once this preview's correction has been approved and applied — the
+   * card swaps its stale 'ready' tag for a green 'approved' one so the state
+   * the GM reads matches the state the campaign is in (re-audit UXF-05).
+   */
+  readonly approvedApplied?: boolean;
 }): React.ReactElement {
   const fundsEffect = findFundsEffect(preview.projectedEvents);
   const timeEffect = findTimeEffect(preview.projectedEvents);
@@ -40,7 +47,11 @@ export function GmPreviewPanel({
         {/* Preview status folded off the status-card bar into the live preview,
             where the GM reads it alongside the projected effect it describes. */}
         <span data-testid="gm-ledger-preview-status">
-          <Badge>{preview.status}</Badge>
+          {approvedApplied ? (
+            <Badge variant="success">approved</Badge>
+          ) : (
+            <Badge>{preview.status}</Badge>
+          )}
         </span>
       </div>
       {approvalReason ? (

--- a/src/components/campaign/gm/__tests__/GmCampaignInterventionControlPlane.test.tsx
+++ b/src/components/campaign/gm/__tests__/GmCampaignInterventionControlPlane.test.tsx
@@ -62,7 +62,7 @@ describe('GmCampaignInterventionControlPlane', () => {
           interventionId: 'gm-ledger-merchant-reversal',
           transactionId: 'gm-ledger-merchant-reversal',
           changedStateRefs: ['campaign:campaign-gm-reload:finances'],
-          publicSummary: 'Merchant charge corrected by -2,500.00 C-bills.',
+          publicSummary: 'Merchant charge corrected by +2,500.00 C-bills.',
           before: {
             balanceCents: 100_000_000,
             transactionIds: [],
@@ -72,7 +72,7 @@ describe('GmCampaignInterventionControlPlane', () => {
             transaction: {
               id: 'gm-ledger-merchant-reversal',
               type: TransactionType.PartPurchase,
-              amountCents: -250_000,
+              amountCents: 250_000,
               date: '3025-01-03T00:00:00.000Z',
               description: 'GM merchant charge reversal',
             },
@@ -126,7 +126,7 @@ describe('GmCampaignInterventionControlPlane', () => {
     );
 
     expect(screen.getByTestId('gm-ledger-player-log')).toHaveTextContent(
-      'Merchant charge corrected by -2,500.00 C-bills.',
+      'Merchant charge corrected by +2,500.00 C-bills.',
     );
     expect(screen.getByTestId('gm-ledger-player-log')).toHaveTextContent(
       'Campaign time corrected by 2 days.',
@@ -135,7 +135,7 @@ describe('GmCampaignInterventionControlPlane', () => {
       /Hidden campaign|Hidden time|black-market|GM-only/i,
     );
     expect(screen.getByTestId('gm-ledger-private-log')).toHaveTextContent(
-      'Merchant charge corrected by -2,500.00 C-bills.',
+      'Merchant charge corrected by +2,500.00 C-bills.',
     );
     expect(screen.getByTestId('gm-ledger-private-log')).toHaveTextContent(
       'Campaign time corrected by 2 days.',
@@ -167,14 +167,14 @@ describe('GmCampaignInterventionControlPlane', () => {
     expect(
       screen.getByTestId('gm-ledger-preview-net-effect'),
     ).toHaveTextContent(
-      '1,000,000.00 C-bills -> 997,500.00 C-bills (-2,500.00 C-bills)',
+      '1,000,000.00 C-bills -> 1,002,500.00 C-bills (+2,500.00 C-bills)',
     );
 
     fireEvent.click(screen.getByTestId('gm-ledger-approve-btn'));
 
     expect(onApplyCampaignUpdate).toHaveBeenCalledTimes(1);
     const updates = onApplyCampaignUpdate.mock.calls[0][0];
-    expect(updates.finances.balance.format()).toBe('997,500.00 C-bills');
+    expect(updates.finances.balance.format()).toBe('1,002,500.00 C-bills');
     expect(updates.finances.transactions).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -613,7 +613,7 @@ describe('GmCampaignPlayerLedgerView', () => {
           interventionId: 'gm-ledger-merchant-reversal',
           transactionId: 'gm-ledger-merchant-reversal',
           changedStateRefs: ['campaign:campaign-gm-guest:finances'],
-          publicSummary: 'Merchant charge corrected by -2,500.00 C-bills.',
+          publicSummary: 'Merchant charge corrected by +2,500.00 C-bills.',
           before: {
             balanceCents: 100_000_000,
             transactionIds: [],
@@ -623,7 +623,7 @@ describe('GmCampaignPlayerLedgerView', () => {
             transaction: {
               id: 'gm-ledger-merchant-reversal',
               type: TransactionType.PartPurchase,
-              amountCents: -250_000,
+              amountCents: 250_000,
               date: '3025-01-03T00:00:00.000Z',
               description: 'GM merchant charge reversal',
             },
@@ -676,7 +676,7 @@ describe('GmCampaignPlayerLedgerView', () => {
       'GM controls are available only to the campaign owner or co-op host',
     );
     expect(screen.getByTestId('gm-ledger-player-log')).toHaveTextContent(
-      'Merchant charge corrected by -2,500.00 C-bills.',
+      'Merchant charge corrected by +2,500.00 C-bills.',
     );
     expect(screen.getByTestId('gm-ledger-player-log')).toHaveTextContent(
       'Campaign time corrected by 2 days.',

--- a/src/lib/campaign/persistence/__tests__/serverFieldMirror.test.ts
+++ b/src/lib/campaign/persistence/__tests__/serverFieldMirror.test.ts
@@ -172,7 +172,7 @@ function buildExtendedCampaign(): ICampaignWithCommand & {
         family: 'funds-transaction',
         transactionId: 'gm-event-001',
         changedStateRefs: ['campaign:campaign-001:finances'],
-        publicSummary: 'Merchant charge corrected by -2,500.00 C-bills.',
+        publicSummary: 'Merchant charge corrected by +2,500.00 C-bills.',
         before: {
           balanceCents: 38_000_000,
           transactionIds: ['tx-1'],
@@ -182,7 +182,7 @@ function buildExtendedCampaign(): ICampaignWithCommand & {
           transaction: {
             id: 'gm-event-001',
             type: TransactionType.PartPurchase,
-            amountCents: -250_000,
+            amountCents: 250_000,
             date: '3025-02-01T00:00:00.000Z',
             description: 'GM merchant charge reversal',
           },

--- a/src/lib/interventions/__tests__/GmCampaignInterventionImplementer.test.ts
+++ b/src/lib/interventions/__tests__/GmCampaignInterventionImplementer.test.ts
@@ -165,7 +165,7 @@ describe('GM campaign intervention implementer', () => {
         payload({
           family: 'funds-transaction',
           transactionId: 'gm-economy-1',
-          amountCents: -250_000,
+          amountCents: 250_000,
           description: 'Reverse duplicated merchant charge.',
           transactionType: TransactionType.PartPurchase,
           date: '3025-02-02T00:00:00.000Z',
@@ -276,12 +276,12 @@ describe('GM campaign intervention implementer', () => {
           {
             family: 'funds-transaction',
             transactionId: 'merchant-reversal-1',
-            amountCents: -250_000,
+            amountCents: 250_000,
             description: 'Reverse duplicated merchant charge.',
             transactionType: TransactionType.PartPurchase,
             date: '3025-02-02T00:00:00.000Z',
           },
-          'Merchant charge corrected by -2,500.00 C-bills.',
+          'Merchant charge corrected by +2,500.00 C-bills.',
         ),
       ),
       state,
@@ -294,7 +294,7 @@ describe('GM campaign intervention implementer', () => {
     const playerProjection = actionLedger.projectForPlayer();
     const gmProjection = actionLedger.projectForGm();
 
-    expect(result.state.finances.balance.centsValue).toBe(99_750_000);
+    expect(result.state.finances.balance.centsValue).toBe(100_250_000);
     expect(result.state.finances.transactions).toHaveLength(1);
     expect(result.state.finances.transactions[0]).toMatchObject({
       id: 'merchant-reversal-1',
@@ -302,7 +302,7 @@ describe('GM campaign intervention implementer', () => {
       description: 'Reverse duplicated merchant charge.',
     });
     expect(result.state.finances.transactions[0].amount.centsValue).toBe(
-      -250_000,
+      250_000,
     );
     expect(replayed).toEqual(result.state);
     expect(playerProjection.map((record) => record.id)).toEqual([

--- a/src/stores/campaign/__tests__/campaignPersistenceRoundTrip.test.ts
+++ b/src/stores/campaign/__tests__/campaignPersistenceRoundTrip.test.ts
@@ -331,7 +331,7 @@ describe('D-1 — campaign persistence round-trip (save → reload seam)', () =>
           family: 'funds-transaction',
           transactionId: 'gm-event-001',
           changedStateRefs: ['campaign:round-trip:finances'],
-          publicSummary: 'Merchant charge corrected by -2,500.00 C-bills.',
+          publicSummary: 'Merchant charge corrected by +2,500.00 C-bills.',
           before: {
             balanceCents: base.finances.balance.amount * 100,
             transactionIds: base.finances.transactions.map(
@@ -343,7 +343,7 @@ describe('D-1 — campaign persistence round-trip (save → reload seam)', () =>
             transaction: {
               id: 'gm-event-001',
               type: TransactionType.PartPurchase,
-              amountCents: -250_000,
+              amountCents: 250_000,
               date: '3025-02-01T00:00:00.000Z',
               description: 'GM merchant charge reversal',
             },


### PR DESCRIPTION
## Summary
- **One filled primary per state** (re-audit VD-02/IS-01): `Generate correction` holds the filled treatment until a preview resolves; `Approve cascade` takes the filled success treatment when ready; `Take manual control` demotes to a separated low-salience destructive outline (IS-03).
- **Post-approval state fix** (UXF-05): approval latch disables Approve after the correction applies and swaps the preview card's stale `ready` badge for a green `approved` badge.
- **Contrast** (A11Y-R3): dark text on the amber/emerald filled buttons restores >=4.5:1 (white-on-amber measured ~2:1).
- **DC-02 arithmetic**: the merchant duplicated-charge reversal now REFUNDS +2,500.00 C-bills (it was deducting a second time, contradicting its own rationale copy). All coupled fixtures/assertions updated to the 1,002,500 balance.

## Verification
- oxfmt check clean; typecheck 0 errors
- jest: 120/120 across gm components, interventions, serverFieldMirror, persistence round-trip
- GM QC validators: campaign-ledger 0 errors, time-cascade 0 errors; jest wrapper 5/5
- `qc:command-evidence` capture+validate green (6/6 slices); PNGs 06/07/08 pixel-verified: one filled primary per state, approved badge post-approval, corrected +2,500 refund math end-to-end