### PR TITLE
fix(starmap): distinct faction palette, chip annotations, cluster auto-fit

### DIFF
--- a/src/components/campaign/StarmapDisplay.tsx
+++ b/src/components/campaign/StarmapDisplay.tsx
@@ -12,7 +12,16 @@
 import type Konva from 'konva';
 
 import React, { useState, useCallback, useMemo, useRef } from 'react';
-import { Stage, Layer, Circle, Text, Ring, Group } from 'react-konva';
+import {
+  Stage,
+  Layer,
+  Circle,
+  Text,
+  Ring,
+  Group,
+  Label,
+  Tag,
+} from 'react-konva';
 
 export interface IStarSystem {
   id: string;
@@ -38,7 +47,10 @@ export interface IStarmapSystemAnnotation {
 
 export const FACTION_COLORS: Record<string, string> = {
   Lyran: '#1e40af',
-  Davion: '#b91c1c',
+  // Davion gold (canonical House Davion sunburst). Was #b91c1c — a near
+  // twin of Kurita's #dc2626 that made the two houses indistinguishable
+  // on the map (re-audit DC-04/A11Y-R5). Kurita keeps the Dragon red.
+  Davion: '#eab308',
   Liao: '#15803d',
   Kurita: '#dc2626',
   Marik: '#7c3aed',
@@ -56,6 +68,102 @@ const MIN_ZOOM = 0.1;
 const MAX_ZOOM = 3;
 const ZOOM_STEP = 1.1;
 const INITIAL_POSITION = { x: 160, y: 64 };
+/**
+ * Padding (screen px) reserved around the fitted cluster when auto-framing
+ * the view — sized so name labels (right of dot) and annotation chips
+ * (below dot) stay on-canvas for edge systems (re-audit UXF-08:
+ * Gibson/Skye labels clipped at the stage edge).
+ */
+const FIT_PADDING = 90;
+/** Fit zoom ceiling — never auto-zoom past the close-LOD baseline. */
+const FIT_MAX_ZOOM = 1.25;
+/**
+ * Fit zoom floor — keeps the initial frame at label-bearing LOD. Distant
+ * outlier systems (e.g. the Clan homeworlds far off the Inner Sphere) may
+ * start off-canvas rather than shrinking the whole map to dots; pan/zoom
+ * reaches them.
+ */
+const FIT_MIN_ZOOM = 0.7;
+/** Percentile trim applied per axis so outliers don't dominate the fit. */
+const FIT_TRIM = 0.05;
+
+// Percentile-trimmed extent of one axis: sorts the values and drops the
+// outer FIT_TRIM share on each side, so a single distant system does not
+// stretch the frame.
+function trimmedExtent(values: readonly number[]): {
+  min: number;
+  max: number;
+} {
+  const sorted = [...values].sort((a, b) => a - b);
+  const lo = Math.floor(sorted.length * FIT_TRIM);
+  const hi = Math.ceil(sorted.length * (1 - FIT_TRIM)) - 1;
+  return { min: sorted[lo], max: sorted[Math.max(hi, lo)] };
+}
+
+/**
+ * Fit the camera to the dense cluster of systems (percentile-trimmed
+ * bounding box) with label padding. Falls back to the legacy fixed offset
+ * while the stage is unmeasured or the system list is empty, so tests and
+ * first paint stay deterministic.
+ */
+function computeFitView(
+  systems: readonly IStarSystem[],
+  stageSize: { width: number; height: number },
+): { zoom: number; position: { x: number; y: number } } {
+  if (systems.length === 0 || stageSize.width <= 0 || stageSize.height <= 0) {
+    return { zoom: 1, position: INITIAL_POSITION };
+  }
+
+  const xExtent = trimmedExtent(systems.map((s) => s.position.x));
+  const yExtent = trimmedExtent(systems.map((s) => s.position.y));
+  const spanX = Math.max(xExtent.max - xExtent.min, 1);
+  const spanY = Math.max(yExtent.max - yExtent.min, 1);
+
+  const usableWidth = Math.max(stageSize.width - FIT_PADDING * 2, 1);
+  const usableHeight = Math.max(stageSize.height - FIT_PADDING * 2, 1);
+  const zoom = Math.min(
+    Math.max(Math.min(usableWidth / spanX, usableHeight / spanY), FIT_MIN_ZOOM),
+    FIT_MAX_ZOOM,
+  );
+
+  return {
+    zoom,
+    position: {
+      x: FIT_PADDING - xExtent.min * zoom + (usableWidth - spanX * zoom) / 2,
+      y: FIT_PADDING - yExtent.min * zoom + (usableHeight - spanY * zoom) / 2,
+    },
+  };
+}
+
+/**
+ * Greedy minimal pan that pulls each must-include point (selected system,
+ * annotated systems — the actionable ones) inside the padded viewport
+ * without changing zoom. The trimmed fit frames the dense cluster, but the
+ * route target can sit outside it; the annotation is useless off-canvas.
+ */
+function panToInclude(
+  view: { zoom: number; position: { x: number; y: number } },
+  points: readonly { x: number; y: number }[],
+  stageSize: { width: number; height: number },
+): { zoom: number; position: { x: number; y: number } } {
+  const { zoom } = view;
+  const position = { ...view.position };
+  for (const point of points) {
+    const screenX = point.x * zoom + position.x;
+    const screenY = point.y * zoom + position.y;
+    if (screenX < FIT_PADDING) {
+      position.x += FIT_PADDING - screenX;
+    } else if (screenX > stageSize.width - FIT_PADDING) {
+      position.x -= screenX - (stageSize.width - FIT_PADDING);
+    }
+    if (screenY < FIT_PADDING) {
+      position.y += FIT_PADDING - screenY;
+    } else if (screenY > stageSize.height - FIT_PADDING) {
+      position.y -= screenY - (stageSize.height - FIT_PADDING);
+    }
+  }
+  return { zoom, position };
+}
 
 type LODLevel = 'far' | 'medium' | 'close';
 
@@ -180,19 +288,43 @@ const StarSystemNode = React.memo(function StarSystemNode({
         />
       )}
 
-      {annotation && lod !== 'far' && (
+      {/* Faction name as text at close zoom — a non-color channel so the
+          faction encoding does not rely on the dot fill alone (re-audit
+          A11Y-R5; doctrine AMBIENT-CHROME rule: no color-only status). */}
+      {showLabel && lod === 'close' && (
         <Text
-          // Prefix a CVD-safe glyph by tone so annotation status does not rely
-          // on color alone (doctrine AMBIENT-CHROME rule: no color-only status).
-          text={`${annotationToneGlyph(annotation.tone)}${annotation.label}`}
-          x={-displaySize - 8}
-          y={displaySize + 8}
-          fontSize={10}
+          text={system.faction}
+          x={displaySize + 6}
+          y={7}
+          fontSize={8}
           fontFamily="system-ui, -apple-system, sans-serif"
-          fill={annotationColor}
-          fontStyle="bold"
+          fill="#94a3b8"
+          shadowColor="#000000"
+          shadowBlur={2}
+          shadowOpacity={0.8}
           listening={false}
         />
+      )}
+
+      {annotation && lod !== 'far' && (
+        // Chip-styled annotation anchored directly under its own dot. The
+        // dark tag keeps the text legible when it overlaps a neighboring
+        // system's label (re-audit VD-05: the route annotation used to render
+        // as bare text drifting into the 'Benjamin' label), and the below-dot
+        // anchor makes its owner unambiguous.
+        <Label x={-displaySize} y={displaySize + 4} listening={false}>
+          <Tag fill="#0f172a" opacity={0.85} cornerRadius={3} />
+          <Text
+            // Prefix a CVD-safe glyph by tone so annotation status does not
+            // rely on color alone (doctrine AMBIENT-CHROME rule).
+            text={`${annotationToneGlyph(annotation.tone)}${annotation.label}`}
+            fontSize={10}
+            fontFamily="system-ui, -apple-system, sans-serif"
+            fill={annotationColor}
+            fontStyle="bold"
+            padding={3}
+          />
+        </Label>
       )}
     </Group>
   );
@@ -213,6 +345,9 @@ export function StarmapDisplay({
   const [hoveredSystem, setHoveredSystem] = useState<string | null>(null);
   // Faction legend starts collapsed (pill) so it never crowds the canvas.
   const [legendOpen, setLegendOpen] = useState(false);
+  // Once the user pans or zooms, the auto-fit effect stops re-framing the
+  // camera under them; Reset restores the fitted frame.
+  const userAdjustedViewRef = useRef(false);
 
   const lod = useMemo(() => getLODLevel(zoom), [zoom]);
 
@@ -232,6 +367,36 @@ export function StarmapDisplay({
     resizeObserver.observe(container);
     return () => resizeObserver.disconnect();
   }, []);
+
+  // The systems the frame MUST show even when the trimmed fit excludes
+  // them: the selected system and every annotated system (current
+  // location, route target) — those carry the actionable chips.
+  const mustIncludePoints = useMemo(
+    () =>
+      systems
+        .filter(
+          (system) =>
+            system.id === selectedSystem ||
+            Boolean(systemAnnotations?.[system.id]),
+        )
+        .map((system) => system.position),
+    [systems, selectedSystem, systemAnnotations],
+  );
+
+  // Auto-fit the camera to the dense system cluster (with label padding)
+  // once real measurements land — the fixed INITIAL_POSITION left edge
+  // systems (Gibson, Skye) with clipped labels (re-audit UXF-08) — then
+  // pan minimally so the selected/annotated systems are in frame.
+  React.useEffect(() => {
+    if (userAdjustedViewRef.current) return;
+    const fit = panToInclude(
+      computeFitView(systems, stageSize),
+      mustIncludePoints,
+      stageSize,
+    );
+    setZoom(fit.zoom);
+    setPosition(fit.position);
+  }, [systems, stageSize, mustIncludePoints]);
 
   const handleWheel = useCallback(
     (e: Konva.KonvaEventObject<WheelEvent>) => {
@@ -260,6 +425,7 @@ export function StarmapDisplay({
         y: pointer.y - mousePointTo.y * newScale,
       };
 
+      userAdjustedViewRef.current = true;
       setZoom(newScale);
       setPosition(newPos);
     },
@@ -267,6 +433,7 @@ export function StarmapDisplay({
   );
 
   const handleDragEnd = useCallback((e: Konva.KonvaEventObject<DragEvent>) => {
+    userAdjustedViewRef.current = true;
     setPosition({ x: e.target.x(), y: e.target.y() });
   }, []);
 
@@ -284,17 +451,27 @@ export function StarmapDisplay({
   );
 
   const handleZoomIn = useCallback(() => {
+    userAdjustedViewRef.current = true;
     setZoom((z) => Math.min(MAX_ZOOM, z * ZOOM_STEP));
   }, []);
 
   const handleZoomOut = useCallback(() => {
+    userAdjustedViewRef.current = true;
     setZoom((z) => Math.max(MIN_ZOOM, z / ZOOM_STEP));
   }, []);
 
   const handleResetView = useCallback(() => {
-    setZoom(1);
-    setPosition(INITIAL_POSITION);
-  }, []);
+    // Reset returns to the fitted frame (not the legacy fixed offset) and
+    // re-arms auto-fit so subsequent container resizes keep the map framed.
+    userAdjustedViewRef.current = false;
+    const fit = panToInclude(
+      computeFitView(systems, stageSize),
+      mustIncludePoints,
+      stageSize,
+    );
+    setZoom(fit.zoom);
+    setPosition(fit.position);
+  }, [systems, stageSize, mustIncludePoints]);
 
   return (
     <div


### PR DESCRIPTION
## Summary
Re-audit VD-05/UXF-08/A11Y-R5/DC-04 (board task #11):

- **Davion recolored to canonical gold** (`#eab308`) — its old `#b91c1c` was a near twin of Kurita's `#dc2626`, making the two houses indistinguishable on the map
- **Faction name renders as a text sub-label** under each system name at close zoom — the faction encoding no longer relies on dot color alone (CVD)
- **Annotations render as dark-tagged chips** anchored directly under their own dot — legible over neighboring labels (the Luthien route annotation used to drift as bare text into the 'Benjamin' label) and unambiguous about ownership
- **Initial camera auto-fits the dense system cluster** (percentile-trimmed bounding box + label padding) instead of a fixed offset that clipped Gibson/Skye at the stage edge; a greedy minimal pan guarantees the selected + annotated systems (current location, route target) are in frame; a zoom floor keeps the frame at label-bearing LOD so distant outliers (Clan homeworlds) never shrink the map to dots. User pan/zoom disarms auto-fit; Reset restores the fitted frame.

## Verification
- typecheck clean; starmap-adjacent suites green
- `qc:command-evidence` capture+validate 6/6
- Screens 01/02 pixel-verified: gold-vs-red faction split, faction sub-labels, Luthien chip annotation clear of Benjamin, Skye/Terra labels fully in-frame