### PR TITLE
fix(gameplay): derive record-sheet weapons table from engine catalog data

### DIFF
--- a/src/engine/InteractiveSession.accessors.ts
+++ b/src/engine/InteractiveSession.accessors.ts
@@ -1,3 +1,4 @@
+import type { IWeapon } from '@/simulation/ai/types';
 import type {
   IGameSession,
   IGameState,
@@ -27,6 +28,18 @@ export function getInteractiveSessionSession(
   context: IInteractiveSessionRuntimeContext,
 ): IGameSession {
   return context.getSession();
+}
+
+/**
+ * Surface the cached engine weapons for a unit so display surfaces (record
+ * sheet weapons table, valid-target derivation) can read the same catalog
+ * data the resolvers use. Empty array for unknown ids.
+ */
+export function getInteractiveSessionUnitWeapons(
+  context: IInteractiveSessionRuntimeContext,
+  unitId: string,
+): readonly IWeapon[] {
+  return context.weaponsByUnit.get(unitId) ?? [];
 }
 
 export function getInteractiveSessionMovementCapability(

--- a/src/engine/InteractiveSession.ts
+++ b/src/engine/InteractiveSession.ts
@@ -52,6 +52,7 @@ import {
   getInteractiveSessionMovementCapability,
   getInteractiveSessionSession,
   getInteractiveSessionState,
+  getInteractiveSessionUnitWeapons,
 } from './InteractiveSession.accessors';
 import {
   activateInteractiveSessionMovementEnhancement,
@@ -364,6 +365,17 @@ export class InteractiveSession {
    */
   getMovementCapability = (unitId: string): IMovementCapability | null => {
     return getInteractiveSessionMovementCapability(this.runtimeContext, unitId);
+  };
+
+  /**
+   * Surface the cached engine weapons for a unit so the gameplay store can
+   * derive the record sheet's weapons table (and valid-target derivation)
+   * from the same catalog data the resolvers use — previously only the demo
+   * fixtures populated that display map, so every real session rendered an
+   * empty weapons table (board task #14, same family as the 0/0 armor bug).
+   */
+  getUnitWeapons = (unitId: string): readonly IWeapon[] => {
+    return getInteractiveSessionUnitWeapons(this.runtimeContext, unitId);
   };
 
   /**

--- a/src/stores/__tests__/useGameplayStore.session.supplemental.test.ts
+++ b/src/stores/__tests__/useGameplayStore.session.supplemental.test.ts
@@ -44,7 +44,21 @@ function adaptedMech(id: string, side: GameSide): IAdaptedUnit {
     destroyed: false,
     lockState: LockState.Pending,
     tonnage: 100,
-    weapons: [],
+    weapons: [
+      {
+        id: 'medium-laser',
+        name: 'Medium Laser',
+        location: 'LEFT_ARM',
+        shortRange: 3,
+        mediumRange: 6,
+        longRange: 9,
+        damage: 5,
+        heat: 3,
+        minRange: 0,
+        ammoPerTon: -1,
+        destroyed: false,
+      },
+    ],
     walkMP: 3,
     runMP: 5,
     jumpMP: 0,
@@ -98,6 +112,19 @@ describe('setInteractiveSessionLogic supplemental display derivation', () => {
       maxStructure: Record<string, Record<string, number>>;
       pilotNames: Record<string, string>;
       heatSinks: Record<string, number>;
+      unitWeapons: Record<
+        string,
+        readonly {
+          id: string;
+          name: string;
+          location: string;
+          destroyed: boolean;
+          firedThisTurn: boolean;
+          damage: number | string;
+          heat: number;
+          ranges: { short: number; medium: number; long: number };
+        }[]
+      >;
     };
 
     expect(applied.maxArmor['unit-p1']).toEqual({
@@ -118,5 +145,18 @@ describe('setInteractiveSessionLogic supplemental display derivation', () => {
     expect(applied.pilotNames['unit-o1']).toBeUndefined();
     expect(applied.heatSinks['unit-p1']).toBe(20);
     expect(applied.heatSinks['unit-o1']).toBe(20);
+    // Weapons project from the engine's cached catalog arrays into the
+    // display IWeaponStatus shape (location normalized to snake_case).
+    expect(applied.unitWeapons['unit-p1']).toHaveLength(1);
+    expect(applied.unitWeapons['unit-p1'][0]).toMatchObject({
+      id: 'medium-laser',
+      name: 'Medium Laser',
+      location: 'left_arm',
+      destroyed: false,
+      firedThisTurn: false,
+      damage: 5,
+      heat: 3,
+      ranges: { short: 3, medium: 6, long: 9 },
+    });
   });
 });

--- a/src/stores/useGameplayStore.session.ts
+++ b/src/stores/useGameplayStore.session.ts
@@ -11,6 +11,7 @@
  */
 
 import type { InteractiveSession } from '@/engine/GameEngine';
+import type { IWeapon } from '@/simulation/ai/types';
 
 import {
   createDemoHeatSinks,
@@ -163,15 +164,17 @@ function getLoadSessionErrorMessage(error: unknown): string {
  * damage, so this also holds for sessions recovered mid-battle.
  */
 function deriveSupplementalDisplayData(
-  session: IGameSession,
+  interactiveSession: InteractiveSession,
 ): Pick<
   SessionSlice,
-  'maxArmor' | 'maxStructure' | 'pilotNames' | 'heatSinks'
+  'maxArmor' | 'maxStructure' | 'pilotNames' | 'heatSinks' | 'unitWeapons'
 > {
+  const session = interactiveSession.getSession();
   const maxArmor: Record<string, Record<string, number>> = {};
   const maxStructure: Record<string, Record<string, number>> = {};
   const pilotNames: Record<string, string> = {};
   const heatSinks: Record<string, number> = {};
+  const unitWeapons: Record<string, readonly IWeaponStatus[]> = {};
 
   for (const unit of session.units) {
     if (unit.armorByLocation) {
@@ -190,9 +193,66 @@ function deriveSupplementalDisplayData(
     if (unitHeatSinks !== undefined) {
       heatSinks[unit.id] = unitHeatSinks;
     }
+    // Weapons come from the engine's cached per-unit catalog data — the same
+    // arrays the resolvers use — so the record sheet's weapons table and the
+    // valid-target derivation stop depending on demo fixtures (task #14).
+    // Older mocks without the accessor keep the empty-map behavior.
+    if (typeof interactiveSession.getUnitWeapons === 'function') {
+      const engineWeapons = interactiveSession.getUnitWeapons(unit.id);
+      if (engineWeapons.length > 0) {
+        unitWeapons[unit.id] = engineWeapons.map(weaponStatusFromEngineWeapon);
+      }
+    }
   }
 
-  return { maxArmor, maxStructure, pilotNames, heatSinks };
+  return { maxArmor, maxStructure, pilotNames, heatSinks, unitWeapons };
+}
+
+// Known source location labels -> the snake_case keys the record sheet's
+// location tables use (same normalization rule as the armor adapter).
+function normalizeWeaponLocation(location: string | undefined): string {
+  if (!location) return 'unknown';
+  return location.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+}
+
+/**
+ * Project an engine `IWeapon` (simulation/AI shape) into the display
+ * `IWeaponStatus` the record sheet renders. `firedThisTurn` starts false at
+ * adoption; ammo counters are omitted (optional fields — the inline ammo
+ * display falls back gracefully) because bin-level ammo lives on the unit
+ * state, not the weapon.
+ */
+function weaponStatusFromEngineWeapon(weapon: IWeapon): IWeaponStatus {
+  return {
+    id: weapon.id,
+    name: weapon.name,
+    location: normalizeWeaponLocation(weapon.location),
+    ...(weapon.mountingArc !== undefined
+      ? { mountingArc: weapon.mountingArc }
+      : {}),
+    ...(weapon.mountingArcs !== undefined
+      ? { mountingArcs: weapon.mountingArcs }
+      : {}),
+    ...(weapon.vehicleMountLocation !== undefined
+      ? { vehicleMountLocation: weapon.vehicleMountLocation }
+      : {}),
+    ...(weapon.vehicleIsTurretMounted !== undefined
+      ? { vehicleIsTurretMounted: weapon.vehicleIsTurretMounted }
+      : {}),
+    destroyed: weapon.destroyed ?? false,
+    firedThisTurn: false,
+    heat: weapon.heat,
+    damage: weapon.damage,
+    ranges: {
+      short: weapon.shortRange,
+      medium: weapon.mediumRange,
+      long: weapon.longRange,
+      ...(weapon.extremeRange !== undefined
+        ? { extreme: weapon.extremeRange }
+        : {}),
+      ...(weapon.minRange > 0 ? { minimum: weapon.minRange } : {}),
+    },
+  };
 }
 
 /**
@@ -220,7 +280,7 @@ export function setInteractiveSessionLogic(
     spectatorMode: null,
     isLoading: false,
     error: null,
-    ...deriveSupplementalDisplayData(session),
+    ...deriveSupplementalDisplayData(interactiveSession),
   });
 }
 
@@ -243,6 +303,6 @@ export function setSpectatorModeLogic(
     spectatorMode,
     isLoading: false,
     error: null,
-    ...deriveSupplementalDisplayData(session),
+    ...deriveSupplementalDisplayData(interactiveSession),
   });
 }


### PR DESCRIPTION
## Summary
Board task #14 — same family as the 0/0 armor bug (#998): the store's `unitWeapons` display map was only populated by the demo-fixture path, so every real interactive session rendered an **empty weapons table** and fed an empty map into **valid-weapon-target derivation**.

- `InteractiveSession.getUnitWeapons` accessor (mirrors `getMovementCapability`) over the engine's cached per-unit weapon arrays
- `deriveSupplementalDisplayData` projects them into display `IWeaponStatus` rows — location normalized to the record sheet's snake_case keys; ranges/heat/damage/arc metadata carried through; ammo counters omitted (bin-level ammo lives on unit state; the inline counter falls back gracefully)
- Applied on both interactive and spectator adoption; legacy mocks without the accessor keep the empty-map behavior

## Verification
- typecheck clean; stores+engine 71 suites / 1153 tests green (supplemental derivation test extended with weapon projection assertions)
- qc:command-evidence capture+validate 6/6