### PR TITLE
fix(engine): seed BattleMech armor/structure/heat sinks into session state

### DIFF
--- a/src/engine/GameEngine.ts
+++ b/src/engine/GameEngine.ts
@@ -43,6 +43,7 @@ import {
   InteractiveSession,
   type IInteractiveSessionLinkage,
 } from './InteractiveSession';
+import { gameUnitsWithAdaptedCombatSeeds } from './InteractiveSession.setup';
 
 export { InteractiveSession };
 
@@ -106,7 +107,13 @@ export class GameEngine {
       scenarioId: linkage.scenarioId ?? null,
     };
 
-    let session = createGameSession(gameConfig, gameUnits);
+    // Same combat-seed splice as the interactive constructor — without it,
+    // auto-resolved battles ran every BattleMech at 0 armor / 0 structure
+    // (one penetrating hit destroyed the location).
+    let session = createGameSession(
+      gameConfig,
+      gameUnitsWithAdaptedCombatSeeds(gameUnits, playerUnits, opponentUnits),
+    );
     session = startGame(session, GameSide.Player);
 
     const botPlayer = new BotPlayer(this.random);

--- a/src/engine/InteractiveSession.setup.ts
+++ b/src/engine/InteractiveSession.setup.ts
@@ -84,7 +84,16 @@ function representedTonnage(tonnage: number | undefined): number {
     : 65;
 }
 
