### PR TITLE
fix(command-screens): readiness severity semantics + copy/lexicon + low-tier polish

### DIFF
--- a/e2e/campaign-starmap-logistics.spec.ts
+++ b/e2e/campaign-starmap-logistics.spec.ts
@@ -183,8 +183,10 @@ test.describe('campaign starmap logistics', () => {
         await expect(page.getByTestId('starmap-current-system')).toContainText(
           'Luthien',
         );
+        // Arrival-appropriate copy (re-audit DC-05): the already-here state
+        // reads 'at destination', not the engine's raw 'blocked'.
         await expect(page.getByTestId('starmap-route-status')).toContainText(
-          'blocked',
+          'at destination',
         );
         await expect(page.getByTestId('starmap-arrival-date')).toContainText(
           '3025-03-14 (now)',

--- a/src/components/gameplay/GameplayLayout.actionContext.ts
+++ b/src/components/gameplay/GameplayLayout.actionContext.ts
@@ -74,6 +74,8 @@ export function buildTacticalActionContext({
       plannedMovement,
       selectedUnit,
     ),
+    activeUnitHasMASC: selectedUnit?.hasMASC ?? false,
+    activeUnitHasSupercharger: selectedUnit?.hasSupercharger ?? false,
     activeUnitConversionMode: selectedUnit?.conversionMode,
     activeUnitVehicleMotionType: getVehicleMotionType(selectedUnit),
     activeUnitVehicleAltitude: getVehicleAltitude(selectedUnit),

--- a/src/components/gameplay/MovementIntentComposer/BudgetResolver.tsx
+++ b/src/components/gameplay/MovementIntentComposer/BudgetResolver.tsx
@@ -51,9 +51,12 @@ export interface BudgetResolverProps {
   readonly hint?: string | null;
 }
 
+// "enemy to-hit +N" — the modifier applies to ENEMIES shooting at this
+// unit (movement makes it harder to hit). The old "attacker to-hit" left
+// ambiguous whose attacks it modified (re-audit DC-08).
 function formatToHit(modifier: number): string {
-  if (modifier === 0) return 'to-hit +0';
-  return `attacker to-hit ${modifier > 0 ? '+' : ''}${modifier}`;
+  if (modifier === 0) return 'enemy to-hit +0';
+  return `enemy to-hit ${modifier > 0 ? '+' : ''}${modifier}`;
 }
 
 function BudgetOptionRow({

--- a/src/components/gameplay/RecordSheetDisplay.tsx
+++ b/src/components/gameplay/RecordSheetDisplay.tsx
@@ -314,6 +314,17 @@ export function RecordSheetDisplay({
   );
 }
 
+// Kebab-slug form used to detect when a designation/chassis field is just
+// the unit name again in slug or verbatim form (re-audit VD-08: the rail
+// header printed the unit's identity three times, once as a raw catalog
+// slug). Real designations ('AS7-D' next to 'Atlas AS7-D') still render.
+function toIdentitySlug(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
+}
+
 function RecordSheetHeader({
   unitName,
   designation,
@@ -329,6 +340,11 @@ function RecordSheetHeader({
   readonly tonnage: number | undefined;
   readonly chassis: string | undefined;
 }): React.ReactElement {
+  const designationDuplicatesName =
+    toIdentitySlug(designation) === toIdentitySlug(unitName);
+  const chassisDuplicatesName =
+    chassis !== undefined &&
+    toIdentitySlug(chassis) === toIdentitySlug(unitName);
   return (
     <div className="border-border-theme mb-4 border-b pb-2">
       <div className="flex items-center gap-3">
@@ -349,8 +365,12 @@ function RecordSheetHeader({
         )}
       </div>
       <div className="text-text-theme-secondary mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm">
-        <span data-testid="record-sheet-designation">{designation}</span>
-        {chassis && <span data-testid="record-sheet-chassis">{chassis}</span>}
+        {!designationDuplicatesName && (
+          <span data-testid="record-sheet-designation">{designation}</span>
+        )}
+        {chassis && !chassisDuplicatesName && (
+          <span data-testid="record-sheet-chassis">{chassis}</span>
+        )}
         {tonnage !== undefined && (
           <span data-testid="record-sheet-tonnage">{tonnage} tons</span>
         )}

--- a/src/components/gameplay/TacticalActionDock/TacticalActionDock.tsx
+++ b/src/components/gameplay/TacticalActionDock/TacticalActionDock.tsx
@@ -219,8 +219,11 @@ function CommandGroup({
         </div>
       )}
       {dangerCommands.length > 0 && (
+        // Wider break + heavier rule than the intra-group gap: the
+        // irreversible cluster (Eject / Withdraw / Concede) must not read
+        // as just-another-neighbor of routine commands (re-audit IS-04).
         <div
-          className="flex flex-wrap items-center gap-2 border-l border-red-500/50 pl-2"
+          className="ml-6 flex flex-wrap items-center gap-2 border-l-2 border-red-500/60 pl-4"
           data-testid={`command-group-${category}-danger`}
         >
           <span className="text-xs font-semibold text-red-200 uppercase">

--- a/src/components/gameplay/TacticalActionDock/commands/movementCommands.ts
+++ b/src/components/gameplay/TacticalActionDock/commands/movementCommands.ts
@@ -47,11 +47,17 @@ export function buildMovementCommands(
   // commands so the same verb never renders on two surfaces (re-audit
   // VD-01/UXF-01/IS-02).
   const composerOwnsComposition = ctx?.movementComposerActive === true;
+  // Equipment-reality gate (re-audit DC-03): a unit that mounts no MASC /
+  // Supercharger must not surface the activation affordance at all — the
+  // engine refuses the action anyway, so the button was a dead promise.
+  // `undefined` (legacy contexts without the flag) keeps the old behavior.
+  const showMASC = ctx?.activeUnitHasMASC !== false;
+  const showSupercharger = ctx?.activeUnitHasSupercharger !== false;
   return [
     ...(composerOwnsComposition ? [] : MovementTraversalCommands),
     ...(composerOwnsComposition ? [] : MovementPostureCommands),
-    MovementActivateMASCCommand,
-    MovementActivateSuperchargerCommand,
+    ...(showMASC ? [MovementActivateMASCCommand] : []),
+    ...(showSupercharger ? [MovementActivateSuperchargerCommand] : []),
     ...buildRuntimeMovementStateCommands(ctx),
     MovementStabilizeCommand,
     MovementCancelCommand,

--- a/src/components/gameplay/TacticalTurnRail/TacticalTurnRail.tsx
+++ b/src/components/gameplay/TacticalTurnRail/TacticalTurnRail.tsx
@@ -169,11 +169,11 @@ function RailToken({
           </span>
         )}
       </div>
+      {/* Name only — the raw catalog slug (`atlas-as7-d`) that used to render
+          under it was an internal identifier leak at failing contrast
+          (re-audit DC-07/A11Y-R6); the name already carries the variant. */}
       <span className="w-full truncate leading-tight font-medium">
         {unit.name}
-      </span>
-      <span className="truncate font-mono text-[10px] leading-tight opacity-60">
-        {unit.unitRef}
       </span>
     </button>
   );
@@ -198,13 +198,15 @@ function BlockerBadge({
 
   return (
     <div
-      className="flex flex-shrink-0 items-center gap-1 rounded bg-amber-600/80 px-2 py-1 text-xs text-white"
+      // Dark text on the amber fill — white-on-amber measured well below AA
+      // (re-audit A11Y-R7), same treatment as the GM ledger's filled CTAs.
+      className="flex flex-shrink-0 items-center gap-1 rounded bg-amber-400 px-2 py-1 text-xs font-semibold text-slate-950"
       data-testid="rail-blocker-badge"
       aria-label={`${count} unit${count === 1 ? '' : 's'} awaiting ${phaseLabel}`}
       role="status"
     >
       <span className="font-bold">{count}</span>
-      <span className="opacity-80">pending</span>
+      <span>pending</span>
     </div>
   );
 }

--- a/src/components/gameplay/minimap/Minimap.tsx
+++ b/src/components/gameplay/minimap/Minimap.tsx
@@ -13,7 +13,7 @@
  * - `role="region"` with `aria-label`
  */
 
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 
 import type { IHexCoordinate, IUnitToken } from '@/types/gameplay';
 
@@ -59,6 +59,15 @@ export interface MinimapProps {
   readonly visible?: boolean;
 }
 
+/**
+ * Host panels shorter than this cannot show the 200px minimap (top-right)
+ * AND the bottom-right camera/overlay control column without the two
+ * translucently painting over each other (re-audit VD-07). Below it the
+ * glanceable AMBIENT minimap yields to the interactive controls. jsdom
+ * reports 0 heights, so 0 is treated as "unmeasured -> show".
+ */
+const MINIMAP_MIN_HOST_HEIGHT = 460;
+
 export function Minimap({
   radius,
   tokens,
@@ -68,7 +77,24 @@ export function Minimap({
   visible = true,
 }: MinimapProps): React.ReactElement | null {
   const [hoveredUnitId, setHoveredUnitId] = useState<string | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [hostTooShort, setHostTooShort] = useState(false);
   const bounds = useMemo(() => worldBoundsForRadius(radius), [radius]);
+
+  // Auto-yield on short map panels: watch the positioned host's height and
+  // drop the minimap when both it and the control column cannot fit.
+  useEffect(() => {
+    const host = containerRef.current?.offsetParent;
+    if (!(host instanceof HTMLElement)) return;
+    const check = (): void => {
+      const height = host.clientHeight;
+      setHostTooShort(height > 0 && height < MINIMAP_MIN_HOST_HEIGHT);
+    };
+    check();
+    const observer = new ResizeObserver(check);
+    observer.observe(host);
+    return () => observer.disconnect();
+  }, [visible]);
 
   const viewportRect = useMemo(
     () =>
@@ -103,7 +129,13 @@ export function Minimap({
 
   return (
     <div
-      className="absolute rounded-md bg-slate-900/85 shadow-lg ring-1 ring-slate-700/60 backdrop-blur-sm"
+      // `invisible` (not unmount / display:none) when the host is too short:
+      // the element stays in flow so the ResizeObserver keeps measuring and
+      // restores the minimap the moment the panel grows tall enough.
+      ref={containerRef}
+      className={`absolute rounded-md bg-slate-900/85 shadow-lg ring-1 ring-slate-700/60 backdrop-blur-sm ${
+        hostTooShort ? 'pointer-events-none invisible' : ''
+      }`}
       style={{
         top: MINIMAP_MARGIN,
         right: MINIMAP_MARGIN,
@@ -111,7 +143,9 @@ export function Minimap({
         height: MINIMAP_SIZE,
       }}
       data-testid="minimap"
+      data-minimap-yielded={hostTooShort ? 'true' : undefined}
       role="region"
+      aria-hidden={hostTooShort ? 'true' : undefined}
       aria-label="Tactical map overview. Click or drag to pan the main camera."
     >
       <svg

--- a/src/lib/campaign/readiness/missionReadinessProjection.ts
+++ b/src/lib/campaign/readiness/missionReadinessProjection.ts
@@ -161,8 +161,9 @@ function buildUnitProjection({
       code: 'pilot_unassigned',
       severity: 'warning',
       subjectId: unit.unitId,
-      message:
-        'No pilot is assigned; assign one before launch if pilot rules apply.',
+      // Direct imperative — the old "if pilot rules apply" hedge read as the
+      // app being unsure of its own rules (re-audit DC-06).
+      message: 'No pilot assigned. Assign one before launch.',
       actionLabel: 'Assign pilot',
       actionHref: pilotAssignmentHref(baseCampaignHref, unit.unitId),
     });

--- a/src/pages-modules/gameplay/campaigns/missionLaunchReadinessPanel.tsx
+++ b/src/pages-modules/gameplay/campaigns/missionLaunchReadinessPanel.tsx
@@ -16,6 +16,16 @@ function readinessStatusVariant(
   return 'red';
 }
 
+// Severity glyph shared with the starmap annotation convention (doctrine
+// AMBIENT-CHROME rule): status never reads through color alone.
+function readinessStatusGlyph(
+  status: IMissionReadinessUnitProjection['status'],
+): string {
+  if (status === 'eligible') return '✓ ';
+  if (status === 'risky') return '▲ ';
+  return '! ';
+}
+
 function launchReadinessVariant(
   projection: IMissionReadinessProjection,
 ): 'success' | 'warning' | 'red' {
@@ -24,9 +34,9 @@ function launchReadinessVariant(
 }
 
 function launchReadinessLabel(projection: IMissionReadinessProjection): string {
-  if (!projection.canLaunch) return 'Launch blocked';
-  if (projection.warnings.length === 0) return 'Launch ready';
-  return `Ready with warnings (${projection.warnings.length})`;
+  if (!projection.canLaunch) return '! Launch blocked';
+  if (projection.warnings.length === 0) return '✓ Launch ready';
+  return `▲ Ready with warnings (${projection.warnings.length})`;
 }
 
 export function MissionReadinessPanel({
@@ -88,6 +98,7 @@ export function MissionReadinessPanel({
                     variant={readinessStatusVariant(unitProjection.status)}
                     size="sm"
                   >
+                    {readinessStatusGlyph(unitProjection.status)}
                     {unitProjection.status}
                   </Badge>
                 </span>
@@ -101,13 +112,22 @@ export function MissionReadinessPanel({
                     {unitProjection.reasons.map((reason) => (
                       <li
                         key={`${unit.unitId}-${reason.code}`}
+                        // Blockers announce (alert); warnings inform (status) —
+                        // and both carry the severity glyph so the message
+                        // never reads through color alone.
+                        role={
+                          reason.severity === 'blocker' ? 'alert' : 'status'
+                        }
                         className={
                           reason.severity === 'blocker'
                             ? 'flex flex-wrap items-center gap-2 text-xs text-rose-300'
                             : 'flex flex-wrap items-center gap-2 text-xs text-amber-300'
                         }
                       >
-                        <span>{reason.message}</span>
+                        <span>
+                          {reason.severity === 'blocker' ? '! ' : '▲ '}
+                          {reason.message}
+                        </span>
                         {reason.actionHref ? (
                           <Link
                             href={reason.actionHref}
@@ -122,9 +142,13 @@ export function MissionReadinessPanel({
                   </ul>
                 ) : null}
                 {buildCustomizeHref ? (
+                  // Real button affordance at AA contrast (re-audit UXF-02:
+                  // the old sky-100-on-10%-tint label washed out inside the
+                  // warning card) — but still visually SECONDARY to the
+                  // amber 'Assign pilot' remediation link above it.
                   <Link
                     href={buildCustomizeHref(unit.unitId)}
-                    className="mt-2 inline-flex rounded border border-sky-400/70 bg-sky-500/10 px-2 py-1 text-xs font-semibold text-sky-100 hover:border-sky-300 hover:bg-sky-500/20"
+                    className="mt-2 inline-flex rounded border border-sky-300 bg-sky-500/20 px-2.5 py-1 text-xs font-semibold text-sky-50 hover:bg-sky-500/30"
                     data-testid={`mission-readiness-customize-${unit.unitId}`}
                   >
                     Open refit editor

--- a/src/pages/gameplay/campaigns/[id]/starmap.tsx
+++ b/src/pages/gameplay/campaigns/[id]/starmap.tsx
@@ -173,7 +173,15 @@ export default function CampaignStarmapPage(): React.ReactElement {
           <div className="grid gap-3 sm:grid-cols-4">
             <Metric
               label="Status"
-              value={travelPreview?.status ?? 'blocked'}
+              // 'blocked' is the engine's word for "no travel to plan" — but
+              // when the only block is that the fleet is already AT the
+              // selected system, the player just completed a successful
+              // arrival and the cell must say so (re-audit DC-05).
+              value={
+                selectedIsBlockedCurrentSystem
+                  ? 'at destination'
+                  : (travelPreview?.status ?? 'blocked')
+              }
               testId="starmap-route-status"
             />
             <Metric

--- a/src/types/gameplay/TacticalCommandInterfaces.ts
+++ b/src/types/gameplay/TacticalCommandInterfaces.ts
@@ -196,6 +196,15 @@ export interface ITacticalCommandContext {
   readonly activeUnitHeat?: number;
   /** True when the active unit already has a movement preview/plan queued. */
   readonly activeUnitHasPlannedMovement?: boolean;
+  /**
+   * Whether the active unit mounts MASC / a Supercharger. `false` drops the
+   * matching activation command from the dock entirely — a unit that mounts
+   * neither must not surface the affordance (re-audit DC-03; the engine
+   * would refuse anyway, but a dead button is a broken promise). `undefined`
+   * (legacy contexts) preserves the old always-render behavior.
+   */
+  readonly activeUnitHasMASC?: boolean;
+  readonly activeUnitHasSupercharger?: boolean;
   /** Runtime conversion mode for LAM / QuadVee style movement controls. */
   readonly activeUnitConversionMode?: MovementConversionMode | number;
   /** Represented vehicle motive used by VTOL/WiGE altitude controls. */


### PR DESCRIPTION
## Summary
Paired tasks #12 + #13 (re-audit UXF-02/A11Y-R2, DC-05..08, VD-07/VD-08/DC-03/DC-07/A11Y-R6/R7/IS-04).

**Readiness panel:**
- Severity glyphs (✓/▲/!) on the launch badge + unit status pills — status never reads through color alone
- Reason lines carry the glyph and announce (role=alert for blockers, role=status for warnings)
- 'Open refit editor' restyled to an AA-contrast button affordance, still secondary to 'Assign pilot'

**Copy/lexicon:**
- Starmap STATUS reads 'at destination' after arrival instead of raw 'blocked' (+ e2e assertion updated)
- Pilot warning de-hedged: 'No pilot assigned. Assign one before launch.'
- Budget consequences read 'enemy to-hit +N' (whose attacks the modifier applies to)

**Low-tier:**
- Turn-rail chips drop the raw catalog slug sub-label; record-sheet header dedupes slug/verbatim repeats of the unit name (identity ×3); real designations like 'AS7-D' still render
- 'N pending' rail badge: dark text on amber
- MASC/Supercharger dock commands render only for units that mount the equipment
- Minimap auto-yields when the map panel is too short to host both it and the control column
- CRITICAL cluster (Eject/Withdraw/Concede) separated with a wider break + heavier red rule

Not addressed (by design, per re-audit): H2/H3 capture provenance (prod-build capture, harness labeling).

## Verification
- typecheck clean; 32 affected suites / 235 tests green
- qc:command-evidence capture+validate 6/6
- Screens 03 + 09 pixel-verified (glyphed badges, de-hedged copy, slug-free chips, MASC gone on the Atlas, separated CRITICAL cluster, 'enemy to-hit' budget lines)