-export function gameUnitsWithAdaptedMovementModes(
+/**
+ * Splice the adapted units' construction-derived combat seeds onto the
+ * bare `IGameUnit` metadata before it enters the GameCreated payload:
+ * movement mode, gyro type, vehicle critical availability, and — per the
+ * 0/0 armor instrument-data fix — per-location armor / structure and
+ * heat-sink capacity. Flowing these through the event payload (rather
+ * than mutating state post-hoc) keeps replay, recovery, and multiplayer
+ * hosts deriving identical initial unit states.
+ */
+export function gameUnitsWithAdaptedCombatSeeds(
   gameUnits: readonly IGameUnit[],
   playerUnits: readonly IAdaptedUnit[],
   opponentUnits: readonly IAdaptedUnit[],
@@ -109,14 +118,43 @@ export function gameUnitsWithAdaptedMovementModes(
     const hasVehicleCriticalAvailabilityUpdate =
       unit.vehicleInit !== undefined &&
       vehicleCriticalAvailability !== undefined;
+    // Adapted armor/structure at session start ARE the construction maxima
+    // (the adapter extracts catalog allocation, minus explicit scenario
+    // initial damage). Explicit producer-supplied values win; empty adapted
+    // maps (synthetic fixtures) splice nothing so legacy behavior holds.
+    const hasArmorSeedUpdate =
+      unit.armorByLocation === undefined &&
+      Object.keys(adapted.armor ?? {}).length > 0;
+    const hasStructureSeedUpdate =
+      unit.structureByLocation === undefined &&
+      Object.keys(adapted.structure ?? {}).length > 0;
+    const hasHeatSinkUpdate =
+      unit.heatSinks === undefined && adapted.heatSinks !== undefined;
 
     return hasMovementModeUpdate ||
       hasGyroTypeUpdate ||
-      hasVehicleCriticalAvailabilityUpdate
+      hasVehicleCriticalAvailabilityUpdate ||
+      hasArmorSeedUpdate ||
+      hasStructureSeedUpdate ||
+      hasHeatSinkUpdate
       ? {
           ...unit,
           ...(hasMovementModeUpdate ? { movementMode } : {}),
           ...(hasGyroTypeUpdate ? { gyroType } : {}),
+          ...(hasArmorSeedUpdate
+            ? { armorByLocation: { ...adapted.armor } }
+            : {}),
+          ...(hasStructureSeedUpdate
+            ? { structureByLocation: { ...adapted.structure } }
+            : {}),
+          ...(hasHeatSinkUpdate
+            ? {
+                heatSinks: adapted.heatSinks,
+                ...(adapted.heatSinkType
+                  ? { heatSinkType: adapted.heatSinkType }
+                  : {}),
+              }
+            : {}),
           ...(hasVehicleCriticalAvailabilityUpdate
             ? {
                 vehicleInit: {

--- a/src/engine/InteractiveSession.ts
+++ b/src/engine/InteractiveSession.ts
@@ -91,7 +91,7 @@ import { appendAndPersistInteractiveSessionEvent } from './InteractiveSession.se
 import {
   buildInteractiveSessionGameConfig,
   buildInteractiveSessionUnitMaps,
-  gameUnitsWithAdaptedMovementModes,
+  gameUnitsWithAdaptedCombatSeeds,
 } from './InteractiveSession.setup';
 
 /**
@@ -198,7 +198,7 @@ export class InteractiveSession {
     );
     this.linkage = linkage;
 
-    const gameUnitsWithMovementModes = gameUnitsWithAdaptedMovementModes(
+    const gameUnitsWithCombatSeeds = gameUnitsWithAdaptedCombatSeeds(
       gameUnits,
       playerUnits,
       opponentUnits,
@@ -206,7 +206,7 @@ export class InteractiveSession {
 
     this.session = createGameSession(
       this.gameConfig,
-      gameUnitsWithMovementModes,
+      gameUnitsWithCombatSeeds,
       {
         encounterMeta: linkage.encounterMeta,
         hexTerrain: seedHexTerrainFromGrid(this.grid),

--- a/src/engine/__tests__/InteractiveSession.setup.test.ts
+++ b/src/engine/__tests__/InteractiveSession.setup.test.ts
@@ -18,7 +18,7 @@ import type { IAdaptedUnit } from '../types';
 
 import {
   buildInteractiveSessionUnitMaps,
-  gameUnitsWithAdaptedMovementModes,
+  gameUnitsWithAdaptedCombatSeeds,
 } from '../InteractiveSession.setup';
 
 function vehicleGameUnit(
@@ -103,9 +103,9 @@ describe('buildInteractiveSessionUnitMaps', () => {
   });
 });
 
-describe('gameUnitsWithAdaptedMovementModes', () => {
+describe('gameUnitsWithAdaptedCombatSeeds', () => {
   it('derives represented vehicle weapon locations for crit availability', () => {
-    const [unit] = gameUnitsWithAdaptedMovementModes(
+    const [unit] = gameUnitsWithAdaptedCombatSeeds(
       [vehicleGameUnit()],
       [adaptedVehicle([weaponAt(VehicleLocation.FRONT)])],
       [],
@@ -122,7 +122,7 @@ describe('gameUnitsWithAdaptedMovementModes', () => {
   });
 
   it('keeps destroyed vehicle weapons unavailable for weapon crits but available for stabilizers', () => {
-    const [unit] = gameUnitsWithAdaptedMovementModes(
+    const [unit] = gameUnitsWithAdaptedCombatSeeds(
       [vehicleGameUnit()],
       [adaptedVehicle([weaponAt(VehicleLocation.REAR, true)])],
       [],
@@ -138,8 +138,64 @@ describe('gameUnitsWithAdaptedMovementModes', () => {
     });
   });
 
+  it('splices adapted armor/structure/heat sinks onto bare game units', () => {
+    const adapted = {
+      ...adaptedVehicle([]),
+      armor: { head: 9, center_torso: 47, center_torso_rear: 14 },
+      structure: { head: 3, center_torso: 31 },
+      heatSinks: 20,
+      heatSinkType: 'single' as const,
+    };
+    const bareUnit: IGameUnit = {
+      id: 'target',
+      name: 'Probe Mech',
+      side: GameSide.Opponent,
+      unitRef: 'probe-mech',
+      pilotRef: 'probe-pilot',
+      gunnery: 4,
+      piloting: 5,
+    };
+
+    const [unit] = gameUnitsWithAdaptedCombatSeeds([bareUnit], [], [adapted]);
+
+    expect(unit.armorByLocation).toEqual({
+      head: 9,
+      center_torso: 47,
+      center_torso_rear: 14,
+    });
+    expect(unit.structureByLocation).toEqual({ head: 3, center_torso: 31 });
+    expect(unit.heatSinks).toBe(20);
+    expect(unit.heatSinkType).toBe('single');
+  });
+
+  it('leaves explicit producer-supplied seeds and empty adapted maps alone', () => {
+    const bareUnit: IGameUnit = {
+      id: 'target',
+      name: 'Probe Mech',
+      side: GameSide.Opponent,
+      unitRef: 'probe-mech',
+      pilotRef: 'probe-pilot',
+      gunnery: 4,
+      piloting: 5,
+      armorByLocation: { head: 1 },
+      heatSinks: 13,
+    };
+
+    // Adapted maps empty (synthetic fixture) -> no armor/structure splice;
+    // explicit producer values win over adapted ones.
+    const [unit] = gameUnitsWithAdaptedCombatSeeds(
+      [bareUnit],
+      [],
+      [{ ...adaptedVehicle([]), heatSinks: 20 }],
+    );
+
+    expect(unit.armorByLocation).toEqual({ head: 1 });
+    expect(unit.structureByLocation).toBeUndefined();
+    expect(unit.heatSinks).toBe(13);
+  });
+
   it('preserves explicit cargo and stabilizer availability fields', () => {
-    const [unit] = gameUnitsWithAdaptedMovementModes(
+    const [unit] = gameUnitsWithAdaptedCombatSeeds(
       [
         vehicleGameUnit({
           criticalAvailability: {

--- a/src/simulation/__tests__/integration.chunk-2.test-helpers.ts
+++ b/src/simulation/__tests__/integration.chunk-2.test-helpers.ts
@@ -58,9 +58,13 @@ const PROFILE_AVG_GAME_BUDGET_MS = readPositiveIntEnv(
   'SIMULATION_PROFILE_AVG_GAME_BUDGET_MS',
   1500,
 );
+// Widened 120s → 360s (3× per the repo perf-budget convention) when
+// `gameUnitsWithAdaptedCombatSeeds` started seeding real per-location
+// armor/structure into auto-resolved sessions — games last more turns now
+// that armor absorbs damage; the contended 100-game batch measured ~148s.
 const PROFILE_TIME_BUDGET_MS = readPositiveIntEnv(
   'SIMULATION_PROFILE_TIME_BUDGET_MS',
-  120000,
+  360000,
 );
 
 // Statistical proofs are only meaningful at the full batch size: at the CI

--- a/src/simulation/__tests__/swarm-throughput.test.ts
+++ b/src/simulation/__tests__/swarm-throughput.test.ts
@@ -41,10 +41,17 @@ function readPositiveIntEnv(name: string, fallback: number): number {
 /** Number of sequential runs to execute. */
 const RUN_COUNT = readPositiveIntEnv('SWARM_THROUGHPUT_RUN_COUNT', 1000);
 
-/** Wall-clock time budget in milliseconds (60 seconds by default). */
+/**
+ * Wall-clock time budget in milliseconds. Widened 60s → 180s (3× per the
+ * repo perf-budget convention) when `gameUnitsWithAdaptedCombatSeeds`
+ * started seeding real per-location armor/structure into auto-resolved
+ * sessions — battles genuinely last more turns now that armor absorbs
+ * damage (the prior empty maps made every penetrating hit destroy the
+ * location), measured ~70s for the 1000-run batch on a current dev box.
+ */
 const TIME_BUDGET_MS = readPositiveIntEnv(
   'SWARM_THROUGHPUT_TIME_BUDGET_MS',
-  60_000,
+  180_000,
 );
 const JEST_TIMEOUT_MS =
   TIME_BUDGET_MS + Math.max(5_000, Math.ceil(TIME_BUDGET_MS * 0.1));

--- a/src/stores/__tests__/useGameplayStore.session.supplemental.test.ts
+++ b/src/stores/__tests__/useGameplayStore.session.supplemental.test.ts
@@ -1,0 +1,122 @@
+/**
+ * setInteractiveSessionLogic supplemental display derivation.
+ *
+ * A real interactive session (non-demo) must populate the record-sheet
+ * supplemental maps — max armor/structure, pilot names, heat sinks — from
+ * the session's own GameCreated payload units instead of leaving the
+ * demo-fixture-only maps empty (re-audit UXF-06/DC-01: the tactical unit
+ * card rendered 0/0 armor+structure and 'Unknown Pilot' for every live
+ * unit).
+ */
+import type { IAdaptedUnit } from '@/engine/types';
+
+import { createMinimalGrid } from '@/engine/GameEngine.helpers';
+import { InteractiveSession } from '@/engine/InteractiveSession';
+import { SeededRandom } from '@/simulation/core/SeededRandom';
+import { setInteractiveSessionLogic } from '@/stores/useGameplayStore.session';
+import {
+  Facing,
+  GameSide,
+  LockState,
+  MovementType,
+  type IGameUnit,
+} from '@/types/gameplay';
+
+function adaptedMech(id: string, side: GameSide): IAdaptedUnit {
+  return {
+    id,
+    side,
+    position: { q: 0, r: side === GameSide.Player ? 5 : -5 },
+    facing: Facing.North,
+    heat: 0,
+    movementThisTurn: MovementType.Stationary,
+    hexesMovedThisTurn: 0,
+    heatSinks: 20,
+    heatSinkType: 'single',
+    armor: { head: 9, center_torso: 47, center_torso_rear: 14 },
+    structure: { head: 3, center_torso: 31 },
+    startingInternalStructure: { head: 3, center_torso: 31 },
+    destroyedLocations: [],
+    destroyedEquipment: [],
+    ammo: {},
+    pilotWounds: 0,
+    pilotConscious: true,
+    destroyed: false,
+    lockState: LockState.Pending,
+    tonnage: 100,
+    weapons: [],
+    walkMP: 3,
+    runMP: 5,
+    jumpMP: 0,
+  };
+}
+
+function gameUnit(id: string, side: GameSide, pilotRef: string): IGameUnit {
+  return {
+    id,
+    name: `Unit ${id}`,
+    side,
+    unitRef: 'probe-mech',
+    pilotRef,
+    gunnery: 4,
+    piloting: 5,
+  };
+}
+
+describe('setInteractiveSessionLogic supplemental display derivation', () => {
+  it('derives max armor/structure, pilot names, and heat sinks from the session', () => {
+    const player = adaptedMech('unit-p1', GameSide.Player);
+    const opponent = adaptedMech('unit-o1', GameSide.Opponent);
+    const interactiveSession = new InteractiveSession(
+      8,
+      12,
+      new SeededRandom(42),
+      createMinimalGrid(8),
+      [player],
+      [opponent],
+      [
+        gameUnit('unit-p1', GameSide.Player, 'Natasha Kerensky'),
+        // The quick-game builder stamps 'Unknown' when no pilot exists —
+        // the derivation must skip it so the record sheet's own fallback
+        // ('Unknown Pilot') stays the single voice.
+        gameUnit('unit-o1', GameSide.Opponent, 'Unknown'),
+      ],
+    );
+
+    const updates: Record<string, unknown>[] = [];
+    const set = (partial: unknown): void => {
+      updates.push(partial as Record<string, unknown>);
+    };
+
+    setInteractiveSessionLogic(
+      interactiveSession,
+      set as Parameters<typeof setInteractiveSessionLogic>[1],
+    );
+
+    const applied = Object.assign({}, ...updates) as {
+      maxArmor: Record<string, Record<string, number>>;
+      maxStructure: Record<string, Record<string, number>>;
+      pilotNames: Record<string, string>;
+      heatSinks: Record<string, number>;
+    };
+
+    expect(applied.maxArmor['unit-p1']).toEqual({
+      head: 9,
+      center_torso: 47,
+      center_torso_rear: 14,
+    });
+    expect(applied.maxStructure['unit-p1']).toEqual({
+      head: 3,
+      center_torso: 31,
+    });
+    expect(applied.maxArmor['unit-o1']).toEqual({
+      head: 9,
+      center_torso: 47,
+      center_torso_rear: 14,
+    });
+    expect(applied.pilotNames['unit-p1']).toBe('Natasha Kerensky');
+    expect(applied.pilotNames['unit-o1']).toBeUndefined();
+    expect(applied.heatSinks['unit-p1']).toBe(20);
+    expect(applied.heatSinks['unit-o1']).toBe(20);
+  });
+});

--- a/src/stores/useGameplayStore.session.ts
+++ b/src/stores/useGameplayStore.session.ts
@@ -149,6 +149,53 @@ function getLoadSessionErrorMessage(error: unknown): string {
 }
 
 /**
+ * Derive the record-sheet supplemental display maps (max armor /
+ * structure, pilot names, heat-sink capacity) from a live session.
+ *
+ * Before this seam existed only the demo path populated these maps
+ * (from `@/__fixtures__/gameplay`), so every REAL interactive session
+ * rendered the unit card with 0/0 armor+structure, 'Unknown Pilot', and
+ * the 10-sink default (re-audit UXF-06/DC-01). The GameCreated payload
+ * units now carry `armorByLocation` / `structureByLocation` / `heatSinks`
+ * (spliced from the adapted catalog units by
+ * `gameUnitsWithAdaptedCombatSeeds`), which double as the display maxima —
+ * construction values are the per-location caps regardless of current
+ * damage, so this also holds for sessions recovered mid-battle.
+ */
+function deriveSupplementalDisplayData(
+  session: IGameSession,
+): Pick<
+  SessionSlice,
+  'maxArmor' | 'maxStructure' | 'pilotNames' | 'heatSinks'
+> {
+  const maxArmor: Record<string, Record<string, number>> = {};
+  const maxStructure: Record<string, Record<string, number>> = {};
+  const pilotNames: Record<string, string> = {};
+  const heatSinks: Record<string, number> = {};
+
+  for (const unit of session.units) {
+    if (unit.armorByLocation) {
+      maxArmor[unit.id] = { ...unit.armorByLocation };
+    }
+    if (unit.structureByLocation) {
+      maxStructure[unit.id] = { ...unit.structureByLocation };
+    }
+    // The quick-game builder stamps 'Unknown' when no pilot exists; skip it
+    // so the record sheet's own 'Unknown Pilot' fallback stays the one voice.
+    if (unit.pilotRef && unit.pilotRef !== 'Unknown') {
+      pilotNames[unit.id] = unit.pilotRef;
+    }
+    const unitHeatSinks =
+      session.currentState.units[unit.id]?.heatSinks ?? unit.heatSinks;
+    if (unitHeatSinks !== undefined) {
+      heatSinks[unit.id] = unitHeatSinks;
+    }
+  }
+
+  return { maxArmor, maxStructure, pilotNames, heatSinks };
+}
+
+/**
  * Adopt an interactive session into the store. Picks a sensible
  * starting `interactivePhase` based on the session's current phase
  * (Initiative -> SelectUnit; everything else also defaults to
@@ -173,6 +220,7 @@ export function setInteractiveSessionLogic(
     spectatorMode: null,
     isLoading: false,
     error: null,
+    ...deriveSupplementalDisplayData(session),
   });
 }
 
@@ -195,5 +243,6 @@ export function setSpectatorModeLogic(
     spectatorMode,
     isLoading: false,
     error: null,
+    ...deriveSupplementalDisplayData(session),
   });
 }

--- a/src/types/gameplay/GameSessionUnitTypes.ts
+++ b/src/types/gameplay/GameSessionUnitTypes.ts
@@ -276,6 +276,25 @@ export interface IGameUnit {
    */
   readonly armorTypeByLocation?: Readonly<Record<string, string>>;
   /**
+   * Optional per-location armor points seeded into combat state at
+   * GameCreated. Producers (`InteractiveSession` / `GameEngine.runToCompletion`
+   * via `gameUnitsWithAdaptedCombatSeeds`) copy the adapted unit's catalog
+   * armor here so `createInitialUnitState` seeds `IUnitGameState.armor` with
+   * real values — the legacy empty map made every BattleMech location read 0
+   * armor and let any penetrating hit destroy the location instantly, while
+   * vehicles/aero/protos/BA already seeded through their `*Init` blocks.
+   * Rear torso keys use the `<location>_rear` form. Missing preserves the
+   * legacy synthetic-fixture behavior (empty map).
+   */
+  readonly armorByLocation?: Readonly<Record<string, number>>;
+  /**
+   * Optional per-location internal structure seeded into combat state at
+   * GameCreated alongside `armorByLocation`. Also seeds
+   * `startingInternalStructure` so the retreat trigger's structure-loss
+   * ratio reads real starting values.
+   */
+  readonly structureByLocation?: Readonly<Record<string, number>>;
+  /**
    * Per-location ammo explosion containment projected from construction data
    * into interactive game sessions. Missing keys mean no CASE protection.
    */

--- a/src/utils/gameplay/gameState/initialization.ts
+++ b/src/utils/gameplay/gameState/initialization.ts
@@ -130,17 +130,24 @@ export function createInitialUnitState(
     initiativeEquipment: unit.initiativeEquipment,
     c3Equipment: unit.c3Equipment,
     weaponLocationById: unit.weaponLocationById,
-    armor: {},
-    structure: {},
+    // Seed armor/structure from the construction inputs when the producer
+    // supplied them (per-type units seed through their `*Init` blocks;
+    // BattleMechs seed through `armorByLocation`/`structureByLocation`,
+    // spliced from the adapted catalog unit by
+    // `gameUnitsWithAdaptedCombatSeeds`). Legacy synthetic fixtures omit
+    // both and keep the empty-map behavior.
+    armor: unit.armorByLocation ? { ...unit.armorByLocation } : {},
+    structure: unit.structureByLocation ? { ...unit.structureByLocation } : {},
     // Per `add-bot-retreat-behavior` § 2 (Trigger A): the retreat trigger
     // needs the points-of-internal-structure ratio
-    // `sum(starting - current) / sum(starting)`. The base initialization
-    // path leaves `structure` empty (production callers, e.g. CompendiumAdapter,
-    // override with per-tonnage values); we mirror that here. The damage
-    // reducer (`applyDamageApplied`) bootstraps `startingInternalStructure`
-    // on first damage to a location when a producer didn't seed it
-    // explicitly, so legacy callers keep working without a migration.
-    startingInternalStructure: {},
+    // `sum(starting - current) / sum(starting)`. Seeded with the full
+    // starting structure when construction inputs are present; otherwise
+    // the damage reducer (`applyDamageApplied`) bootstraps
+    // `startingInternalStructure` on first damage to a location, so legacy
+    // callers keep working without a migration.
+    startingInternalStructure: unit.structureByLocation
+      ? { ...unit.structureByLocation }
+      : {},
     destroyedLocations: [],
     destroyedEquipment: [],
     ammo: {},


### PR DESCRIPTION
## Summary
Root cause of the **0/0 armor+structure instrument-data bug** (re-audit UXF-06/DC-01, task #10): every unit type except BattleMechs seeds combat state through its `IGameUnit.*Init` construction block — mechs hit the legacy `armor: {}` path in `createInitialUnitState`. Both the record sheet **and the damage pipeline** read those empty maps, so live units displayed 0/0 on every location and any penetrating hit destroyed the location outright (effective one-hit kills in interactive and auto-resolved battles).

- `IGameUnit`: new optional `armorByLocation` / `structureByLocation` construction seeds (mirrors the vehicle/aero/proto/BA `*Init` pattern)
- `createInitialUnitState` consumes them (armor, structure, and `startingInternalStructure` for the retreat trigger's loss ratio)
- `gameUnitsWithAdaptedMovementModes` → `gameUnitsWithAdaptedCombatSeeds`: also splices adapted catalog armor/structure/heat sinks onto bare game units; applied in both the `InteractiveSession` constructor and `GameEngine.runToCompletion` so seeds flow through the **GameCreated payload** (replay / recovery / multiplayer derive identical states)
- `setInteractiveSessionLogic` / `setSpectatorModeLogic` derive the record sheet's supplemental display maps (max armor/structure, pilot names, heat sinks) from the session instead of demo fixtures
- swarm-throughput + integration profiling budgets widened 3× per the repo perf-budget convention — battles genuinely last more turns now that armor absorbs damage (70s/148s measured vs 60s/120s old budgets)

## Verification
- typecheck clean; oxfmt clean
- engine + gameState + stores: 80 suites / 1201 tests green
- simulation + gameplay UI + quickgame + pages-modules: 445 suites green (2 perf-budget failures root-caused to the longer battles and widened per convention, then green)
- new coverage: combat-seed splice unit tests + store supplemental-derivation test
- `qc:command-evidence` capture+validate 6/6; screen 09 pixel-verified: Atlas Head AR 9/9 / IS 3/3, CT 47/47 / RR 14/14 / IS 31/31 with condition bars, HEAT (20 sinks) + 20 heat/turn dissipation (was 0/0 everywhere + 10-sink default)

Follow-up filed (board #14): the weapons table has the same fixture-only gap.